### PR TITLE
fix(trust): correct Fulcio v2 OID mappings for keyless identity

### DIFF
--- a/.github/workflows/sign-instruction-files.yml
+++ b/.github/workflows/sign-instruction-files.yml
@@ -31,26 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-sign-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build nono CLI
-        run: cargo build --release -p nono-cli
+      - name: Install nono
+        run: |
+          curl -fsSL https://github.com/always-further/nono/releases/download/v0.6.0-alpha.2/nono-v0.6.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv nono /usr/local/bin/
 
       - name: Sign instruction files
-        run: ./target/release/nono trust sign --keyless --all
+        run: nono trust sign --keyless --all
 
       - name: Commit bundles
         run: |


### PR DESCRIPTION
The previous OID constants (.1.8, .1.10, .1.11) mapped to wrong v2 semantics — OIDC issuer, commit SHA, and runner environment instead of source repository, git ref, and workflow. Correct to .1.12, .1.14, .1.18 with v1 fallback OIDs .1.5 and .1.6.

Normalize v2 repository URI (https://github.com/org/repo -> org/repo) and build config URI (full workflow URL@ref -> .github/workflows/file.yml) so extracted identities match trust-policy.json publisher entries.

Also switch the signing workflow from building nono from source to using the release binary.