### PR TITLE
Add multi-subject file attestation for companion artifact signing

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -660,6 +660,8 @@ pub enum TrustCommands {
     List(TrustListArgs),
     /// Generate a new ECDSA P-256 signing key pair
     Keygen(TrustKeygenArgs),
+    /// Export the public key for a signing key (base64 DER)
+    ExportKey(TrustExportKeyArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -730,6 +732,17 @@ pub struct TrustKeygenArgs {
     /// Overwrite existing key with the same ID
     #[arg(long)]
     pub force: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TrustExportKeyArgs {
+    /// Key identifier to export (default: "default")
+    #[arg(long, value_name = "NAME", default_value = "default")]
+    pub id: String,
+
+    /// Output as PEM instead of base64 DER
+    #[arg(long)]
+    pub pem: bool,
 }
 
 #[cfg(test)]
@@ -1097,6 +1110,36 @@ mod tests {
                     assert!(keygen_args.force);
                 }
                 _ => panic!("Expected Keygen subcommand"),
+            },
+            _ => panic!("Expected Trust command"),
+        }
+    }
+
+    #[test]
+    fn test_trust_export_key_defaults() {
+        let cli = Cli::parse_from(["nono", "trust", "export-key"]);
+        match cli.command {
+            Commands::Trust(args) => match args.command {
+                TrustCommands::ExportKey(export_args) => {
+                    assert_eq!(export_args.id, "default");
+                    assert!(!export_args.pem);
+                }
+                _ => panic!("Expected ExportKey subcommand"),
+            },
+            _ => panic!("Expected Trust command"),
+        }
+    }
+
+    #[test]
+    fn test_trust_export_key_with_options() {
+        let cli = Cli::parse_from(["nono", "trust", "export-key", "--id", "my-key", "--pem"]);
+        match cli.command {
+            Commands::Trust(args) => match args.command {
+                TrustCommands::ExportKey(export_args) => {
+                    assert_eq!(export_args.id, "my-key");
+                    assert!(export_args.pem);
+                }
+                _ => panic!("Expected ExportKey subcommand"),
             },
             _ => panic!("Expected Trust command"),
         }

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -96,7 +96,7 @@ pub(super) fn handle_seccomp_notification(
     initial_caps: &[(std::path::PathBuf, bool)],
     rate_limiter: &mut RateLimiter,
     denials: &mut Vec<DenialRecord>,
-    trust_interceptor: Option<&mut TrustInterceptor>,
+    mut trust_interceptor: Option<&mut TrustInterceptor>,
 ) -> Result<()> {
     use nono::sandbox::{
         classify_access_from_flags, deny_notif, inject_fd, notif_id_valid, read_notif_path,

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -245,39 +245,41 @@ pub(super) fn handle_seccomp_notification(
     // 7. Trust verification for instruction files (TOCTOU protection)
     // If the path is an instruction file, verify it and stash the digest
     // for re-verification at open time. Failed verification results in early denial.
-    let verified_digest: Option<String> =
-        if let Some(trust_result) = trust_interceptor.and_then(|ti| ti.check_path(&path)) {
-            match trust_result {
-                Ok(verified) => {
-                    debug!(
-                        "Seccomp: instruction file {} verified (publisher: {})",
-                        path.display(),
-                        verified.publisher,
-                    );
-                    Some(verified.digest)
-                }
-                Err(reason) => {
-                    // Instruction file failed trust verification — auto-deny
-                    debug!(
-                        "Seccomp: instruction file {} failed trust verification: {}",
-                        path.display(),
-                        reason
-                    );
-                    record_denial(
-                        denials,
-                        DenialRecord {
-                            path: path.clone(),
-                            access,
-                            reason: DenialReason::PolicyBlocked,
-                        },
-                    );
-                    let _ = deny_notif(notify_fd, notif.id);
-                    return Ok(());
-                }
+    let verified_digest: Option<String> = if let Some(trust_result) = trust_interceptor
+        .as_mut()
+        .and_then(|ti| ti.check_path(&path))
+    {
+        match trust_result {
+            Ok(verified) => {
+                debug!(
+                    "Seccomp: instruction file {} verified (publisher: {})",
+                    path.display(),
+                    verified.publisher,
+                );
+                Some(verified.digest)
             }
-        } else {
-            None
-        };
+            Err(reason) => {
+                // Instruction file failed trust verification — auto-deny
+                debug!(
+                    "Seccomp: instruction file {} failed trust verification: {}",
+                    path.display(),
+                    reason
+                );
+                record_denial(
+                    denials,
+                    DenialRecord {
+                        path: path.clone(),
+                        access,
+                        reason: DenialReason::PolicyBlocked,
+                    },
+                );
+                let _ = deny_notif(notify_fd, notif.id);
+                return Ok(());
+            }
+        }
+    } else {
+        None
+    };
 
     // 8. Delegate to approval backend (for both instruction and non-instruction files)
     let request = nono::supervisor::CapabilityRequest {

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -244,119 +244,77 @@ pub(super) fn handle_seccomp_notification(
 
     // 7. Trust verification for instruction files (TOCTOU protection)
     // If the path is an instruction file, verify it and stash the digest
-    // for re-verification at open time.
-    let mut verified_digest: Option<String> = None;
-    let decision = if let Some(trust_result) = trust_interceptor
-        .as_deref_mut()
-        .and_then(|ti| ti.check_path(&path))
-    {
-        match trust_result {
-            Ok(verified) => {
-                debug!(
-                    "Seccomp: instruction file {} verified (publisher: {})",
-                    path.display(),
-                    verified.publisher,
-                );
-                // Stash the verified digest for TOCTOU re-check at open time
-                verified_digest = Some(verified.digest);
-                // Instruction file verified — proceed to approval backend
-                match config.approval_backend.request_capability(
-                    &nono::supervisor::CapabilityRequest {
-                        request_id: format!("seccomp-{}", unique_request_id()),
-                        path: path.clone(),
-                        access,
-                        reason: Some(
-                            "Sandbox intercepted file operation (seccomp-notify)".to_string(),
-                        ),
-                        child_pid: child.as_raw() as u32,
-                        session_id: config.session_id.to_string(),
-                    },
-                ) {
-                    Ok(d) => {
-                        if d.is_denied() {
-                            record_denial(
-                                denials,
-                                DenialRecord {
-                                    path: path.clone(),
-                                    access,
-                                    reason: DenialReason::UserDenied,
-                                },
-                            );
-                        }
-                        d
-                    }
-                    Err(e) => {
-                        warn!("Approval backend error for seccomp notification: {}", e);
-                        record_denial(
-                            denials,
-                            DenialRecord {
-                                path: path.clone(),
-                                access,
-                                reason: DenialReason::BackendError,
-                            },
-                        );
-                        let _ = deny_notif(notify_fd, notif.id);
-                        return Ok(());
-                    }
+    // for re-verification at open time. Failed verification results in early denial.
+    let verified_digest: Option<String> =
+        if let Some(trust_result) = trust_interceptor.and_then(|ti| ti.check_path(&path)) {
+            match trust_result {
+                Ok(verified) => {
+                    debug!(
+                        "Seccomp: instruction file {} verified (publisher: {})",
+                        path.display(),
+                        verified.publisher,
+                    );
+                    Some(verified.digest)
                 }
-            }
-            Err(reason) => {
-                // Instruction file failed trust verification — auto-deny
-                debug!(
-                    "Seccomp: instruction file {} failed trust verification: {}",
-                    path.display(),
-                    reason
-                );
-                record_denial(
-                    denials,
-                    DenialRecord {
-                        path: path.clone(),
-                        access,
-                        reason: DenialReason::PolicyBlocked,
-                    },
-                );
-                let _ = deny_notif(notify_fd, notif.id);
-                return Ok(());
-            }
-        }
-    } else {
-        // 8. Not an instruction file — delegate to approval backend directly
-        let request = nono::supervisor::CapabilityRequest {
-            request_id: format!("seccomp-{}", unique_request_id()),
-            path: path.clone(),
-            access,
-            reason: Some("Sandbox intercepted file operation (seccomp-notify)".to_string()),
-            child_pid: child.as_raw() as u32,
-            session_id: config.session_id.to_string(),
-        };
-
-        match config.approval_backend.request_capability(&request) {
-            Ok(d) => {
-                if d.is_denied() {
+                Err(reason) => {
+                    // Instruction file failed trust verification — auto-deny
+                    debug!(
+                        "Seccomp: instruction file {} failed trust verification: {}",
+                        path.display(),
+                        reason
+                    );
                     record_denial(
                         denials,
                         DenialRecord {
                             path: path.clone(),
                             access,
-                            reason: DenialReason::UserDenied,
+                            reason: DenialReason::PolicyBlocked,
                         },
                     );
+                    let _ = deny_notif(notify_fd, notif.id);
+                    return Ok(());
                 }
-                d
             }
-            Err(e) => {
-                warn!("Approval backend error for seccomp notification: {}", e);
+        } else {
+            None
+        };
+
+    // 8. Delegate to approval backend (for both instruction and non-instruction files)
+    let request = nono::supervisor::CapabilityRequest {
+        request_id: format!("seccomp-{}", unique_request_id()),
+        path: path.clone(),
+        access,
+        reason: Some("Sandbox intercepted file operation (seccomp-notify)".to_string()),
+        child_pid: child.as_raw() as u32,
+        session_id: config.session_id.to_string(),
+    };
+
+    let decision = match config.approval_backend.request_capability(&request) {
+        Ok(d) => {
+            if d.is_denied() {
                 record_denial(
                     denials,
                     DenialRecord {
                         path: path.clone(),
                         access,
-                        reason: DenialReason::BackendError,
+                        reason: DenialReason::UserDenied,
                     },
                 );
-                let _ = deny_notif(notify_fd, notif.id);
-                return Ok(());
             }
+            d
+        }
+        Err(e) => {
+            warn!("Approval backend error for seccomp notification: {}", e);
+            record_denial(
+                denials,
+                DenialRecord {
+                    path: path.clone(),
+                    access,
+                    reason: DenialReason::BackendError,
+                },
+            );
+            let _ = deny_notif(notify_fd, notif.id);
+            return Ok(());
         }
     };
 

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -6,8 +6,11 @@
 //! - Path opens performed by the supervisor must re-validate policy boundaries.
 //! - Security boundary: the supervisor's `open_path_for_access()` + `inject_fd()`
 //!   is authoritative. `notif_id_valid()` only proves notification liveness.
+//! - Instruction files undergo trust verification with TOCTOU protection via
+//!   digest re-check at fd open time.
 
 use super::*;
+use crate::trust_intercept::TrustInterceptor;
 
 /// Token-bucket rate limiter for supervisor expansion requests.
 ///
@@ -69,14 +72,19 @@ impl RateLimiter {
 /// 4. Check never_grant -> deny (BEFORE initial-set fast-path)
 /// 5. Fast-path: if path is in initial set, open + inject fd immediately
 /// 6. Rate limit check -> deny if exceeded
-/// 7. Delegate to approval backend
-/// 8. Second TOCTOU check before inject/deny
-/// 9. If approved: open path + inject fd. If denied: deny notification.
+/// 7. Trust verification for instruction files (if trust_interceptor present)
+/// 8. Delegate to approval backend
+/// 9. Second TOCTOU check before inject/deny
+/// 10. If approved: open path + inject fd (with TOCTOU digest re-check for
+///     instruction files). If denied: deny notification.
 ///
 /// TOCTOU boundary note:
 /// - The child controls userspace pointers until syscall completion.
 /// - We treat notification ID validation as a liveness guard only.
 /// - Authorization is bound to the file descriptor opened by the supervisor.
+/// - Instruction files undergo additional TOCTOU protection: the verified
+///   digest is re-checked against the opened fd to detect races between
+///   trust verification and file open.
 ///
 /// The initial_caps parameter contains (path, is_file) tuples:
 /// - For files (is_file=true): only exact path matches are allowed
@@ -88,6 +96,7 @@ pub(super) fn handle_seccomp_notification(
     initial_caps: &[(std::path::PathBuf, bool)],
     rate_limiter: &mut RateLimiter,
     denials: &mut Vec<DenialRecord>,
+    trust_interceptor: Option<&mut TrustInterceptor>,
 ) -> Result<()> {
     use nono::sandbox::{
         classify_access_from_flags, deny_notif, inject_fd, notif_id_valid, read_notif_path,
@@ -233,54 +242,139 @@ pub(super) fn handle_seccomp_notification(
         return Ok(());
     }
 
-    // 7. Delegate to approval backend
-    let request = nono::supervisor::CapabilityRequest {
-        request_id: format!("seccomp-{}", unique_request_id()),
-        path: path.clone(),
-        access,
-        reason: Some("Sandbox intercepted file operation (seccomp-notify)".to_string()),
-        child_pid: child.as_raw() as u32,
-        session_id: config.session_id.to_string(),
-    };
-
-    let decision = match config.approval_backend.request_capability(&request) {
-        Ok(d) => {
-            if d.is_denied() {
+    // 7. Trust verification for instruction files (TOCTOU protection)
+    // If the path is an instruction file, verify it and stash the digest
+    // for re-verification at open time.
+    let mut verified_digest: Option<String> = None;
+    let decision = if let Some(trust_result) = trust_interceptor
+        .as_deref_mut()
+        .and_then(|ti| ti.check_path(&path))
+    {
+        match trust_result {
+            Ok(verified) => {
+                debug!(
+                    "Seccomp: instruction file {} verified (publisher: {})",
+                    path.display(),
+                    verified.publisher,
+                );
+                // Stash the verified digest for TOCTOU re-check at open time
+                verified_digest = Some(verified.digest);
+                // Instruction file verified — proceed to approval backend
+                match config.approval_backend.request_capability(
+                    &nono::supervisor::CapabilityRequest {
+                        request_id: format!("seccomp-{}", unique_request_id()),
+                        path: path.clone(),
+                        access,
+                        reason: Some(
+                            "Sandbox intercepted file operation (seccomp-notify)".to_string(),
+                        ),
+                        child_pid: child.as_raw() as u32,
+                        session_id: config.session_id.to_string(),
+                    },
+                ) {
+                    Ok(d) => {
+                        if d.is_denied() {
+                            record_denial(
+                                denials,
+                                DenialRecord {
+                                    path: path.clone(),
+                                    access,
+                                    reason: DenialReason::UserDenied,
+                                },
+                            );
+                        }
+                        d
+                    }
+                    Err(e) => {
+                        warn!("Approval backend error for seccomp notification: {}", e);
+                        record_denial(
+                            denials,
+                            DenialRecord {
+                                path: path.clone(),
+                                access,
+                                reason: DenialReason::BackendError,
+                            },
+                        );
+                        let _ = deny_notif(notify_fd, notif.id);
+                        return Ok(());
+                    }
+                }
+            }
+            Err(reason) => {
+                // Instruction file failed trust verification — auto-deny
+                debug!(
+                    "Seccomp: instruction file {} failed trust verification: {}",
+                    path.display(),
+                    reason
+                );
                 record_denial(
                     denials,
                     DenialRecord {
                         path: path.clone(),
                         access,
-                        reason: DenialReason::UserDenied,
+                        reason: DenialReason::PolicyBlocked,
                     },
                 );
+                let _ = deny_notif(notify_fd, notif.id);
+                return Ok(());
             }
-            d
         }
-        Err(e) => {
-            warn!("Approval backend error for seccomp notification: {}", e);
-            record_denial(
-                denials,
-                DenialRecord {
-                    path: path.clone(),
-                    access,
-                    reason: DenialReason::BackendError,
-                },
-            );
-            let _ = deny_notif(notify_fd, notif.id);
-            return Ok(());
+    } else {
+        // 8. Not an instruction file — delegate to approval backend directly
+        let request = nono::supervisor::CapabilityRequest {
+            request_id: format!("seccomp-{}", unique_request_id()),
+            path: path.clone(),
+            access,
+            reason: Some("Sandbox intercepted file operation (seccomp-notify)".to_string()),
+            child_pid: child.as_raw() as u32,
+            session_id: config.session_id.to_string(),
+        };
+
+        match config.approval_backend.request_capability(&request) {
+            Ok(d) => {
+                if d.is_denied() {
+                    record_denial(
+                        denials,
+                        DenialRecord {
+                            path: path.clone(),
+                            access,
+                            reason: DenialReason::UserDenied,
+                        },
+                    );
+                }
+                d
+            }
+            Err(e) => {
+                warn!("Approval backend error for seccomp notification: {}", e);
+                record_denial(
+                    denials,
+                    DenialRecord {
+                        path: path.clone(),
+                        access,
+                        reason: DenialReason::BackendError,
+                    },
+                );
+                let _ = deny_notif(notify_fd, notif.id);
+                return Ok(());
+            }
         }
     };
 
-    // 8. Second TOCTOU check before acting on the decision
+    // 9. Second TOCTOU check before acting on the decision
     if !notif_id_valid(notify_fd, notif.id)? {
         debug!("Seccomp notification expired (second TOCTOU check)");
         return Ok(());
     }
 
-    // 9. Act on the decision
+    // 10. Act on the decision
+    // Pass verified_digest to enable TOCTOU re-verification for instruction files
     if decision.is_granted() {
-        match open_path_for_access(&canonicalized, &access, config.never_grant, None) {
+        match open_path_for_access(
+            &canonicalized,
+            &access,
+            config.never_grant,
+            verified_digest.as_deref(),
+        ) {
             Ok(file) => {
                 inject_fd(notify_fd, notif.id, file.as_raw_fd())?;
             }

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -6,6 +6,7 @@
 use crate::cli::LearnArgs;
 use nono::{NonoError, Result};
 use std::collections::BTreeSet;
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -16,8 +16,6 @@ use std::collections::{HashMap, HashSet};
 #[cfg(target_os = "linux")]
 use std::io::{BufRead, BufReader};
 #[cfg(target_os = "linux")]
-use std::net::IpAddr;
-#[cfg(target_os = "linux")]
 use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};

--- a/crates/nono-cli/src/trust_intercept.rs
+++ b/crates/nono-cli/src/trust_intercept.rs
@@ -433,7 +433,10 @@ mod tests {
         let skills = dir.path().join("SKILLS.md");
         std::fs::write(&skills, "# Skills").unwrap();
 
-        let policy = TrustPolicy::default();
+        let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
+            ..TrustPolicy::default()
+        };
         let mut interceptor = TrustInterceptor::new(policy, dir.path().to_path_buf()).unwrap();
 
         // Should return Some (it IS an instruction file)
@@ -448,6 +451,7 @@ mod tests {
         std::fs::write(&skills, "# Skills").unwrap();
 
         let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -468,6 +472,7 @@ mod tests {
         std::fs::write(&skills, "# Skills v1").unwrap();
 
         let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -495,6 +500,7 @@ mod tests {
         let digest = trust::bytes_digest(content);
 
         let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Audit,
             blocklist: trust::Blocklist {
                 digests: vec![trust::BlocklistEntry {

--- a/crates/nono/src/trust/bundle.rs
+++ b/crates/nono/src/trust/bundle.rs
@@ -444,8 +444,8 @@ pub fn verify_bundle_subject_name(bundle: &Bundle, expected_path: &Path) -> Resu
 
 /// Extract the `predicateType` from a bundle's DSSE envelope payload.
 ///
-/// Returns the predicate type string (e.g., `novo.sh/attestation/instruction-file/v1`
-/// or `novo.sh/attestation/trust-policy/v1`).
+/// Returns the predicate type string (e.g., `nono.sh/attestation/instruction-file/v1`
+/// or `nono.sh/attestation/trust-policy/v1`).
 ///
 /// # Errors
 ///

--- a/crates/nono/src/trust/bundle.rs
+++ b/crates/nono/src/trust/bundle.rs
@@ -444,8 +444,8 @@ pub fn verify_bundle_subject_name(bundle: &Bundle, expected_path: &Path) -> Resu
 
 /// Extract the `predicateType` from a bundle's DSSE envelope payload.
 ///
-/// Returns the predicate type string (e.g., `nono.dev/attestation/instruction-file/v1`
-/// or `nono.dev/attestation/trust-policy/v1`).
+/// Returns the predicate type string (e.g., `novo.sh/attestation/instruction-file/v1`
+/// or `novo.sh/attestation/trust-policy/v1`).
 ///
 /// # Errors
 ///
@@ -715,6 +715,62 @@ pub fn bundle_path_for(artifact_path: &Path) -> std::path::PathBuf {
     let mut bundle = artifact_path.as_os_str().to_owned();
     bundle.push(".bundle");
     std::path::PathBuf::from(bundle)
+}
+
+/// Resolve the conventional path for a multi-subject trust bundle.
+///
+/// Multi-subject bundles are stored as `.nono-trust.bundle` in the given
+/// directory (typically the project root or skill directory).
+#[must_use]
+pub fn multi_subject_bundle_path(dir_path: &Path) -> std::path::PathBuf {
+    dir_path.join(".nono-trust.bundle")
+}
+
+// ---------------------------------------------------------------------------
+// Multi-subject extraction
+// ---------------------------------------------------------------------------
+
+/// Extract all subjects from a bundle's DSSE envelope.
+///
+/// Returns `Vec<(name, sha256_hex)>` — one entry per subject in the
+/// in-toto statement. Works for both single-subject and multi-subject bundles.
+///
+/// # Errors
+///
+/// Returns `NonoError::TrustVerification` if the bundle cannot be parsed
+/// or any subject is missing a SHA-256 digest.
+pub fn extract_all_subjects(bundle: &Bundle, bundle_path: &Path) -> Result<Vec<(String, String)>> {
+    let contents = DsseContents::from_bundle(bundle, bundle_path)?;
+    let subjects = contents
+        .statement
+        .get("subject")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| NonoError::TrustVerification {
+            path: bundle_path.display().to_string(),
+            reason: "no subjects array in statement".to_string(),
+        })?;
+
+    let mut result = Vec::with_capacity(subjects.len());
+    for subject in subjects {
+        let name = subject
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| NonoError::TrustVerification {
+                path: bundle_path.display().to_string(),
+                reason: "subject missing name".to_string(),
+            })?;
+        let digest = subject
+            .get("digest")
+            .and_then(|v| v.get("sha256"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| NonoError::TrustVerification {
+                path: bundle_path.display().to_string(),
+                reason: format!("subject '{name}' missing sha256 digest"),
+            })?;
+        result.push((name.to_string(), digest.to_string()));
+    }
+
+    Ok(result)
 }
 
 // ---------------------------------------------------------------------------
@@ -1030,6 +1086,72 @@ mod tests {
             publisher.matches(&identity),
             "publisher should match extracted identity"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // multi_subject_bundle_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multi_subject_bundle_path_in_cwd() {
+        let path = multi_subject_bundle_path(Path::new("."));
+        assert_eq!(path, Path::new("./.nono-trust.bundle"));
+    }
+
+    #[test]
+    fn multi_subject_bundle_path_in_dir() {
+        let path = multi_subject_bundle_path(Path::new("/home/user/project"));
+        assert_eq!(path, Path::new("/home/user/project/.nono-trust.bundle"));
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_all_subjects
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_all_subjects_single() {
+        // Create a real signed bundle with one subject
+        let kp = crate::trust::signing::generate_signing_key().unwrap();
+        let json = crate::trust::signing::sign_bytes(b"content", "file.md", &kp, "key").unwrap();
+        let bundle = Bundle::from_json(&json).unwrap();
+
+        let subjects = extract_all_subjects(&bundle, Path::new("test.bundle")).unwrap();
+        assert_eq!(subjects.len(), 1);
+        assert_eq!(subjects[0].0, "file.md");
+        assert_eq!(subjects[0].1.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn extract_all_subjects_multi() {
+        // Create a real signed bundle with multiple subjects
+        let kp = crate::trust::signing::generate_signing_key().unwrap();
+        let files = vec![
+            (
+                std::path::PathBuf::from("SKILL.md"),
+                crate::trust::digest::bytes_digest(b"skill"),
+            ),
+            (
+                std::path::PathBuf::from("lib/helper.py"),
+                crate::trust::digest::bytes_digest(b"helper"),
+            ),
+            (
+                std::path::PathBuf::from("config.json"),
+                crate::trust::digest::bytes_digest(b"config"),
+            ),
+        ];
+        let json = crate::trust::signing::sign_files(&files, &kp, "key").unwrap();
+        let bundle = Bundle::from_json(&json).unwrap();
+
+        let subjects = extract_all_subjects(&bundle, Path::new("test.bundle")).unwrap();
+        assert_eq!(subjects.len(), 3);
+        assert_eq!(subjects[0].0, "SKILL.md");
+        assert_eq!(subjects[1].0, "lib/helper.py");
+        assert_eq!(subjects[2].0, "config.json");
+
+        // Digests should match what we computed
+        assert_eq!(subjects[0].1, crate::trust::digest::bytes_digest(b"skill"));
+        assert_eq!(subjects[1].1, crate::trust::digest::bytes_digest(b"helper"));
+        assert_eq!(subjects[2].1, crate::trust::digest::bytes_digest(b"config"));
     }
 
     fn make_empty_cert_chain_bundle_json() -> String {

--- a/crates/nono/src/trust/dsse.rs
+++ b/crates/nono/src/trust/dsse.rs
@@ -21,10 +21,17 @@ pub const IN_TOTO_PAYLOAD_TYPE: &str = "application/vnd.in-toto+json";
 pub const IN_TOTO_STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
 
 /// The predicate type for nono instruction file attestations.
-pub const NONO_PREDICATE_TYPE: &str = "https://nono.dev/attestation/instruction-file/v1";
+pub const NONO_PREDICATE_TYPE: &str = "https://novo.sh/attestation/instruction-file/v1";
 
 /// The predicate type for nono trust policy attestations.
-pub const NONO_POLICY_PREDICATE_TYPE: &str = "https://nono.dev/attestation/trust-policy/v1";
+pub const NONO_POLICY_PREDICATE_TYPE: &str = "https://novo.sh/attestation/trust-policy/v1";
+
+/// The predicate type for nono multi-file attestations.
+///
+/// Used when multiple files are signed together in a single bundle
+/// (e.g., a skill's SKILL.md + companion scripts). All files appear
+/// as subjects in the same in-toto statement.
+pub const NONO_MULTI_SUBJECT_PREDICATE_TYPE: &str = "https://nono.sh/attestation/multi-file/v1";
 
 /// A DSSE (Dead Simple Signing Envelope).
 ///
@@ -426,6 +433,39 @@ pub fn new_policy_statement(
         signer_predicate,
         NONO_POLICY_PREDICATE_TYPE,
     )
+}
+
+/// Create a new in-toto statement for a multi-file attestation.
+///
+/// Each `(name, sha256_hex)` pair becomes a subject in the statement.
+/// Used when signing multiple files together (e.g., SKILL.md + lib/script.py).
+///
+/// # Panics
+///
+/// Does not panic. Returns a statement with the provided subjects.
+#[must_use]
+pub fn new_multi_subject_statement(
+    subjects: &[(String, String)],
+    signer_predicate: serde_json::Value,
+) -> InTotoStatement {
+    let subject = subjects
+        .iter()
+        .map(|(name, sha256_hex)| {
+            let mut digest = HashMap::new();
+            digest.insert("sha256".to_string(), sha256_hex.clone());
+            InTotoSubject {
+                name: name.clone(),
+                digest,
+            }
+        })
+        .collect();
+
+    InTotoStatement {
+        statement_type: IN_TOTO_STATEMENT_TYPE.to_string(),
+        subject,
+        predicate_type: NONO_MULTI_SUBJECT_PREDICATE_TYPE.to_string(),
+        predicate: signer_predicate,
+    }
 }
 
 /// Create a DSSE envelope wrapping an in-toto statement.
@@ -871,6 +911,89 @@ mod tests {
     #[test]
     fn instruction_and_policy_predicate_types_differ() {
         assert_ne!(NONO_PREDICATE_TYPE, NONO_POLICY_PREDICATE_TYPE);
+    }
+
+    #[test]
+    fn multi_subject_predicate_type_is_unique() {
+        assert_ne!(NONO_MULTI_SUBJECT_PREDICATE_TYPE, NONO_PREDICATE_TYPE);
+        assert_ne!(
+            NONO_MULTI_SUBJECT_PREDICATE_TYPE,
+            NONO_POLICY_PREDICATE_TYPE
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // new_multi_subject_statement
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multi_subject_statement_structure() {
+        let subjects = vec![
+            ("SKILL.md".to_string(), "aaa111".to_string()),
+            ("lib/script.py".to_string(), "bbb222".to_string()),
+        ];
+        let predicate = serde_json::json!({
+            "version": 1,
+            "signer": { "kind": "keyed", "key_id": "test" }
+        });
+        let stmt = new_multi_subject_statement(&subjects, predicate);
+
+        assert_eq!(stmt.statement_type, IN_TOTO_STATEMENT_TYPE);
+        assert_eq!(stmt.predicate_type, NONO_MULTI_SUBJECT_PREDICATE_TYPE);
+        assert_eq!(stmt.subject.len(), 2);
+        assert_eq!(stmt.subject[0].name, "SKILL.md");
+        assert_eq!(stmt.subject[0].digest["sha256"], "aaa111");
+        assert_eq!(stmt.subject[1].name, "lib/script.py");
+        assert_eq!(stmt.subject[1].digest["sha256"], "bbb222");
+    }
+
+    #[test]
+    fn multi_subject_statement_single_subject() {
+        let subjects = vec![("only.md".to_string(), "digest123".to_string())];
+        let predicate = serde_json::json!({"version": 1});
+        let stmt = new_multi_subject_statement(&subjects, predicate);
+
+        assert_eq!(stmt.subject.len(), 1);
+        assert_eq!(stmt.subject[0].name, "only.md");
+    }
+
+    #[test]
+    fn multi_subject_statement_roundtrips_through_envelope() {
+        let subjects = vec![
+            ("a.md".to_string(), "aaa".to_string()),
+            ("b.py".to_string(), "bbb".to_string()),
+            ("c.json".to_string(), "ccc".to_string()),
+        ];
+        let predicate = serde_json::json!({
+            "version": 1,
+            "signer": { "kind": "keyed", "key_id": "test" }
+        });
+        let stmt = new_multi_subject_statement(&subjects, predicate);
+        let envelope = new_envelope(&stmt).unwrap();
+        let extracted = envelope.extract_statement().unwrap();
+
+        assert_eq!(extracted.subject.len(), 3);
+        assert_eq!(extracted.predicate_type, NONO_MULTI_SUBJECT_PREDICATE_TYPE);
+        assert_eq!(extracted.subject[0].name, "a.md");
+        assert_eq!(extracted.subject[1].name, "b.py");
+        assert_eq!(extracted.subject[2].name, "c.json");
+    }
+
+    #[test]
+    fn multi_subject_statement_preserves_signer_predicate() {
+        let subjects = vec![("f.md".to_string(), "ddd".to_string())];
+        let predicate = serde_json::json!({
+            "version": 1,
+            "signer": { "kind": "keyed", "key_id": "nono-keystore:default" }
+        });
+        let stmt = new_multi_subject_statement(&subjects, predicate);
+        let identity = stmt.extract_signer().unwrap();
+        match identity {
+            super::super::types::SignerIdentity::Keyed { key_id } => {
+                assert_eq!(key_id, "nono-keystore:default");
+            }
+            _ => panic!("expected keyed signer"),
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/nono/src/trust/dsse.rs
+++ b/crates/nono/src/trust/dsse.rs
@@ -21,10 +21,10 @@ pub const IN_TOTO_PAYLOAD_TYPE: &str = "application/vnd.in-toto+json";
 pub const IN_TOTO_STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
 
 /// The predicate type for nono instruction file attestations.
-pub const NONO_PREDICATE_TYPE: &str = "https://novo.sh/attestation/instruction-file/v1";
+pub const NONO_PREDICATE_TYPE: &str = "https://nono.sh/attestation/instruction-file/v1";
 
 /// The predicate type for nono trust policy attestations.
-pub const NONO_POLICY_PREDICATE_TYPE: &str = "https://novo.sh/attestation/trust-policy/v1";
+pub const NONO_POLICY_PREDICATE_TYPE: &str = "https://nono.sh/attestation/trust-policy/v1";
 
 /// The predicate type for nono multi-file attestations.
 ///

--- a/crates/nono/src/trust/mod.rs
+++ b/crates/nono/src/trust/mod.rs
@@ -38,26 +38,28 @@ pub mod signing;
 pub mod types;
 
 pub use bundle::{
-    bundle_path_for, extract_bundle_digest, extract_predicate_type, extract_signer_identity,
-    load_bundle, load_bundle_from_str, load_production_trusted_root, load_trusted_root,
-    load_trusted_root_from_str, parse_cert_info, verify_bundle, verify_bundle_keyed,
-    verify_bundle_subject_name, verify_bundle_with_digest, verify_keyed_signature, Bundle,
-    CertificateInfo, DerPublicKey, Sha256Hash, SigstoreVerificationResult, TrustedRoot,
-    VerificationPolicy,
+    bundle_path_for, extract_all_subjects, extract_bundle_digest, extract_predicate_type,
+    extract_signer_identity, load_bundle, load_bundle_from_str, load_production_trusted_root,
+    load_trusted_root, load_trusted_root_from_str, multi_subject_bundle_path, parse_cert_info,
+    verify_bundle, verify_bundle_keyed, verify_bundle_subject_name, verify_bundle_with_digest,
+    verify_keyed_signature, Bundle, CertificateInfo, DerPublicKey, Sha256Hash,
+    SigstoreVerificationResult, TrustedRoot, VerificationPolicy,
 };
 pub use digest::{bytes_digest, file_digest};
 pub use dsse::{
-    new_envelope, new_instruction_statement, new_policy_statement, new_statement, pae,
-    DsseEnvelope, DsseSignature, InTotoStatement, InTotoSubject, IN_TOTO_PAYLOAD_TYPE,
-    IN_TOTO_STATEMENT_TYPE, NONO_POLICY_PREDICATE_TYPE, NONO_PREDICATE_TYPE,
+    new_envelope, new_instruction_statement, new_multi_subject_statement, new_policy_statement,
+    new_statement, pae, DsseEnvelope, DsseSignature, InTotoStatement, InTotoSubject,
+    IN_TOTO_PAYLOAD_TYPE, IN_TOTO_STATEMENT_TYPE, NONO_MULTI_SUBJECT_PREDICATE_TYPE,
+    NONO_POLICY_PREDICATE_TYPE, NONO_PREDICATE_TYPE,
 };
 pub use policy::{
     evaluate_file, find_instruction_files, load_policy_from_file, load_policy_from_str,
     merge_policies,
 };
 pub use signing::{
-    export_public_key, generate_signing_key, key_id_hex, sign_bytes, sign_instruction_file,
-    sign_policy_bytes, sign_policy_file, write_bundle, KeyPair, SigningScheme,
+    export_public_key, generate_signing_key, key_id_hex, sign_bytes, sign_files,
+    sign_instruction_file, sign_policy_bytes, sign_policy_file, write_bundle, KeyPair,
+    SigningScheme, MAX_MULTI_SUBJECT_FILES,
 };
 pub use types::{
     BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, InstructionPatterns, Publisher,

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -34,12 +34,7 @@ impl Default for TrustPolicy {
     fn default() -> Self {
         Self {
             version: 1,
-            instruction_patterns: vec![
-                "SKILLS*".to_string(),
-                "CLAUDE*".to_string(),
-                "AGENT*".to_string(),
-                ".claude/**/*.md".to_string(),
-            ],
+            instruction_patterns: Vec::new(),
             publishers: Vec::new(),
             blocklist: Blocklist::default(),
             enforcement: Enforcement::default(),
@@ -487,9 +482,10 @@ mod tests {
         TrustPolicy {
             version: 1,
             instruction_patterns: vec![
-                "SKILLS*".to_string(),
-                "CLAUDE*".to_string(),
-                "AGENT*".to_string(),
+                "SKILLS*.md".to_string(),
+                "CLAUDE*.md".to_string(),
+                "AGENT*.md".to_string(),
+                ".github/copilot-instructions.md".to_string(),
                 ".claude/**/*.md".to_string(),
             ],
             publishers: vec![
@@ -532,18 +528,22 @@ mod tests {
         assert!(matcher.is_match("SKILLS.md"));
         assert!(matcher.is_match("SKILLS-custom.md"));
         assert!(matcher.is_match("CLAUDE.md"));
-        assert!(matcher.is_match("CLAUDErc"));
-        assert!(matcher.is_match("AGENT.MD"));
+        assert!(matcher.is_match("AGENT.md"));
         assert!(matcher.is_match("AGENTS.md"));
-        assert!(matcher.is_match("AGENTS.MD"));
+        assert!(matcher.is_match(".github/copilot-instructions.md"));
+        assert!(matcher.is_match(".claude/projects/foo/MEMORY.md"));
+        // Extensionless names must NOT match (avoids blocking executables
+        // on case-insensitive filesystems like macOS HFS+/APFS)
+        assert!(!matcher.is_match("claude"));
+        assert!(!matcher.is_match("CLAUDErc"));
     }
 
     #[test]
     fn instruction_patterns_returns_originals() {
         let policy = sample_policy();
         let matcher = policy.instruction_matcher().unwrap();
-        assert_eq!(matcher.patterns().len(), 4);
-        assert_eq!(matcher.patterns()[0], "SKILLS*");
+        assert_eq!(matcher.patterns().len(), 5);
+        assert_eq!(matcher.patterns()[0], "SKILLS*.md");
     }
 
     #[test]

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -28,7 +28,7 @@ There are two signing modes supported:
 
 **Keyed signing** -- A private key(s) is stored in the system keystore (macOS Keychain / Linux Secret Service). Suitable for individual developers and local workflows. Plans are in place to extend the key store to support more backends (e.g., HashiCorp Vault, AWS KMS) in the future.
 
-**Keyless signing** -- Ephemeral key + OIDC identity + Fulcio certificate + Rekor transparency log. Suitable for CI/CD pipelines and organizations. The signer's identity is cryptographically bound to the signature via the OIDC token.
+**Keyless signing** -- Ephemeral key + OIDC identity + Fulcio certificate + Rekor transparency log. Suitable for CI/CD pipelines with ambient OIDC tokens (e.g., GitHub Actions with `permissions: id-token: write`). The signer's identity is cryptographically bound to the signature via the OIDC token. Interactive browser-based keyless signing is not yet supported.
 
 Both modes produce [Sigstore bundle](https://docs.sigstore.dev/about/bundle/) v0.3 files, recognizable by the `.bundle` extension, stored alongside the signed file (e.g., `SKILLS.md.bundle`). Each bundle contains the signature, signing certificate, and metadata needed for verification.
 
@@ -45,12 +45,20 @@ This creates an ECDSA P-256 key pair and stores the private key in the system ke
 ### 2. Sign instruction files
 
 ```bash
+# Sign a single file (uses default key)
 nono trust sign SKILLS.md
-# or sign all instruction files at once
+
+# Sign with a specific key
+nono trust sign SKILLS.md --key my-signing-key
+
+# Sign multiple files into a single multi-subject bundle
+nono trust sign SKILLS.md CLAUDE.md helper.py
+
+# Sign all instruction files matching trust policy patterns
 nono trust sign --all
 ```
 
-Each signed file gets a `.bundle` sidecar (e.g., `SKILLS.md.bundle`). Commit these alongside the instruction files.
+When signing multiple files, nono creates a single `.nono-trust.bundle` file containing all subjects. This is more efficient for projects with many instruction files. Single-file signing creates per-file `.bundle` sidecars (e.g., `SKILLS.md.bundle`). Commit these alongside the instruction files.
 
 ### 3. Create a trust policy
 
@@ -70,15 +78,25 @@ Create `trust-policy.json` in the project root:
   "publishers": [
     {
       "name": "local-dev",
-      "key_id": "default"
+      "key_id": "default",
+      "public_key": "<BASE64_PUBLIC_KEY>"
     }
   ],
   "blocklist": {
-    "digests": []
+    "digests": [],
+    "publishers": []
   },
   "enforcement": "deny"
 }
 ```
+
+To get the public key in base64 format for the policy:
+
+```bash
+nono trust export-key --id default
+```
+
+This outputs the public key in base64 DER format, which you paste into the `public_key` field.
 
 ### 4. Sign the trust policy
 
@@ -121,14 +139,17 @@ A `SKILLS.md` in a subdirectory or unpacked from a dependency is caught by `SKIL
 
 Trusted publisher identities. A file's signature must match at least one publisher entry to be trusted.
 
-**Keyed publishers** match by key ID:
+**Keyed publishers** match by key ID and verify with the embedded public key:
 
 ```json
 {
   "name": "local-dev",
-  "key_id": "default"
+  "key_id": "default",
+  "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
 }
 ```
+
+The `public_key` field contains the base64-encoded DER SPKI public key. Use `nono trust export-key` to obtain this value.
 
 **Keyless (OIDC) publishers** match by identity claims from the Fulcio certificate:
 
@@ -242,15 +263,24 @@ With a user-level policy in place, project policies merge additively on top. A p
 
 ### nono trust sign
 
-Sign instruction files, producing `.bundle` sidecars.
+Sign instruction files. Single files produce per-file `.bundle` sidecars; multiple files produce a single `.nono-trust.bundle` multi-subject bundle.
 
 ```bash
-nono trust sign SKILLS.md                  # keyed (default key)
+nono trust sign SKILLS.md                  # keyed (default key), creates SKILLS.md.bundle
 nono trust sign SKILLS.md --key my-key     # keyed (specific key)
-nono trust sign SKILLS.md --keyless        # keyless (OIDC + Fulcio + Rekor)
-nono trust sign SKILLS.md CLAUDE.md        # multiple files
-nono trust sign --all                      # all instruction files in CWD
+nono trust sign SKILLS.md CLAUDE.md        # multi-subject bundle (.nono-trust.bundle)
+nono trust sign --all                      # all instruction files in CWD (multi-subject)
 ```
+
+**Keyless signing** (CI environments only):
+
+```bash
+nono trust sign SKILLS.md --keyless        # requires ambient OIDC (e.g., GitHub Actions)
+```
+
+<Note>
+  Keyless signing requires a CI environment with ambient OIDC tokens, such as GitHub Actions with `permissions: id-token: write`. Interactive browser-based keyless signing is not yet supported. Use keyed signing for local development.
+</Note>
 
 ### nono trust verify
 
@@ -280,11 +310,21 @@ nono trust list
 
 ### nono trust keygen
 
-Generate a signing key and store it in the system keystore.
+Generate an ECDSA P-256 signing key pair and store it in the system keystore (macOS Keychain / Linux Secret Service).
 
 ```bash
-nono trust keygen                          # default key ID
+nono trust keygen                          # default key ID ("default")
 nono trust keygen --id my-signing-key      # named key
+```
+
+### nono trust export-key
+
+Export the public key for a signing key in base64 DER format. Use this to populate the `public_key` field in trust policy publishers.
+
+```bash
+nono trust export-key                      # export default key
+nono trust export-key --id my-signing-key  # export named key
+nono trust export-key --pem                # output as PEM instead of base64 DER
 ```
 
 ### nono trust sign-policy
@@ -425,21 +465,31 @@ The `NONO_TRUST_OVERRIDE=1` environment variable is also supported for CI/CD con
 
 ## Signature Storage
 
-Bundles are stored as `<filename>.bundle` alongside the signed file:
+Bundles are stored in two formats depending on how files are signed:
+
+**Per-file bundles** (single file signing): `<filename>.bundle`
 
 ```
 project/
   SKILLS.md
   SKILLS.md.bundle
-  CLAUDE.md
-  CLAUDE.md.bundle
-  .claude/
-    commands/
-      deploy.md
-      deploy.md.bundle
   trust-policy.json
   trust-policy.json.bundle
 ```
+
+**Multi-subject bundles** (multiple files signed together): `.nono-trust.bundle`
+
+```
+project/
+  SKILLS.md
+  CLAUDE.md
+  helper.py
+  .nono-trust.bundle           # contains all subjects
+  trust-policy.json
+  trust-policy.json.bundle
+```
+
+Multi-subject bundles are more efficient for projects with many instruction files. The bundle contains cryptographic digests for each subject file, and a single signature covers all of them.
 
 Bundles are checked into version control. A missing bundle for a file that matches instruction patterns triggers verification failure.
 

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -43,7 +43,7 @@ The DSSE payload is an [in-toto v1 attestation statement](https://github.com/in-
       }
     }
   ],
-  "predicateType": "https://novo.sh/attestation/instruction-file/v1",
+  "predicateType": "https://nono.sh/attestation/instruction-file/v1",
   "predicate": {
     "version": 1,
     "signer": {
@@ -54,7 +54,7 @@ The DSSE payload is an [in-toto v1 attestation statement](https://github.com/in-
 }
 ```
 
-The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono instruction file attestation. Trust policy signatures use a separate predicate type: `https://novo.sh/attestation/trust-policy/v1`.
+The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono instruction file attestation. Trust policy signatures use a separate predicate type: `https://nono.sh/attestation/trust-policy/v1`.
 
 For keyless signing, the predicate carries OIDC provenance:
 
@@ -174,7 +174,7 @@ If any component of the cache key changes (file modified, replaced, moved), the 
 
 The trust policy itself must be signed to establish a root of trust. Without this, an attacker who can write to the project directory can modify `trust-policy.json` to add themselves as a publisher or weaken enforcement.
 
-Policy bundles use the predicate type `https://novo.sh/attestation/trust-policy/v1` to distinguish them from instruction file bundles.
+Policy bundles use the predicate type `https://nono.sh/attestation/trust-policy/v1` to distinguish them from instruction file bundles.
 
 During pre-exec scan, policy signature verification runs first:
 

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -43,7 +43,7 @@ The DSSE payload is an [in-toto v1 attestation statement](https://github.com/in-
       }
     }
   ],
-  "predicateType": "https://nono.dev/attestation/instruction-file/v1",
+  "predicateType": "https://novo.sh/attestation/instruction-file/v1",
   "predicate": {
     "version": 1,
     "signer": {
@@ -54,7 +54,7 @@ The DSSE payload is an [in-toto v1 attestation statement](https://github.com/in-
 }
 ```
 
-The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono instruction file attestation. Trust policy signatures use a separate predicate type: `https://nono.dev/attestation/trust-policy/v1`.
+The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono instruction file attestation. Trust policy signatures use a separate predicate type: `https://novo.sh/attestation/trust-policy/v1`.
 
 For keyless signing, the predicate carries OIDC provenance:
 
@@ -174,7 +174,7 @@ If any component of the cache key changes (file modified, replaced, moved), the 
 
 The trust policy itself must be signed to establish a root of trust. Without this, an attacker who can write to the project directory can modify `trust-policy.json` to add themselves as a publisher or weaken enforcement.
 
-Policy bundles use the predicate type `https://nono.dev/attestation/trust-policy/v1` to distinguish them from instruction file bundles.
+Policy bundles use the predicate type `https://novo.sh/attestation/trust-policy/v1` to distinguish them from instruction file bundles.
 
 During pre-exec scan, policy signature verification runs first:
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -62,6 +62,22 @@ Set up nono on this system. Verifies installation, tests sandbox support, and op
 nono setup [OPTIONS]
 ```
 
+### `nono trust`
+
+Manage instruction file attestation. Sign, verify, and manage trust for AI agent instruction files.
+
+```bash
+nono trust <SUBCOMMAND>
+```
+
+Subcommands:
+- `sign` - Sign instruction files
+- `sign-policy` - Sign a trust policy file
+- `verify` - Verify instruction files against the trust policy
+- `list` - List instruction files and their verification status
+- `keygen` - Generate a new signing key pair
+- `export-key` - Export the public key for a signing key
+
 ## `nono learn` Options
 
 <Note>
@@ -527,6 +543,77 @@ Available context flags:
 - `--net-block` - Block network access
 - `--profile`, `-p` - Use a named profile
 - `--workdir` - Working directory for `$WORKDIR` expansion
+
+## `nono trust` Options
+
+### `nono trust sign`
+
+Sign instruction files, producing bundles for verification.
+
+```bash
+nono trust sign <FILES...>                 # Sign specific files
+nono trust sign --all                      # Sign all instruction files in CWD
+nono trust sign SKILLS.md --key my-key     # Use a specific key
+```
+
+| Option | Description |
+|--------|-------------|
+| `--all` | Sign all instruction files matching trust policy patterns |
+| `--key <KEY_ID>` | Key ID from system keystore (default: "default") |
+| `--keyless` | Use Sigstore keyless signing (CI environments only) |
+| `--policy <FILE>` | Trust policy file (default: auto-discover) |
+
+<Note>
+  When signing multiple files, a single `.nono-trust.bundle` multi-subject bundle is created. Single-file signing creates per-file `.bundle` sidecars.
+</Note>
+
+### `nono trust sign-policy`
+
+Sign a trust policy file.
+
+```bash
+nono trust sign-policy                     # Sign trust-policy.json in CWD
+nono trust sign-policy path/to/policy.json # Sign specific file
+nono trust sign-policy --key my-key        # Use a specific key
+```
+
+### `nono trust verify`
+
+Verify instruction files against the trust policy.
+
+```bash
+nono trust verify <FILES...>               # Verify specific files
+nono trust verify --all                    # Verify all instruction files in CWD
+nono trust verify --policy path/to/policy  # Use specific trust policy
+```
+
+### `nono trust list`
+
+List instruction files and their verification status.
+
+```bash
+nono trust list                            # Human-readable output
+nono trust list --json                     # JSON output
+```
+
+### `nono trust keygen`
+
+Generate an ECDSA P-256 signing key pair and store it in the system keystore.
+
+```bash
+nono trust keygen                          # Default key ID ("default")
+nono trust keygen --id my-signing-key      # Named key
+```
+
+### `nono trust export-key`
+
+Export the public key for use in trust policy `public_key` fields.
+
+```bash
+nono trust export-key                      # Export default key (base64 DER)
+nono trust export-key --id my-key          # Export named key
+nono trust export-key --pem                # Output as PEM format
+```
 
 ## `nono setup` Options
 


### PR DESCRIPTION
A signed SKILLS.md can reference companion artifacts (scripts, configs) that could be compromised post-signing. This adds multi-subject in-toto attestation: multiple files are signed into a single .nono-trust.bundle with all file digests as subjects. One signature covers the entire set and any file change invalidates the bundle.

Library:
- Multi-subject DSSE statement with dedicated predicate type
- sign_files() for keyed multi-file signing
- extract_all_subjects() and multi_subject_bundle_path() helpers
- Refactored sign_statement() shared helper from sign_bytes_inner

CLI:
- nono trust sign with multiple files produces .nono-trust.bundle
- Both keyed and keyless (Fulcio + Rekor) multi-subject signing
- nono trust verify handles .nono-trust.bundle directly and via --all
- nono trust export-key command for scripted trust-policy.json setup
- Pre-exec scan discovers and verifies .nono-trust.bundle in scan root
- Verified subjects added as read-only sandbox capabilities
- Multi-subject files deduplicated from per-file verification
- Duplicate trust policy load warning eliminated in verify --all