### PR TITLE
Rename undo to rollback, decouple --rollback from --supervised

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs repo rebuild
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.DOCS_PAT }}
           repository: always-further/nono-docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ crates/nono-cli/src/                # CLI - security policy and UX
 ├── hooks.rs                        # Claude Code hook installation
 ├── setup.rs                        # System setup and verification
 ├── output.rs                       # Banner, dry-run output, prompts
-├── undo_ui.rs                      # Interactive undo review and restore prompts
+├── rollback_ui.rs                  # Interactive rollback review and restore prompts
 ├── learn.rs                        # strace-based path discovery (Linux only)
 ├── config/
 │   ├── mod.rs                      # Config module root
@@ -85,7 +85,7 @@ The library is a **pure sandbox primitive**. It applies ONLY what clients explic
 | `DiagnosticFormatter` | Profile loading and hooks |
 | `QueryContext` | All output and UX |
 | `keystore` | `learn` mode |
-| `undo` module (ObjectStore, SnapshotManager, MerkleTree, ExclusionFilter) | Undo lifecycle, exclusion policy, undo UI |
+| `undo` module (ObjectStore, SnapshotManager, MerkleTree, ExclusionFilter) | Rollback lifecycle, exclusion policy, rollback UI |
 
 ## Build & Test
 
@@ -131,7 +131,7 @@ make fmt             # Auto-format
 
 1. **No escape hatch**: Once sandbox is applied via `restrict_self()` (Landlock) or `sandbox_init()` (Seatbelt), there is no API to expand permissions.
 
-2. **Fork+wait process model**: nono stays alive as a parent process. On child failure, prints a diagnostic footer to stderr. Three execution strategies: `Direct` (exec, backward compat), `Monitor` (sandbox-then-fork, default), `Supervised` (fork-then-sandbox, for undo).
+2. **Fork+wait process model**: nono stays alive as a parent process. On child failure, prints a diagnostic footer to stderr. Three execution strategies: `Direct` (exec, backward compat), `Monitor` (sandbox-then-fork, default), `Supervised` (fork-then-sandbox, for rollbacks/expansion).
 
 3. **Capability resolution**: All paths are canonicalized at grant time to prevent symlink escapes.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 AI agents get filesystem access, run shell commands, and are inherently open to prompt injection. The standard response is guardrails and policies. The problem is that policies can be bypassed and guardrails linguistically overcome.
 
-Kernel-enforced sandboxing (Landlock on Linux, Seatbelt on macOS) blocks unauthorized access at the syscall level. Destructive commands are denied before they run. Secrets are injected securely without touching disk. Every filesystem change gets an undo snapshot. Every command leaves a tamper resistant trail. When the agent needs to do something outside its permissions, a supervisor handles approval.
+Kernel-enforced sandboxing (Landlock on Linux, Seatbelt on macOS) blocks unauthorized access at the syscall level. Destructive commands are denied before they run. Secrets are injected securely without touching disk. Every filesystem change gets a rollback snapshot. Every command leaves a tamper resistant trail. When the agent needs to do something outside its permissions, a supervisor handles approval.
 
 ## CLI
 
@@ -177,10 +177,10 @@ nono takes content-addressable snapshots of your working directory before the sa
 
 ```bash
 # List snapshots taken during sandboxed sessions
-nono undo list
+nono rollback list
 
 # Interactively review and restore changes
-nono undo restore
+nono rollback restore
 ```
 
 ### Supervisor and Capability Expansion (Coming Soon!)
@@ -188,8 +188,8 @@ nono undo restore
 On Linux, nono can run in supervised mode where the sandboxed process starts with minimal permissions. When the agent needs access to a file outside its sandbox, the request is intercepted via seccomp user notification and routed to the supervisor, which prompts the user for approval. Approved access is granted transparently by injecting file descriptors -- the agent never needs to know about nono. Sensitive paths (system config, SSH keys, etc.) are configured as never-grantable regardless of user approval.
 
 ```bash
-# Run in supervised mode — agent starts locked down, requests are prompted
-nono run --supervised --allow-cwd -- claude
+# Run with rollback snapshots and capability expansion
+nono run --rollback --supervised --allow-cwd -- claude
 ```
  
 ### Audit Trail (Coming Soon!)

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -158,7 +158,7 @@ impl CapabilitySetExt for CapabilitySet {
 
         // Process profile filesystem config (profile-specific paths on top of groups).
         // These are marked as CapabilitySource::Profile so they are displayed in
-        // the banner but NOT tracked for undo snapshots (only User-sourced paths
+        // the banner but NOT tracked for rollback snapshots (only User-sourced paths
         // representing the project workspace are tracked).
         let fs = &profile.filesystem;
 

--- a/crates/nono-cli/src/config/user.rs
+++ b/crates/nono-cli/src/config/user.rs
@@ -24,8 +24,8 @@ pub struct UserConfig {
     pub extensions: UserExtensions,
     #[serde(default)]
     pub trusted_keys: HashMap<String, TrustedKeyInfo>,
-    #[serde(default)]
-    pub undo: UndoSettings,
+    #[serde(default, alias = "undo")]
+    pub rollback: RollbackSettings,
 }
 
 /// Metadata for user config
@@ -92,9 +92,9 @@ pub struct TrustedKeyInfo {
     pub fingerprint: Option<String>,
 }
 
-/// Undo system settings
+/// Rollback system settings
 #[derive(Debug, Clone, Deserialize)]
-pub struct UndoSettings {
+pub struct RollbackSettings {
     /// Maximum number of sessions to retain
     #[serde(default = "default_max_sessions")]
     pub max_sessions: usize,
@@ -122,7 +122,7 @@ fn default_stale_grace_hours() -> u64 {
     24
 }
 
-impl Default for UndoSettings {
+impl Default for RollbackSettings {
     fn default() -> Self {
         Self {
             max_sessions: default_max_sessions(),
@@ -241,28 +241,28 @@ alice = { name = "Alice", fingerprint = "abc123" }
     }
 
     #[test]
-    fn test_undo_settings_defaults() {
+    fn test_rollback_settings_defaults() {
         let toml = "";
         let config: UserConfig = toml::from_str(toml).expect("Failed to parse");
-        assert_eq!(config.undo.max_sessions, 10);
-        assert!((config.undo.max_storage_gb - 5.0).abs() < f64::EPSILON);
-        assert_eq!(config.undo.max_snapshots, 100);
-        assert_eq!(config.undo.stale_grace_hours, 24);
+        assert_eq!(config.rollback.max_sessions, 10);
+        assert!((config.rollback.max_storage_gb - 5.0).abs() < f64::EPSILON);
+        assert_eq!(config.rollback.max_snapshots, 100);
+        assert_eq!(config.rollback.stale_grace_hours, 24);
     }
 
     #[test]
-    fn test_undo_settings_custom() {
+    fn test_rollback_settings_custom() {
         let toml = r#"
-[undo]
+[rollback]
 max_sessions = 20
 max_storage_gb = 10.0
 max_snapshots = 50
 stale_grace_hours = 48
 "#;
         let config: UserConfig = toml::from_str(toml).expect("Failed to parse");
-        assert_eq!(config.undo.max_sessions, 20);
-        assert!((config.undo.max_storage_gb - 10.0).abs() < f64::EPSILON);
-        assert_eq!(config.undo.max_snapshots, 50);
-        assert_eq!(config.undo.stale_grace_hours, 48);
+        assert_eq!(config.rollback.max_sessions, 20);
+        assert!((config.rollback.max_storage_gb - 10.0).abs() < f64::EPSILON);
+        assert_eq!(config.rollback.max_snapshots, 50);
+        assert_eq!(config.rollback.stale_grace_hours, 48);
     }
 }

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -126,13 +126,20 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
 }
 
 /// Print supervised mode status
-pub fn print_supervised_info(silent: bool) {
+pub fn print_supervised_info(silent: bool, rollback: bool, supervised: bool) {
     if silent {
         return;
     }
+    let detail = match (rollback, supervised) {
+        (true, true) => "rollback snapshots + approval sidecar",
+        (true, false) => "rollback snapshots",
+        (false, true) => "approval sidecar",
+        (false, false) => return, // shouldn't happen
+    };
     eprintln!(
         "{}",
-        "Supervised mode: child sandboxed, parent manages undo snapshots.".truecolor(150, 150, 150)
+        format!("Supervised mode: child sandboxed, parent manages {detail}.")
+            .truecolor(150, 150, 150)
     );
     eprintln!();
 }
@@ -180,15 +187,12 @@ pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
     eprintln!("Command: {:?}", command);
 }
 
-/// Print undo tracking status during session start
-pub fn print_undo_tracking(paths: &[std::path::PathBuf], silent: bool) {
+/// Print rollback tracking status during session start
+pub fn print_rollback_tracking(paths: &[std::path::PathBuf], silent: bool) {
     if silent {
         return;
     }
-    eprintln!(
-        "{}",
-        "Undo snapshots enabled (supervised mode).".truecolor(150, 150, 150)
-    );
+    eprintln!("{}", "Rollback snapshots enabled.".truecolor(150, 150, 150));
     if paths.len() <= 3 {
         for path in paths {
             eprintln!(
@@ -213,8 +217,8 @@ pub fn print_undo_tracking(paths: &[std::path::PathBuf], silent: bool) {
     eprintln!();
 }
 
-/// Print post-exit summary of changes detected by the undo system
-pub fn print_undo_session_summary(changes: &[nono::undo::Change], silent: bool) {
+/// Print post-exit summary of changes detected by the rollback system
+pub fn print_rollback_session_summary(changes: &[nono::undo::Change], silent: bool) {
     if silent || changes.is_empty() {
         return;
     }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -115,8 +115,8 @@ pub struct ProfileDef {
     pub workdir: profile::WorkdirConfig,
     #[serde(default)]
     pub hooks: profile::HooksConfig,
-    #[serde(default)]
-    pub undo: profile::UndoConfig,
+    #[serde(default, alias = "undo")]
+    pub rollback: profile::RollbackConfig,
     #[serde(default)]
     pub interactive: bool,
 }
@@ -144,7 +144,7 @@ impl ProfileDef {
             secrets: self.secrets.clone(),
             workdir: self.workdir.clone(),
             hooks: self.hooks.clone(),
-            undo: self.undo.clone(),
+            rollback: self.rollback.clone(),
             interactive: self.interactive,
         }
     }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -136,19 +136,19 @@ pub struct SecurityConfig {
     pub trust_groups: Vec<String>,
 }
 
-/// Undo snapshot configuration in a profile
+/// Rollback snapshot configuration in a profile
 ///
-/// Controls which files are excluded from undo snapshots. Patterns are
+/// Controls which files are excluded from rollback snapshots. Patterns are
 /// matched against path components (exact match) or, if they contain `/`,
 /// as substrings of the full path. Glob patterns are matched against
 /// the filename (last path component).
 #[derive(Debug, Clone, Default, Deserialize)]
-pub struct UndoConfig {
-    /// Patterns to exclude from undo snapshots.
+pub struct RollbackConfig {
+    /// Patterns to exclude from rollback snapshots.
     /// Added on top of the CLI's base exclusion list.
     #[serde(default)]
     pub exclude_patterns: Vec<String>,
-    /// Glob patterns to exclude from undo snapshots.
+    /// Glob patterns to exclude from rollback snapshots.
     /// Matched against the filename using standard glob syntax.
     #[serde(default)]
     pub exclude_globs: Vec<String>,
@@ -171,8 +171,8 @@ pub struct Profile {
     pub workdir: WorkdirConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
-    #[serde(default)]
-    pub undo: UndoConfig,
+    #[serde(default, alias = "undo")]
+    pub rollback: RollbackConfig,
     /// App has interactive UI that needs TTY preserved (implies --exec mode)
     #[serde(default)]
     pub interactive: bool,

--- a/crates/nono-cli/src/rollback_ui.rs
+++ b/crates/nono-cli/src/rollback_ui.rs
@@ -1,14 +1,14 @@
-//! Post-exit interactive review/restore UI for the undo system
+//! Post-exit interactive review/restore UI for the rollback system
 //!
-//! Presents the user with a summary of changes made during the supervised
-//! session and offers to restore to the initial state.
+//! Presents the user with a summary of changes made during the session
+//! and offers to restore to the initial state.
 
 use colored::Colorize;
 use nono::undo::{Change, ChangeType, SnapshotManager, SnapshotManifest};
 use nono::Result;
 use std::io::{BufRead, IsTerminal, Write};
 
-/// Run the post-exit undo review UI.
+/// Run the post-exit rollback review UI.
 ///
 /// Shows a change summary and prompts the user to restore or exit.
 /// Returns `true` if the user chose to restore.

--- a/docs/cli/features/atomic-rollbacks.mdx
+++ b/docs/cli/features/atomic-rollbacks.mdx
@@ -3,11 +3,13 @@ title: Atomic Rollbacks
 description: Content-addressable filesystem snapshots with integrity verification
 ---
 
-nono can take filesystem snapshots before and after sandboxed execution, allowing you to review and reverse any changes an agent made. The undo system uses content-addressable storage with SHA-256 deduplication and Merkle tree integrity verification.
+nono can take filesystem snapshots before and after sandboxed execution, allowing you to review and reverse any changes an agent made. The rollback system uses content-addressable storage with SHA-256 deduplication and Merkle tree integrity verification.
+
+The idea is that if an agent makes unintended changes to your filesystem, you can easily see what changed and restore any modified or deleted files back to their original state. This provides a safety net when running powerful agents that have write access to your files.
 
 ## How It Works
 
-When you run a command in supervised mode, nono:
+When you run a command with `--rollback`, nono:
 
 1. **Takes a baseline snapshot** of all files in tracked directories before the command starts
 2. **Runs the command** inside the sandbox
@@ -15,12 +17,12 @@ When you run a command in supervised mode, nono:
 4. **Shows an interactive diff** of all changes, offering to restore any modified or deleted files
 
 ```bash
-# Enable undo with supervised mode
-nono run --supervised --profile claude-code -- claude
+# Enable rollback snapshots
+nono run --rollback --profile claude-code -- claude
 ```
 
 <Note>
-Undo requires `--supervised` mode because the parent process needs to remain unsandboxed to write snapshots to `~/.nono/undo/`.
+`--rollback` automatically selects supervised execution because the parent process needs to remain unsandboxed to write snapshots to `~/.nono/rollbacks/`.
 </Note>
 
 ## Snapshot Architecture
@@ -39,10 +41,10 @@ Each snapshot builds a Merkle tree over all tracked files. The root hash provide
 
 ### Session Structure
 
-Sessions are stored in `~/.nono/undo/` with the following layout:
+Sessions are stored in `~/.nono/rollbacks/` with the following layout:
 
 ```
-~/.nono/undo/
+~/.nono/rollbacks/
   <session-id>/
     manifest.json       # Session metadata, Merkle roots, timestamps
     objects/            # Content-addressable file store
@@ -56,7 +58,7 @@ Session IDs use the format `YYYYMMDD-HHMMSS-PID` (e.g., `20260214-143022-12345`)
 
 ### Exclusion Filters
 
-Not every file needs tracking. The undo system respects:
+Not every file needs tracking. The rollback system respects:
 
 - **Profile-defined patterns**: Common build artifacts like `node_modules`, `.next`, `__pycache__`, `target`
 - **Profile-defined globs**: Patterns like `*.tmp.[0-9]*.[0-9]*`
@@ -66,101 +68,119 @@ These exclusions keep snapshots fast and storage efficient.
 
 ## Commands
 
-### `nono undo list`
+### `nono rollback list`
 
-List past sessions that have recorded changes.
+List past sessions grouped by project directory.
 
 ```bash
-# Show recent sessions
-nono undo list
+# Show recent sessions (grouped by project)
+nono rollback list
+
+# Filter to a specific project
+nono rollback list --path ~/dev/my-project
 
 # Show only the 5 most recent
-nono undo list --recent 5
+nono rollback list --recent 5
 
 # Include sessions with no file changes
-nono undo list --all
+nono rollback list --all
 
 # Machine-readable output
-nono undo list --json
+nono rollback list --json
 ```
 
-Output shows session ID, timestamp, command, and number of files changed.
+Example output:
 
-### `nono undo show`
+```
+[nono] 10 session(s)
+
+  ~/dev/sprockets (7 sessions)
+    20260219-092017-8117  just now  claude  ~2 modified
+    20260219-091403-90291  7m ago  claude  ~2 modified
+    20260218-134433-28210  19h ago  claude  +5 files
+    ...
+
+  ~/dev/widgets (3 sessions)
+    20260219-100000-1234  5m ago  claude  +2 files
+    20260218-120000-5678  1d ago  claude  ~1 modified
+    ...
+```
+
+### `nono rollback show`
 
 Inspect the changes made during a session.
 
 ```bash
 # Show summary of changes
-nono undo show 20260214-143022-12345
+nono rollback show 20260214-143022-12345
 
 # Show unified diff (git-style)
-nono undo show 20260214-143022-12345 --diff
+nono rollback show 20260214-143022-12345 --diff
 
 # Side-by-side diff
-nono undo show 20260214-143022-12345 --side-by-side
+nono rollback show 20260214-143022-12345 --side-by-side
 
 # Show full file content from snapshot
-nono undo show 20260214-143022-12345 --full
+nono rollback show 20260214-143022-12345 --full
 
 # Machine-readable output
-nono undo show 20260214-143022-12345 --json
+nono rollback show 20260214-143022-12345 --json
 ```
 
-### `nono undo restore`
+### `nono rollback restore`
 
 Restore files from a past session to their pre-change state.
 
 ```bash
 # Restore all files to baseline state
-nono undo restore 20260214-143022-12345
+nono rollback restore 20260214-143022-12345
 
 # Restore to a specific snapshot (0 = baseline, 1 = final)
-nono undo restore 20260214-143022-12345 --snapshot 0
+nono rollback restore 20260214-143022-12345 --snapshot 0
 
 # Preview what would change without modifying files
-nono undo restore 20260214-143022-12345 --dry-run
+nono rollback restore 20260214-143022-12345 --dry-run
 ```
 
 Restoration uses atomic rename per file to prevent partial restores.
 
-### `nono undo verify`
+### `nono rollback verify`
 
 Verify the integrity of a stored session by recomputing Merkle tree hashes and checking all objects in the store.
 
 ```bash
-nono undo verify 20260214-143022-12345
+nono rollback verify 20260214-143022-12345
 ```
 
 Reports any missing objects, hash mismatches, or corrupted metadata.
 
-### `nono undo cleanup`
+### `nono rollback cleanup`
 
 Remove old sessions to reclaim disk space.
 
 ```bash
 # Keep only the 10 most recent sessions
-nono undo cleanup --keep 10
+nono rollback cleanup --keep 10
 
 # Remove sessions older than 30 days
-nono undo cleanup --older-than 30
+nono rollback cleanup --older-than 30
 
 # Preview what would be deleted
-nono undo cleanup --dry-run
+nono rollback cleanup --dry-run
 
 # Remove all sessions (requires confirmation)
-nono undo cleanup --all
+nono rollback cleanup --all
 ```
 
 ## Interactive Post-Exit Flow
 
-When a supervised command exits and file changes are detected, nono presents an interactive review:
+When a `--rollback` command exits and file changes are detected, nono presents an interactive review:
 
 1. Shows a summary of all changes (created, modified, deleted files)
 2. Offers to show diffs for individual files
 3. Asks whether to restore some or all files
 
-Use `--no-undo-prompt` to suppress the interactive UI while still taking snapshots (useful for scripting).
+Use `--no-rollback-prompt` to suppress the interactive UI while still taking snapshots (useful for scripting).
 
 ## Storage Management
 
@@ -169,14 +189,14 @@ Use `--no-undo-prompt` to suppress the interactive UI while still taking snapsho
 | Max sessions | 10 | Oldest sessions pruned automatically |
 | Max storage | 5 GB | Total storage limit for all sessions |
 
-Configure these in your nono config file or use `nono undo cleanup` for manual management.
+Configure these in your nono config file or use `nono rollback cleanup` for manual management.
 
-## Profile Undo Configuration
+## Profile Rollback Configuration
 
-Profiles can customize undo behavior:
+Profiles can customize rollback behavior:
 
 ```toml
-[undo]
+[rollback]
 exclude_patterns = ["node_modules", ".next", "__pycache__", "target"]
 exclude_globs = ["*.tmp.[0-9]*.[0-9]*"]
 ```

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -16,16 +16,16 @@ Audit data is a natural byproduct of the snapshot system. Each session records:
 - **Merkle roots**: Cryptographic commitment to filesystem state at each snapshot
 - **Exit code**: How the process terminated
 
-No additional configuration is needed - audit trails are captured automatically when undo snapshots are enabled (i.e., in supervised mode).
+No additional configuration is needed - audit trails are captured automatically when rollback snapshots are enabled (i.e., with `--rollback`).
 
 ## Commands
 
 ### `nono audit list`
 
-List all recorded sessions with filtering.
+List all recorded sessions, grouped by project directory.
 
 ```bash
-# Show all sessions
+# Show all sessions (grouped by project)
 nono audit list
 
 # Show only today's sessions
@@ -38,13 +38,30 @@ nono audit list --since 2026-02-01 --until 2026-02-15
 nono audit list --command claude
 
 # Filter by tracked path
-nono audit list --path /Users/luke/project
+nono audit list --path ~/dev/my-project
 
 # Show only the 10 most recent
 nono audit list --recent 10
 
 # Machine-readable output
 nono audit list --json
+```
+
+Example output:
+
+```
+[nono] 14 session(s)
+
+  ~/dev/sprockets (11 sessions)
+    20260219-092017-8117 completed claude
+    20260219-091403-90291 completed claude
+    20260218-134433-28210 completed claude
+    ...
+
+  ~/dev/widgets (3 sessions)
+    20260219-100000-1234 completed claude
+    20260218-120000-5678 completed my-agent
+    ...
 ```
 
 Filters can be combined:
@@ -100,15 +117,15 @@ nono audit list --path /etc/config.yaml
 nono audit show <session-id> --json
 ```
 
-## Relationship to Undo
+## Relationship to Rollbacks
 
-Audit and undo share the same underlying session data:
+Audit and rollback share the same underlying session data:
 
-| Aspect | Audit | Undo |
-|--------|-------|------|
-| Scope | All supervised sessions | Sessions with file changes |
+| Aspect | Audit | Rollback |
+|--------|-------|----------|
+| Scope | All sessions with `--rollback` | Sessions with file changes |
 | Purpose | Record keeping | Recovery |
-| Commands | `nono audit list/show` | `nono undo list/show/restore/verify/cleanup` |
+| Commands | `nono audit list/show` | `nono rollback list/show/restore/verify/cleanup` |
 | Data | Metadata + change summary | Metadata + full file content |
 
-The `nono audit` commands are read-only - they report on session history. The `nono undo` commands can additionally restore files and manage storage.
+The `nono audit` commands are read-only - they report on session history. The `nono rollback` commands can additionally restore files and manage storage.

--- a/docs/cli/features/execution-modes.mdx
+++ b/docs/cli/features/execution-modes.mdx
@@ -7,11 +7,11 @@ nono provides three execution modes that trade off between attack surface, featu
 
 ## Overview
 
-| Mode | Flag | Parent Sandboxed | Undo | Expansion | Attack Surface |
-|------|------|-----------------|------|-----------|----------------|
+| Mode | Flag | Parent Sandboxed | Rollback | Expansion | Attack Surface |
+|------|------|-----------------|----------|-----------|----------------|
 | Direct | `--exec` | N/A (no parent) | No | No | Minimal |
 | Monitor | (default) | Yes | No | No | Small |
-| Supervised | `--supervised` | No | Yes | Linux only | Larger |
+| Supervised | `--rollback` / `--supervised` | No | `--rollback` only | Linux only | Larger |
 
 ## Direct Mode
 
@@ -28,7 +28,7 @@ nono applies the sandbox and then `exec()`s directly into the target command. no
 
 **Trade-offs:**
 - No diagnostic footer on errors
-- No undo snapshots
+- No rollback snapshots
 - No capability expansion
 
 Profiles with `interactive = true` (like `claude-code`) use Direct mode by default to preserve TTY behavior.
@@ -47,7 +47,7 @@ nono applies the sandbox to itself, then forks. Both the parent and child are sa
 
 **Trade-offs:**
 - Small overhead (parent process stays alive)
-- Cannot write undo snapshots (parent is sandboxed too)
+- Cannot write rollback snapshots (parent is sandboxed too)
 - Cannot do capability expansion (parent is sandboxed too)
 
 **Features:**
@@ -57,40 +57,50 @@ nono applies the sandbox to itself, then forks. Both the parent and child are sa
 ## Supervised Mode
 
 ```bash
+# Enable rollback snapshots
+nono run --rollback --allow-cwd -- my-command
+
+# Enable approval sidecar (capability expansion on Linux)
 nono run --supervised --allow-cwd -- my-command
+
+# Both: rollback snapshots + approval sidecar
+nono run --rollback --supervised --allow-cwd -- my-command
 ```
 
-nono forks first, then sandboxes only the child. The parent remains unsandboxed to provide runtime services.
+nono forks first, then sandboxes only the child. The parent remains unsandboxed to provide runtime services. Either `--rollback` or `--supervised` (or both) triggers supervised execution.
 
-**When to use:**
-- When you want [undo snapshots](/cli/features/atomic-rollbacks) to recover from agent mistakes
-- When you want [capability expansion](/cli/features/supervisor) (Linux only)
-- Long-running agent sessions where recovery matters
+**`--rollback`** enables [atomic rollback snapshots](/cli/features/atomic-rollbacks) - content-addressable filesystem snapshots that let you restore files to their pre-session state.
+
+**`--supervised`** enables the [approval sidecar](/cli/features/supervisor) - on Linux, the parent can grant additional capabilities at runtime via seccomp user notification.
 
 **Trade-offs:**
 - Larger attack surface (unsandboxed parent, mitigated by ptrace hardening)
 - Incompatible with `--secrets` (keyring threads deadlock across fork)
 
 **Features:**
-- Undo snapshots (baseline + final)
-- Interactive post-exit review of changes
-- Capability expansion prompts (Linux only)
+- Rollback snapshots (baseline + final) with `--rollback`
+- Interactive post-exit review of changes with `--rollback`
+- Capability expansion prompts (Linux only) with `--supervised`
 - Diagnostic footer on non-zero exit
 
 ## Choosing a Mode
 
 ```
-Do you need undo or capability expansion?
-├── Yes → Supervised (--supervised)
+Do you need rollback snapshots?
+├── Yes → --rollback
 └── No
     │
-    Do you need diagnostic output on errors?
-    ├── Yes → Monitor (default, no flag needed)
+    Do you need capability expansion (Linux)?
+    ├── Yes → --supervised
     └── No
         │
-        Do you need minimal overhead or TTY preservation?
-        ├── Yes → Direct (--exec)
-        └── No → Monitor (default)
+        Do you need diagnostic output on errors?
+        ├── Yes → Monitor (default, no flag needed)
+        └── No
+            │
+            Do you need minimal overhead or TTY preservation?
+            ├── Yes → Direct (--exec)
+            └── No → Monitor (default)
 ```
 
-For most users running AI agents interactively, the default Monitor mode is the right choice. Switch to Supervised when you want the safety net of undo snapshots.
+For most users running AI agents interactively, the default Monitor mode is the right choice. Add `--rollback` when you want the safety net of atomic rollback snapshots.

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -130,13 +130,13 @@ The `interactive` field (default: `false`) indicates whether the application has
 
 When `true`, nono uses direct exec mode (equivalent to `--exec` flag), which preserves the terminal for apps like Claude Code, vim, or htop.
 
-### Undo Exclusions
+### Rollback Exclusions
 
-The `undo` section controls which files are excluded from [atomic rollback](/cli/features/atomic-rollbacks) snapshots:
+The `rollback` section controls which files are excluded from [atomic rollback](/cli/features/atomic-rollbacks) snapshots:
 
 ```json
 {
-  "undo": {
+  "rollback": {
     "exclude_patterns": ["node_modules", ".next", "__pycache__", "target"],
     "exclude_globs": ["*.tmp.[0-9]*.[0-9]*"]
   }

--- a/docs/cli/features/supervisor.mdx
+++ b/docs/cli/features/supervisor.mdx
@@ -3,15 +3,22 @@ title: Supervisor Mode
 description: Transparent capability expansion and runtime approval
 ---
 
-Supervisor mode keeps a parent process alive outside the sandbox to provide runtime services that a fully sandboxed process cannot perform on its own. This enables transparent capability expansion on Linux and undo snapshots on both platforms.
+Supervisor mode keeps a parent process alive outside the sandbox to provide runtime services that a fully sandboxed process cannot perform on its own. This enables transparent capability expansion on Linux and rollback snapshots on both platforms.
 
 ## Enabling Supervisor Mode
 
 ```bash
+# Enable approval sidecar (capability expansion on Linux)
 nono run --supervised --profile claude-code -- claude
+
+# Enable rollback snapshots
+nono run --rollback --profile claude-code -- claude
+
+# Both: rollback snapshots + approval sidecar
+nono run --rollback --supervised --profile claude-code -- claude
 ```
 
-The `--supervised` flag changes the execution model:
+Either `--supervised` or `--rollback` (or both) activates supervised execution. The flags change the execution model:
 
 1. nono forks before applying the sandbox
 2. The **child** is sandboxed and runs the command
@@ -56,7 +63,7 @@ Requests exceeding the rate limit are automatically denied.
 
 Capability expansion is not available on macOS. Apple's SIP (System Integrity Protection) strips `DYLD_INSERT_LIBRARIES` from Apple Platform Binaries, making transparent interposition infeasible for commands that route through `/usr/bin/env`, `/bin/bash`, or `/bin/sh`.
 
-On macOS, supervised mode provides undo snapshots and the diagnostic footer, but does not prompt for capability expansion.
+On macOS, supervised mode provides rollback snapshots and the diagnostic footer, but does not prompt for capability expansion.
 
 ## never_grant
 
@@ -100,6 +107,6 @@ In both Monitor and Supervised modes, when the child exits with a non-zero exit 
 
 ## Limitations
 
-- `--supervised` is incompatible with `--secrets` (keyring threads cause a deadlock across fork)
+- `--supervised` and `--rollback` are incompatible with `--secrets` (keyring threads cause a deadlock across fork)
 - The unsandboxed parent represents a larger attack surface than Monitor mode. The parent applies ptrace hardening to mitigate this.
-- Capability expansion is Linux-only. macOS supervised mode provides undo and diagnostics only.
+- Capability expansion is Linux-only. macOS supervised mode provides rollback snapshots and diagnostics only.

--- a/docs/cli/getting_started/quickstart.mdx
+++ b/docs/cli/getting_started/quickstart.mdx
@@ -35,7 +35,7 @@ See [Profiles & Groups](/cli/features/profiles-groups) for all built-in profiles
 | `nono run` | Run a command inside the sandbox |
 | `nono shell` | Start an interactive shell inside the sandbox |
 | `nono why` | Check why a path/network operation would be allowed or denied |
-| `nono undo` | [Manage undo sessions](/cli/features/atomic-rollbacks) - list, show, restore, verify, cleanup snapshots |
+| `nono rollback` | [Manage rollback sessions](/cli/features/atomic-rollbacks) - list, show, restore, verify, cleanup snapshots |
 | `nono audit` | [View audit trail](/cli/features/audit) - list and inspect past sandboxed sessions |
 | `nono learn` | [Discover required paths](/cli/features/learn) - trace a command to find what it accesses (Linux only) |
 | `nono setup` | System setup and verification - generate profiles, check shell integration |

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -285,6 +285,47 @@ nono run --profile claude-code --allow-cwd -- claude
 nono -s run --profile claude-code --allow-cwd -- claude
 ```
 
+### Execution Mode Flags
+
+#### `--rollback`
+
+Enable [atomic rollback snapshots](/cli/features/atomic-rollbacks) for the session. Takes content-addressable snapshots of writable directories so you can restore to the pre-session state after the command exits. Automatically selects supervised execution.
+
+```bash
+nono run --rollback --profile claude-code -- claude
+nono run --rollback --allow-cwd -- my-agent
+```
+
+#### `--supervised`
+
+Enable the approval sidecar for runtime capability expansion. On Linux, the supervisor can grant additional filesystem access via seccomp user notification when the sandboxed process requests it.
+
+```bash
+nono run --supervised --allow-cwd -- my-agent
+```
+
+Can be combined with `--rollback` for both snapshots and capability expansion:
+
+```bash
+nono run --rollback --supervised --allow-cwd -- my-agent
+```
+
+#### `--no-rollback-prompt`
+
+Suppress the interactive post-exit review when using `--rollback`. Snapshots are still taken but the user is not prompted to review or restore changes. Useful for scripting.
+
+```bash
+nono run --rollback --no-rollback-prompt --allow-cwd -- my-agent
+```
+
+#### `--exec`
+
+Use direct execution mode. nono applies the sandbox and then `exec()`s directly into the target command. No parent process remains.
+
+```bash
+nono run --exec --allow-cwd -- my-command
+```
+
 ### Operational Flags
 
 #### `--dry-run`


### PR DESCRIPTION
Replace all user-facing "undo" terminology with "rollback" / "Atomic Rollbacks". Add --rollback flag that auto-selects supervised execution for snapshots without requiring --supervised. The --supervised flag now independently controls the approval sidecar.

Flag semantics:
  (none)                  -> Monitor mode, no snapshots
  --rollback              -> Supervised, snapshots only
  --supervised            -> Supervised, approval sidecar only
  --rollback --supervised -> Supervised, both

CLI changes:
- nono undo -> nono rollback (list/show/restore/verify/cleanup)
- --no-undo-prompt -> --no-rollback-prompt
- UndoConfig/UndoSettings -> RollbackConfig/RollbackSettings
- Storage path ~/.nono/undo/ -> ~/.nono/rollbacks/
- Module renames: undo_commands -> rollback_commands, undo_session -> rollback_session, undo_ui -> rollback_ui

Rollback and audit list now group sessions by project directory with --path filter support. Supervised status message is context-aware (shows "rollback snapshots", "approval sidecar", or both).

Security: child process is now set non-dumpable (PR_SET_DUMPABLE=0) in rollback-only mode where /proc/CHILD/mem access is not needed.

Library module stays as `undo` internally (no breaking change for bindings). No backward compatibility aliases.