### PR TITLE
feat: add multiple credential injection modes for custom credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "url",
+ "urlencoding",
  "webpki-roots",
  "zeroize",
 ]
@@ -2887,6 +2888,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -5,7 +5,7 @@
 
 use crate::profile::CustomCredentialDef;
 use nono::{NonoError, Result};
-use nono_proxy::config::{ProxyConfig, RouteConfig};
+use nono_proxy::config::{InjectMode, ProxyConfig, RouteConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::debug;
@@ -201,16 +201,25 @@ pub fn resolve_credentials(
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: Some(cred.credential_key.clone()),
+                inject_mode: cred.inject_mode.clone(),
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
+                path_pattern: cred.path_pattern.clone(),
+                path_replacement: cred.path_replacement.clone(),
+                query_param_name: cred.query_param_name.clone(),
             });
         } else if let Some(cred) = policy.credentials.get(name) {
+            // Built-in credentials always use header mode
             routes.push(RouteConfig {
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: Some(cred.credential_key.clone()),
+                inject_mode: InjectMode::Header,
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             });
         }
         // We already validated existence above, so this else branch won't be hit
@@ -359,8 +368,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: "telegram_bot_token".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -388,8 +401,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "https://my-proxy.example.com/openai".to_string(),
                 credential_key: "my_openai_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "X-Custom-Auth".to_string(),
                 credential_format: "Token {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -413,8 +430,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: "telegram_bot_token".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -448,8 +469,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "http://localhost:8080/api".to_string(),
                 credential_key: "local_api_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -519,8 +544,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "http://127.1.2.3:8080/api".to_string(),
                 credential_key: "local_api_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -541,8 +570,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "http://0.0.0.0:3000/api".to_string(),
                 credential_key: "local_api_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 
@@ -563,8 +596,12 @@ mod tests {
             CustomCredentialDef {
                 upstream: "https://api.example.com".to_string(),
                 credential_key: "api_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "X-Custom-Auth".to_string(),
                 credential_format: "Token {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             },
         );
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1082,9 +1082,8 @@ mod tests {
     // - upstream URL (HTTPS required, HTTP only for loopback)
     // ============================================================================
 
-    #[test]
-    fn test_validate_custom_credential_valid() {
-        let cred = CustomCredentialDef {
+    fn header_cred_builder() -> CustomCredentialDef {
+        CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
             inject_mode: InjectMode::Header,
@@ -1093,37 +1092,27 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
-        };
+        }
+    }
+
+    #[test]
+    fn test_validate_custom_credential_valid() {
+        let cred = header_cred_builder();
         assert!(validate_custom_credential("test", &cred).is_ok());
     }
 
     #[test]
     fn test_validate_custom_credential_http_loopback_allowed() {
-        let cred = CustomCredentialDef {
-            upstream: "http://127.0.0.1:8080/api".to_string(),
-            credential_key: "local_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.upstream = "http://127.0.0.1:8080/api".to_string();
+        cred.credential_key = "local_key".to_string();
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
     #[test]
     fn test_validate_custom_credential_http_remote_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "http://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.upstream = "http://api.example.com".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("HTTP to remote should be rejected");
         assert!(err.to_string().contains("HTTPS"));
@@ -1131,16 +1120,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_invalid_header_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "X-Header\r\nEvil: injected".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.inject_header = "X-Header\r\nEvil: injected".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CRLF in header should be rejected");
         assert!(err.to_string().contains("invalid characters"));
@@ -1148,16 +1129,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_invalid_format_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}\r\nEvil: header".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.credential_format = "Bearer {}\r\nEvil: header".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CRLF in format should be rejected");
         assert!(err.to_string().contains("CRLF"));
@@ -1165,16 +1138,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_invalid_key_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api-key".to_string(), // hyphens not allowed
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.credential_key = "api-key".to_string(); // hyphens not allowed
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("hyphen in key should be rejected");
         assert!(err.to_string().contains("alphanumeric"));
@@ -1182,16 +1147,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_empty_header_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.inject_header = "".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("empty header should be rejected");
         assert!(err.to_string().contains("cannot be empty"));
@@ -1199,16 +1156,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_header_with_space_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "X Header".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.inject_header = "X Header".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("space in header should be rejected");
         assert!(err.to_string().contains("invalid characters"));
@@ -1216,16 +1165,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_header_with_colon_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "X-Header:".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.inject_header = "X-Header:".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("colon in header should be rejected");
         assert!(err.to_string().contains("invalid characters"));
@@ -1233,32 +1174,15 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_valid_special_header_chars() {
-        // RFC 7230 tchar special chars should be allowed in header names
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "X-Header!".to_string(), // ! is valid tchar
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.inject_header = "X-Header!".to_string(); // ! is valid tchar
         assert!(validate_custom_credential("test", &cred).is_ok());
     }
 
     #[test]
     fn test_validate_custom_credential_format_with_cr_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}\rEvil: header".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.credential_format = "Bearer {}\rEvil: header".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CR in format should be rejected");
         assert!(err.to_string().contains("CRLF"));
@@ -1266,16 +1190,8 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_format_with_lf_rejected() {
-        let cred = CustomCredentialDef {
-            upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}\nEvil: header".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.credential_format = "Bearer {}\nEvil: header".to_string();
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("LF in format should be rejected");
         assert!(err.to_string().contains("CRLF"));
@@ -1284,16 +1200,8 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_various_valid_formats() {
         for format in ["Bearer {}", "Token {}", "{}", "Basic {}", "ApiKey={}"] {
-            let cred = CustomCredentialDef {
-                upstream: "https://api.example.com".to_string(),
-                credential_key: "api_key".to_string(),
-                inject_mode: InjectMode::Header,
-                inject_header: "Authorization".to_string(),
-                credential_format: format.to_string(),
-                path_pattern: None,
-                path_replacement: None,
-                query_param_name: None,
-            };
+            let mut cred = header_cred_builder();
+            cred.credential_format = format.to_string();
             assert!(
                 validate_custom_credential("test", &cred).is_ok(),
                 "Expected format '{}' to be valid",
@@ -1304,46 +1212,25 @@ mod tests {
 
     #[test]
     fn test_validate_custom_credential_http_localhost_allowed() {
-        let cred = CustomCredentialDef {
-            upstream: "http://localhost:3000/api".to_string(),
-            credential_key: "local_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.upstream = "http://localhost:3000/api".to_string();
+        cred.credential_key = "local_key".to_string();
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
     #[test]
     fn test_validate_custom_credential_http_ipv6_loopback_allowed() {
-        let cred = CustomCredentialDef {
-            upstream: "http://[::1]:8080/api".to_string(),
-            credential_key: "local_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.upstream = "http://[::1]:8080/api".to_string();
+        cred.credential_key = "local_key".to_string();
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
     #[test]
     fn test_validate_custom_credential_http_0_0_0_0_allowed() {
-        let cred = CustomCredentialDef {
-            upstream: "http://0.0.0.0:3000/api".to_string(),
-            credential_key: "local_key".to_string(),
-            inject_mode: InjectMode::Header,
-            inject_header: "Authorization".to_string(),
-            credential_format: "Bearer {}".to_string(),
-            path_pattern: None,
-            path_replacement: None,
-            query_param_name: None,
-        };
+        let mut cred = header_cred_builder();
+        cred.upstream = "http://0.0.0.0:3000/api".to_string();
+        cred.credential_key = "local_key".to_string();
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+// Re-export InjectMode from nono-proxy for use in profiles
+pub use nono_proxy::config::InjectMode;
+
 /// Profile metadata
 #[derive(Debug, Clone, Default, Deserialize)]
 #[allow(dead_code)]
@@ -53,19 +56,50 @@ pub struct FilesystemConfig {
 /// Allows users to define their own credential services in profiles,
 /// enabling `--proxy-credential` to work with any API without requiring
 /// changes to the built-in `network-policy.json`.
+///
+/// Supports multiple injection modes:
+/// - `header`: Inject into HTTP header with format string (default)
+/// - `url_path`: Replace pattern in URL path (e.g., Telegram Bot API `/bot{}/`)
+/// - `query_param`: Add/replace query parameter (e.g., `?api_key=...`)
+/// - `basic_auth`: HTTP Basic Authentication (credential as `username:password`)
 #[derive(Debug, Clone, Deserialize)]
 pub struct CustomCredentialDef {
     /// Upstream URL to proxy requests to (e.g., "https://api.telegram.org")
     pub upstream: String,
     /// Keystore account name for the credential (e.g., "telegram_bot_token")
     pub credential_key: String,
+    /// Injection mode (default: "header")
+    #[serde(default)]
+    pub inject_mode: InjectMode,
+
+    // --- Header mode fields ---
     /// HTTP header to inject the credential into (default: "Authorization")
+    /// Only used when inject_mode is "header".
     #[serde(default = "default_inject_header")]
     pub inject_header: String,
     /// Format string for the credential value (default: "Bearer {}")
     /// Use {} as placeholder for the credential value.
+    /// Only used when inject_mode is "header".
     #[serde(default = "default_credential_format")]
     pub credential_format: String,
+
+    // --- URL path mode fields ---
+    /// Pattern to match in incoming URL path. Use {} as placeholder for phantom token.
+    /// Example: "/bot{}/" matches "/bot<token>/getMe"
+    /// Only used when inject_mode is "url_path".
+    #[serde(default)]
+    pub path_pattern: Option<String>,
+    /// Pattern for outgoing URL path. Use {} as placeholder for real credential.
+    /// Defaults to same as path_pattern if not specified.
+    /// Only used when inject_mode is "url_path".
+    #[serde(default)]
+    pub path_replacement: Option<String>,
+
+    // --- Query param mode fields ---
+    /// Name of the query parameter to add/replace with the credential.
+    /// Only used when inject_mode is "query_param".
+    #[serde(default)]
+    pub query_param_name: Option<String>,
 }
 
 fn default_inject_header() -> String {
@@ -101,11 +135,58 @@ fn is_http_token_char(c: char) -> bool {
 /// Validate a custom credential definition for security issues.
 ///
 /// Checks:
-/// - `inject_header` must be a valid HTTP token (RFC 7230)
-/// - `credential_format` must not contain CRLF sequences
 /// - `credential_key` must be alphanumeric + underscores only
 /// - `upstream` must be HTTPS (or HTTP for loopback only)
+/// - Mode-specific validation:
+///   - `header`: inject_header must be valid HTTP token, credential_format no CRLF
+///   - `url_path`: path_pattern required, no CRLF in patterns
+///   - `query_param`: query_param_name required, valid query param name
+///   - `basic_auth`: no additional required fields
 fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<()> {
+    // Validate credential_key (alphanumeric + underscore) - required for all modes
+    if cred.credential_key.is_empty() {
+        return Err(NonoError::ProfileParse(format!(
+            "credential_key for custom credential '{}' cannot be empty",
+            name
+        )));
+    }
+    if !cred
+        .credential_key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "credential_key '{}' for custom credential '{}' must contain only \
+             alphanumeric characters and underscores",
+            cred.credential_key, name
+        )));
+    }
+
+    // Validate upstream URL (HTTPS required, HTTP only for loopback)
+    validate_upstream_url(&cred.upstream, name)?;
+
+    // Mode-specific validation
+    match cred.inject_mode {
+        InjectMode::Header => {
+            validate_header_mode(name, cred)?;
+        }
+        InjectMode::UrlPath => {
+            validate_url_path_mode(name, cred)?;
+        }
+        InjectMode::QueryParam => {
+            validate_query_param_mode(name, cred)?;
+        }
+        InjectMode::BasicAuth => {
+            // No additional required fields for basic_auth mode
+            // Credential value is expected to be "username:password" format
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate header injection mode fields.
+fn validate_header_mode(name: &str, cred: &CustomCredentialDef) -> Result<()> {
     // Validate inject_header (RFC 7230 token)
     if cred.inject_header.is_empty() {
         return Err(NonoError::ProfileParse(format!(
@@ -130,27 +211,81 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
         )));
     }
 
-    // Validate credential_key (alphanumeric + underscore)
-    if cred.credential_key.is_empty() {
-        return Err(NonoError::ProfileParse(format!(
-            "credential_key for custom credential '{}' cannot be empty",
+    Ok(())
+}
+
+/// Validate URL path injection mode fields.
+fn validate_url_path_mode(name: &str, cred: &CustomCredentialDef) -> Result<()> {
+    // path_pattern is required for url_path mode
+    let pattern = cred.path_pattern.as_ref().ok_or_else(|| {
+        NonoError::ProfileParse(format!(
+            "path_pattern is required for custom credential '{}' with inject_mode 'url_path'",
             name
-        )));
-    }
-    if !cred
-        .credential_key
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+        ))
+    })?;
+
+    // Pattern must contain {} placeholder
+    if !pattern.contains("{}") {
         return Err(NonoError::ProfileParse(format!(
-            "credential_key '{}' for custom credential '{}' must contain only \
-             alphanumeric characters and underscores",
-            cred.credential_key, name
+            "path_pattern '{}' for custom credential '{}' must contain {{}} placeholder for the token",
+            pattern, name
         )));
     }
 
-    // Validate upstream URL (HTTPS required, HTTP only for loopback)
-    validate_upstream_url(&cred.upstream, name)?;
+    // No CRLF in pattern
+    if pattern.contains('\r') || pattern.contains('\n') {
+        return Err(NonoError::ProfileParse(format!(
+            "path_pattern for custom credential '{}' contains invalid CRLF characters",
+            name
+        )));
+    }
+
+    // Validate path_replacement if specified
+    if let Some(replacement) = &cred.path_replacement {
+        if !replacement.contains("{}") {
+            return Err(NonoError::ProfileParse(format!(
+                "path_replacement '{}' for custom credential '{}' must contain {{}} placeholder",
+                replacement, name
+            )));
+        }
+        if replacement.contains('\r') || replacement.contains('\n') {
+            return Err(NonoError::ProfileParse(format!(
+                "path_replacement for custom credential '{}' contains invalid CRLF characters",
+                name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate query parameter injection mode fields.
+fn validate_query_param_mode(name: &str, cred: &CustomCredentialDef) -> Result<()> {
+    // query_param_name is required for query_param mode
+    let param_name = cred.query_param_name.as_ref().ok_or_else(|| {
+        NonoError::ProfileParse(format!(
+            "query_param_name is required for custom credential '{}' with inject_mode 'query_param'",
+            name
+        ))
+    })?;
+
+    // Validate query param name (alphanumeric + underscore + hyphen)
+    if param_name.is_empty() {
+        return Err(NonoError::ProfileParse(format!(
+            "query_param_name for custom credential '{}' cannot be empty",
+            name
+        )));
+    }
+    if !param_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "query_param_name '{}' for custom credential '{}' must contain only \
+             alphanumeric characters, underscores, and hyphens",
+            param_name, name
+        )));
+    }
 
     Ok(())
 }
@@ -952,8 +1087,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("test", &cred).is_ok());
     }
@@ -963,8 +1102,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "http://127.0.0.1:8080/api".to_string(),
             credential_key: "local_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
@@ -974,8 +1117,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "http://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("HTTP to remote should be rejected");
@@ -987,8 +1134,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "X-Header\r\nEvil: injected".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CRLF in header should be rejected");
@@ -1000,8 +1151,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}\r\nEvil: header".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CRLF in format should be rejected");
@@ -1013,8 +1168,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api-key".to_string(), // hyphens not allowed
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("hyphen in key should be rejected");
@@ -1026,8 +1185,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("empty header should be rejected");
@@ -1039,8 +1202,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "X Header".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("space in header should be rejected");
@@ -1052,8 +1219,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "X-Header:".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("colon in header should be rejected");
@@ -1066,8 +1237,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "X-Header!".to_string(), // ! is valid tchar
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("test", &cred).is_ok());
     }
@@ -1077,8 +1252,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}\rEvil: header".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("CR in format should be rejected");
@@ -1090,8 +1269,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
             credential_key: "api_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}\nEvil: header".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("LF in format should be rejected");
@@ -1104,8 +1287,12 @@ mod tests {
             let cred = CustomCredentialDef {
                 upstream: "https://api.example.com".to_string(),
                 credential_key: "api_key".to_string(),
+                inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: format.to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             };
             assert!(
                 validate_custom_credential("test", &cred).is_ok(),
@@ -1120,8 +1307,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "http://localhost:3000/api".to_string(),
             credential_key: "local_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
@@ -1131,8 +1322,12 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "http://[::1]:8080/api".to_string(),
             credential_key: "local_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
@@ -1142,9 +1337,164 @@ mod tests {
         let cred = CustomCredentialDef {
             upstream: "http://0.0.0.0:3000/api".to_string(),
             credential_key: "local_key".to_string(),
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         };
         assert!(validate_custom_credential("local", &cred).is_ok());
+    }
+
+    // ============================================================================
+    // Injection Mode Validation Tests
+    // ============================================================================
+
+    #[test]
+    fn test_validate_url_path_mode_valid() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.telegram.org".to_string(),
+            credential_key: "telegram_token".to_string(),
+            inject_mode: InjectMode::UrlPath,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: Some("/bot{}/".to_string()),
+            path_replacement: None,
+            query_param_name: None,
+        };
+        assert!(validate_custom_credential("telegram", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_path_mode_missing_pattern() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.telegram.org".to_string(),
+            credential_key: "telegram_token".to_string(),
+            inject_mode: InjectMode::UrlPath,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None, // Missing required field
+            path_replacement: None,
+            query_param_name: None,
+        };
+        let result = validate_custom_credential("telegram", &cred);
+        let err = result.expect_err("missing path_pattern should be rejected");
+        assert!(err.to_string().contains("path_pattern is required"));
+    }
+
+    #[test]
+    fn test_validate_url_path_mode_pattern_without_placeholder() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.telegram.org".to_string(),
+            credential_key: "telegram_token".to_string(),
+            inject_mode: InjectMode::UrlPath,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: Some("/bot/token/".to_string()), // No {} placeholder
+            path_replacement: None,
+            query_param_name: None,
+        };
+        let result = validate_custom_credential("telegram", &cred);
+        let err = result.expect_err("pattern without {} should be rejected");
+        assert!(err.to_string().contains("{}"));
+    }
+
+    #[test]
+    fn test_validate_url_path_mode_with_replacement() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.telegram.org".to_string(),
+            credential_key: "telegram_token".to_string(),
+            inject_mode: InjectMode::UrlPath,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: Some("/bot{}/".to_string()),
+            path_replacement: Some("/v2/bot{}/".to_string()),
+            query_param_name: None,
+        };
+        assert!(validate_custom_credential("telegram", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_path_mode_replacement_without_placeholder() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.telegram.org".to_string(),
+            credential_key: "telegram_token".to_string(),
+            inject_mode: InjectMode::UrlPath,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: Some("/bot{}/".to_string()),
+            path_replacement: Some("/v2/bot/fixed/".to_string()), // No {} placeholder
+            query_param_name: None,
+        };
+        let result = validate_custom_credential("telegram", &cred);
+        let err = result.expect_err("replacement without {} should be rejected");
+        assert!(err.to_string().contains("{}"));
+    }
+
+    #[test]
+    fn test_validate_query_param_mode_valid() {
+        let cred = CustomCredentialDef {
+            upstream: "https://maps.googleapis.com".to_string(),
+            credential_key: "google_maps_key".to_string(),
+            inject_mode: InjectMode::QueryParam,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: Some("key".to_string()),
+        };
+        assert!(validate_custom_credential("google_maps", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_query_param_mode_missing_param_name() {
+        let cred = CustomCredentialDef {
+            upstream: "https://maps.googleapis.com".to_string(),
+            credential_key: "google_maps_key".to_string(),
+            inject_mode: InjectMode::QueryParam,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None, // Missing required field
+        };
+        let result = validate_custom_credential("google_maps", &cred);
+        let err = result.expect_err("missing query_param_name should be rejected");
+        assert!(err.to_string().contains("query_param_name is required"));
+    }
+
+    #[test]
+    fn test_validate_query_param_mode_empty_param_name() {
+        let cred = CustomCredentialDef {
+            upstream: "https://maps.googleapis.com".to_string(),
+            credential_key: "google_maps_key".to_string(),
+            inject_mode: InjectMode::QueryParam,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: Some("".to_string()), // Empty
+        };
+        let result = validate_custom_credential("google_maps", &cred);
+        let err = result.expect_err("empty query_param_name should be rejected");
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_basic_auth_mode_valid() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: "example_basic_auth".to_string(),
+            inject_mode: InjectMode::BasicAuth,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+        };
+        // BasicAuth mode doesn't require additional fields
+        // Credential value is expected to be "username:password" format
+        assert!(validate_custom_credential("example", &cred).is_ok());
     }
 }

--- a/crates/nono-proxy/Cargo.toml
+++ b/crates/nono-proxy/Cargo.toml
@@ -29,6 +29,7 @@ keyring = "3"
 base64 = "0.22"
 subtle = "2"
 url = "2"
+urlencoding = "2"
 
 # TLS for upstream connections (reverse proxy mode)
 hyper-rustls = { version = "0.27", features = ["http1", "ring", "webpki-tokio"] }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -1,12 +1,13 @@
 //! Credential loading and management for reverse proxy mode.
 //!
 //! Loads API credentials from the system keystore at proxy startup.
-//! Credentials are stored in `Zeroizing<String>` and injected as HTTP
-//! headers on reverse proxy requests. The sandboxed agent never sees
-//! the real credentials.
+//! Credentials are stored in `Zeroizing<String>` and injected into
+//! requests via headers, URL paths, query parameters, or Basic Auth.
+//! The sandboxed agent never sees the real credentials.
 
-use crate::config::RouteConfig;
+use crate::config::{InjectMode, RouteConfig};
 use crate::error::{ProxyError, Result};
+use base64::Engine;
 use std::collections::HashMap;
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
@@ -14,12 +15,28 @@ use zeroize::Zeroizing;
 /// A loaded credential ready for injection.
 #[derive(Debug)]
 pub struct LoadedCredential {
+    /// Injection mode
+    pub inject_mode: InjectMode,
+    /// Upstream URL (e.g., "https://api.openai.com")
+    pub upstream: String,
+    /// Raw credential value from keystore (for modes that need it directly)
+    pub raw_credential: Zeroizing<String>,
+
+    // --- Header mode ---
     /// Header name to inject (e.g., "Authorization")
     pub header_name: String,
     /// Formatted header value (e.g., "Bearer sk-...")
     pub header_value: Zeroizing<String>,
-    /// Upstream URL (e.g., "https://api.openai.com")
-    pub upstream: String,
+
+    // --- URL path mode ---
+    /// Pattern to match in incoming path (with {} placeholder)
+    pub path_pattern: Option<String>,
+    /// Pattern for outgoing path (with {} placeholder)
+    pub path_replacement: Option<String>,
+
+    // --- Query param mode ---
+    /// Query parameter name
+    pub query_param_name: Option<String>,
 }
 
 /// Credential store for all configured routes.
@@ -39,17 +56,39 @@ impl CredentialStore {
 
         for route in routes {
             if let Some(ref key) = route.credential_key {
-                debug!("Loading credential for route prefix: {}", route.prefix);
+                debug!(
+                    "Loading credential for route prefix: {} (mode: {:?})",
+                    route.prefix, route.inject_mode
+                );
 
                 let secret = load_from_keyring(key)?;
-                let formatted = route.credential_format.replace("{}", &secret);
+
+                // Format header value based on mode
+                let header_value = match route.inject_mode {
+                    InjectMode::Header => {
+                        Zeroizing::new(route.credential_format.replace("{}", &secret))
+                    }
+                    InjectMode::BasicAuth => {
+                        // Base64 encode the credential for Basic auth
+                        let encoded =
+                            base64::engine::general_purpose::STANDARD.encode(secret.as_bytes());
+                        Zeroizing::new(format!("Basic {}", encoded))
+                    }
+                    // For url_path and query_param, header_value is not used
+                    InjectMode::UrlPath | InjectMode::QueryParam => Zeroizing::new(String::new()),
+                };
 
                 credentials.insert(
                     route.prefix.clone(),
                     LoadedCredential {
-                        header_name: route.inject_header.clone(),
-                        header_value: Zeroizing::new(formatted),
+                        inject_mode: route.inject_mode.clone(),
                         upstream: route.upstream.clone(),
+                        raw_credential: secret,
+                        header_name: route.inject_header.clone(),
+                        header_value,
+                        path_pattern: route.path_pattern.clone(),
+                        path_replacement: route.path_replacement.clone(),
+                        query_param_name: route.query_param_name.clone(),
                     },
                 );
             }
@@ -131,8 +170,12 @@ mod tests {
             prefix: "/test".to_string(),
             upstream: "https://example.com".to_string(),
             credential_key: None,
+            inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
         }];
         let store = CredentialStore::load(&routes);
         assert!(store.is_ok());

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -368,8 +368,12 @@ mod tests {
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
+                inject_mode: crate::config::InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
             }],
             ..Default::default()
         };

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -139,10 +139,125 @@ For APIs not covered by the built-in services, you can define custom credentials
 |-------|----------|---------|-------------|
 | `upstream` | Yes | - | Upstream URL to proxy requests to (must be HTTPS, or HTTP for localhost only) |
 | `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only) |
-| `inject_header` | No | `Authorization` | HTTP header to inject the credential into |
+| `inject_mode` | No | `header` | Credential injection mode: `header`, `url_path`, `query_param`, or `basic_auth` |
+| `inject_header` | No | `Authorization` | HTTP header to inject the credential into (used with `header` and `basic_auth` modes) |
 | `credential_format` | No | `Bearer {}` | Format string for the credential value (`{}` is replaced with the credential) |
+| `path_pattern` | Conditional | - | Required for `url_path` mode. URL path pattern with `{}` placeholder (e.g., `/bot{}/`) |
+| `path_replacement` | No | - | Optional replacement pattern for `url_path` mode (e.g., `/v2/bot{}/`) |
+| `query_param_name` | Conditional | - | Required for `query_param` mode. Query parameter name for credential injection (e.g., `key` or `api_key`) |
 
 **Important:** Use underscores, not hyphens, in credential names (the keys in `custom_credentials`). The credential name is used to generate environment variables like `TELEGRAM_BASE_URL`. Shell variable names cannot contain hyphens, so `my-api` would create `MY-API_BASE_URL` which cannot be referenced as `$MY-API_BASE_URL` in shell scripts. Use `my_api` instead.
+
+#### Injection Modes
+
+Custom credentials support multiple injection patterns to accommodate different API authentication schemes:
+
+##### Header Mode (default)
+
+Injects the credential as an HTTP header with optional formatting. This is the most common authentication pattern.
+
+```json
+{
+  "custom_credentials": {
+    "telegram": {
+      "upstream": "https://api.telegram.org",
+      "credential_key": "telegram_bot_token",
+      "inject_mode": "header",
+      "inject_header": "Authorization",
+      "credential_format": "Bearer {}"
+    }
+  }
+}
+```
+
+##### URL Path Mode
+
+Replaces a phantom token in the URL path with the real credential. Useful for APIs like Telegram Bot API that embed authentication tokens in the path (e.g., `/bot{token}/method`).
+
+```json
+{
+  "custom_credentials": {
+    "telegram": {
+      "upstream": "https://api.telegram.org",
+      "credential_key": "telegram_bot_token",
+      "inject_mode": "url_path",
+      "path_pattern": "/bot{}/",
+      "path_replacement": "/bot{}/"
+    }
+  }
+}
+```
+
+The agent sends requests with a phantom token:
+```
+POST http://127.0.0.1:PORT/telegram/bot<NONO_PROXY_TOKEN>/sendMessage
+```
+
+The proxy validates the phantom token matches the session token, then replaces it with the real credential:
+```
+POST https://api.telegram.org/bot<REAL_TOKEN>/sendMessage
+```
+
+##### Query Parameter Mode
+
+Adds or replaces a query parameter with the credential value. Common for APIs that use URL query parameters for authentication (e.g., Google Maps API).
+
+```json
+{
+  "custom_credentials": {
+    "google_maps": {
+      "upstream": "https://maps.googleapis.com",
+      "credential_key": "google_maps_api_key",
+      "inject_mode": "query_param",
+      "query_param_name": "key"
+    }
+  }
+}
+```
+
+The agent sends requests with a phantom token in the query parameter:
+```
+GET http://127.0.0.1:PORT/google_maps/maps/api/geocode/json?key=<NONO_PROXY_TOKEN>&address=...
+```
+
+The proxy validates the phantom token, then replaces it with the real credential:
+```
+GET https://maps.googleapis.com/maps/api/geocode/json?key=<REAL_API_KEY>&address=...
+```
+
+The credential value is URL-encoded automatically.
+
+##### Basic Auth Mode
+
+Injects a Base64-encoded Basic Authentication header. The credential value should be stored in `username:password` format in the keystore.
+
+```json
+{
+  "custom_credentials": {
+    "private_api": {
+      "upstream": "https://api.example.com",
+      "credential_key": "example_basic_auth",
+      "inject_mode": "basic_auth"
+    }
+  }
+}
+```
+
+Store the credential in `username:password` format:
+```bash
+# macOS
+security add-generic-password -s "nono" -a "example_basic_auth" -w "myuser:mypassword"
+
+# Linux
+echo -n "myuser:mypassword" | secret-tool store --label="nono: example_basic_auth" \
+    service nono username example_basic_auth target default
+```
+
+The proxy automatically Base64-encodes the credential and injects it as `Authorization: Basic <encoded>`.
+
+#### Phantom Token Validation
+
+For `url_path` and `query_param` modes, the agent must include the session token (`NONO_PROXY_TOKEN`) as a placeholder in the request. The proxy validates this phantom token before replacing it with the real credential. Invalid or missing phantom tokens result in HTTP 401 Unauthorized responses.
 
 Store the credential in the system keystore:
 

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -142,6 +142,8 @@ For APIs not covered by the built-in services, you can define custom credentials
 | `inject_header` | No | `Authorization` | HTTP header to inject the credential into |
 | `credential_format` | No | `Bearer {}` | Format string for the credential value (`{}` is replaced with the credential) |
 
+**Important:** Use underscores, not hyphens, in credential names (the keys in `custom_credentials`). The credential name is used to generate environment variables like `TELEGRAM_BASE_URL`. Shell variable names cannot contain hyphens, so `my-api` would create `MY-API_BASE_URL` which cannot be referenced as `$MY-API_BASE_URL` in shell scripts. Use `my_api` instead.
+
 Store the credential in the system keystore:
 
 ```bash


### PR DESCRIPTION
Extend custom_credentials to support four authentication patterns:

- header (default): Inject credential into HTTP header with optional formatting
- url_path: Replace phantom token in URL path (e.g., Telegram Bot API /bot{token}/)
- query_param: Add/replace query parameter with credential value
- basic_auth: Inject Base64-encoded Basic Authentication header

The proxy validates phantom tokens based on injection mode before replacing them with real credentials from the keystore. Invalid or missing tokens now return HTTP 401 Unauthorized instead of closing the connection.

Includes profile validation to ensure required fields are present per mode (path_pattern for url_path, query_param_name for query_param).