### PR TITLE
Fix `--proxy-credential` not activating reverse proxy

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -145,7 +145,10 @@ impl CapabilitySetExt for CapabilitySet {
         // Network blocking or proxy mode
         if args.net_block {
             caps.set_network_blocked(true);
-        } else if args.network_profile.is_some() || !args.proxy_allow.is_empty() {
+        } else if args.network_profile.is_some()
+            || !args.proxy_allow.is_empty()
+            || !args.proxy_credential.is_empty()
+        {
             // Proxy mode: port 0 is a placeholder, updated when proxy starts.
             // bind_ports are passed through allow_bind CLI flag.
             caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
@@ -275,6 +278,7 @@ impl CapabilitySetExt for CapabilitySet {
             caps.set_network_blocked(true);
         } else if profile.network.network_profile.is_some()
             || !profile.network.proxy_allow.is_empty()
+            || !profile.network.proxy_credentials.is_empty()
         {
             // Profile requests proxy mode; port 0 is a placeholder.
             // bind_ports come from CLI args (--allow-bind).
@@ -363,7 +367,10 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
     // CLI network blocking overrides profile
     if args.net_block {
         caps.set_network_blocked(true);
-    } else if args.network_profile.is_some() || !args.proxy_allow.is_empty() {
+    } else if args.network_profile.is_some()
+        || !args.proxy_allow.is_empty()
+        || !args.proxy_credential.is_empty()
+    {
         // CLI proxy flags override profile network settings.
         // bind_ports come from --allow-bind CLI flag.
         caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -145,10 +145,7 @@ impl CapabilitySetExt for CapabilitySet {
         // Network blocking or proxy mode
         if args.net_block {
             caps.set_network_blocked(true);
-        } else if args.network_profile.is_some()
-            || !args.proxy_allow.is_empty()
-            || !args.proxy_credential.is_empty()
-        {
+        } else if args.has_proxy_flags() {
             // Proxy mode: port 0 is a placeholder, updated when proxy starts.
             // bind_ports are passed through allow_bind CLI flag.
             caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
@@ -276,10 +273,7 @@ impl CapabilitySetExt for CapabilitySet {
         // Network blocking or proxy mode from profile
         if profile.network.block {
             caps.set_network_blocked(true);
-        } else if profile.network.network_profile.is_some()
-            || !profile.network.proxy_allow.is_empty()
-            || !profile.network.proxy_credentials.is_empty()
-        {
+        } else if profile.network.has_proxy_flags() {
             // Profile requests proxy mode; port 0 is a placeholder.
             // bind_ports come from CLI args (--allow-bind).
             caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
@@ -367,10 +361,7 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
     // CLI network blocking overrides profile
     if args.net_block {
         caps.set_network_blocked(true);
-    } else if args.network_profile.is_some()
-        || !args.proxy_allow.is_empty()
-        || !args.proxy_credential.is_empty()
-    {
+    } else if args.has_proxy_flags() {
         // CLI proxy flags override profile network settings.
         // bind_ports come from --allow-bind CLI flag.
         caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -313,6 +313,15 @@ pub struct SandboxArgs {
     pub dry_run: bool,
 }
 
+impl SandboxArgs {
+    /// Whether any CLI flag requires proxy mode activation.
+    pub fn has_proxy_flags(&self) -> bool {
+        self.network_profile.is_some()
+            || !self.proxy_allow.is_empty()
+            || !self.proxy_credential.is_empty()
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct RunArgs {
     #[command(flatten)]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -366,6 +366,15 @@ pub struct NetworkConfig {
     pub custom_credentials: HashMap<String, CustomCredentialDef>,
 }
 
+impl NetworkConfig {
+    /// Whether any profile setting requires proxy mode activation.
+    pub fn has_proxy_flags(&self) -> bool {
+        self.network_profile.is_some()
+            || !self.proxy_allow.is_empty()
+            || !self.proxy_credentials.is_empty()
+    }
+}
+
 /// Secrets configuration in a profile
 ///
 /// Maps keystore account names to environment variable names.


### PR DESCRIPTION
`--proxy-credential` does not trigger `ProxyOnly` network mode, which results in the reverse proxy never startting and no credential env vars injected into the child process. Only `--network-profile` or `--proxy-allow` activated proxy mode.

Add proxy_credential presence check to all three ProxyOnly activation paths in capability_ext.rs: `from_args()`, `from_profile()`, and `add_cli_overrides()`.