### PR TITLE
fix: Linux keyring compatibility and proxy credential fixes

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -48,6 +48,7 @@
       "hosts": [
         "github.com",
         "api.github.com",
+        "codeload.github.com",
         "raw.githubusercontent.com",
         "objects.githubusercontent.com",
         "github-releases.githubusercontent.com",
@@ -99,6 +100,25 @@
     }
   },
   "profiles": {
+    "opencode": {
+      "groups": [
+        "llm_apis",
+        "package_registries",
+        "github",
+        "sigstore",
+        "documentation"
+      ],
+      "credentials": ["google-ai"]
+    },
+    "developer": {
+      "groups": [
+        "llm_apis",
+        "package_registries",
+        "github",
+        "sigstore",
+        "documentation"
+      ]
+    },
     "claude-code": {
       "groups": [
         "llm_apis",
@@ -128,7 +148,7 @@
   },
   "credentials": {
     "openai": {
-      "upstream": "https://api.openai.com",
+      "upstream": "https://api.openai.com/v1",
       "credential_key": "openai_api_key",
       "inject_header": "Authorization",
       "credential_format": "Bearer {}"
@@ -142,6 +162,12 @@
     "gemini": {
       "upstream": "https://generativelanguage.googleapis.com",
       "credential_key": "gemini_api_key",
+      "inject_header": "x-goog-api-key",
+      "credential_format": "{}"
+    },
+    "google-ai": {
+      "upstream": "https://generativelanguage.googleapis.com",
+      "credential_key": "google_generative_ai_api_key",
       "inject_header": "x-goog-api-key",
       "credential_format": "{}"
     }

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -548,6 +548,70 @@
         "exclude_patterns": ["node_modules", ".next"]
       },
       "interactive": true
+    },
+    "python-dev": {
+      "meta": {
+        "name": "python-dev",
+        "version": "1.0.0",
+        "description": "Python SDK development profile with pyenv, conda, and pip support",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": ["python_runtime"]
+      },
+      "trust_groups": [],
+      "filesystem": {},
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
+    },
+    "node-dev": {
+      "meta": {
+        "name": "node-dev",
+        "version": "1.0.0",
+        "description": "Node.js SDK development profile with nvm, fnm, and npm support",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": ["node_runtime"]
+      },
+      "trust_groups": [],
+      "filesystem": {},
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
+    },
+    "go-dev": {
+      "meta": {
+        "name": "go-dev",
+        "version": "1.0.0",
+        "description": "Go SDK development profile with GOPATH and module support",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": ["go_runtime"]
+      },
+      "trust_groups": [],
+      "filesystem": {},
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
+    },
+    "rust-dev": {
+      "meta": {
+        "name": "rust-dev",
+        "version": "1.0.0",
+        "description": "Rust SDK development profile with cargo and rustup support",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": ["rust_runtime"]
+      },
+      "trust_groups": [],
+      "filesystem": {},
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
     }
   }
 }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -59,8 +59,10 @@ pub fn resolve_program(program: &str) -> Result<PathBuf> {
 /// Main thread (1) + up to 3 keyring threads for D-Bus/Security.framework.
 const MAX_KEYRING_THREADS: usize = 4;
 /// Maximum threads allowed when crypto library thread pool is active.
-/// Main thread (1) + up to 3 aws-lc-rs ECDSA worker threads (idle on condvar).
-const MAX_CRYPTO_THREADS: usize = 4;
+/// Main thread (1) + tokio proxy workers (2) + aws-lc-rs ECDSA pool (4).
+/// When --network-profile is used with trust scanning, both the proxy runtime
+/// and crypto verification threads may be active simultaneously.
+const MAX_CRYPTO_THREADS: usize = 7;
 /// Hard cap on retained denial records to prevent memory exhaustion.
 const MAX_DENIAL_RECORDS: usize = 1000;
 /// Hard cap on request IDs tracked for replay detection.

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -132,15 +132,18 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
 }
 
 /// Print supervised mode status
-pub fn print_supervised_info(silent: bool, rollback: bool, supervised: bool) {
+pub fn print_supervised_info(silent: bool, rollback: bool, supervised: bool, proxy_active: bool) {
     if silent {
         return;
     }
-    let detail = match (rollback, supervised) {
-        (true, true) => "rollback snapshots + approval sidecar",
-        (true, false) => "rollback snapshots",
-        (false, true) => "approval sidecar",
-        (false, false) => return, // shouldn't happen
+    let detail = match (rollback, supervised, proxy_active) {
+        (true, true, _) => "rollback snapshots + approval sidecar",
+        (true, false, true) => "rollback snapshots + network proxy",
+        (true, false, false) => "rollback snapshots",
+        (false, true, true) => "approval sidecar + network proxy",
+        (false, true, false) => "approval sidecar",
+        (false, false, true) => "network proxy",
+        (false, false, false) => return, // shouldn't happen
     };
     eprintln!(
         "{}",

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -85,9 +85,12 @@ impl CredentialStore {
     }
 }
 
+/// The keyring service name used by nono for all credentials.
+const KEYRING_SERVICE: &str = "nono";
+
 /// Load a secret from the system keyring.
 fn load_from_keyring(account: &str) -> Result<Zeroizing<String>> {
-    let entry = keyring::Entry::new("nono-proxy", account).map_err(|e| {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| {
         ProxyError::Credential(format!(
             "failed to create keyring entry for '{}': {}",
             account, e

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -257,12 +257,11 @@ fn validate_phantom_token(
             let value = line.split_once(':').map(|(_, v)| v.trim()).unwrap_or("");
 
             // Handle "Bearer <token>" format (strip "Bearer " prefix if present)
-            let token_value = if lower.contains("bearer ") {
-                value
-                    .strip_prefix("Bearer ")
-                    .or_else(|| value.strip_prefix("bearer "))
-                    .unwrap_or(value)
-                    .trim()
+            // Use case-insensitive check, then slice original value by length
+            let value_lower = value.to_lowercase();
+            let token_value = if value_lower.starts_with("bearer ") {
+                // "bearer ".len() == 7
+                value[7..].trim()
             } else {
                 value
             };

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -48,6 +48,14 @@ pub struct ReverseProxyCtx<'a> {
 /// `buffered_body` contains any bytes the BufReader read ahead beyond the
 /// headers. These are prepended to the body read from the stream to prevent
 /// data loss.
+///
+/// ## Phantom Token Pattern
+///
+/// The client (SDK) sends the session token as its "API key". The proxy:
+/// 1. Extracts the service from the path (e.g., `/openai/v1/chat` → `openai`)
+/// 2. Looks up which header that service uses (e.g., `Authorization` or `x-api-key`)
+/// 3. Validates the phantom token from that header
+/// 4. Replaces it with the real credential from keyring
 pub async fn handle_reverse_proxy(
     first_line: &str,
     stream: &mut TcpStream,
@@ -59,9 +67,6 @@ pub async fn handle_reverse_proxy(
     let (method, path, version) = parse_request_line(first_line)?;
     debug!("Reverse proxy: {} {}", method, path);
 
-    // Validate session token from X-Nono-Token header
-    validate_nono_token(remaining_header, ctx.session_token)?;
-
     // Extract service prefix from path (e.g., "/openai/v1/chat" -> ("openai", "/v1/chat"))
     let (service, upstream_path) = parse_service_prefix(&path)?;
 
@@ -72,6 +77,11 @@ pub async fn handle_reverse_proxy(
         .ok_or_else(|| ProxyError::UnknownService {
             prefix: service.clone(),
         })?;
+
+    // Validate phantom token from the auth header the SDK uses.
+    // The SDK sends the session token as its "API key"; we validate it here
+    // before swapping in the real credential.
+    validate_phantom_token(remaining_header, &cred.header_name, ctx.session_token)?;
 
     // Parse upstream URL
     let upstream_url = format!("{}{}", cred.upstream.trim_end_matches('/'), upstream_path);
@@ -227,42 +237,67 @@ fn parse_service_prefix(path: &str) -> Result<(String, String)> {
     }
 }
 
-/// Validate the X-Nono-Token header.
-fn validate_nono_token(header_bytes: &[u8], session_token: &Zeroizing<String>) -> Result<()> {
+/// Validate the phantom token from the service's auth header.
+///
+/// The SDK sends the session token as its "API key" in the standard auth header
+/// for that service (e.g., `Authorization: Bearer <token>` for OpenAI,
+/// `x-api-key: <token>` for Anthropic). We validate the token matches the
+/// session token before swapping in the real credential.
+fn validate_phantom_token(
+    header_bytes: &[u8],
+    header_name: &str,
+    session_token: &Zeroizing<String>,
+) -> Result<()> {
     let header_str = std::str::from_utf8(header_bytes).map_err(|_| ProxyError::InvalidToken)?;
+    let header_name_lower = header_name.to_lowercase();
 
     for line in header_str.lines() {
         let lower = line.to_lowercase();
-        if lower.starts_with("x-nono-token:") {
+        if lower.starts_with(&format!("{}:", header_name_lower)) {
             let value = line.split_once(':').map(|(_, v)| v.trim()).unwrap_or("");
-            if token::constant_time_eq(value.as_bytes(), session_token.as_bytes()) {
+
+            // Handle "Bearer <token>" format (strip "Bearer " prefix if present)
+            let token_value = if lower.contains("bearer ") {
+                value
+                    .strip_prefix("Bearer ")
+                    .or_else(|| value.strip_prefix("bearer "))
+                    .unwrap_or(value)
+                    .trim()
+            } else {
+                value
+            };
+
+            if token::constant_time_eq(token_value.as_bytes(), session_token.as_bytes()) {
                 return Ok(());
             }
-            warn!("Invalid X-Nono-Token");
+            warn!("Invalid phantom token in {} header", header_name);
             return Err(ProxyError::InvalidToken);
         }
     }
 
-    warn!("Missing X-Nono-Token header");
+    warn!(
+        "Missing {} header for phantom token validation",
+        header_name
+    );
     Err(ProxyError::InvalidToken)
 }
 
-/// Filter headers, removing X-Nono-Token, Host, Content-Length, and x-api-key.
+/// Filter headers, removing Host, Content-Length, and auth headers.
 ///
 /// Content-Length is re-added after body is read, and Host is rewritten
 /// to the upstream. Authorization and x-api-key headers are stripped since
-/// we inject our own credential.
+/// we inject our own credential (the phantom token is validated but not forwarded).
 fn filter_headers(header_bytes: &[u8]) -> Vec<(String, String)> {
     let header_str = std::str::from_utf8(header_bytes).unwrap_or("");
     let mut headers = Vec::new();
 
     for line in header_str.lines() {
         let lower = line.to_lowercase();
-        if lower.starts_with("x-nono-token:")
-            || lower.starts_with("host:")
+        if lower.starts_with("host:")
             || lower.starts_with("content-length:")
             || lower.starts_with("authorization:")
             || lower.starts_with("x-api-key:")
+            || lower.starts_with("x-goog-api-key:")
             || line.trim().is_empty()
         {
             continue;
@@ -472,29 +507,50 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_nono_token_valid() {
+    fn test_validate_phantom_token_bearer_valid() {
         let token = Zeroizing::new("secret123".to_string());
-        let header = b"X-Nono-Token: secret123\r\nContent-Type: application/json\r\n\r\n";
-        assert!(validate_nono_token(header, &token).is_ok());
+        let header = b"Authorization: Bearer secret123\r\nContent-Type: application/json\r\n\r\n";
+        assert!(validate_phantom_token(header, "Authorization", &token).is_ok());
     }
 
     #[test]
-    fn test_validate_nono_token_invalid() {
+    fn test_validate_phantom_token_bearer_invalid() {
         let token = Zeroizing::new("secret123".to_string());
-        let header = b"X-Nono-Token: wrong\r\n\r\n";
-        assert!(validate_nono_token(header, &token).is_err());
+        let header = b"Authorization: Bearer wrong\r\n\r\n";
+        assert!(validate_phantom_token(header, "Authorization", &token).is_err());
     }
 
     #[test]
-    fn test_validate_nono_token_missing() {
+    fn test_validate_phantom_token_x_api_key_valid() {
+        let token = Zeroizing::new("secret123".to_string());
+        let header = b"x-api-key: secret123\r\nContent-Type: application/json\r\n\r\n";
+        assert!(validate_phantom_token(header, "x-api-key", &token).is_ok());
+    }
+
+    #[test]
+    fn test_validate_phantom_token_x_goog_api_key_valid() {
+        let token = Zeroizing::new("secret123".to_string());
+        let header = b"x-goog-api-key: secret123\r\nContent-Type: application/json\r\n\r\n";
+        assert!(validate_phantom_token(header, "x-goog-api-key", &token).is_ok());
+    }
+
+    #[test]
+    fn test_validate_phantom_token_missing() {
         let token = Zeroizing::new("secret123".to_string());
         let header = b"Content-Type: application/json\r\n\r\n";
-        assert!(validate_nono_token(header, &token).is_err());
+        assert!(validate_phantom_token(header, "Authorization", &token).is_err());
     }
 
     #[test]
-    fn test_filter_headers_removes_token_host_auth() {
-        let header = b"X-Nono-Token: secret\r\nHost: localhost:8080\r\nAuthorization: Bearer old\r\nContent-Type: application/json\r\nAccept: */*\r\n\r\n";
+    fn test_validate_phantom_token_case_insensitive_header() {
+        let token = Zeroizing::new("secret123".to_string());
+        let header = b"AUTHORIZATION: Bearer secret123\r\n\r\n";
+        assert!(validate_phantom_token(header, "Authorization", &token).is_ok());
+    }
+
+    #[test]
+    fn test_filter_headers_removes_host_auth() {
+        let header = b"Host: localhost:8080\r\nAuthorization: Bearer old\r\nContent-Type: application/json\r\nAccept: */*\r\n\r\n";
         let filtered = filter_headers(header);
         assert_eq!(filtered.len(), 2);
         assert_eq!(filtered[0].0, "Content-Type");
@@ -504,6 +560,14 @@ mod tests {
     #[test]
     fn test_filter_headers_removes_x_api_key() {
         let header = b"x-api-key: sk-old\r\nContent-Type: application/json\r\n\r\n";
+        let filtered = filter_headers(header);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].0, "Content-Type");
+    }
+
+    #[test]
+    fn test_filter_headers_removes_x_goog_api_key() {
+        let header = b"x-goog-api-key: gemini-key\r\nContent-Type: application/json\r\n\r\n";
         let filtered = filter_headers(header);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].0, "Content-Type");

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -28,7 +28,7 @@ Streaming responses (SSE for chat completions, MCP Streamable HTTP, A2A JSON-RPC
 
 ```bash
 # 1. Store credentials in the system keystore
-security add-generic-password -s "nono-proxy" -a "openai" -w "sk-..."  # macOS
+security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."  # macOS
 
 # 2. Run with credential injection
 nono run --allow-cwd --network-profile claude-code --proxy-credential openai -- my-agent
@@ -38,21 +38,39 @@ The proxy sets `OPENAI_BASE_URL=http://127.0.0.1:<port>/openai` in the child's e
 
 ## Storing Credentials
 
-Credentials are stored in the system keyring under the service name `nono-proxy`:
+Credentials are stored in the system keyring under the service name `nono`. The username/account corresponds to the `credential_key` defined in `network-policy.json`:
+
+| CLI Service | Keyring Username | Keyring Service |
+|-------------|------------------|-----------------|
+| `openai` | `openai_api_key` | `nono` |
+| `anthropic` | `anthropic_api_key` | `nono` |
+| `gemini` | `gemini_api_key` | `nono` |
+| `google-ai` | `google_generative_ai_api_key` | `nono` |
 
 ### macOS
 
 ```bash
-security add-generic-password -s "nono-proxy" -a "openai" -w "sk-..."
-security add-generic-password -s "nono-proxy" -a "anthropic" -w "sk-ant-..."
+security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."
+security add-generic-password -s "nono" -a "anthropic_api_key" -w "sk-ant-..."
+security add-generic-password -s "nono" -a "gemini_api_key" -w "your-gemini-key"
 ```
 
 ### Linux
 
+The `keyring` crate uses `service`, `username`, and `target` attributes. You must use these exact attribute names:
+
 ```bash
-secret-tool store --label="nono-proxy: openai" service nono-proxy username openai
-secret-tool store --label="nono-proxy: anthropic" service nono-proxy username anthropic
+echo -n "sk-..." | secret-tool store --label="nono: openai_api_key" \
+    service nono username openai_api_key target default
+
+echo -n "sk-ant-..." | secret-tool store --label="nono: anthropic_api_key" \
+    service nono username anthropic_api_key target default
+
+echo -n "your-gemini-key" | secret-tool store --label="nono: gemini_api_key" \
+    service nono username gemini_api_key target default
 ```
+
+**Important:** Use `username` (not `account`) as the attribute name. The `target default` attribute is required for the keyring crate to find the entry.
 
 ## Environment Variables
 
@@ -71,8 +89,12 @@ The built-in `network-policy.json` defines default credential routes:
 
 | Service | Upstream | Header | Format |
 |---------|----------|--------|--------|
-| openai | https://api.openai.com | Authorization | Bearer {} |
+| openai | https://api.openai.com/v1 | Authorization | Bearer {} |
 | anthropic | https://api.anthropic.com | x-api-key | {} |
+| gemini | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
+| google-ai | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
+
+**Note:** OpenAI's upstream includes `/v1` because the OpenAI SDK expects the base URL to include the version prefix. Anthropic's SDK adds `/v1/messages` automatically, so its upstream is the root URL.
 
 ### Custom Routes in Profiles
 

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -91,8 +91,10 @@ Network profiles are composable groups of allowed hosts, similar to filesystem p
 
 | Profile | Groups | Use Case |
 |---------|--------|----------|
-| `claude-code` | LLM APIs, package registries, GitHub, Sigstore, docs | Claude Code agent |
 | `minimal` | LLM APIs only | Minimal API access |
+| `developer` | LLM APIs, package registries, GitHub, Sigstore, docs | General development |
+| `claude-code` | LLM APIs, package registries, GitHub, Sigstore, docs | Claude Code agent |
+| `opencode` | Same as developer + bundled google-ai credential | OpenCode agent |
 | `enterprise` | All groups + cloud provider suffixes | Corporate environments |
 
 ### Groups
@@ -104,9 +106,9 @@ Network profiles are composable groups of allowed hosts, similar to filesystem p
 | `github` | github.com, api.github.com, raw.githubusercontent.com, ... |
 | `sigstore` | fulcio.sigstore.dev, rekor.sigstore.dev, tuf-repo-cdn.sigstore.dev |
 | `documentation` | docs.python.org, developer.mozilla.org, doc.rust-lang.org, ... |
-| `google_cloud` | *.googleapis.com, *.google.com |
-| `azure` | *.azure.com, *.microsoft.com |
-| `aws_bedrock` | *.amazonaws.com |
+| `google_cloud` | *.googleapis.com |
+| `azure` | *.openai.azure.com, *.cognitiveservices.azure.com |
+| `aws_bedrock` | *.bedrock.amazonaws.com, *.bedrock-runtime.amazonaws.com |
 
 ### Custom Profiles
 

--- a/docs/cli/features/secrets.mdx
+++ b/docs/cli/features/secrets.mdx
@@ -31,7 +31,7 @@ security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."
 
 **Linux:**
 ```bash
-secret-tool store --label="nono: openai_api_key" service nono username openai_api_key
+secret-tool store --label="nono: openai_api_key" service nono username openai_api_key target default
 ```
 
 ### 2. Use the Secret
@@ -135,19 +135,26 @@ sudo pacman -S libsecret gnome-keyring
 
 #### Using the Terminal
 
+The `keyring` crate requires `service`, `username`, and `target` attributes. You must use these exact attribute names:
+
 ```bash
 # Store (prompts for password)
-secret-tool store --label="nono: openai_api_key" service nono username openai_api_key
+secret-tool store --label="nono: openai_api_key" service nono username openai_api_key target default
+
+# Store non-interactively
+echo -n "sk-..." | secret-tool store --label="nono: openai_api_key" service nono username openai_api_key target default
 
 # Retrieve (for testing)
-secret-tool lookup service nono username openai_api_key
+secret-tool lookup service nono username openai_api_key target default
 
 # Delete
-secret-tool clear service nono username openai_api_key
+secret-tool clear service nono username openai_api_key target default
 
-# List all secrets (requires seahorse or similar)
+# List all nono secrets
 secret-tool search --all service nono
 ```
+
+**Important:** The `target default` attribute is required for the keyring crate to find the entry.
 
 #### Using GNOME Passwords (Seahorse)
 
@@ -242,7 +249,7 @@ The secret doesn't exist in the keystore. Store it first:
 security add-generic-password -s "nono" -a "openai_api_key" -w
 
 # Linux
-secret-tool store --label="nono: openai_api_key" service nono username openai_api_key
+secret-tool store --label="nono: openai_api_key" service nono username openai_api_key target default
 ```
 
 ### Keystore Locked
@@ -467,7 +474,7 @@ fi
 **3. Store secrets:**
 ```bash
 # After unlocking the keyring
-secret-tool store --label="nono: openai_api_key" service nono username openai_api_key
+secret-tool store --label="nono: openai_api_key" service nono username openai_api_key target default
 ```
 
 ### Option 4: systemd User Service


### PR DESCRIPTION
Linux keyring compatibility and proxy credential fixes

- Fix Linux secret-tool attributes: keyring crate v3 uses `username` (not `account`) and requires `target default` attribute
- Fix OpenAI upstream URL to include `/v1` (SDK expects version prefix)
- Add `codeload.github.com` to github group (GitHub redirects downloads)
- Add `developer` and `opencode` network profiles
- Add `google-ai` credential service for GOOGLE_GENERATIVE_AI_API_KEY
- Update credential-injection and secrets docs with correct keyring usage
- Fix credential route table to show all services with correct upstreams