### PR TITLE
Deny process-info for other processes to prevent info leaks

### DIFF
--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -616,23 +616,23 @@ mod tests {
 
         // Should allow process-info for SELF (needed for dyld, code signing, etc.)
         assert!(
-            profile.contains("(allow process-info* (target self))"),
+            profile.contains("(allow process-info* (target self))\n"),
             "Profile should allow process-info for self"
         );
 
         // Should deny process-info for OTHERS to prevent `ps aux` style attacks
         assert!(
-            profile.contains("(deny process-info* (target others))"),
+            profile.contains("(deny process-info* (target others))\n"),
             "Profile should deny process-info for other processes"
         );
 
         // Should allow specific process operations needed for execution
         assert!(
-            profile.contains("(allow process-exec*)"),
+            profile.contains("(allow process-exec*)\n"),
             "Profile should allow process execution"
         );
         assert!(
-            profile.contains("(allow process-fork)"),
+            profile.contains("(allow process-fork)\n"),
             "Profile should allow process forking"
         );
     }


### PR DESCRIPTION
The Seatbelt profile used (allow process*) could allow sandboxed processes to inspect other processes via ps aux, top, etc. This could leak secrets from command-line arguments of other programs running as the same user.

Replace blanket process* with targeted permissions:
- process-exec* and process-fork for execution
- process-info* (target self) for dyld/code signing
- process-info* (target others) DENIED to block inspection