### PR TITLE
fix: proxy host filtering and credential resolution for sandboxed

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -101,26 +101,7 @@
     }
   },
   "profiles": {
-    "opencode": {
-      "groups": [
-        "llm_apis",
-        "package_registries",
-        "github",
-        "sigstore",
-        "documentation"
-      ],
-      "credentials": ["google-ai"]
-    },
     "developer": {
-      "groups": [
-        "llm_apis",
-        "package_registries",
-        "github",
-        "sigstore",
-        "documentation"
-      ]
-    },
-    "claude-code": {
       "groups": [
         "llm_apis",
         "package_registries",
@@ -150,25 +131,21 @@
   "credentials": {
     "openai": {
       "upstream": "https://api.openai.com/v1",
-      "credential_key": "openai_api_key",
       "inject_header": "Authorization",
       "credential_format": "Bearer {}"
     },
     "anthropic": {
       "upstream": "https://api.anthropic.com",
-      "credential_key": "anthropic_api_key",
       "inject_header": "x-api-key",
       "credential_format": "{}"
     },
     "gemini": {
       "upstream": "https://generativelanguage.googleapis.com",
-      "credential_key": "gemini_api_key",
       "inject_header": "x-goog-api-key",
       "credential_format": "{}"
     },
     "google-ai": {
       "upstream": "https://generativelanguage.googleapis.com",
-      "credential_key": "google_generative_ai_api_key",
       "inject_header": "x-goog-api-key",
       "credential_format": "{}"
     }

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -490,7 +490,7 @@
         "allow_file": ["$HOME/.claude.json"],
         "read_file": ["$HOME/Library/Keychains/login.keychain-db", "$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
       },
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "hooks": {
         "claude-code": {
@@ -524,7 +524,7 @@
           "$TMPDIR/openclaw-$UID"
         ]
       },
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "read" },
       "undo": {
         "exclude_patterns": ["node_modules", ".next"]
@@ -549,7 +549,7 @@
           "$HOME/.local/share/opencode"
         ]
       },
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "undo": {
         "exclude_patterns": ["node_modules", ".next"]
@@ -568,7 +568,7 @@
       },
       "trust_groups": [],
       "filesystem": {},
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "interactive": false
     },
@@ -584,7 +584,7 @@
       },
       "trust_groups": [],
       "filesystem": {},
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "interactive": false
     },
@@ -600,7 +600,7 @@
       },
       "trust_groups": [],
       "filesystem": {},
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "interactive": false
     },
@@ -616,7 +616,7 @@
       },
       "trust_groups": [],
       "filesystem": {},
-      "network": { "block": false },
+      "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "interactive": false
     }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -650,8 +650,13 @@ fn build_proxy_config_from_flags(
     )?;
     resolved.routes = routes;
 
-    // Build the proxy config with extra hosts from CLI/profile
-    let mut proxy_config = network_policy::build_proxy_config(&resolved, &flags.proxy_allow_hosts);
+    // Expand --proxy-allow entries: group names become their hosts,
+    // literal hostnames pass through as-is.
+    let expanded_proxy_allow =
+        network_policy::expand_proxy_allow(&net_policy, &flags.proxy_allow_hosts);
+
+    // Build the proxy config with expanded extra hosts
+    let mut proxy_config = network_policy::build_proxy_config(&resolved, &expanded_proxy_allow);
 
     // Wire in external proxy if specified
     if let Some(ref addr) = flags.external_proxy {

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -61,7 +61,10 @@ pub struct NetworkProfileDef {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CredentialDef {
     pub upstream: String,
-    pub credential_key: String,
+    /// Keystore account name. Defaults to the service name (the map key)
+    /// if not specified, so the keychain account matches the credential name.
+    #[serde(default)]
+    pub credential_key: Option<String>,
     #[serde(default = "default_inject_header")]
     pub inject_header: String,
     #[serde(default = "default_credential_format")]
@@ -210,11 +213,13 @@ pub fn resolve_credentials(
                 env_var: cred.env_var.clone(),
             });
         } else if let Some(cred) = policy.credentials.get(name) {
-            // Built-in credentials always use header mode
+            // Built-in credentials always use header mode.
+            // credential_key defaults to the service name if not set.
+            let key = cred.credential_key.clone().unwrap_or_else(|| name.clone());
             routes.push(RouteConfig {
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
-                credential_key: Some(cred.credential_key.clone()),
+                credential_key: Some(key),
                 inject_mode: InjectMode::Header,
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -255,6 +260,29 @@ pub fn build_proxy_config(resolved: &ResolvedNetworkPolicy, extra_hosts: &[Strin
     }
 }
 
+/// Expand `--proxy-allow` entries: if an entry matches a group name in the
+/// network policy, expand it to the group's hosts and suffixes. Otherwise
+/// treat it as a literal hostname.
+pub fn expand_proxy_allow(policy: &NetworkPolicy, entries: &[String]) -> Vec<String> {
+    let mut result = Vec::new();
+    for entry in entries {
+        if let Some(group) = policy.groups.get(entry.as_str()) {
+            result.extend(group.hosts.clone());
+            for suffix in &group.suffixes {
+                let wildcard = if suffix.starts_with('.') {
+                    format!("*{}", suffix)
+                } else {
+                    format!("*.{}", suffix)
+                };
+                result.push(wildcard);
+            }
+        } else {
+            result.push(entry.clone());
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -270,10 +298,10 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_claude_code_profile() {
+    fn test_resolve_developer_profile() {
         let json = embedded_network_policy_json();
         let policy = load_network_policy(json).unwrap();
-        let resolved = resolve_network_profile(&policy, "claude-code").unwrap();
+        let resolved = resolve_network_profile(&policy, "developer").unwrap();
         assert!(!resolved.hosts.is_empty());
         // Should include known LLM API hosts
         assert!(resolved.hosts.contains(&"api.openai.com".to_string()));

--- a/crates/nono-proxy/src/connect.rs
+++ b/crates/nono-proxy/src/connect.rs
@@ -39,8 +39,12 @@ pub async fn handle_connect(
     let (host, port) = parse_connect_target(first_line)?;
     debug!("CONNECT request to {}:{}", host, port);
 
-    // Validate session token from Proxy-Authorization header
-    validate_proxy_auth(remaining_header, session_token)?;
+    // Validate session token from Proxy-Authorization header.
+    // Non-fatal for CONNECT: Node.js undici doesn't send Proxy-Authorization
+    // from URL userinfo for CONNECT requests.
+    if let Err(e) = validate_proxy_auth(remaining_header, session_token) {
+        debug!("CONNECT auth skipped: {}", e);
+    }
 
     // Check host against filter (DNS resolution happens here)
     let check = filter.check_host(&host, port).await?;

--- a/crates/nono-proxy/src/token.rs
+++ b/crates/nono-proxy/src/token.rs
@@ -7,7 +7,7 @@
 
 use crate::error::{ProxyError, Result};
 use subtle::ConstantTimeEq;
-use tracing::warn;
+use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
 /// Length of the random token in bytes (256 bits of entropy).
@@ -83,7 +83,7 @@ pub fn validate_proxy_auth(header_bytes: &[u8], session_token: &Zeroizing<String
         }
     }
 
-    warn!("Missing Proxy-Authorization header");
+    debug!("Missing Proxy-Authorization header");
     Err(ProxyError::InvalidToken)
 }
 


### PR DESCRIPTION
profiles

Sandbox profiles had no network_profile set, so the proxy started with an empty host allowlist and blocked all traffic. Credential keys were hardcoded per-provider instead of defaulting to the service name.

- Set network_profile on all sandbox profiles in policy.json
- Consolidate duplicate network profiles into single "developer" profile
- Default credential_key to service name (keychain account matches credential)
- Remove hardcoded credential_key from all built-in credential definitions
- Expand --proxy-allow group names to their constituent hosts
- Downgrade missing Proxy-Authorization to debug (Node.js undici omits it)
- Make CONNECT auth non-fatal since host filtering is the real security