### PR TITLE
Setup command improvements

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -288,9 +288,10 @@ impl SetupRunner {
             dangerous_commands.len()
         );
 
-        // Show a sample of blocked commands (sorted for consistency)
-        let mut sample: Vec<_> = dangerous_commands.iter().take(8).cloned().collect();
-        sample.sort();
+        // Show a sample of blocked commands (sort first for deterministic output)
+        let mut all_commands: Vec<_> = dangerous_commands.iter().cloned().collect();
+        all_commands.sort();
+        let sample: Vec<_> = all_commands.into_iter().take(8).collect();
         println!("      {}, ...", sample.join(", "));
 
         println!("  ✓ Network access: allowed by default (use --net-block to disable)");
@@ -304,17 +305,22 @@ impl SetupRunner {
 
         for name in &profiles {
             // Load profile to get description
-            if let Ok(p) = profile::load_profile(name, true) {
-                let desc = p
-                    .meta
-                    .description
-                    .unwrap_or_else(|| "No description".to_string());
-                let net_status = if p.network.block {
-                    "network blocked"
-                } else {
-                    "network allowed"
-                };
-                println!("  • {} - {} ({})", name, desc, net_status);
+            match profile::load_profile(name, true) {
+                Ok(p) => {
+                    let desc = p
+                        .meta
+                        .description
+                        .unwrap_or_else(|| "No description".to_string());
+                    let net_status = if p.network.block {
+                        "network blocked"
+                    } else {
+                        "network allowed"
+                    };
+                    println!("  * {} - {} ({})", name, desc, net_status);
+                }
+                Err(e) => {
+                    println!("  * {} - <warning: failed to load: {}>", name, e);
+                }
             }
         }
 


### PR DESCRIPTION
The nono setup command now shows much more helpful information:

New sections added:

- Default protections - Shows counts of sensitive paths (36) and dangerous commands (44) blocked by default, plus a sample of blocked commands

Built-in profiles - Lists all 4 built-in profiles with descriptions and network status:

- cargo-build - Rust cargo build (network blocked)
- claude-code - Anthropic Claude Code CLI agent (network allowed)
- openclaw - OpenClaw messaging gateway (network allowed)
- opencode - OpenCode AI coding assistant (network allowed)


Improved quick start examples - Now shows practical profile-based examples:

nono run --profile claude-code -- claude
nono run --allow . -- <command>
nono run --profile cargo-build -- cargo build
nono why ~/.ssh/id_rsa