### PR TITLE
Add --exec and --no-diagnostics flags to run command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,8 @@ fn run_sandbox(
         &prepared.caps,
         prepared.secrets,
         interactive,
-        silent || no_diagnostics,
+        silent,
+        no_diagnostics,
     )
 }
 
@@ -329,6 +330,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         prepared.secrets,
         true, // Force interactive for shell
         silent,
+        false, // Shell doesn't support --no-diagnostics
     )
 }
 
@@ -339,6 +341,7 @@ fn execute_sandboxed(
     loaded_secrets: Vec<keystore::LoadedSecret>,
     interactive: bool,
     silent: bool,
+    no_diagnostics: bool,
 ) -> Result<()> {
     // Check if command is blocked using config module
     if let Some(blocked) =
@@ -413,7 +416,7 @@ fn execute_sandboxed(
         caps,
         env_vars,
         cap_file: &cap_file_path,
-        no_diagnostics: silent,
+        no_diagnostics: silent || no_diagnostics,
         threading,
     };
 


### PR DESCRIPTION
The --exec flag forces direct exec mode (TTY preservation) from the CLI, overriding the profile's interactive setting. This lets users run interactive apps without needing a profile that sets interactive.

The --no-diagnostics flag suppresses the diagnostic footer on command failure, useful for scripts that parse stderr.

Also adds serde(deny_unknown_fields) to WorkdirConfig to reject misplaced fields like `interactive` under [workdir], with tests covering both the valid top-level placement and the rejected case.