### PR TITLE
Add nono learn command and fix opencode profile for Linux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ nono --allow . -- curl https://example.com
 ## Coding Standards
 - Error Handling: Use NonoError for all errors; propagation via ? only.
 - Unwrap Policy: Strictly forbid .unwrap() and .expect(); use clippy::unwrap_used to enforce.
+- Use proper error propagation and handling with Result<T, E> and Option<T> for expected and recoverable errors
 - Unsafe Code: Restrict unsafe to FFI; must be wrapped in safe APIs with // SAFETY: docs.
 - Path Security: Validate and canonicalize all paths before applying capabilities.
 - Arithmetic: Use checked_, saturating_, or overflowing_ methods for security-critical math.
@@ -102,6 +103,7 @@ nono --allow . -- curl https://example.com
 - Dependencies: Mandatory cargo-audit and cargo-deny checks in CI.
 - Testing: Write unit tests for all new capability types and sandbox logic.
 - Attributes: Apply #[must_use] to all functions returning critical Results.
+- Avoid blanket permissions on entire directories; be specific about which paths are allowed and which operations (read/write) are permitted.
 
 ## Security Considerations
 

--- a/data/security-lists.toml
+++ b/data/security-lists.toml
@@ -1,6 +1,17 @@
 # nono Security Lists
 #
 # This file contains the security-critical blocklists for nono sandbox.
+#
+# POLICY REFERENCE:
+# =================
+# [sensitive_paths]    -> DENY content read, ALLOW metadata (stat/exists)
+#                         Enforced in: src/sandbox/macos.rs, src/sandbox/linux.rs
+#
+# [dangerous_commands] -> BLOCK execution (command refused before running)
+#                         Enforced in: src/config/mod.rs::is_command_blocked()
+#
+# [system_read_paths]  -> ALLOW read access (required for executables to run)
+#                         Enforced in: src/sandbox/macos.rs, src/sandbox/linux.rs
 
 [meta]
 version = 1
@@ -8,6 +19,9 @@ schema_version = "0.2.0"
 # updated field set during signing
 
 [sensitive_paths]
+# POLICY: DENY content read (metadata allowed)
+
+# POLICY: DENY
 # Credentials and secrets
 ssh = ["~/.ssh"]
 aws = ["~/.aws"]
@@ -17,11 +31,13 @@ kubernetes = ["~/.kube"]
 docker = ["~/.docker"]
 gnupg = ["~/.gnupg"]
 
+# POLICY: DENY
 # Password managers and keystores
 keychain = ["~/Library/Keychains"]
 password_store = ["~/.password-store"]
 onepassword = ["~/.1password"]
 
+# POLICY: DENY
 # macOS-specific sensitive data
 macos_private = [
     "~/Library/Messages",
@@ -32,6 +48,7 @@ macos_private = [
     "~/Library/Application Support/MobileSync",
 ]
 
+# POLICY: DENY
 # Browser profiles (cookies, saved passwords, sessions)
 browser_data = [
     "~/Library/Application Support/Google/Chrome",
@@ -41,6 +58,7 @@ browser_data = [
     "~/Library/Application Support/Brave Browser",
 ]
 
+# POLICY: DENY
 # Credential files
 credential_files = [
     "~/.git-credentials",
@@ -49,6 +67,7 @@ credential_files = [
     "~/.vault-token",
 ]
 
+# POLICY: DENY
 # Directories that may contain secrets
 secrets_dirs = [
     "~/.credentials",
@@ -58,6 +77,7 @@ secrets_dirs = [
     "~/.terraform.d",
 ]
 
+# POLICY: DENY
 # Shell configurations (often embed secrets/tokens)
 shell_configs = [
     # Zsh
@@ -79,6 +99,7 @@ shell_configs = [
     "~/.envrc",
 ]
 
+# POLICY: DENY
 # Command history (may contain sensitive commands)
 history_files = [
     "~/.bash_history",
@@ -87,8 +108,13 @@ history_files = [
 ]
 
 [dangerous_commands]
+# POLICY: BLOCK execution
+
+# POLICY: BLOCK
 # Commands blocked by default due to destructive potential
 file_destruction = ["rm", "rmdir", "shred", "srm"]
+
+# POLICY: BLOCK
 disk_destruction = [
     "dd",
     "mkfs",
@@ -101,18 +127,34 @@ disk_destruction = [
     "gdisk",
     "wipefs",
 ]
+
+# POLICY: BLOCK
 permission_chaos = ["chmod", "chown", "chgrp", "chattr"]
+
+# POLICY: BLOCK
 system_modification = ["init", "shutdown", "reboot", "halt", "poweroff", "systemctl"]
+
+# POLICY: BLOCK
 package_managers = ["apt", "apt-get", "dpkg", "yum", "dnf", "pacman", "brew", "pip"]
+
+# POLICY: BLOCK
 dangerous_file_ops = ["mv", "cp", "truncate"]
+
+# POLICY: BLOCK
 network_exfiltration = ["scp", "rsync", "sftp", "ftp"]
+
+# POLICY: BLOCK
 arbitrary_execution = ["xargs"]
+
+# POLICY: BLOCK
 privilege_escalation = ["sudo", "su", "doas", "pkexec"]
 
 [system_read_paths]
+# POLICY: ALLOW read access
 # System paths needed for executables to run
 # Platform-specific paths are in separate sections
 
+# POLICY: ALLOW read
 # Common to both platforms
 common = [
     "/bin",
@@ -123,6 +165,7 @@ common = [
 ]
 
 [system_read_paths.linux]
+# POLICY: ALLOW read access
 # Shared libraries (including multiarch paths for Debian/Ubuntu)
 libraries = [
     "/lib",
@@ -137,6 +180,7 @@ libraries = [
     "/usr/local/lib64",
 ]
 
+# POLICY: ALLOW read
 # Dynamic linker configuration
 linker = [
     "/etc/ld.so.cache",
@@ -144,6 +188,7 @@ linker = [
     "/etc/ld.so.conf.d",
 ]
 
+# POLICY: ALLOW read
 # System configuration commonly needed by programs
 config = [
     "/etc/passwd",
@@ -155,14 +200,17 @@ config = [
     "/etc/machine-id",
 ]
 
+# POLICY: ALLOW read
 # Locale and timezone data
 locale = [
     "/usr/share/locale",
+    "/usr/share/locale-langpack",
     "/usr/share/zoneinfo",
     "/etc/localtime",
     "/etc/timezone",
 ]
 
+# POLICY: ALLOW read
 # SSL certificates
 ssl = [
     "/etc/ssl",
@@ -170,6 +218,7 @@ ssl = [
     "/usr/share/ca-certificates",
 ]
 
+# POLICY: ALLOW read
 # Terminfo for terminal apps
 terminfo = [
     "/usr/share/terminfo",
@@ -177,6 +226,7 @@ terminfo = [
     "/etc/terminfo",
 ]
 
+# POLICY: ALLOW read
 # Device files - only safe, commonly needed devices
 # (NOT /dev as a whole, which would expose /dev/sda, /dev/mem, etc.)
 devices = [
@@ -194,6 +244,7 @@ devices = [
     "/dev/pts",
 ]
 
+# POLICY: ALLOW read
 # Proc and sys filesystems
 proc = [
     "/proc",
@@ -202,6 +253,7 @@ proc = [
     "/var/run",
 ]
 
+# POLICY: ALLOW read
 # NixOS / Nix package manager
 # All Nix-managed binaries and libraries live in /nix/store
 nix = [
@@ -209,6 +261,7 @@ nix = [
 ]
 
 [system_read_paths.macos]
+# POLICY: ALLOW read access (except 'writable' which is ALLOW write)
 # macOS executables and libraries
 executables = [
     "/System/Library",
@@ -217,15 +270,18 @@ executables = [
     "/usr/local/lib",
 ]
 
+# POLICY: ALLOW read
 # macOS allows broader dev access (sandboxed differently)
 devices = ["/dev"]
 
+# POLICY: ALLOW read
 # Frameworks
 frameworks = [
     "/System/Library/Frameworks",
     "/Library/Frameworks",
 ]
 
+# POLICY: ALLOW read
 # Dynamic linker cache (critical for dyld)
 dyld = [
     "/private/var/db/dyld",
@@ -233,6 +289,7 @@ dyld = [
     "/var/db",
 ]
 
+# POLICY: ALLOW read
 # SSL certificates and system config
 ssl = [
     "/private/etc/ssl",
@@ -241,6 +298,7 @@ ssl = [
     "/private/etc",
 ]
 
+# POLICY: ALLOW read
 # Locale and timezone data, plus shared data
 locale = [
     "/usr/share/zoneinfo",
@@ -249,11 +307,13 @@ locale = [
     "/usr/share",
 ]
 
+# POLICY: ALLOW read
 # Terminfo for terminal apps
 terminfo = [
     "/usr/share/terminfo",
 ]
 
+# POLICY: ALLOW read
 # System paths and their symlink targets
 # macOS uses /private for actual paths with symlinks from root
 # Also need /System/Volumes for modern macOS (10.15+) which uses APFS volumes
@@ -270,6 +330,7 @@ system = [
     "/Volumes",
 ]
 
+# POLICY: ALLOW read
 # User library paths (need ~ expansion at runtime)
 # Only specific subdirectories, not all of ~/Library
 user_library = [
@@ -278,6 +339,7 @@ user_library = [
     "~/Library/Preferences",
 ]
 
+# POLICY: ALLOW read
 # User-local executables and version managers
 # These paths contain user-installed tools and version managers
 user_local = [
@@ -290,6 +352,7 @@ user_local = [
     "~/.fnm",
 ]
 
+# POLICY: ALLOW write access
 # macOS writable system paths (needed for many tools)
 writable = [
     "/private/tmp",

--- a/docs/clients/opencode.mdx
+++ b/docs/clients/opencode.mdx
@@ -26,7 +26,12 @@ The built-in profile provides:
 - **Read+write access** to `~/.config/opencode` (configuration)
 - **Read+write access** to `~/.cache/opencode` (cache)
 - **Read+write access** to `~/.local/share/opencode` (data)
+- **Read+write access** to `/tmp` (temp files)
 - **Network access** enabled (required for AI provider API calls)
+
+<Note>
+  The profile grants access to `/tmp` because opencode writes temp files directly to `$TMPDIR` with dynamic filenames (e.g., `{timestamp}.md` for editor buffers, `opencode-clipboard.png` for clipboard images). Landlock cannot grant access to files with unpredictable names without granting the parent directory.
+</Note>
 
 ## Custom Profile
 

--- a/docs/usage/flags.mdx
+++ b/docs/usage/flags.mdx
@@ -46,12 +46,74 @@ nono why --host <HOST> [--port <PORT>] [OPTIONS]
 nono why --self --path <PATH> --op <OP> [OPTIONS]  # Inside sandbox
 ```
 
+### `nono learn`
+
+Trace a command to discover required filesystem paths. Uses strace to monitor file accesses and outputs paths that would need to be allowed in a nono profile. (Linux only)
+
+```bash
+nono learn [OPTIONS] -- <COMMAND> [ARGS...]
+```
+
 ### `nono setup`
 
 Set up nono on this system. Verifies installation, tests sandbox support, and optionally generates example profiles.
 
 ```bash
 nono setup [OPTIONS]
+```
+
+## `nono learn` Options
+
+<Note>
+  `nono learn` is only available on Linux as it requires strace. The command runs WITHOUT sandbox restrictions to discover what paths your application needs.
+</Note>
+
+### `--profile`, `-p`
+
+Compare against an existing profile to show only missing paths.
+
+```bash
+nono learn --profile opencode -- opencode
+```
+
+### `--toml`
+
+Output discovered paths as a TOML fragment suitable for a profile.
+
+```bash
+nono learn --toml -- my-app > paths.toml
+```
+
+### `--timeout`
+
+Limit trace duration in seconds.
+
+```bash
+nono learn --timeout 30 -- my-long-running-app
+```
+
+### `--all`
+
+Show all accessed paths, not just those that would be blocked by the sandbox.
+
+```bash
+nono learn --all -- my-app
+```
+
+### `--trust-unsigned`
+
+Trust unsigned user profiles when using `--profile`.
+
+```bash
+nono learn --profile my-custom-profile --trust-unsigned -- my-app
+```
+
+### `--verbose`, `-v`
+
+Enable verbose output. Can be specified multiple times.
+
+```bash
+nono learn -vv -- my-app
 ```
 
 ## `nono run` Options

--- a/docs/usage/troubleshooting.mdx
+++ b/docs/usage/troubleshooting.mdx
@@ -306,6 +306,49 @@ uname -r
 
 ---
 
+## Using `nono learn` to Discover Required Paths
+
+If you're getting permission errors and aren't sure which paths your application needs, use `nono learn` to trace file accesses:
+
+```bash
+# Discover all paths accessed by your app
+nono learn -- my-app
+
+# Compare against an existing profile to see what's missing
+nono learn --profile my-profile -- my-app
+
+# Output as TOML for easy profile creation
+nono learn --toml -- my-app
+```
+
+<Note>
+  `nono learn` is only available on Linux (requires strace). The command runs WITHOUT sandbox restrictions to accurately trace file accesses.
+</Note>
+
+### Example Workflow
+
+1. Run learn mode to discover paths:
+   ```bash
+   nono learn -- opencode
+   ```
+
+2. Review the output to see which paths are needed:
+   ```
+   Read paths needed:
+     /usr/share/locale-langpack
+     /home/user/.config/opencode
+
+   Write paths needed:
+     /home/user/.cache/opencode
+   ```
+
+3. Add the paths to your nono command or profile:
+   ```bash
+   nono run --read /usr/share/locale-langpack --allow ~/.config/opencode -- opencode
+   ```
+
+---
+
 ## Getting Help
 
 If you're still stuck:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,23 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Trace a command to discover required filesystem paths (Linux only)
+    #[command(trailing_var_arg = true)]
+    #[command(after_help = "EXAMPLES:
+    # Discover paths needed by a command
+    nono learn -- my-app
+
+    # With an existing profile to see what's missing
+    nono learn --profile my-profile -- my-app
+
+    # Output as TOML for profile
+    nono learn --toml -- node server.js
+
+    # Limit trace duration
+    nono learn --timeout 30 -- my-app
+")]
+    Learn(Box<LearnArgs>),
+
     /// Run a command inside the sandbox
     #[command(trailing_var_arg = true)]
     #[command(after_help = "EXAMPLES:
@@ -306,6 +323,37 @@ pub struct WhyArgs {
     /// Trust unsigned user profiles
     #[arg(long)]
     pub trust_unsigned: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct LearnArgs {
+    /// Use a named profile to compare against (shows only missing paths)
+    #[arg(long, short = 'p', value_name = "NAME")]
+    pub profile: Option<String>,
+
+    /// Output discovered paths as TOML fragment for profile
+    #[arg(long)]
+    pub toml: bool,
+
+    /// Timeout in seconds (default: run until command exits)
+    #[arg(long, value_name = "SECS")]
+    pub timeout: Option<u64>,
+
+    /// Show all accessed paths, not just those that would be blocked
+    #[arg(long)]
+    pub all: bool,
+
+    /// Trust unsigned user profiles
+    #[arg(long)]
+    pub trust_unsigned: bool,
+
+    /// Enable verbose output
+    #[arg(long, short = 'v', action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Command to trace
+    #[arg(required = true)]
+    pub command: Vec<String>,
 }
 
 /// Operation type for why command

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,9 @@ pub enum NonoError {
 
     #[error("Hook installation failed: {0}")]
     HookInstall(String),
+
+    #[error("Learn mode error: {0}")]
+    LearnError(String),
 }
 
 pub type Result<T> = std::result::Result<T, NonoError>;

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -472,12 +472,12 @@ fn is_covered_by_profile(path: &Path, profile_paths: &HashSet<String>) -> bool {
 #[cfg(target_os = "linux")]
 fn expand_home(path: &str) -> String {
     if path.starts_with('~') {
-        if let Some(home) = std::env::var("HOME").ok() {
+        if let Ok(home) = std::env::var("HOME") {
             return path.replacen('~', &home, 1);
         }
     }
     if path.starts_with("$HOME") {
-        if let Some(home) = std::env::var("HOME").ok() {
+        if let Ok(home) = std::env::var("HOME") {
             return path.replacen("$HOME", &home, 1);
         }
     }

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -1,0 +1,583 @@
+//! Learn mode: trace file accesses to discover required paths
+//!
+//! Uses strace to monitor a command's file system accesses and produces
+//! a list of paths that would need to be allowed in a nono profile.
+
+use crate::cli::LearnArgs;
+use crate::error::{NonoError, Result};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+use crate::config;
+#[cfg(target_os = "linux")]
+use crate::profile::{self, Profile};
+#[cfg(target_os = "linux")]
+use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::io::{BufRead, BufReader};
+#[cfg(target_os = "linux")]
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::process::{Command, Stdio};
+#[cfg(target_os = "linux")]
+use tracing::{debug, info, warn};
+
+/// Result of learning file access patterns
+#[derive(Debug)]
+pub struct LearnResult {
+    /// Paths that need read access
+    pub read_paths: BTreeSet<PathBuf>,
+    /// Paths that need write access
+    pub write_paths: BTreeSet<PathBuf>,
+    /// Paths that need read+write access
+    pub readwrite_paths: BTreeSet<PathBuf>,
+    /// Paths that were accessed but are already covered by system paths
+    pub system_covered: BTreeSet<PathBuf>,
+    /// Paths that were accessed but are already covered by profile
+    pub profile_covered: BTreeSet<PathBuf>,
+}
+
+impl LearnResult {
+    #[cfg(target_os = "linux")]
+    fn new() -> Self {
+        Self {
+            read_paths: BTreeSet::new(),
+            write_paths: BTreeSet::new(),
+            readwrite_paths: BTreeSet::new(),
+            system_covered: BTreeSet::new(),
+            profile_covered: BTreeSet::new(),
+        }
+    }
+
+    /// Check if any paths were discovered
+    pub fn has_paths(&self) -> bool {
+        !self.read_paths.is_empty()
+            || !self.write_paths.is_empty()
+            || !self.readwrite_paths.is_empty()
+    }
+
+    /// Format as TOML fragment for profile
+    pub fn to_toml(&self) -> String {
+        let mut lines = Vec::new();
+        lines.push("[filesystem]".to_string());
+
+        if !self.readwrite_paths.is_empty() {
+            lines.push("allow = [".to_string());
+            for path in &self.readwrite_paths {
+                lines.push(format!("    \"{}\",", path.display()));
+            }
+            lines.push("]".to_string());
+        } else {
+            lines.push("allow = []".to_string());
+        }
+
+        if !self.read_paths.is_empty() {
+            lines.push("read = [".to_string());
+            for path in &self.read_paths {
+                lines.push(format!("    \"{}\",", path.display()));
+            }
+            lines.push("]".to_string());
+        } else {
+            lines.push("read = []".to_string());
+        }
+
+        if !self.write_paths.is_empty() {
+            lines.push("write = [".to_string());
+            for path in &self.write_paths {
+                lines.push(format!("    \"{}\",", path.display()));
+            }
+            lines.push("]".to_string());
+        } else {
+            lines.push("write = []".to_string());
+        }
+
+        lines.join("\n")
+    }
+
+    /// Format as human-readable summary
+    pub fn to_summary(&self) -> String {
+        let mut lines = Vec::new();
+
+        if !self.read_paths.is_empty() {
+            lines.push("Read access needed:".to_string());
+            for path in &self.read_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.write_paths.is_empty() {
+            lines.push("Write access needed:".to_string());
+            for path in &self.write_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.readwrite_paths.is_empty() {
+            lines.push("Read+Write access needed:".to_string());
+            for path in &self.readwrite_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.system_covered.is_empty() {
+            lines.push(format!(
+                "\n({} paths already covered by system defaults)",
+                self.system_covered.len()
+            ));
+        }
+
+        if !self.profile_covered.is_empty() {
+            lines.push(format!(
+                "({} paths already covered by profile)",
+                self.profile_covered.len()
+            ));
+        }
+
+        if lines.is_empty() {
+            lines.push("No additional paths needed.".to_string());
+        }
+
+        lines.join("\n")
+    }
+}
+
+/// Check if strace is available
+#[cfg(target_os = "linux")]
+fn check_strace() -> Result<()> {
+    match Command::new("strace").arg("--version").output() {
+        Ok(output) if output.status.success() => Ok(()),
+        _ => Err(NonoError::LearnError(
+            "strace not found. Install with: apt install strace".to_string(),
+        )),
+    }
+}
+
+/// Run learn mode (non-Linux stub)
+#[cfg(not(target_os = "linux"))]
+pub fn run_learn(_args: &LearnArgs) -> Result<LearnResult> {
+    Err(NonoError::LearnError(
+        "nono learn is only available on Linux (requires strace)".to_string(),
+    ))
+}
+
+/// Run learn mode (Linux implementation)
+#[cfg(target_os = "linux")]
+pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
+    check_strace()?;
+
+    // Load profile if specified
+    let profile = if let Some(ref profile_name) = args.profile {
+        Some(profile::load_profile(profile_name, args.trust_unsigned)?)
+    } else {
+        None
+    };
+
+    // Run strace and collect paths
+    let raw_accesses = run_strace(&args.command, args.timeout)?;
+
+    // Process and categorize paths
+    let result = process_accesses(raw_accesses, profile.as_ref(), args.all)?;
+
+    Ok(result)
+}
+
+/// Represents a file access from strace
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone)]
+struct FileAccess {
+    path: PathBuf,
+    is_write: bool,
+}
+
+/// Run strace on the command and collect file accesses
+#[cfg(target_os = "linux")]
+fn run_strace(command: &[String], timeout: Option<u64>) -> Result<Vec<FileAccess>> {
+    use std::time::{Duration, Instant};
+
+    if command.is_empty() {
+        return Err(NonoError::NoCommand);
+    }
+
+    let mut strace_args = vec![
+        "-f".to_string(), // Follow forks
+        "-e".to_string(), // Trace these syscalls
+        "openat,open,access,stat,lstat,readlink,execve,creat,mkdir,rename,unlink".to_string(),
+        "-o".to_string(),
+        "/dev/stderr".to_string(), // Output to stderr so we can capture it
+        "--".to_string(),
+    ];
+    strace_args.extend(command.iter().cloned());
+
+    info!("Running strace with args: {:?}", strace_args);
+
+    let mut child = Command::new("strace")
+        .args(&strace_args)
+        .stdout(Stdio::inherit()) // Let command output go to terminal
+        .stderr(Stdio::piped()) // Capture strace output
+        .spawn()
+        .map_err(|e| NonoError::LearnError(format!("Failed to spawn strace: {}", e)))?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| NonoError::LearnError("Failed to capture strace stderr".to_string()))?;
+
+    let start = Instant::now();
+    let timeout_duration = timeout.map(Duration::from_secs);
+
+    let mut accesses = Vec::new();
+    let reader = BufReader::new(stderr);
+
+    for line in reader.lines() {
+        // Check timeout
+        if let Some(timeout) = timeout_duration {
+            if start.elapsed() > timeout {
+                warn!("Timeout reached, killing child process");
+                let _ = child.kill();
+                break;
+            }
+        }
+
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                debug!("Error reading strace line: {}", e);
+                continue;
+            }
+        };
+
+        // Parse strace output
+        if let Some(access) = parse_strace_line(&line) {
+            accesses.push(access);
+        }
+    }
+
+    // Wait for child to finish
+    let _ = child.wait();
+
+    Ok(accesses)
+}
+
+/// Parse a single strace line to extract file access
+#[cfg(target_os = "linux")]
+fn parse_strace_line(line: &str) -> Option<FileAccess> {
+    // strace output format examples:
+    // openat(AT_FDCWD, "/etc/passwd", O_RDONLY|O_CLOEXEC) = 3
+    // openat(AT_FDCWD, "/tmp/foo", O_WRONLY|O_CREAT|O_TRUNC, 0644) = 4
+    // access("/etc/ld.so.preload", R_OK) = -1 ENOENT
+    // stat("/usr/bin/bash", {st_mode=...) = 0
+    // execve("/usr/bin/ls", ["ls"], ...) = 0
+
+    // Skip lines that don't contain syscalls we care about
+    let syscalls = [
+        "openat", "open", "access", "stat", "lstat", "readlink", "execve", "creat", "mkdir",
+        "rename", "unlink",
+    ];
+
+    let syscall = syscalls
+        .iter()
+        .find(|&s| line.contains(&format!("{}(", s)))?;
+
+    // Extract the path from the syscall
+    let path = extract_path_from_syscall(line, syscall)?;
+
+    // Determine if this is a write access
+    let is_write = is_write_access(line, syscall);
+
+    // Filter out invalid paths
+    if path.is_empty() || path == "." || path == ".." {
+        return None;
+    }
+
+    Some(FileAccess {
+        path: PathBuf::from(path),
+        is_write,
+    })
+}
+
+/// Extract path from strace syscall line
+#[cfg(target_os = "linux")]
+fn extract_path_from_syscall(line: &str, syscall: &str) -> Option<String> {
+    // Find the opening paren after syscall
+    let start_idx = line.find(&format!("{}(", syscall))?;
+    let after_paren = &line[start_idx + syscall.len() + 1..];
+
+    // For openat, skip AT_FDCWD
+    let path_start = if syscall == "openat" {
+        // Skip "AT_FDCWD, " or similar
+        if let Some(comma_idx) = after_paren.find(',') {
+            comma_idx + 2 // Skip ", "
+        } else {
+            return None;
+        }
+    } else {
+        0
+    };
+
+    let remaining = &after_paren[path_start..];
+
+    // Path should be in quotes
+    if !remaining.starts_with('"') {
+        return None;
+    }
+
+    // Find closing quote
+    let end_quote = remaining[1..].find('"')?;
+    let path = &remaining[1..end_quote + 1];
+
+    // Unescape common escapes
+    let path = path
+        .replace("\\n", "\n")
+        .replace("\\t", "\t")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\");
+
+    Some(path)
+}
+
+/// Determine if a syscall represents a write access
+#[cfg(target_os = "linux")]
+fn is_write_access(line: &str, syscall: &str) -> bool {
+    match syscall {
+        "creat" | "mkdir" | "unlink" | "rename" => true,
+        "openat" | "open" => {
+            // Check flags for write intent
+            line.contains("O_WRONLY")
+                || line.contains("O_RDWR")
+                || line.contains("O_CREAT")
+                || line.contains("O_TRUNC")
+        }
+        _ => false,
+    }
+}
+
+/// Process raw accesses into categorized result
+#[cfg(target_os = "linux")]
+fn process_accesses(
+    accesses: Vec<FileAccess>,
+    profile: Option<&Profile>,
+    show_all: bool,
+) -> Result<LearnResult> {
+    let mut result = LearnResult::new();
+
+    // Get system paths that are already allowed
+    let system_read_paths = config::get_system_read_paths();
+    let system_read_set: HashSet<&str> = system_read_paths.iter().map(|s| s.as_str()).collect();
+
+    // Get profile paths if available
+    let profile_paths: HashSet<String> = if let Some(prof) = profile {
+        let mut paths = HashSet::new();
+        paths.extend(prof.filesystem.allow.iter().cloned());
+        paths.extend(prof.filesystem.read.iter().cloned());
+        paths.extend(prof.filesystem.write.iter().cloned());
+        paths
+    } else {
+        HashSet::new()
+    };
+
+    // Track unique paths (canonicalized where possible)
+    let mut seen_paths: HashSet<PathBuf> = HashSet::new();
+
+    for access in accesses {
+        // Try to canonicalize, fall back to original
+        let canonical = access.path.canonicalize().unwrap_or(access.path.clone());
+
+        // Skip if we've seen this path
+        if seen_paths.contains(&canonical) {
+            continue;
+        }
+        seen_paths.insert(canonical.clone());
+
+        // Check if covered by system paths
+        if is_covered_by_set(&canonical, &system_read_set) {
+            if show_all {
+                result.system_covered.insert(canonical);
+            }
+            continue;
+        }
+
+        // Check if covered by profile
+        if is_covered_by_profile(&canonical, &profile_paths) {
+            if show_all {
+                result.profile_covered.insert(canonical);
+            }
+            continue;
+        }
+
+        // Categorize by access type
+        // Collapse to parent directories for cleaner output
+        let collapsed = collapse_to_parent(&canonical);
+
+        if access.is_write {
+            // Check if already in read, upgrade to readwrite
+            if result.read_paths.contains(&collapsed) {
+                result.read_paths.remove(&collapsed);
+                result.readwrite_paths.insert(collapsed);
+            } else if !result.readwrite_paths.contains(&collapsed) {
+                result.write_paths.insert(collapsed);
+            }
+        } else {
+            // Read access
+            if result.write_paths.contains(&collapsed) {
+                result.write_paths.remove(&collapsed);
+                result.readwrite_paths.insert(collapsed);
+            } else if !result.readwrite_paths.contains(&collapsed) {
+                result.read_paths.insert(collapsed);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Check if a path is covered by a set of allowed paths
+#[cfg(target_os = "linux")]
+fn is_covered_by_set(path: &Path, allowed: &HashSet<&str>) -> bool {
+    for allowed_path in allowed {
+        let allowed_expanded = expand_home(allowed_path);
+        if let Ok(allowed_canonical) = std::fs::canonicalize(&allowed_expanded) {
+            if path.starts_with(&allowed_canonical) {
+                return true;
+            }
+        }
+        // Also check without canonicalization for paths that may not exist
+        let allowed_path_buf = PathBuf::from(&allowed_expanded);
+        if path.starts_with(&allowed_path_buf) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if a path is covered by profile paths
+#[cfg(target_os = "linux")]
+fn is_covered_by_profile(path: &Path, profile_paths: &HashSet<String>) -> bool {
+    for profile_path in profile_paths {
+        let expanded = expand_home(profile_path);
+        if let Ok(canonical) = std::fs::canonicalize(&expanded) {
+            if path.starts_with(&canonical) {
+                return true;
+            }
+        }
+        let path_buf = PathBuf::from(&expanded);
+        if path.starts_with(&path_buf) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Expand ~ to home directory
+#[cfg(target_os = "linux")]
+fn expand_home(path: &str) -> String {
+    if path.starts_with('~') {
+        if let Some(home) = std::env::var("HOME").ok() {
+            return path.replacen('~', &home, 1);
+        }
+    }
+    if path.starts_with("$HOME") {
+        if let Some(home) = std::env::var("HOME").ok() {
+            return path.replacen("$HOME", &home, 1);
+        }
+    }
+    path.to_string()
+}
+
+/// Collapse a file path to its parent directory for cleaner output
+#[cfg(target_os = "linux")]
+fn collapse_to_parent(path: &Path) -> PathBuf {
+    // Don't collapse if it's already a directory
+    if path.is_dir() {
+        return path.to_path_buf();
+    }
+
+    // Collapse files to their parent directory
+    path.parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_strace_openat() {
+        let line = r#"openat(AT_FDCWD, "/etc/passwd", O_RDONLY|O_CLOEXEC) = 3"#;
+        let access = parse_strace_line(line).unwrap();
+        assert_eq!(access.path, PathBuf::from("/etc/passwd"));
+        assert!(!access.is_write);
+    }
+
+    #[test]
+    fn test_parse_strace_openat_write() {
+        let line = r#"openat(AT_FDCWD, "/tmp/test", O_WRONLY|O_CREAT|O_TRUNC, 0644) = 4"#;
+        let access = parse_strace_line(line).unwrap();
+        assert_eq!(access.path, PathBuf::from("/tmp/test"));
+        assert!(access.is_write);
+    }
+
+    #[test]
+    fn test_parse_strace_stat() {
+        let line = r#"stat("/usr/bin/bash", {st_mode=S_IFREG|0755, ...}) = 0"#;
+        let access = parse_strace_line(line).unwrap();
+        assert_eq!(access.path, PathBuf::from("/usr/bin/bash"));
+        assert!(!access.is_write);
+    }
+
+    #[test]
+    fn test_parse_strace_execve() {
+        let line = r#"execve("/usr/bin/ls", ["ls", "-la"], 0x...) = 0"#;
+        let access = parse_strace_line(line).unwrap();
+        assert_eq!(access.path, PathBuf::from("/usr/bin/ls"));
+        assert!(!access.is_write);
+    }
+
+    #[test]
+    fn test_extract_path_from_openat() {
+        let line = r#"openat(AT_FDCWD, "/some/path", O_RDONLY) = 3"#;
+        let path = extract_path_from_syscall(line, "openat").unwrap();
+        assert_eq!(path, "/some/path");
+    }
+
+    #[test]
+    fn test_is_write_access() {
+        assert!(is_write_access(
+            "openat(..., O_WRONLY|O_CREAT, ...)",
+            "openat"
+        ));
+        assert!(is_write_access("openat(..., O_RDWR, ...)", "openat"));
+        assert!(!is_write_access("openat(..., O_RDONLY, ...)", "openat"));
+        assert!(is_write_access("creat(...)", "creat"));
+        assert!(is_write_access("mkdir(...)", "mkdir"));
+    }
+
+    #[test]
+    fn test_expand_home() {
+        std::env::set_var("HOME", "/home/test");
+        assert_eq!(expand_home("~/foo"), "/home/test/foo");
+        assert_eq!(expand_home("$HOME/bar"), "/home/test/bar");
+        assert_eq!(expand_home("/absolute/path"), "/absolute/path");
+    }
+
+    #[test]
+    fn test_collapse_to_parent() {
+        // For a file that doesn't exist, collapse to parent
+        let path = PathBuf::from("/some/dir/file.txt");
+        let collapsed = collapse_to_parent(&path);
+        assert_eq!(collapsed, PathBuf::from("/some/dir"));
+    }
+
+    #[test]
+    fn test_learn_result_to_toml() {
+        let mut result = LearnResult::new();
+        result.read_paths.insert(PathBuf::from("/some/read/path"));
+        result.write_paths.insert(PathBuf::from("/some/write/path"));
+
+        let toml = result.to_toml();
+        assert!(toml.contains("[filesystem]"));
+        assert!(toml.contains("/some/read/path"));
+        assert!(toml.contains("/some/write/path"));
+    }
+}

--- a/src/profile/builtin.rs
+++ b/src/profile/builtin.rs
@@ -116,8 +116,16 @@ fn opencode() -> Profile {
                 "$HOME/.config/opencode".to_string(),
                 "$HOME/.cache/opencode".to_string(),
                 "$HOME/.local/share/opencode".to_string(),
+                "$HOME/.local/state/opencode".to_string(),
+                "$HOME/.opencode".to_string(),
+                "$HOME/.npm".to_string(),
+                "$HOME/.nvm".to_string(),
+                // /tmp required: opencode writes directly to $TMPDIR with dynamic
+                // filenames (e.g., {timestamp}.md, opencode-clipboard.png) rather
+                // than using a subdirectory. Cannot grant specific paths.
+                "/tmp".to_string(),
             ],
-            read: vec![],
+            read: vec!["$HOME/.config/git".to_string()],
             write: vec![],
             allow_file: vec![],
             read_file: vec![],
@@ -129,7 +137,7 @@ fn opencode() -> Profile {
             access: WorkdirAccess::ReadWrite,
         },
         hooks: HooksConfig::default(),
-        interactive: false,
+        interactive: true,
     }
 }
 

--- a/src/sandbox/linux.rs
+++ b/src/sandbox/linux.rs
@@ -115,22 +115,6 @@ pub fn apply(caps: &CapabilitySet) -> Result<()> {
     let read_access = access_to_landlock(FsAccess::Read, TARGET_ABI);
     let system_paths = config::get_system_read_paths();
     for path_str in &system_paths {
-        // Skip virtual filesystems that often fail with EBADFD in containers.
-        // These filesystems (procfs, sysfs, devtmpfs, tmpfs) don't reliably support
-        // Landlock path-based rules, especially in namespaced/containerized environments.
-        // Programs still get access through normal kernel mechanisms.
-        if path_str.starts_with("/dev")
-            || path_str.starts_with("/proc")
-            || path_str.starts_with("/sys")
-            || path_str.starts_with("/run")
-        {
-            debug!(
-                "Skipping virtual filesystem {} (may not support Landlock path rules)",
-                path_str
-            );
-            continue;
-        }
-
         let path = Path::new(path_str);
         if !path.exists() {
             debug!("Skipping system path {} (does not exist)", path_str);


### PR DESCRIPTION
- Add Linux locale-langpack path to system read paths for TUI apps.
- Add $HOME read access to opencode profile for Landlock path traversal.

Document nono learn command in CLI reference and troubleshooting guide.