### PR TITLE
Fix documentation to match current code state

### DIFF
--- a/data/profiles/claude-code.toml
+++ b/data/profiles/claude-code.toml
@@ -16,12 +16,10 @@ access = "readwrite"
 allow = ["$HOME/.claude"]
 read = []
 write = []
-
-[filesystem.files]
 # ~/.claude.json: agent writes settings/state here
-allow = ["$HOME/.claude.json"]
-read = []
-write = []
+allow_file = ["$HOME/.claude.json"]
+read_file = []
+write_file = []
 
 [network]
 block = false

--- a/data/profiles/openclaw.toml
+++ b/data/profiles/openclaw.toml
@@ -20,11 +20,9 @@ allow = [
 ]
 read = []
 write = []
-
-[filesystem.files]
-allow = []
-read = []
-write = []
+allow_file = []
+read_file = []
+write_file = []
 
 [network]
 block = false

--- a/data/profiles/opencode.toml
+++ b/data/profiles/opencode.toml
@@ -13,14 +13,16 @@ min_nono_version = "0.2.0"
 access = "readwrite"
 
 [filesystem]
-allow = []
-read = ["$HOME/.opencode"]
-write = []
-
-[filesystem.files]
-allow = []
+allow = [
+    "$HOME/.config/opencode",
+    "$HOME/.cache/opencode",
+    "$HOME/.local/share/opencode",
+]
 read = []
 write = []
+allow_file = []
+read_file = []
+write_file = []
 
 [network]
 block = false

--- a/docs/clients/claude-code.mdx
+++ b/docs/clients/claude-code.mdx
@@ -24,7 +24,7 @@ nono run --profile claude-code -- claude
 The built-in profile provides:
 - **Read+write access** to the current working directory
 - **Read+write access** to `~/.claude` (agent state, debug logs, project config)
-- **Write access** to `~/.claude.json` (settings file)
+- **Read+write access** to `~/.claude.json` (settings file)
 - **Network access** enabled (required for Anthropic API)
 
 ## Custom Profile

--- a/docs/development/index.mdx
+++ b/docs/development/index.mdx
@@ -34,7 +34,7 @@ This section covers development topics for contributors and maintainers of nono.
 4. **Check formatting and lints**
    ```bash
    cargo fmt -- --check
-   cargo clippy -- -D warnings
+   cargo clippy -- -D warnings -D clippy::unwrap_used
    ```
 
 ## Development Environment
@@ -56,7 +56,7 @@ cargo build
 cargo build --release
 
 # Run with verbose logging
-RUST_LOG=debug cargo run -- --allow . -- echo "test"
+RUST_LOG=debug cargo run -- run --allow . -- echo "test"
 ```
 
 ## Code Standards

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -89,7 +89,7 @@ nono blocks access to sensitive paths by default, even if a parent directory is 
 | `~/.docker/` | Docker credentials |
 | `~/.npmrc` | npm auth tokens |
 | `~/.netrc` | Network credentials |
-| `~/.gitcredentials` | Git credentials |
+| `~/.git-credentials` | Git credentials |
 | `~/.bash_history` | Command history |
 | `~/.zsh_history` | Command history |
 | `~/.bashrc`, `~/.zshrc` | Shell configs (may contain secrets) |

--- a/docs/security/landlock.mdx
+++ b/docs/security/landlock.mdx
@@ -63,8 +63,6 @@ AccessFs::Execute
 
 ```rust
 AccessFs::WriteFile
-AccessFs::RemoveFile
-AccessFs::RemoveDir
 AccessFs::MakeChar
 AccessFs::MakeDir
 AccessFs::MakeReg
@@ -72,8 +70,12 @@ AccessFs::MakeSock
 AccessFs::MakeFifo
 AccessFs::MakeBlock
 AccessFs::MakeSym
-AccessFs::Truncate  // ABI v3+
+AccessFs::RemoveFile  // File deletion (needed for atomic writes)
+AccessFs::Refer       // Rename/hard link across directories (ABI v2+)
+AccessFs::Truncate    // ABI v3+
 ```
+
+Note: `RemoveDir` is intentionally excluded for safety - directory deletion is blocked even within writable paths.
 
 ### Full Access (`--allow`)
 

--- a/docs/security/profiles.mdx
+++ b/docs/security/profiles.mdx
@@ -43,20 +43,39 @@ name = "my-agent"
 version = "1.0.0"
 description = "Profile for my custom agent"
 
+[workdir]
+# Controls automatic CWD sharing: "none", "read", "write", or "readwrite"
+access = "readwrite"
+
 [filesystem]
-allow = ["$WORKDIR"]
-read = ["$HOME/.config/my-agent"]
+# Directory permissions (recursive)
+allow = ["$HOME/.config/my-agent"]
+read = []
 write = []
 
-[filesystem.files]
-read = ["$HOME/.gitconfig"]
-write = []
+# Single file permissions (non-recursive)
+allow_file = []
+read_file = ["$HOME/.gitconfig"]
+write_file = []
 
 [network]
 block = false  # Network allowed by default; set to true to block
 
 # See "Secrets Section" below for configuring secrets
 ```
+
+### Working Directory Section
+
+The `[workdir]` section controls whether and how the current working directory is automatically shared with the sandboxed process. This is set per-profile so each application can declare its own CWD requirements.
+
+| Value | Meaning |
+|-------|---------|
+| `none` | No automatic CWD access (default if section omitted) |
+| `read` | Read-only access to CWD |
+| `write` | Write-only access to CWD |
+| `readwrite` | Full read+write access to CWD |
+
+When a profile specifies a `[workdir]` access level, nono will prompt the user to confirm CWD sharing (unless `--allow-cwd` is used to skip the prompt).
 
 ### Secrets Section
 
@@ -82,10 +101,12 @@ Profiles support these environment variables in path values:
 
 | Variable | Expands To |
 |----------|------------|
-| `$WORKDIR` | Current working directory |
+| `$WORKDIR` | Current working directory (from `--workdir` or cwd) |
 | `$HOME` | User's home directory |
 | `$XDG_CONFIG_HOME` | XDG config directory (default: `~/.config`) |
 | `$XDG_DATA_HOME` | XDG data directory (default: `~/.local/share`) |
+| `$TMPDIR` | System temporary directory |
+| `$UID` | Current user ID |
 
 ## Creating User Profiles
 
@@ -137,19 +158,22 @@ These profiles are compiled into nono and can be used without any configuration.
 [meta]
 name = "claude-code"
 version = "1.0.0"
-description = "Anthropic Claude Code CLI"
+description = "Anthropic Claude Code CLI agent"
+
+[workdir]
+access = "readwrite"
 
 [filesystem]
-allow = ["$WORKDIR", "$HOME/.claude"]
+allow = ["$HOME/.claude"]
 
-[filesystem.files]
-allow = ["$HOME/.claude.json"]
+[filesystem]
+allow_file = ["$HOME/.claude.json"]
 
 [network]
 block = false
 ```
 
-**Grants:** Read+write to working directory and `~/.claude`, write to `~/.claude.json`, full network access.
+**Grants:** Read+write to working directory (via `[workdir]`) and `~/.claude`, read+write to `~/.claude.json`, full network access.
 
 ---
 
@@ -161,9 +185,11 @@ name = "opencode"
 version = "1.0.0"
 description = "OpenCode AI coding assistant"
 
+[workdir]
+access = "readwrite"
+
 [filesystem]
 allow = [
-  "$WORKDIR",
   "$HOME/.config/opencode",
   "$HOME/.cache/opencode",
   "$HOME/.local/share/opencode"
@@ -173,7 +199,7 @@ allow = [
 block = false
 ```
 
-**Grants:** Read+write to working directory and OpenCode config/cache/data directories, full network access.
+**Grants:** Read+write to working directory (via `[workdir]`) and OpenCode config/cache/data directories, full network access.
 
 ---
 
@@ -185,10 +211,14 @@ name = "openclaw"
 version = "1.0.0"
 description = "OpenClaw messaging gateway"
 
+[workdir]
+access = "read"
+
 [filesystem]
 allow = [
   "$HOME/.openclaw",
   "$HOME/.config/openclaw",
+  "$HOME/.local",
   "$TMPDIR/openclaw-$UID"
 ]
 
@@ -196,7 +226,7 @@ allow = [
 block = false
 ```
 
-**Grants:** Read+write to OpenClaw config, state, and temp directories, full network access.
+**Grants:** Read-only access to working directory (via `[workdir]`), read+write to OpenClaw config, state, local data, and temp directories, full network access.
 
 ---
 

--- a/docs/security/seatbelt.mdx
+++ b/docs/security/seatbelt.mdx
@@ -30,8 +30,13 @@ A nono-generated Seatbelt profile follows this structure:
 (version 1)
 (deny default)
 
-; Process and system operations
-(allow process*)
+; Process operations (narrowed - no blanket process*)
+(allow process-exec*)                    ; Execute programs
+(allow process-fork)                     ; Fork child processes
+(allow process-info* (target self))      ; Self-inspection (dyld, code signing)
+(deny process-info* (target others))     ; Block inspecting other processes
+
+; System operations
 (allow sysctl-read)
 (allow mach*)
 (allow ipc*)

--- a/docs/security/vs-containers.mdx
+++ b/docs/security/vs-containers.mdx
@@ -251,5 +251,5 @@ Do you need a different OS to the host?
 ## Next Steps
 
 - [Security Model](index.mdx) - Understanding nono's guarantees
-- [Profiles](../profiles/index.mdx) - Pre-configured sandboxes for common agents
-- [Installation](../installation.mdx) - Get started with nono
+- [Profiles](/security/profiles) - Pre-configured sandboxes for common agents
+- [Installation](/getting_started/installation) - Get started with nono

--- a/docs/usage/flags.mdx
+++ b/docs/usage/flags.mdx
@@ -131,6 +131,33 @@ nono run --allow . --net-block -- cargo build
   Granular network filtering (e.g., allowing only specific domains like `api.anthropic.com`) is a desired feature but not yet supported. Apple Seatbelt has technical limitations that make per-host filtering challenging and would require significant experimentation to implement correctly. This feature may be added in a future release.
 </Note>
 
+### Command Blocking
+
+#### `--allow-command`
+
+Allow a normally-blocked dangerous command. By default, destructive commands like `rm`, `dd`, `chmod` are blocked. Use this flag to override for a specific command.
+
+```bash
+# Allow rm (blocked by default)
+nono run --allow . --allow-command rm -- rm ./temp-file.txt
+
+# Allow multiple commands
+nono run --allow . --allow-command rm --allow-command mv -- my-script.sh
+```
+
+<Note>
+  Even with `--allow-command`, the kernel sandbox still restricts file operations to granted paths. A command can only affect files within directories you explicitly allowed.
+</Note>
+
+#### `--block-command`
+
+Block an additional command beyond the default blocklist.
+
+```bash
+# Block a custom tool in addition to defaults
+nono run --allow . --block-command my-dangerous-tool -- my-script.sh
+```
+
 ### Secrets Options
 
 #### `--secrets`
@@ -170,6 +197,18 @@ Working directory for `$WORKDIR` expansion in profiles (defaults to current dire
 
 ```bash
 nono run --profile claude-code --workdir ./my-project -- claude
+```
+
+#### `--allow-cwd`
+
+Allow access to the current working directory without prompting. By default, nono prompts interactively for CWD sharing. The access level is determined by the profile's `[workdir]` config or defaults to read-only.
+
+```bash
+# Non-interactive mode (e.g., CI/CD)
+nono run --profile claude-code --allow-cwd -- claude
+
+# Silent mode requires --allow-cwd (cannot prompt)
+nono -s run --profile claude-code --allow-cwd -- claude
 ```
 
 #### `--trust-unsigned`

--- a/docs/usage/secrets.mdx
+++ b/docs/usage/secrets.mdx
@@ -495,4 +495,4 @@ systemctl --user start gnome-keyring
 ## Next Steps
 
 - [CLI Reference](/usage/flags) - Complete flag documentation
-- [Profiles](/profiles/index) - Profile system overview
+- [Profiles](/security/profiles) - Profile system overview


### PR DESCRIPTION
Audit all docs against source code and fix 17 discrepancies:

- landlock.mdx: Remove RemoveDir from Write access, add Refer
- seatbelt.mdx: Replace blanket (allow process*) with actual rules
- README.md: Fix nono why syntax, correct kernel protection claims about file deletion scope, fix defense layers table
- security/index.mdx: Fix typo ~/.gitcredentials -> ~/.git-credentials
- claude-code.mdx: Fix ~/.claude.json access level to read+write
- flags.mdx: Add missing --allow-command, --block-command, --allow-cwd
- profiles.mdx: Add [workdir] section, fix built-in profile examples, add $TMPDIR/$UID to env vars, fix filesystem field format
- development/index.mdx: Add missing run subcommand to cargo run example, add -D clippy::unwrap_used to clippy command
- vs-containers.mdx: Fix broken internal links
- secrets.mdx: Fix broken link to profiles page
- data/profiles/opencode.toml: Sync paths with builtin.rs
- data/profiles/claude-code.toml: Replace silently-ignored [filesystem.files] subsection with flat allow_file field
- data/profiles/openclaw.toml: Same [filesystem.files] fix