### PR TITLE
fix: harden supervisor IPC and process lifecycle security

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -617,10 +617,21 @@ fn execute_sandboxed(
             } else {
                 None
             };
+            let supervisor_session_id = rollback_state
+                .as_ref()
+                .map(|(_, _, session_id, _, _, _)| session_id.clone())
+                .unwrap_or_else(|| {
+                    format!(
+                        "supervised-{}-{}",
+                        std::process::id(),
+                        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+                    )
+                });
             let supervisor_cfg = supervisor_cfg_data.as_ref().map(|(checker, backend)| {
                 exec_strategy::SupervisorConfig {
                     never_grant: checker,
                     approval_backend: backend,
+                    session_id: &supervisor_session_id,
                 }
             });
 


### PR DESCRIPTION
Addresses ten security hardening items across the supervisor stack.

`open_path_for_access()` now uses component-wise openat traversal with `O_NOFOLLOW` to close a TOCTOU window;

Unix socket binding acquires a process-local lock and sets `umask(0o077)` before bind to prevent a race on socket creation. IPC replay detection added via per-run `request_id` tracking with a bounded cap, and denial recording is capped at 1000 entries to prevent unbounded memory growth.

`recv_fd()` ancillary parsing now walks `CMSG_FIRSTHDR/CMSG_NXTHDR` correctly and detects `MSG_CTRUNC` and peer-close.

Sensitive `/proc` path checks are extended to cover `/proc/self` and `/proc/thread-self` aliases.

Seccomp audit correlation wires session_id through `SupervisorConfig`. `dirs_home()` cross-checks `HOME` against `getpwuid_r` and prefers the passwd entry on mismatch.

Signal forwarding clears the child PID before fork and uses an RAII guard after wait to prevent stale-PID signals. Socket unlink failures other than `NotFound` are now logged for observability.