### PR TITLE
Add destructive command blocking with defense-in-depth protection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install dbus pkg-config
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install dbus pkg-config
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 (glibc)
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: nono
+
+          # Linux x86_64 (musl - static)
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact: nono
+
+          # Linux aarch64 (glibc)
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: nono
+            cross: true
+
+          # macOS x86_64
+          - target: x86_64-apple-darwin
+            os: macos-13
+            artifact: nono
+
+          # macOS aarch64 (Apple Silicon)
+          - target: aarch64-apple-darwin
+            os: macos-14
+            artifact: nono
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../nono-${{ github.ref_name }}-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nono-${{ matrix.target }}
+          path: nono-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          find . -name "*.tar.gz" -exec mv {} . \;
+          sha256sum *.tar.gz > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/SHA256SUMS.txt
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-nono
+        uses: actions/checkout@v4
+        with:
+          repository: lukehinds/homebrew-nono
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-nono
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nono-*-apple-darwin
+          path: artifacts
+
+      - name: Update formula
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
+          # Calculate SHA256 for both architectures
+          ARM64_SHA=$(sha256sum artifacts/nono-aarch64-apple-darwin/nono-*-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
+          X64_SHA=$(sha256sum artifacts/nono-x86_64-apple-darwin/nono-*-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)
+
+          # Update formula version and checksums
+          cd homebrew-nono
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/nono.rb
+          sed -i "s|releases/download/v[^/]*/|releases/download/v${VERSION}/|g" Formula/nono.rb
+          # Update ARM64 SHA (first sha256 in on_arm block)
+          sed -i "/on_arm/,/end/{s/sha256 \"[a-f0-9]*\"/sha256 \"${ARM64_SHA}\"/}" Formula/nono.rb
+          # Update x64 SHA (sha256 in on_intel block)
+          sed -i "/on_intel/,/end/{s/sha256 \"[a-f0-9]*\"/sha256 \"${X64_SHA}\"/}" Formula/nono.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-nono
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/nono.rb
+          git diff --staged --quiet || git commit -m "Update nono to ${{ github.ref_name }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -55,7 +59,7 @@ jobs:
 
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        run: sudo apt-get install -y musl-tools
 
       - name: Install cross
         if: matrix.cross
@@ -116,6 +120,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-02-01
+
+### Added
+- Filesystem sandboxing with Landlock (Linux) and Seatbelt (macOS)
+- Network blocking capability (`--net-block`)
+- Profile system for reusable configurations
+- `nono run` command for executing sandboxed processes
+- `nono why` command for debugging path access
+- `nono setup` command for system configuration
+- Sensitive path protection (SSH keys, credentials, shell configs)
+- Silent mode (`--silent`) for scripting
+- Dry-run mode for testing configurations
+
+### Security
+- Blocks access to ~/.ssh, ~/.aws, ~/.gnupg, and other sensitive paths by default
+- Uses OS-enforced sandboxing (no escape hatch)
+- All child processes inherit sandbox restrictions
+
+[Unreleased]: https://github.com/lukehinds/nono/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/lukehinds/nono/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "nono"
+name = "nono-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
-name = "nono"
+name = "nono-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.74"
 authors = ["Luke Hinds"]
 description = "The opposite of YOLO - a capability shell for AI agents"
 license = "Apache-2.0"
 repository = "https://github.com/lukehinds/nono"
-keywords = ["sandbox", "security", "capability", "agent", "ai", "sandbox"]
+homepage = "https://github.com/lukehinds/nono"
+documentation = "https://docs.rs/nono-rs"
+readme = "README.md"
+keywords = ["sandbox", "security", "capability", "agent", "landlock"]
 categories = ["command-line-utilities", "development-tools"]
+include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 # CLI
@@ -50,3 +55,10 @@ tempfile = "3"
 [[bin]]
 name = "nono"
 path = "src/main.rs"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -109,6 +109,10 @@ pub struct CapabilitySet {
     pub fs: Vec<FsCapability>,
     /// Network access blocked (network allowed by default; true = blocked)
     pub net_block: bool,
+    /// Commands explicitly allowed (overrides default blocklist)
+    pub allowed_commands: Vec<String>,
+    /// Additional commands to block (extends default blocklist)
+    pub blocked_commands: Vec<String>,
 }
 
 impl CapabilitySet {
@@ -165,6 +169,10 @@ impl CapabilitySet {
 
         // Process --net-block flag
         caps.net_block = args.net_block;
+
+        // Process command allow/block lists
+        caps.allowed_commands = args.allow_command.clone();
+        caps.blocked_commands = args.block_command.clone();
 
         Ok(caps)
     }
@@ -288,6 +296,11 @@ impl CapabilitySet {
         // Network: profile OR CLI flag can block network (network allowed by default)
         caps.net_block = profile.network.block || args.net_block;
 
+        // Process command allow/block lists from CLI
+        // Profile support for commands will be added later
+        caps.allowed_commands = args.allow_command.clone();
+        caps.blocked_commands = args.block_command.clone();
+
         Ok(caps)
     }
 
@@ -410,6 +423,8 @@ mod tests {
             read_file: vec![],
             write_file: vec![],
             net_block: false,
+            allow_command: vec![],
+            block_command: vec![],
             secrets: None,
             profile: None,
             workdir: None,
@@ -440,6 +455,8 @@ mod tests {
             read_file: vec![],
             write_file: vec![file_path],
             net_block: false,
+            allow_command: vec![],
+            block_command: vec![],
             secrets: None,
             profile: None,
             workdir: None,
@@ -471,6 +488,8 @@ mod tests {
             read_file: vec![],
             write_file: vec![],
             net_block: true,
+            allow_command: vec![],
+            block_command: vec![],
             secrets: None,
             profile: None,
             workdir: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,16 @@ pub struct RunArgs {
     #[arg(long)]
     pub net_block: bool,
 
+    // === Command blocking ===
+    /// Allow a normally-blocked dangerous command (use with caution).
+    /// By default, destructive commands like rm, dd, chmod are blocked.
+    #[arg(long, value_name = "CMD")]
+    pub allow_command: Vec<String>,
+
+    /// Block an additional command beyond the default blocklist
+    #[arg(long, value_name = "CMD")]
+    pub block_command: Vec<String>,
+
     // === Secrets options ===
     /// Load secrets from system keystore and inject as environment variables.
     /// Use with --profile to load secrets defined in the profile's [secrets] section,

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum NonoError {
 
     #[error("Secret not found in keystore: {0}")]
     SecretNotFound(String),
+
+    #[error("Command '{command}' is blocked: {reason}")]
+    BlockedCommand { command: String, reason: String },
 }
 
 pub type Result<T> = std::result::Result<T, NonoError>;


### PR DESCRIPTION
Prevent AI agents from executing dangerous commands like `rm -rf ~` through a two-layer defense system:

Layer 1: Command Blocklist (pre-exec)
- Add DANGEROUS_COMMANDS list (~50 commands: rm, dd, chmod, mkfs, sudo, etc.)
- Block file destruction, disk ops, permission changes, package managers
- Add --allow-command flag to override specific blocked commands
- Add --block-command flag to extend the blocklist

Layer 2: Kernel-Level Protection
- Linux: Remove RemoveFile, RemoveDir, Truncate from Landlock write permissions
- macOS: Add (deny file-write-unlink) to Seatbelt profile
- Even if command is allowed, kernel blocks actual deletion

Files changed:
- src/main.rs: DANGEROUS_COMMANDS list, is_blocked_command() validation
- src/error.rs: BlockedCommand error variant
- src/cli.rs: --allow-command, --block-command flags
- src/capability.rs: allowed_commands, blocked_commands fields
- src/sandbox/linux.rs: Exclude delete/truncate from write access
- src/sandbox/macos.rs: Add file-write-unlink deny rule
- README.md: Document command blocking feature