### PR TITLE
Allow static proxy port for determined configuration

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -415,6 +415,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -446,6 +447,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -476,6 +478,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
@@ -510,6 +513,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let err = CapabilitySet::from_args(&args).expect_err("must reject protected state path");
@@ -548,6 +552,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (mut caps, needs_unlink_overrides) =

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -260,6 +260,12 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "HOST:PORT")]
     pub external_proxy: Option<String>,
 
+    /// Fixed port for the credential injection proxy (default: OS-assigned).
+    /// Use this when the sandboxed application requires a known proxy port
+    /// (e.g., for base URL configuration that can't read environment variables).
+    #[arg(long, value_name = "PORT")]
+    pub proxy_port: Option<u16>,
+
     // === Command blocking ===
     /// Allow a normally-blocked dangerous command (use with caution).
     /// By default, destructive commands like rm, dd, chmod are blocked.

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -197,6 +197,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (mut caps, needs_unlink) = CapabilitySet::from_profile(&prof, &workdir, &sandbox_args)?;
@@ -228,6 +229,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            proxy_port: None,
         };
 
         let (mut caps, needs_unlink) = CapabilitySet::from_args(&sandbox_args)?;
@@ -432,6 +434,7 @@ fn run_sandbox(
             custom_credentials: prepared.custom_credentials,
             external_proxy: args.external_proxy.clone(),
             allow_bind_ports: args.allow_bind,
+            proxy_port: args.proxy_port,
         },
     )
 }
@@ -498,6 +501,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             custom_credentials: std::collections::HashMap::new(),
             external_proxy: None,
             allow_bind_ports: Vec::new(),
+            proxy_port: None,
         },
     )
 }
@@ -536,6 +540,8 @@ struct ExecutionFlags {
     external_proxy: Option<String>,
     /// Ports the sandboxed process is allowed to bind (from --allow-bind)
     allow_bind_ports: Vec<u16>,
+    /// Fixed port for the credential proxy (from --proxy-port)
+    proxy_port: Option<u16>,
 }
 
 /// Select execution strategy from user/runtime flags.
@@ -617,6 +623,11 @@ fn build_proxy_config_from_flags(
             address: addr.clone(),
             auth: None,
         });
+    }
+
+    // Set fixed proxy port if specified
+    if let Some(port) = flags.proxy_port {
+        proxy_config.bind_port = port;
     }
 
     Ok(proxy_config)

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -70,6 +70,9 @@ impl ProxyHandle {
         vars.push(("https_proxy".to_string(), proxy_url));
         vars.push(("no_proxy".to_string(), "localhost,127.0.0.1".to_string()));
 
+        // Node.js v22.21.0+ / v24.0.0+ requires this flag for native fetch() to use HTTP_PROXY
+        vars.push(("NODE_USE_ENV_PROXY".to_string(), "1".to_string()));
+
         vars
     }
 

--- a/docs/cli/clients/openclaw.mdx
+++ b/docs/cli/clients/openclaw.mdx
@@ -145,21 +145,234 @@ The profile allows full network access. For stricter isolation, use nono's proxy
 
 ### Credential Injection (Recommended)
 
-Instead of passing API keys directly to OpenClaw, use nono's credential injection to keep secrets out of the agent's memory entirely:
+Instead of passing API keys directly to OpenClaw, use nono's credential injection to keep secrets out of the agent's memory entirely.
+
+**Step 1: Store your API key in the system keyring**
+
+<Tabs>
+<Tab title="macOS">
+```bash
+# Google Gemini
+security add-generic-password -s "nono" -a "gemini_api_key" -w
+
+# OpenAI
+security add-generic-password -s "nono" -a "openai_api_key" -w
+
+# Anthropic
+security add-generic-password -s "nono" -a "anthropic_api_key" -w
+```
+</Tab>
+
+<Tab title="Linux">
+```bash
+# Google Gemini
+secret-tool store --label="nono: gemini_api_key" service nono username gemini_api_key
+
+# OpenAI
+secret-tool store --label="nono: openai_api_key" service nono username openai_api_key
+
+# Anthropic
+secret-tool store --label="nono: anthropic_api_key" service nono username anthropic_api_key
+```
+</Tab>
+</Tabs>
+
+**Step 2: Configure OpenClaw to use nono's proxy**
+
+OpenClaw's SDK doesn't read `*_BASE_URL` environment variables, so you need to configure each provider's `baseUrl` directly.
+
+Provider settings can be configured in two locations:
+- **Global**: `~/.openclaw/openclaw.json` - applies to all agents
+- **Per-agent**: `~/.openclaw/agents/<agentId>/agent/models.json` - overrides global for that agent
+
+Add/update the `models.providers` section with the proxy baseUrl:
+
+<Tabs>
+<Tab title="Google Gemini">
+```json
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "google": {
+        "baseUrl": "http://127.0.0.1:19999/gemini/v1beta",
+        "apiKey": "GEMINI_API_KEY",
+        "api": "google-generative-ai",
+        "models": [
+          {
+            "id": "gemini-2.5-flash",
+            "name": "Gemini 2.5 Flash",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `baseUrl` must include `/v1beta` because the SDK appends paths like `/models/gemini-2.5-flash:streamGenerateContent` directly.
+</Tab>
+
+<Tab title="OpenAI">
+```json
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "openai": {
+        "baseUrl": "http://127.0.0.1:19999/openai/v1",
+        "apiKey": "OPENAI_API_KEY",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "gpt-4o",
+            "name": "GPT-4o",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 128000,
+            "maxTokens": 16384
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `baseUrl` must include `/v1` because the SDK appends paths like `/chat/completions` directly.
+</Tab>
+
+<Tab title="Anthropic">
+```json
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "anthropic": {
+        "baseUrl": "http://127.0.0.1:19999/anthropic/v1",
+        "apiKey": "ANTHROPIC_API_KEY",
+        "api": "anthropic-messages",
+        "models": [
+          {
+            "id": "claude-sonnet-4-20250514",
+            "name": "Claude Sonnet 4",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 200000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `baseUrl` must include `/v1` because the SDK appends paths like `/messages` directly.
+</Tab>
+</Tabs>
+
+<Warning>
+If you have provider config in both `openclaw.json` and `agents/<agentId>/agent/models.json`, the agent-specific config takes precedence. Make sure the `baseUrl` is set correctly in whichever file your agent is actually using.
+</Warning>
+
+**Step 3: Configure auth profile to read from environment**
+
+Edit `~/.openclaw/agents/main/agent/auth-profiles.json` and ensure each profile uses `envVar` instead of a hardcoded key:
+
+<Tabs>
+<Tab title="Google Gemini">
+```json
+{
+  "version": 1,
+  "profiles": {
+    "google:default": {
+      "type": "api_key",
+      "provider": "google",
+      "envVar": "GEMINI_API_KEY"
+    }
+  },
+  "lastGood": {
+    "google": "google:default"
+  }
+}
+```
+</Tab>
+
+<Tab title="OpenAI">
+```json
+{
+  "version": 1,
+  "profiles": {
+    "openai:default": {
+      "type": "api_key",
+      "provider": "openai",
+      "envVar": "OPENAI_API_KEY"
+    }
+  },
+  "lastGood": {
+    "openai": "openai:default"
+  }
+}
+```
+</Tab>
+
+<Tab title="Anthropic">
+```json
+{
+  "version": 1,
+  "profiles": {
+    "anthropic:default": {
+      "type": "api_key",
+      "provider": "anthropic",
+      "envVar": "ANTHROPIC_API_KEY"
+    }
+  },
+  "lastGood": {
+    "anthropic": "anthropic:default"
+  }
+}
+```
+</Tab>
+</Tabs>
+
+**Step 4: Run OpenClaw with credential injection**
 
 ```bash
-nono run --profile openclaw-demo --allow-cwd \
-  --proxy-credential openai --proxy-credential anthropic --proxy-credential gemini \
+# For Google Gemini
+nono run --profile openclaw --allow-cwd \
+  --proxy-credential gemini --proxy-port 19999 \
   --allow-bind 18789 -- openclaw gateway
+
+# For OpenAI
+nono run --profile openclaw --allow-cwd \
+  --proxy-credential openai --proxy-port 19999 \
+  --allow-bind 18789 -- openclaw gateway
+
+# For Anthropic
+nono run --profile openclaw --allow-cwd \
+  --proxy-credential anthropic --proxy-port 19999 \
+  --allow-bind 18789 -- openclaw gateway
+
+# Multiple providers
+nono run --profile openclaw --allow-cwd \
+  --proxy-credential gemini --proxy-credential openai --proxy-credential anthropic \
+  --proxy-port 19999 --allow-bind 18789 -- openclaw gateway
 ```
 
 **How it works:**
-1. Real API keys are stored in your system keyring (never in files or environment)
-2. nono sets `OPENAI_BASE_URL=http://127.0.0.1:PORT/openai` pointing to its local proxy
-3. nono sets `OPENAI_API_KEY` to a session-specific phantom token
-4. OpenClaw sends requests to the proxy with the phantom token
-5. The proxy validates the token, swaps in the real API key, forwards to the upstream API
-6. The real API key never enters the sandboxed process
+1. Real API key is stored in your system keyring (never in files)
+2. nono starts a proxy on port 19999 and sets `GEMINI_API_KEY` to a session-specific phantom token
+3. OpenClaw reads `GEMINI_API_KEY` and sends requests to `http://127.0.0.1:19999/gemini/v1beta`
+4. The proxy validates the phantom token, swaps in the real API key, forwards to Google's API
+5. The real API key never enters the sandboxed process
 
 This protects against prompt injection attacks that attempt to exfiltrate credentials - even if an attacker tricks the agent into revealing its "API key", they only get the worthless phantom token.
 

--- a/docs/cli/clients/openclaw.mdx
+++ b/docs/cli/clients/openclaw.mdx
@@ -368,10 +368,10 @@ nono run --profile openclaw --allow-cwd \
 ```
 
 **How it works:**
-1. Real API key is stored in your system keyring (never in files)
-2. nono starts a proxy on port 19999 and sets `GEMINI_API_KEY` to a session-specific phantom token
-3. OpenClaw reads `GEMINI_API_KEY` and sends requests to `http://127.0.0.1:19999/gemini/v1beta`
-4. The proxy validates the phantom token, swaps in the real API key, forwards to Google's API
+1. Real API keys are stored in your system keyring (never in files)
+2. nono starts a proxy on port 19999 and sets provider-specific API key environment variables (e.g., `GEMINI_API_KEY`, `OPENAI_API_KEY`) to a session-specific phantom token
+3. OpenClaw reads the phantom token and sends requests to the configured `baseUrl` (e.g., `http://127.0.0.1:19999/gemini/v1beta`)
+4. The proxy validates the phantom token, swaps in the real API key, and forwards the request to the provider's API
 5. The real API key never enters the sandboxed process
 
 This protects against prompt injection attacks that attempt to exfiltrate credentials - even if an attacker tricks the agent into revealing its "API key", they only get the worthless phantom token.

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -273,6 +273,22 @@ Chain outbound connections through an external (enterprise) proxy. The default d
 nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:3128 -- my-agent
 ```
 
+#### `--proxy-port`
+
+Set a fixed port for the credential injection proxy (default: OS-assigned ephemeral port). Use this when the sandboxed application requires a known proxy port that can't be configured via environment variables.
+
+```bash
+# Use a fixed proxy port for applications that need base URL configuration
+nono run --profile openclaw --proxy-port 19999 --allow-bind 18789 -- openclaw gateway
+
+# The credential proxy will always be at http://127.0.0.1:19999
+# Configure the application to use this base URL for API calls
+```
+
+<Note>
+Without `--proxy-port`, nono uses an OS-assigned ephemeral port and sets environment variables like `GEMINI_BASE_URL=http://127.0.0.1:PORT/gemini`. Applications that read these env vars don't need `--proxy-port`. Use it only when the application requires manual base URL configuration.
+</Note>
+
 #### `--allow-bind`
 
 Allow the sandboxed process to bind and listen on a TCP port. Required when running server applications (like AI gateways) in proxy mode.


### PR DESCRIPTION
Set a fixed port for the credential injection proxy (default: OS-assigned ephemeral port). this can be used when the sandboxed application requires a determined proxy port.
