### PR TITLE
Fail hard when Landlock network filtering is not enforced

### DIFF
--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -203,9 +203,21 @@ pub fn apply(caps: &CapabilitySet) -> Result<()> {
             info!("Landlock sandbox fully enforced");
         }
         landlock::RulesetStatus::PartiallyEnforced => {
-            // This is normal - the kernel supports a subset of features we requested.
-            // The sandbox is still active and enforcing restrictions.
-            debug!("Landlock sandbox enforced in best-effort mode");
+            if needs_network_handling {
+                // Network filtering requires Landlock ABI v4 (kernel 6.7+).
+                // On older kernels the network rules are silently dropped,
+                // resulting in partial enforcement. Refuse to continue when
+                // the caller explicitly requested network restrictions.
+                return Err(NonoError::SandboxInit(
+                    "Landlock sandbox was only partially enforced. Network filtering \
+                     requires kernel 6.7+ (Landlock ABI v4). Refusing to start \
+                     without network restrictions."
+                        .to_string(),
+                ));
+            }
+            // Filesystem-only partial enforcement is acceptable — the kernel
+            // enforces the subset of fs features it supports.
+            debug!("Landlock sandbox enforced in best-effort mode (filesystem only)");
         }
         landlock::RulesetStatus::NotEnforced => {
             return Err(NonoError::SandboxInit(


### PR DESCRIPTION
When `--net-block` or proxy mode is used on kernels < 6.7 (Landlock ABI < v4), network rules are silently dropped and `restrict_self()` returns `PartiallyEnforced`. Previously this was accepted, causing the banner to display `"outbound: blocked"` while network access remained unrestricted.

Return an error on `PartiallyEnforced` when network handling was requested. Filesystem-only partial enforcement remains acceptable.