### PR TITLE
Round up of security hardening work

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -24,7 +24,9 @@
     "~/.ssh/id_ed25519",
     "~/.ssh/id_ecdsa",
     "~/.ssh/id_dsa",
-    "~/.gnupg"
+    "~/.gnupg",
+    "/proc/kcore",
+    "/proc/kmem"
   ],
   "base_groups": [
     "deny_credentials",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -48,6 +48,7 @@
   "groups": {
     "deny_credentials": {
       "description": "Block access to cryptographic keys, tokens, and cloud credentials",
+      "required": true,
       "deny": {
         "access": [
           "~/.ssh",
@@ -72,6 +73,7 @@
     },
     "deny_keychains_macos": {
       "description": "Block access to macOS keychains and password stores",
+      "required": true,
       "platform": "macos",
       "deny": {
         "access": [
@@ -84,6 +86,7 @@
     },
     "deny_keychains_linux": {
       "description": "Block access to Linux keyrings and password stores",
+      "required": true,
       "platform": "linux",
       "deny": {
         "access": [
@@ -95,6 +98,7 @@
     },
     "deny_browser_data_macos": {
       "description": "Block access to macOS browser stored data (cookies, saved passwords, sessions)",
+      "required": true,
       "platform": "macos",
       "deny": {
         "access": [
@@ -109,6 +113,7 @@
     },
     "deny_browser_data_linux": {
       "description": "Block access to Linux browser stored data (cookies, saved passwords, sessions)",
+      "required": true,
       "platform": "linux",
       "deny": {
         "access": [
@@ -122,6 +127,7 @@
     },
     "deny_macos_private": {
       "description": "Block access to macOS private data (messages, mail, cookies)",
+      "required": true,
       "platform": "macos",
       "deny": {
         "access": [
@@ -135,6 +141,7 @@
     },
     "deny_shell_history": {
       "description": "Block access to shell command history files",
+      "required": true,
       "deny": {
         "access": [
           "~/.bash_history",
@@ -146,6 +153,7 @@
     },
     "deny_shell_configs": {
       "description": "Block access to shell configuration files that may embed secrets",
+      "required": true,
       "deny": {
         "access": [
           "~/.zshrc",

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -329,7 +329,7 @@ pub fn execute_monitor(config: &ExecConfig<'_>) -> Result<i32> {
     }
 
     // Validate threading context before fork
-    let thread_count = get_thread_count();
+    let thread_count = get_thread_count()?;
     match (config.threading, thread_count) {
         (_, 1) => {}
         (ThreadingContext::KeyringExpected, n) if n <= MAX_KEYRING_THREADS => {
@@ -603,7 +603,7 @@ pub fn execute_supervised(
     // Validate single-threaded execution before fork.
     // Supervised mode applies sandbox in child (allocates), so extra threads
     // would risk deadlock from contended allocator locks.
-    let thread_count = get_thread_count();
+    let thread_count = get_thread_count()?;
     if thread_count != 1 {
         return Err(NonoError::SandboxInit(format!(
             "Cannot fork in supervised mode: process has {} threads (expected 1). \
@@ -1195,22 +1195,27 @@ fn setup_signal_forwarding(child: Pid) {
 /// Get the current thread count for the process.
 ///
 /// Used to verify single-threaded execution before fork().
-/// Returns 1 if the count cannot be determined (conservative assumption).
-fn get_thread_count() -> usize {
+/// Returns an error if the count cannot be determined, since fork()
+/// safety depends on knowing the exact thread count.
+fn get_thread_count() -> Result<usize> {
     #[cfg(target_os = "linux")]
     {
         // On Linux, read /proc/self/status for accurate thread count
-        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
-            for line in status.lines() {
-                if let Some(count_str) = line.strip_prefix("Threads:") {
-                    if let Ok(count) = count_str.trim().parse::<usize>() {
-                        return count;
-                    }
-                }
+        let status = std::fs::read_to_string("/proc/self/status").map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "Cannot read /proc/self/status for thread count: {e}"
+            ))
+        })?;
+        for line in status.lines() {
+            if let Some(count_str) = line.strip_prefix("Threads:") {
+                return count_str.trim().parse::<usize>().map_err(|e| {
+                    NonoError::SandboxInit(format!("Cannot parse thread count: {e}"))
+                });
             }
         }
-        // Fallback: assume single-threaded if we can't read /proc
-        1
+        return Err(NonoError::SandboxInit(
+            "Thread count not found in /proc/self/status".to_string(),
+        ));
     }
 
     #[cfg(target_os = "macos")]
@@ -1230,17 +1235,19 @@ fn get_thread_count() -> usize {
                 // Deallocate the thread list (required by mach API contract)
                 let list_size = thread_count as usize * std::mem::size_of::<libc::thread_act_t>();
                 libc::vm_deallocate(task, thread_list as libc::vm_address_t, list_size);
-                return thread_count as usize;
+                return Ok(thread_count as usize);
             }
         }
-        // Fallback: assume single-threaded if mach call fails
-        1
+        Err(NonoError::SandboxInit(
+            "Cannot determine thread count via mach task_threads API".to_string(),
+        ))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        // On other platforms, assume single-threaded (conservative)
-        1
+        Err(NonoError::SandboxInit(
+            "Cannot determine thread count on this platform".to_string(),
+        ))
     }
 }
 
@@ -1606,6 +1613,25 @@ fn open_path_for_access(
             path.display(),
             canonical.display(),
         )));
+    }
+
+    // Block sensitive per-PID /proc paths that can't be enumerated in never_grant
+    // (they contain dynamic PIDs). These expose process memory/environment of
+    // arbitrary processes.
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(suffix) = canonical.to_str().and_then(|s| s.strip_prefix("/proc/")) {
+            let parts: Vec<&str> = suffix.splitn(2, '/').collect();
+            if parts.len() == 2 && parts[0].chars().all(|c| c.is_ascii_digit()) {
+                let sensitive = ["mem", "environ", "maps", "syscall", "stack"];
+                if sensitive.contains(&parts[1]) {
+                    return Err(NonoError::SandboxInit(format!(
+                        "Access to /proc/{}/{} is blocked by policy",
+                        parts[0], parts[1],
+                    )));
+                }
+            }
+        }
     }
 
     let result = match access {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -7,7 +7,7 @@ use landlock::{
     Access, AccessFs, AccessNet, BitFlags, PathBeneath, PathFd, Ruleset, RulesetAttr,
     RulesetCreatedAttr, ABI,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// The target ABI version we support (highest we know about)
 const TARGET_ABI: ABI = ABI::V5;

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -107,9 +107,11 @@ pub fn apply(caps: &CapabilitySet) -> Result<()> {
                 NonoError::SandboxInit(format!("Failed to handle net access: {}", e))
             })?
         } else {
-            warn!("Network blocking requested but kernel ABI doesn't support it (requires V4+)");
-            eprintln!("WARNING: Network blocking requested but kernel Landlock ABI doesn't support it (requires V4+). Network access will NOT be restricted.");
-            ruleset_builder
+            return Err(NonoError::SandboxInit(
+                "Network blocking requested but kernel Landlock ABI doesn't support it \
+                 (requires V4+). Refusing to start without network restrictions."
+                    .to_string(),
+            ));
         }
     } else {
         ruleset_builder

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -284,6 +284,10 @@ nono ships with 22 built-in groups:
 - `unlink_protection` - Prevents file deletion, with override for user-writable paths
 - `dangerous_commands` - Blocks `rm`, `dd`, `chmod`, `sudo`, `mkfs`, etc.
 
+<Note>
+  Command blocking is a best-effort surface-level control. It matches against the executable name being invoked directly. A process can bypass this by calling the equivalent syscall from within an allowed interpreter (e.g., `os.remove()` in Python, `fs.unlinkSync()` in Node.js) or by invoking a renamed copy of the binary. For hard filesystem protection, rely on the kernel-enforced deny groups and `unlink_protection`, which cannot be bypassed from userspace regardless of how the operation is invoked.
+</Note>
+
 ### Platform-Specific Groups
 
 Groups with a `platform` field only apply on that OS:

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -223,6 +223,10 @@ nono run --allow-cwd --allow-command rm --allow-command mv -- my-script.sh
   Even with `--allow-command`, the kernel sandbox still restricts file operations to granted paths. A command can only affect files within directories you explicitly allowed.
 </Note>
 
+<Note>
+  Command blocking is a best-effort surface-level control. It matches against the executable name being invoked directly. It does not prevent a process from performing the equivalent operation through language-level APIs (e.g., `os.remove()` in Python), shell built-ins, or renamed binaries. For hard protection against destructive filesystem operations, rely on kernel-enforced deny groups (`deny.access`, `deny.unlink`) and path-based sandboxing, which apply regardless of how the operation is invoked.
+</Note>
+
 #### `--block-command`
 
 Block an additional command beyond the default blocklist.


### PR DESCRIPTION
## Security hardening: sec-fixes branch (4 commits)

### 9857f2b – Enforce required deny groups and sanitize supervisor prompt input
- `required: true` flag on 8 critical deny groups prevents `trust_groups` from removing them
- `sanitize_for_terminal()` strips all ANSI escape sequence types (CSI, OSC, DCS, APC, PM, SOS) from untrusted supervisor approval prompt input

### 1b91a96 – Harden fail-closed paths and expand input validation
- Linux network blocking errors when Landlock ABI < v4 (was warn-and-continue)
- Strict UTF-8 validation for Seatbelt deny rule paths (replaces `to_string_lossy`)
- `$HOME`/`$HOME/` expansion in policy path resolver
- `/proc/kcore`, `/proc/kmem` added to `never_grant`; per-PID `/proc` sensitive file blocking in supervisor
- Rollback session canonicalization fails closed
- `get_thread_count()` returns `Result` instead of silently falling back to 1
- Command blocking limitations documented in profiles-groups and flags docs

### edbc972 – Fix /proc supervisor bypass via task/<tid> subpath and add cmdline
- Full component split so `/proc/<pid>/task/<tid>/mem` is blocked alongside `/proc/<pid>/mem`
- `cmdline` added to sensitive proc file list

### 4dd96fb – Fix rollback list --path matching for macOS symlink aliases
- Skip redundant re-canonicalization of already-canonical stored paths
- `canonical_candidates()` generates macOS symlink equivalents (`/tmp` ↔ `/private/tmp`) for reliable filter matching
