### PR TITLE
Allow profile loading outside of XDG Home

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -225,8 +225,10 @@ pub struct SandboxArgs {
     pub secrets: Option<String>,
 
     // === Profile options ===
-    /// Use a named profile (built-in or from ~/.config/nono/profiles/)
-    #[arg(long, short = 'p', value_name = "NAME")]
+    /// Use a profile by name or file path.
+    /// Names resolve from ~/.config/nono/profiles/ then built-ins.
+    /// Paths (containing '/' or ending in .json) load directly.
+    #[arg(long, short = 'p', value_name = "NAME_OR_PATH")]
     pub profile: Option<String>,
 
     /// Allow access to current working directory without prompting.

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -249,8 +249,9 @@ fn merge_base_groups(profile: &mut Profile) -> Result<()> {
         .filter(|g| !profile.security.trust_groups.contains(g))
         .collect();
     // Append profile-specific groups (avoiding duplicates)
+    let mut seen: std::collections::HashSet<String> = merged.iter().cloned().collect();
     for g in &profile.security.groups {
-        if !merged.contains(g) {
+        if seen.insert(g.clone()) {
             merged.push(g.clone());
         }
     }


### PR DESCRIPTION
`--profile` is now dual purposed, load an inbuilt profile, or if a path is provided, load from file. 

Relates to: #76 