### PR TITLE
Don't run full CI on actions version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   test:
     name: Test
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -61,6 +62,7 @@ jobs:
 
   ffi-header:
     name: Verify FFI Header
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +86,7 @@ jobs:
 
   clippy:
     name: Clippy
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -106,6 +109,7 @@ jobs:
 
   integration:
     name: Integration Tests
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When dependabot updates a github action, we don't need a full CI run.