### PR TITLE
Allow the sandboxed process to bind and listen on a TCP port

### DIFF
--- a/bindings/c/src/capability_set.rs
+++ b/bindings/c/src/capability_set.rs
@@ -230,7 +230,10 @@ pub unsafe extern "C" fn nono_capability_set_set_proxy_port(
     }
     let caps = unsafe { &mut *caps };
     caps.inner
-        .set_network_mode_mut(nono::NetworkMode::ProxyOnly { port });
+        .set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+            port,
+            bind_ports: vec![],
+        });
     NonoErrorCode::Ok
 }
 
@@ -248,7 +251,7 @@ pub unsafe extern "C" fn nono_capability_set_proxy_port(caps: *const NonoCapabil
     }
     let caps = unsafe { &*caps };
     match caps.inner.network_mode() {
-        nono::NetworkMode::ProxyOnly { port } => *port,
+        nono::NetworkMode::ProxyOnly { port, .. } => *port,
         _ => 0,
     }
 }

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -127,7 +127,10 @@ pub fn validate_network_mode(raw: u32) -> Option<nono::NetworkMode> {
     match raw {
         NONO_NETWORK_MODE_BLOCKED => Some(nono::NetworkMode::Blocked),
         NONO_NETWORK_MODE_ALLOW_ALL => Some(nono::NetworkMode::AllowAll),
-        NONO_NETWORK_MODE_PROXY_ONLY => Some(nono::NetworkMode::ProxyOnly { port: 0 }),
+        NONO_NETWORK_MODE_PROXY_ONLY => Some(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        }),
         _ => None,
     }
 }

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -146,8 +146,12 @@ impl CapabilitySetExt for CapabilitySet {
         if args.net_block {
             caps.set_network_blocked(true);
         } else if args.network_profile.is_some() || !args.proxy_allow.is_empty() {
-            // Proxy mode: port 0 is a placeholder, updated when proxy starts
-            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly { port: 0 });
+            // Proxy mode: port 0 is a placeholder, updated when proxy starts.
+            // bind_ports are passed through allow_bind CLI flag.
+            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
+                port: 0,
+                bind_ports: args.allow_bind.clone(),
+            });
         }
 
         // Command allow/block lists
@@ -272,8 +276,12 @@ impl CapabilitySetExt for CapabilitySet {
         } else if profile.network.network_profile.is_some()
             || !profile.network.proxy_allow.is_empty()
         {
-            // Profile requests proxy mode; port 0 is a placeholder
-            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly { port: 0 });
+            // Profile requests proxy mode; port 0 is a placeholder.
+            // bind_ports come from CLI args (--allow-bind).
+            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
+                port: 0,
+                bind_ports: args.allow_bind.clone(),
+            });
         }
 
         // Apply CLI overrides (CLI args take precedence)
@@ -356,8 +364,12 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
     if args.net_block {
         caps.set_network_blocked(true);
     } else if args.network_profile.is_some() || !args.proxy_allow.is_empty() {
-        // CLI proxy flags override profile network settings
-        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly { port: 0 });
+        // CLI proxy flags override profile network settings.
+        // bind_ports come from --allow-bind CLI flag.
+        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: args.allow_bind.clone(),
+        });
     }
 
     // Command allow/block from CLI
@@ -402,6 +414,7 @@ mod tests {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -432,6 +445,7 @@ mod tests {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -461,6 +475,7 @@ mod tests {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -494,6 +509,7 @@ mod tests {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let err = CapabilitySet::from_args(&args).expect_err("must reject protected state path");
@@ -531,6 +547,7 @@ mod tests {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (mut caps, needs_unlink_overrides) =

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -246,6 +246,15 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "SERVICE")]
     pub proxy_credential: Vec<String>,
 
+    /// Allow the sandboxed process to bind (listen) on a specific TCP port.
+    /// Use this for server apps that need to accept connections while still
+    /// routing outbound HTTP through the credential proxy.
+    /// Can be specified multiple times for multiple ports.
+    /// Note: On macOS, Seatbelt cannot filter by port, so this enables blanket
+    /// bind/inbound access. On Linux, per-port filtering is enforced.
+    #[arg(long, value_name = "PORT")]
+    pub allow_bind: Vec<u16>,
+
     /// Chain through an external (enterprise) proxy.
     /// Format: host:port (e.g., squid.corp.internal:3128)
     #[arg(long, value_name = "HOST:PORT")]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -431,7 +431,7 @@ fn run_sandbox(
             proxy_credentials,
             custom_credentials: prepared.custom_credentials,
             external_proxy: args.external_proxy.clone(),
-            allow_bind_ports: args.allow_bind.clone(),
+            allow_bind_ports: args.allow_bind,
         },
     )
 }
@@ -713,10 +713,7 @@ fn execute_sandboxed(
         // Include allow_bind_ports so the sandboxed process can listen on those ports
         // while still routing outbound HTTP through the credential injection proxy.
         let port = handle.port;
-        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
-            port,
-            bind_ports: flags.allow_bind_ports.clone(),
-        });
+        // Log before moving allow_bind_ports
         if flags.allow_bind_ports.is_empty() {
             info!("Network proxy started on localhost:{}", port);
         } else {
@@ -725,6 +722,10 @@ fn execute_sandboxed(
                 port, flags.allow_bind_ports
             );
         }
+        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+            port,
+            bind_ports: flags.allow_bind_ports,
+        });
 
         // Collect proxy env vars for the child process
         for (k, v) in handle.env_vars() {

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -196,6 +196,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (mut caps, needs_unlink) = CapabilitySet::from_profile(&prof, &workdir, &sandbox_args)?;
@@ -226,6 +227,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             config: None,
             verbose: 0,
             dry_run: false,
+            allow_bind: vec![],
         };
 
         let (mut caps, needs_unlink) = CapabilitySet::from_args(&sandbox_args)?;
@@ -429,6 +431,7 @@ fn run_sandbox(
             proxy_credentials,
             custom_credentials: prepared.custom_credentials,
             external_proxy: args.external_proxy.clone(),
+            allow_bind_ports: args.allow_bind.clone(),
         },
     )
 }
@@ -494,6 +497,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             proxy_credentials: Vec::new(),
             custom_credentials: std::collections::HashMap::new(),
             external_proxy: None,
+            allow_bind_ports: Vec::new(),
         },
     )
 }
@@ -530,6 +534,8 @@ struct ExecutionFlags {
     custom_credentials: std::collections::HashMap<String, profile::CustomCredentialDef>,
     /// External proxy address (from --external-proxy)
     external_proxy: Option<String>,
+    /// Ports the sandboxed process is allowed to bind (from --allow-bind)
+    allow_bind_ports: Vec<u16>,
 }
 
 /// Select execution strategy from user/runtime flags.
@@ -703,10 +709,22 @@ fn execute_sandboxed(
             .block_on(async { nono_proxy::server::start(proxy_config.clone()).await })
             .map_err(|e| NonoError::SandboxInit(format!("Failed to start proxy: {}", e)))?;
 
-        // Update the sandbox capability port to the actual bound port
+        // Update the sandbox capability port to the actual bound port.
+        // Include allow_bind_ports so the sandboxed process can listen on those ports
+        // while still routing outbound HTTP through the credential injection proxy.
         let port = handle.port;
-        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly { port });
-        info!("Network proxy started on localhost:{}", port);
+        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+            port,
+            bind_ports: flags.allow_bind_ports.clone(),
+        });
+        if flags.allow_bind_ports.is_empty() {
+            info!("Network proxy started on localhost:{}", port);
+        } else {
+            info!(
+                "Network proxy started on localhost:{}, bind ports: {:?}",
+                port, flags.allow_bind_ports
+            );
+        }
 
         // Collect proxy env vars for the child process
         for (k, v) in handle.env_vars() {

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -120,8 +120,18 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         NetworkMode::Blocked => {
             eprintln!("    outbound: {}", "blocked".red());
         }
-        NetworkMode::ProxyOnly { port } => {
-            eprintln!("    outbound: {} (localhost:{})", "proxy".yellow(), port);
+        NetworkMode::ProxyOnly { port, bind_ports } => {
+            if bind_ports.is_empty() {
+                eprintln!("    outbound: {} (localhost:{})", "proxy".yellow(), port);
+            } else {
+                let ports_str: Vec<String> = bind_ports.iter().map(|p| p.to_string()).collect();
+                eprintln!(
+                    "    outbound: {} (localhost:{}), bind: {}",
+                    "proxy".yellow(),
+                    port,
+                    ports_str.join(", ")
+                );
+            }
         }
         NetworkMode::AllowAll => {
             eprintln!("    outbound: {}", "allowed".green());

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -365,8 +365,17 @@ impl<'a> DiagnosticFormatter<'a> {
             NetworkMode::Blocked => {
                 lines.push("[nono]   Network: blocked".to_string());
             }
-            NetworkMode::ProxyOnly { port } => {
-                lines.push(format!("[nono]   Network: proxy (localhost:{})", port));
+            NetworkMode::ProxyOnly { port, bind_ports } => {
+                if bind_ports.is_empty() {
+                    lines.push(format!("[nono]   Network: proxy (localhost:{})", port));
+                } else {
+                    let ports_str: Vec<String> = bind_ports.iter().map(|p| p.to_string()).collect();
+                    lines.push(format!(
+                        "[nono]   Network: proxy (localhost:{}), bind: {}",
+                        port,
+                        ports_str.join(", ")
+                    ));
+                }
             }
             NetworkMode::AllowAll => {
                 lines.push("[nono]   Network: allowed".to_string());
@@ -555,7 +564,10 @@ mod tests {
     fn test_standard_footer_shows_network_proxy() {
         use crate::NetworkMode;
         let mut caps = CapabilitySet::new().block_network();
-        caps.set_network_mode_mut(NetworkMode::ProxyOnly { port: 12345 });
+        caps.set_network_mode_mut(NetworkMode::ProxyOnly {
+            port: 12345,
+            bind_ports: vec![],
+        });
         caps.add_fs(FsCapability {
             original: PathBuf::from("/test/project"),
             resolved: PathBuf::from("/test/project"),

--- a/docs/cli/clients/openclaw.mdx
+++ b/docs/cli/clients/openclaw.mdx
@@ -141,7 +141,50 @@ OpenClaw requires network access to communicate with:
 - AI provider APIs (OpenAI, Anthropic, etc.)
 - Optional web search APIs (Brave Search)
 
-The profile allows full network access. Future nono versions will support per-host filtering to restrict connections to only required endpoints.
+The profile allows full network access. For stricter isolation, use nono's proxy mode with credential injection (see below).
+
+### Credential Injection (Recommended)
+
+Instead of passing API keys directly to OpenClaw, use nono's credential injection to keep secrets out of the agent's memory entirely:
+
+```bash
+nono run --profile openclaw-demo --allow-cwd \
+  --proxy-credential openai --proxy-credential anthropic --proxy-credential gemini \
+  --allow-bind 18789 -- openclaw gateway
+```
+
+**How it works:**
+1. Real API keys are stored in your system keyring (never in files or environment)
+2. nono sets `OPENAI_BASE_URL=http://127.0.0.1:PORT/openai` pointing to its local proxy
+3. nono sets `OPENAI_API_KEY` to a session-specific phantom token
+4. OpenClaw sends requests to the proxy with the phantom token
+5. The proxy validates the token, swaps in the real API key, forwards to the upstream API
+6. The real API key never enters the sandboxed process
+
+This protects against prompt injection attacks that attempt to exfiltrate credentials - even if an attacker tricks the agent into revealing its "API key", they only get the worthless phantom token.
+
+See [Credential Injection](/cli/features/credential-injection) for setup instructions.
+
+### Server Apps and Port Binding
+
+OpenClaw Gateway listens on a WebSocket port (default 18789) to accept connections from UI clients and nodes. In proxy mode, you must explicitly allow this with `--allow-bind`:
+
+```bash
+nono run --profile openclaw --allow-bind 18789 \
+  --proxy-credential openai -- openclaw gateway
+```
+
+<Warning>
+**macOS limitation:** Seatbelt cannot filter by port number. When `--allow-bind` is specified on macOS, the sandbox permits binding to any port and accepting inbound connections from any source.
+
+This is a broader permission than intended, but the security impact is limited:
+- Outbound connections are still restricted to the proxy (credential exfiltration is blocked)
+- Filesystem access is still limited to granted paths
+- An attacker would need to know the machine's IP and which port the agent opened
+- Even if they connect, they can only send data in - the agent cannot exfiltrate responses
+
+On Linux with Landlock ABI v4+, per-port filtering is enforced and only the specified ports can be bound.
+</Warning>
 
 ### Running as a Daemon
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -273,6 +273,35 @@ Chain outbound connections through an external (enterprise) proxy. The default d
 nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:3128 -- my-agent
 ```
 
+#### `--allow-bind`
+
+Allow the sandboxed process to bind and listen on a TCP port. Required when running server applications (like AI gateways) in proxy mode.
+
+```bash
+# Allow OpenClaw gateway to listen on its default port
+nono run --profile openclaw --allow-bind 18789 \
+  --proxy-credential openai -- openclaw gateway
+
+# Allow a development server
+nono run --allow-cwd --network-profile developer --allow-bind 3000 -- npm run dev
+```
+
+<Warning>
+**macOS limitation:** Seatbelt cannot filter by port number. When `--allow-bind` is specified on macOS, the sandbox permits binding to **any** port and accepting inbound connections from any source.
+
+This is a broader permission than intended, but the security impact is limited:
+- Outbound connections are still restricted to allowed hosts via the proxy
+- Filesystem access is still limited to granted paths
+- An attacker would need to know the machine's IP and which port the agent opened
+- Even if they connect, they can only send data in — the agent cannot exfiltrate responses to arbitrary hosts
+
+On Linux with Landlock ABI v4+, per-port filtering is enforced and only the specified ports can be bound.
+</Warning>
+
+<Note>
+`--allow-bind` only has effect in proxy mode (when `--network-profile` or `--proxy-allow` is active). Without proxy mode, network operations use the default OS-level allow/deny and bind is not restricted.
+</Note>
+
 ## `nono shell` Options
 
 `nono shell` supports the same permission, profile, secrets, and dry-run flags as `nono run`, plus:


### PR DESCRIPTION
 Allow the sandboxed process to bind and listen on a TCP port. Required when running server applications (like AI gateways) in proxy mode.

```bash
# Allow OpenClaw gateway to listen on its default port
nono run --profile openclaw --allow-bind 18789 \
  --proxy-credential openai -- openclaw gateway

# Allow a development server
nono run --allow-cwd --network-profile developer --allow-bind 3000 -- npm run dev
```

*macOS limitation:** Seatbelt cannot filter by port number. When `--allow-bind` is specified on macOS, the sandbox
permits binding to **any** port and accepting inbound connections from any source.
This is a broader permission than intended, but the security impact is limited:
- Outbound connections are still restricted to allowed hosts via the proxy
- Filesystem access is still limited to granted paths
- An attacker would need to know the machine's IP and which port the agent opened
- Even if they connect, they can only send data in — the agent cannot exfiltrate responses to arbitrary hosts

On Linux with Landlock ABI v4+, per-port filtering is enforced and only the specified ports can be bound.