### PR TITLE
Add file-specific permission flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,19 +20,38 @@ use std::path::PathBuf;
 
     # With network access enabled
     nono --allow . --net-allow -- claude
+
+    # Allow specific files (not directories)
+    nono --allow . --write-file ~/.claude.json -- claude
 ")]
 pub struct Args {
-    /// Paths to allow read+write access (can be specified multiple times)
-    #[arg(long, short = 'a', value_name = "PATH")]
+    // === Directory permissions (recursive) ===
+
+    /// Directories to allow read+write access (recursive)
+    #[arg(long, short = 'a', value_name = "DIR")]
     pub allow: Vec<PathBuf>,
 
-    /// Paths to allow read-only access (can be specified multiple times)
-    #[arg(long, short = 'r', value_name = "PATH")]
+    /// Directories to allow read-only access (recursive)
+    #[arg(long, short = 'r', value_name = "DIR")]
     pub read: Vec<PathBuf>,
 
-    /// Paths to allow write-only access (can be specified multiple times)
-    #[arg(long, short = 'w', value_name = "PATH")]
+    /// Directories to allow write-only access (recursive)
+    #[arg(long, short = 'w', value_name = "DIR")]
     pub write: Vec<PathBuf>,
+
+    // === Single file permissions ===
+
+    /// Single files to allow read+write access
+    #[arg(long, value_name = "FILE")]
+    pub allow_file: Vec<PathBuf>,
+
+    /// Single files to allow read-only access
+    #[arg(long, value_name = "FILE")]
+    pub read_file: Vec<PathBuf>,
+
+    /// Single files to allow write-only access
+    #[arg(long, value_name = "FILE")]
+    pub write_file: Vec<PathBuf>,
 
     /// Enable network access (binary: all outbound allowed when flag is present)
     /// Note: Per-host filtering not supported by OS sandbox; this is on/off only
@@ -59,7 +78,12 @@ pub struct Args {
 impl Args {
     /// Check if any filesystem capabilities are specified
     pub fn has_fs_caps(&self) -> bool {
-        !self.allow.is_empty() || !self.read.is_empty() || !self.write.is_empty()
+        !self.allow.is_empty()
+            || !self.read.is_empty()
+            || !self.write.is_empty()
+            || !self.allow_file.is_empty()
+            || !self.read_file.is_empty()
+            || !self.write_file.is_empty()
     }
 
     /// Check if network access is enabled

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,12 @@ pub enum NonoError {
     #[error("Path does not exist: {0}")]
     PathNotFound(PathBuf),
 
+    #[error("Expected a directory but got a file: {0}")]
+    ExpectedDirectory(PathBuf),
+
+    #[error("Expected a file but got a directory: {0}")]
+    ExpectedFile(PathBuf),
+
     #[error("Failed to canonicalize path {path}: {source}")]
     PathCanonicalization {
         path: PathBuf,


### PR DESCRIPTION
We now have file and folder specific flags

```
--allow <DIR> | Directory (recursive) | subpath
--read <DIR> | Directory (recursive) | subpath
--write <DIR> | Directory (recursive) | subpath
--allow-file <FILE> | Single file | literal
--read-file <FILE> | Single file | literal
--write-file <FILE> | Single file | literal
```