### PR TITLE
feat: remove RFC1918 private network CIDR deny list from host filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,9 +1124,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iri-string"
@@ -1361,7 +1358,6 @@ dependencies = [
  "getrandom 0.4.1",
  "globset",
  "ignore",
- "ipnet",
  "keyring",
  "landlock",
  "libc",
@@ -1431,7 +1427,6 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "keyring",
  "nono",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,6 @@ hyper = { version = "1", features = ["http1", "server", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 http-body-util = "0.1"
 
-# Network filtering
-ipnet = { version = "2", features = ["serde"] }
-
 # Testing
 tempfile = "3"
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Sign instruction files directly within GitHub Actions workflows. Users can then 
 
 ### Network Filtering
 
-Allowlist-based host filtering via a local proxy. The sandbox blocks all direct outbound connections — the agent can only reach explicitly allowed hosts. Cloud metadata endpoints and private network ranges are hardcoded as denied. DNS rebinding protection checks resolved IPs against the deny list before connecting.
+Allowlist-based host filtering via a local proxy. The sandbox blocks all direct outbound connections — the agent can only reach explicitly allowed hosts. Cloud metadata endpoints are hardcoded as denied.
 
 ```bash
 nono run --supervised --proxy-allow api.openai.com --proxy-allow api.anthropic.com -- my-agent

--- a/crates/nono-proxy/Cargo.toml
+++ b/crates/nono-proxy/Cargo.toml
@@ -17,7 +17,6 @@ tokio.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 http-body-util.workspace = true
-ipnet.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/nono-proxy/README.md
+++ b/crates/nono-proxy/README.md
@@ -16,8 +16,8 @@ Network filtering proxy for the [nono](https://crates.io/crates/nono) sandbox.
 
 ## Security Properties
 
-- **Cloud metadata deny list is hardcoded** -- Cloud metadata endpoints (169.254.169.254, metadata.google.internal, metadata.azure.internal) are always blocked regardless of allowlist configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
-- **DNS rebinding protection** -- The proxy resolves DNS and connects to resolved addresses, not re-resolved hostnames.
+- **Cloud metadata deny list is hardcoded** -- Cloud metadata hostnames (169.254.169.254, metadata.google.internal, metadata.azure.internal) are always blocked regardless of allowlist configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
+- **DNS rebinding protection** -- The proxy resolves DNS, checks all resolved IPs against the link-local range (169.254.0.0/16, fe80::/10), and connects to resolved addresses (not re-resolved hostnames). This prevents DNS rebinding attacks targeting cloud metadata.
 - **Session token authentication** -- Each session generates a 256-bit random token. CONNECT requests use `Proxy-Authorization` (Basic or Bearer); reverse proxy requests use `X-Nono-Token`.
 - **Credential isolation** -- API keys are loaded from the OS keyring, stored in `Zeroizing<String>`, injected at the HTTP header level, and never exposed to the sandboxed process.
 - **Constant-time token comparison** -- Prevents timing side-channel attacks on session token validation.

--- a/crates/nono-proxy/README.md
+++ b/crates/nono-proxy/README.md
@@ -10,14 +10,14 @@ Network filtering proxy for the [nono](https://crates.io/crates/nono) sandbox.
 
 | Mode | Module | Description |
 |------|--------|-------------|
-| CONNECT tunnel | `connect` | Host-filtered HTTPS tunnelling. Validates the target host against an allowlist and CIDR deny ranges, then establishes a raw TCP tunnel. TLS is end-to-end. |
+| CONNECT tunnel | `connect` | Host-filtered HTTPS tunnelling. Validates the target host against an allowlist and cloud metadata deny list, then establishes a raw TCP tunnel. TLS is end-to-end. |
 | Reverse proxy | `reverse` | Credential injection for API calls. Requests to `http://127.0.0.1:<port>/<service>/...` are forwarded upstream with the real API key injected as an HTTP header. |
-| External proxy | `external` | Enterprise proxy passthrough. CONNECT requests are chained through a corporate proxy with the default deny list enforced as a floor. |
+| External proxy | `external` | Enterprise proxy passthrough. CONNECT requests are chained through a corporate proxy with cloud metadata endpoints still denied. |
 
 ## Security Properties
 
-- **Default deny list is hardcoded** -- Cloud metadata endpoints (169.254.169.254), RFC1918 private networks, link-local, and loopback ranges are always blocked regardless of allowlist configuration.
-- **DNS rebinding protection** -- The proxy resolves DNS and checks all resolved IPs against deny CIDRs before connecting. Callers connect to resolved addresses, not re-resolved hostnames.
+- **Cloud metadata deny list is hardcoded** -- Cloud metadata endpoints (169.254.169.254, metadata.google.internal, metadata.azure.internal) are always blocked regardless of allowlist configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
+- **DNS rebinding protection** -- The proxy resolves DNS and connects to resolved addresses, not re-resolved hostnames.
 - **Session token authentication** -- Each session generates a 256-bit random token. CONNECT requests use `Proxy-Authorization` (Basic or Bearer); reverse proxy requests use `X-Nono-Token`.
 - **Credential isolation** -- API keys are loaded from the OS keyring, stored in `Zeroizing<String>`, injected at the HTTP header level, and never exposed to the sandboxed process.
 - **Constant-time token comparison** -- Prevents timing side-channel attacks on session token validation.

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -3,7 +3,6 @@
 //! Defines the configuration for the proxy server, including allowed hosts,
 //! credential routes, and external proxy settings.
 
-use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
@@ -38,10 +37,6 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub allowed_hosts: Vec<String>,
 
-    /// Additional CIDR ranges to deny (on top of built-in defaults).
-    #[serde(default)]
-    pub deny_cidrs: Vec<IpNet>,
-
     /// Reverse proxy credential routes.
     #[serde(default)]
     pub routes: Vec<RouteConfig>,
@@ -62,7 +57,6 @@ impl Default for ProxyConfig {
             bind_addr: default_bind_addr(),
             bind_port: 0,
             allowed_hosts: Vec::new(),
-            deny_cidrs: Vec::new(),
             routes: Vec::new(),
             external_proxy: None,
             max_connections: 256,

--- a/crates/nono-proxy/src/connect.rs
+++ b/crates/nono-proxy/src/connect.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles `CONNECT host:port HTTP/1.1` requests by:
 //! 1. Validating the session token
-//! 2. Checking the host against the filter (deny CIDRs, then allowlist)
+//! 2. Checking the host against the filter (cloud metadata deny list, then allowlist)
 //! 3. Establishing a TCP connection to the upstream
 //! 4. Returning `200 Connection Established`
 //! 5. Relaying bytes bidirectionally (transparent TLS tunnel)
@@ -52,8 +52,7 @@ pub async fn handle_connect(
     }
 
     // Connect to the resolved IP directly — NOT re-resolving the hostname.
-    // This eliminates the DNS rebinding TOCTOU: the IPs were already checked
-    // against deny CIDRs in check_host() above.
+    // This eliminates the DNS rebinding TOCTOU window.
     let resolved = &check.resolved_addrs;
     if resolved.is_empty() {
         let reason = "DNS resolution returned no addresses".to_string();

--- a/crates/nono-proxy/src/connect.rs
+++ b/crates/nono-proxy/src/connect.rs
@@ -52,7 +52,8 @@ pub async fn handle_connect(
     }
 
     // Connect to the resolved IP directly — NOT re-resolving the hostname.
-    // This eliminates the DNS rebinding TOCTOU window.
+    // This eliminates the DNS rebinding TOCTOU: the IPs were already checked
+    // against the link-local range in check_host() above.
     let resolved = &check.resolved_addrs;
     if resolved.is_empty() {
         let reason = "DNS resolution returned no addresses".to_string();

--- a/crates/nono-proxy/src/external.rs
+++ b/crates/nono-proxy/src/external.rs
@@ -1,9 +1,8 @@
 //! External proxy passthrough handler (Mode 3 — Enterprise).
 //!
 //! Chains CONNECT requests to an upstream enterprise proxy (Squid, Cisco WSA,
-//! Zscaler, etc.). Nono's `default_deny` (cloud metadata, RFC1918) applies as
-//! a security floor before forwarding. The enterprise proxy makes the final
-//! allow/deny decision.
+//! Zscaler, etc.). Cloud metadata endpoints are still denied before forwarding.
+//! The enterprise proxy makes the final allow/deny decision.
 
 use crate::audit;
 use crate::config::ExternalProxyConfig;
@@ -18,7 +17,7 @@ use zeroize::Zeroizing;
 /// Handle a CONNECT request by chaining it to an external proxy.
 ///
 /// 1. Validate session token
-/// 2. Check host against default_deny (SSRF floor)
+/// 2. Check host against cloud metadata deny list
 /// 3. Connect to enterprise proxy
 /// 4. Send CONNECT to enterprise proxy (with optional Proxy-Authorization)
 /// 5. Wait for enterprise proxy 200
@@ -38,11 +37,8 @@ pub async fn handle_external_proxy(
     // Validate session token
     validate_proxy_auth(remaining_header, session_token)?;
 
-    // Check default_deny (SSRF protection floor).
-    // For external proxy mode, we connect to the enterprise proxy (not the resolved
-    // IP directly), so the DNS rebinding TOCTOU doesn't apply — the enterprise proxy
-    // does its own resolution. But we still check deny CIDRs on the resolved IPs here
-    // to prevent requesting known-bad targets even through the enterprise proxy.
+    // Check cloud metadata deny list.
+    // Cloud metadata endpoints are always blocked even through enterprise proxies.
     let check = filter.check_host(&host, port).await?;
     if !check.result.is_allowed() {
         let reason = check.result.reason();

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -1,11 +1,11 @@
 //! Async host filtering wrapping the library's [`HostFilter`](nono::HostFilter).
 //!
 //! Performs DNS resolution via `tokio::net::lookup_host()` and checks
-//! resolved IPs against deny CIDRs before checking the hostname allowlist.
+//! the hostname against the cloud metadata deny list and allowlist.
 
 use crate::error::Result;
 use nono::net_filter::{FilterResult, HostFilter};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use tracing::debug;
 
 /// Result of a filter check including resolved socket addresses.
@@ -35,7 +35,7 @@ impl ProxyFilter {
         }
     }
 
-    /// Create a filter that allows all hosts (except deny list).
+    /// Create a filter that allows all hosts (except cloud metadata).
     #[must_use]
     pub fn allow_all() -> Self {
         Self {
@@ -45,47 +45,44 @@ impl ProxyFilter {
 
     /// Check a host against the filter with async DNS resolution.
     ///
-    /// Resolves the hostname to IP addresses, then checks all resolved IPs
-    /// against the deny CIDR list. If any IP is denied, the request is blocked
-    /// (DNS rebinding protection).
+    /// Resolves the hostname to IP addresses, checks the hostname against
+    /// the cloud metadata deny list and allowlist.
     ///
     /// On success, returns both the filter result and the resolved socket
     /// addresses. Callers MUST use `resolved_addrs` to connect to the upstream
     /// instead of re-resolving the hostname, eliminating the DNS rebinding
     /// TOCTOU window.
     pub async fn check_host(&self, host: &str, port: u16) -> Result<CheckResult> {
-        // Resolve DNS
+        // Check hostname against deny list and allowlist first
+        let result = self.inner.check_host(host);
+
+        if !result.is_allowed() {
+            return Ok(CheckResult {
+                result,
+                resolved_addrs: Vec::new(),
+            });
+        }
+
+        // Resolve DNS only for allowed hosts
         let addr_str = format!("{}:{}", host, port);
         let resolved: Vec<SocketAddr> = match tokio::net::lookup_host(&addr_str).await {
             Ok(addrs) => addrs.collect(),
             Err(e) => {
                 debug!("DNS resolution failed for {}: {}", host, e);
-                // If DNS fails, we still check the hostname against deny list
-                // (cloud metadata hostnames don't need DNS resolution to be blocked)
                 Vec::new()
             }
         };
 
-        let resolved_ips: Vec<IpAddr> = resolved.iter().map(|a| a.ip()).collect();
-        let result = self.inner.check_host(host, &resolved_ips);
-
-        // Only return resolved addrs on allow to prevent misuse
-        let addrs = if result.is_allowed() {
-            resolved
-        } else {
-            Vec::new()
-        };
-
         Ok(CheckResult {
             result,
-            resolved_addrs: addrs,
+            resolved_addrs: resolved,
         })
     }
 
-    /// Check a host with pre-resolved IPs (no DNS lookup).
+    /// Check a host synchronously (no DNS lookup).
     #[must_use]
-    pub fn check_host_with_ips(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
-        self.inner.check_host(host, resolved_ips)
+    pub fn check_host_sync(&self, host: &str) -> FilterResult {
+        self.inner.check_host(host)
     }
 
     /// Number of allowed hosts configured.
@@ -99,33 +96,29 @@ impl ProxyFilter {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
 
     #[test]
     fn test_proxy_filter_delegates_to_host_filter() {
         let filter = ProxyFilter::new(&["api.openai.com".to_string()]);
-        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
 
-        let result = filter.check_host_with_ips("api.openai.com", &public_ip);
+        let result = filter.check_host_sync("api.openai.com");
         assert!(result.is_allowed());
 
-        let result = filter.check_host_with_ips("evil.com", &public_ip);
+        let result = filter.check_host_sync("evil.com");
         assert!(!result.is_allowed());
     }
 
     #[test]
     fn test_proxy_filter_allow_all() {
         let filter = ProxyFilter::allow_all();
-        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
-        let result = filter.check_host_with_ips("anything.com", &public_ip);
+        let result = filter.check_host_sync("anything.com");
         assert!(result.is_allowed());
     }
 
     #[test]
-    fn test_proxy_filter_denies_private_ips() {
+    fn test_proxy_filter_allows_private_networks() {
         let filter = ProxyFilter::allow_all();
-        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
-        let result = filter.check_host_with_ips("corp.internal", &private_ip);
-        assert!(!result.is_allowed());
+        let result = filter.check_host_sync("corp.internal");
+        assert!(result.is_allowed());
     }
 }

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -1,11 +1,12 @@
 //! Async host filtering wrapping the library's [`HostFilter`](nono::HostFilter).
 //!
-//! Performs DNS resolution via `tokio::net::lookup_host()` and checks
-//! the hostname against the cloud metadata deny list and allowlist.
+//! Performs DNS resolution via `tokio::net::lookup_host()`, checks resolved
+//! IPs against the link-local range (cloud metadata SSRF protection), and
+//! validates the hostname against the cloud metadata deny list and allowlist.
 
 use crate::error::Result;
 use nono::net_filter::{FilterResult, HostFilter};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use tracing::debug;
 
 /// Result of a filter check including resolved socket addresses.
@@ -45,44 +46,47 @@ impl ProxyFilter {
 
     /// Check a host against the filter with async DNS resolution.
     ///
-    /// Resolves the hostname to IP addresses, checks the hostname against
-    /// the cloud metadata deny list and allowlist.
+    /// Resolves the hostname to IP addresses, then checks all resolved IPs
+    /// against the link-local deny range (cloud metadata SSRF protection).
+    /// If any resolved IP is link-local, the request is blocked.
     ///
     /// On success, returns both the filter result and the resolved socket
     /// addresses. Callers MUST use `resolved_addrs` to connect to the upstream
     /// instead of re-resolving the hostname, eliminating the DNS rebinding
     /// TOCTOU window.
     pub async fn check_host(&self, host: &str, port: u16) -> Result<CheckResult> {
-        // Check hostname against deny list and allowlist first
-        let result = self.inner.check_host(host);
-
-        if !result.is_allowed() {
-            return Ok(CheckResult {
-                result,
-                resolved_addrs: Vec::new(),
-            });
-        }
-
-        // Resolve DNS only for allowed hosts
+        // Resolve DNS
         let addr_str = format!("{}:{}", host, port);
         let resolved: Vec<SocketAddr> = match tokio::net::lookup_host(&addr_str).await {
             Ok(addrs) => addrs.collect(),
             Err(e) => {
                 debug!("DNS resolution failed for {}: {}", host, e);
+                // If DNS fails, we still check the hostname against deny list
+                // (cloud metadata hostnames don't need DNS resolution to be blocked)
                 Vec::new()
             }
         };
 
+        let resolved_ips: Vec<IpAddr> = resolved.iter().map(|a| a.ip()).collect();
+        let result = self.inner.check_host(host, &resolved_ips);
+
+        // Only return resolved addrs on allow to prevent misuse
+        let addrs = if result.is_allowed() {
+            resolved
+        } else {
+            Vec::new()
+        };
+
         Ok(CheckResult {
             result,
-            resolved_addrs: resolved,
+            resolved_addrs: addrs,
         })
     }
 
-    /// Check a host synchronously (no DNS lookup).
+    /// Check a host with pre-resolved IPs (no DNS lookup).
     #[must_use]
-    pub fn check_host_sync(&self, host: &str) -> FilterResult {
-        self.inner.check_host(host)
+    pub fn check_host_with_ips(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
+        self.inner.check_host(host, resolved_ips)
     }
 
     /// Number of allowed hosts configured.
@@ -96,29 +100,41 @@ impl ProxyFilter {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::net::Ipv4Addr;
 
     #[test]
     fn test_proxy_filter_delegates_to_host_filter() {
         let filter = ProxyFilter::new(&["api.openai.com".to_string()]);
+        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
 
-        let result = filter.check_host_sync("api.openai.com");
+        let result = filter.check_host_with_ips("api.openai.com", &public_ip);
         assert!(result.is_allowed());
 
-        let result = filter.check_host_sync("evil.com");
+        let result = filter.check_host_with_ips("evil.com", &public_ip);
         assert!(!result.is_allowed());
     }
 
     #[test]
     fn test_proxy_filter_allow_all() {
         let filter = ProxyFilter::allow_all();
-        let result = filter.check_host_sync("anything.com");
+        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
+        let result = filter.check_host_with_ips("anything.com", &public_ip);
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_proxy_filter_allows_private_networks() {
         let filter = ProxyFilter::allow_all();
-        let result = filter.check_host_sync("corp.internal");
+        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
+        let result = filter.check_host_with_ips("corp.internal", &private_ip);
         assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_proxy_filter_denies_link_local() {
+        let filter = ProxyFilter::allow_all();
+        let link_local = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))];
+        let result = filter.check_host_with_ips("evil.com", &link_local);
+        assert!(!result.is_allowed());
     }
 }

--- a/crates/nono-proxy/src/lib.rs
+++ b/crates/nono-proxy/src/lib.rs
@@ -3,8 +3,8 @@
 //! `nono-proxy` provides three proxy modes:
 //!
 //! 1. **CONNECT tunnel** (`connect`) - Host-filtered HTTPS tunnelling.
-//!    The proxy validates the target host against an allowlist and CIDR
-//!    deny ranges, then establishes a raw TCP tunnel.
+//!    The proxy validates the target host against an allowlist and cloud
+//!    metadata deny list, then establishes a raw TCP tunnel.
 //!
 //! 2. **Reverse proxy** (`reverse`) - Credential injection for API calls.
 //!    Requests arrive at `http://127.0.0.1:<port>/<service>/...`, the proxy

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -123,7 +123,7 @@ pub async fn handle_reverse_proxy(
 
     let (upstream_host, upstream_port, upstream_path_full) = parse_upstream_url(&upstream_url)?;
 
-    // DNS resolve + CIDR check via the filter (prevents rebinding TOCTOU)
+    // DNS resolve + host check via the filter
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
     if !check.result.is_allowed() {
         let reason = check.result.reason();

--- a/crates/nono/Cargo.toml
+++ b/crates/nono/Cargo.toml
@@ -24,9 +24,6 @@ walkdir.workspace = true
 ignore.workspace = true
 globset.workspace = true
 
-# CIDR network filtering
-ipnet = "2"
-
 # Unix socket IPC for supervisor
 libc = "0.2"
 

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -10,8 +10,13 @@
 //! - **Cloud metadata endpoints are hardcoded and non-overridable**: Instance
 //!   metadata services (169.254.169.254, metadata.google.internal, etc.) are
 //!   always denied regardless of allowlist configuration.
+//! - **Link-local IP protection**: Resolved IPs in the link-local range
+//!   (169.254.0.0/16, fe80::/10) are always denied to prevent DNS rebinding
+//!   attacks targeting cloud metadata services.
 //! - **Wildcard subdomain matching**: `*.googleapis.com` matches
 //!   `storage.googleapis.com` but not `googleapis.com` itself.
+
+use std::net::IpAddr;
 
 /// Result of a host filter check.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +27,11 @@ pub enum FilterResult {
     DenyHost {
         /// The hostname that was denied
         host: String,
+    },
+    /// Host is denied because a resolved IP is in the link-local range
+    DenyLinkLocal {
+        /// The resolved IP that matched the link-local range
+        ip: IpAddr,
     },
     /// Host is not in the allowlist (default deny)
     DenyNotAllowed {
@@ -45,9 +55,40 @@ impl FilterResult {
             FilterResult::DenyHost { host } => {
                 format!("host {} is in the deny list", host)
             }
+            FilterResult::DenyLinkLocal { ip } => {
+                format!(
+                    "resolved IP {} is in the link-local range (cloud metadata protection)",
+                    ip
+                )
+            }
             FilterResult::DenyNotAllowed { host } => {
                 format!("host {} is not in the allowlist", host)
             }
+        }
+    }
+}
+
+/// Check if an IP address is in the link-local range.
+///
+/// Link-local addresses are used by cloud metadata services (169.254.169.254)
+/// and must be blocked to prevent DNS rebinding SSRF attacks.
+///
+/// - IPv4: 169.254.0.0/16
+/// - IPv6: fe80::/10
+/// - IPv4-mapped IPv6: ::ffff:169.254.x.x (prevents bypass via AAAA records)
+fn is_link_local(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.octets()[0] == 169 && v4.octets()[1] == 254,
+        IpAddr::V6(v6) => {
+            if (v6.segments()[0] & 0xffc0) == 0xfe80 {
+                return true;
+            }
+            // Check IPv4-mapped IPv6 (::ffff:x.x.x.x) to prevent bypass
+            // via attacker-controlled AAAA records pointing to link-local IPs
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.octets()[0] == 169 && v4.octets()[1] == 254;
+            }
+            false
         }
     }
 }
@@ -120,13 +161,19 @@ impl HostFilter {
 
     /// Check a host against the filter.
     ///
+    /// `resolved_ips` should contain the DNS-resolved IP addresses for the host.
+    /// The caller is responsible for performing DNS resolution before calling this
+    /// method. This prevents DNS rebinding attacks: the proxy resolves once, checks
+    /// the resolved IPs here, then connects to the same resolved IP.
+    ///
     /// # Check Order
     ///
     /// 1. Deny hosts (exact match against cloud metadata hostnames)
-    /// 2. Allowlist (exact host match, then wildcard subdomain match)
-    /// 3. Default deny (if not in allowlist and allowlist is non-empty)
+    /// 2. Link-local IP check (resolved IPs in 169.254.0.0/16 or fe80::/10)
+    /// 3. Allowlist (exact host match, then wildcard subdomain match)
+    /// 4. Default deny (if not in allowlist and allowlist is non-empty)
     #[must_use]
-    pub fn check_host(&self, host: &str) -> FilterResult {
+    pub fn check_host(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
         let lower_host = host.to_lowercase();
 
         // 1. Check deny hosts
@@ -136,24 +183,31 @@ impl HostFilter {
             };
         }
 
-        // 2. If no allowlist is configured (allow_all mode), allow
+        // 2. Check resolved IPs for link-local addresses (cloud metadata protection)
+        for ip in resolved_ips {
+            if is_link_local(ip) {
+                return FilterResult::DenyLinkLocal { ip: *ip };
+            }
+        }
+
+        // 3. If no allowlist is configured (allow_all mode), allow
         if self.allowed_hosts.is_empty() && self.allowed_suffixes.is_empty() {
             return FilterResult::Allow;
         }
 
-        // 3. Check exact host match
+        // 4. Check exact host match
         if self.allowed_hosts.contains(&lower_host) {
             return FilterResult::Allow;
         }
 
-        // 4. Check wildcard subdomain match
+        // 5. Check wildcard subdomain match
         for suffix in &self.allowed_suffixes {
             if lower_host.ends_with(suffix.as_str()) && lower_host.len() > suffix.len() {
                 return FilterResult::Allow;
             }
         }
 
-        // 5. Not in allowlist
+        // 6. Not in allowlist
         FilterResult::DenyNotAllowed {
             host: host.to_string(),
         }
@@ -172,25 +226,30 @@ impl HostFilter {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn public_ip() -> Vec<IpAddr> {
+        vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))]
+    }
 
     #[test]
     fn test_exact_host_allowed() {
         let filter = HostFilter::new(&["api.openai.com".to_string()]);
-        let result = filter.check_host("api.openai.com");
+        let result = filter.check_host("api.openai.com", &public_ip());
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_exact_host_case_insensitive() {
         let filter = HostFilter::new(&["API.OpenAI.COM".to_string()]);
-        let result = filter.check_host("api.openai.com");
+        let result = filter.check_host("api.openai.com", &public_ip());
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_host_not_in_allowlist() {
         let filter = HostFilter::new(&["api.openai.com".to_string()]);
-        let result = filter.check_host("evil.com");
+        let result = filter.check_host("evil.com", &public_ip());
         assert!(!result.is_allowed());
         assert!(matches!(result, FilterResult::DenyNotAllowed { .. }));
     }
@@ -200,11 +259,11 @@ mod tests {
         let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
 
         // Subdomain should match
-        let result = filter.check_host("storage.googleapis.com");
+        let result = filter.check_host("storage.googleapis.com", &public_ip());
         assert!(result.is_allowed());
 
         // Deep subdomain should match
-        let result = filter.check_host("us-central1-aiplatform.googleapis.com");
+        let result = filter.check_host("us-central1-aiplatform.googleapis.com", &public_ip());
         assert!(result.is_allowed());
     }
 
@@ -213,7 +272,7 @@ mod tests {
         let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
 
         // Bare domain should NOT match wildcard
-        let result = filter.check_host("googleapis.com");
+        let result = filter.check_host("googleapis.com", &public_ip());
         assert!(!result.is_allowed());
     }
 
@@ -222,7 +281,7 @@ mod tests {
         let filter = HostFilter::new(&["169.254.169.254".to_string()]);
 
         // Should be denied even if in allowlist
-        let result = filter.check_host("169.254.169.254");
+        let result = filter.check_host("169.254.169.254", &public_ip());
         assert!(!result.is_allowed());
         assert!(matches!(result, FilterResult::DenyHost { .. }));
     }
@@ -230,7 +289,7 @@ mod tests {
     #[test]
     fn test_deny_google_metadata() {
         let filter = HostFilter::new(&["metadata.google.internal".to_string()]);
-        let result = filter.check_host("metadata.google.internal");
+        let result = filter.check_host("metadata.google.internal", &public_ip());
         assert!(!result.is_allowed());
     }
 
@@ -238,15 +297,116 @@ mod tests {
     fn test_allow_all_mode() {
         // No allowlist = allow all (except deny list)
         let filter = HostFilter::allow_all();
-        let result = filter.check_host("any-host.example.com");
+        let result = filter.check_host("any-host.example.com", &public_ip());
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_allow_all_allows_private_networks() {
         let filter = HostFilter::allow_all();
-        let result = filter.check_host("internal.corp.com");
+        // RFC1918 addresses are allowed for enterprise use
+        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
+        let result = filter.check_host("internal.corp.com", &private_ip);
         assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_allow_all_allows_192_168() {
+        let filter = HostFilter::allow_all();
+        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))];
+        let result = filter.check_host("nas.local", &private_ip);
+        assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_deny_link_local_ipv4() {
+        let filter = HostFilter::new(&["*.example.com".to_string()]);
+        let link_local = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))];
+        let result = filter.check_host("api.example.com", &link_local);
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyLinkLocal { .. }));
+    }
+
+    #[test]
+    fn test_deny_link_local_ipv6() {
+        let filter = HostFilter::new(&["*.example.com".to_string()]);
+        let link_local = vec![IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1))];
+        let result = filter.check_host("api.example.com", &link_local);
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyLinkLocal { .. }));
+    }
+
+    #[test]
+    fn test_deny_ipv4_mapped_ipv6_link_local() {
+        // Attacker returns AAAA record ::ffff:169.254.169.254 to bypass IPv4 check
+        let filter = HostFilter::new(&["attacker.com".to_string()]);
+        let mapped = vec![IpAddr::V6(Ipv6Addr::new(
+            0, 0, 0, 0, 0, 0xffff, 0xa9fe, 0xa9fe,
+        ))];
+        let result = filter.check_host("attacker.com", &mapped);
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyLinkLocal { .. }));
+    }
+
+    #[test]
+    fn test_deny_ipv4_mapped_ipv6_other_link_local() {
+        // Any link-local in mapped form must be caught
+        let filter = HostFilter::allow_all();
+        let mapped = vec![IpAddr::V6(Ipv6Addr::new(
+            0, 0, 0, 0, 0, 0xffff, 0xa9fe, 0x0001,
+        ))];
+        let result = filter.check_host("evil.com", &mapped);
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_ipv4_mapped_ipv6_non_link_local_allowed() {
+        // ::ffff:104.18.7.96 is a public IP in mapped form — should be allowed
+        let filter = HostFilter::allow_all();
+        let mapped = vec![IpAddr::V6(Ipv6Addr::new(
+            0, 0, 0, 0, 0, 0xffff, 0x6812, 0x0760,
+        ))];
+        let result = filter.check_host("example.com", &mapped);
+        assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_dns_rebinding_to_metadata_ip() {
+        // Attacker's domain resolves to cloud metadata IP — must be blocked
+        let filter = HostFilter::new(&["attacker.com".to_string()]);
+        let metadata_ip = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))];
+        let result = filter.check_host("attacker.com", &metadata_ip);
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyLinkLocal { .. }));
+    }
+
+    #[test]
+    fn test_dns_rebinding_allow_all_blocked() {
+        // Even in allow_all mode, link-local IPs are blocked
+        let filter = HostFilter::allow_all();
+        let metadata_ip = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))];
+        let result = filter.check_host("evil.com", &metadata_ip);
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_empty_resolved_ips_skips_link_local_check() {
+        let filter = HostFilter::new(&["api.openai.com".to_string()]);
+        // No resolved IPs = skip link-local check, just check hostname
+        let result = filter.check_host("api.openai.com", &[]);
+        assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_multiple_ips_any_link_local_denied() {
+        let filter = HostFilter::new(&["multi.example.com".to_string()]);
+        // First IP is public, second is link-local
+        let ips = vec![
+            IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96)),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 0, 1)),
+        ];
+        let result = filter.check_host("multi.example.com", &ips);
+        assert!(!result.is_allowed());
     }
 
     #[test]
@@ -268,5 +428,10 @@ mod tests {
             host: "evil.com".to_string(),
         };
         assert!(deny.reason().contains("evil.com"));
+
+        let link_local = FilterResult::DenyLinkLocal {
+            ip: IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+        };
+        assert!(link_local.reason().contains("link-local"));
     }
 }

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -1,36 +1,23 @@
-//! Network host filtering for proxy-level domain and CIDR matching.
+//! Network host filtering for proxy-level domain matching.
 //!
 //! This module provides application-layer host filtering that complements
 //! the OS-level port restrictions from [`CapabilitySet`](crate::CapabilitySet).
 //! The proxy uses [`HostFilter`] to decide whether to allow or deny CONNECT
-//! requests based on hostname allowlists and CIDR deny ranges.
+//! requests based on hostname allowlists and a cloud metadata deny list.
 //!
 //! # Security Properties
 //!
-//! - **Default deny list is hardcoded and non-overridable**: Cloud metadata
-//!   endpoints, RFC1918 private networks, link-local, and loopback ranges
-//!   are always denied regardless of allowlist configuration.
-//! - **DNS rebinding protection**: Callers resolve DNS first and pass resolved
-//!   IPs; the filter checks all resolved IPs against deny CIDRs before
-//!   checking the hostname allowlist.
+//! - **Cloud metadata endpoints are hardcoded and non-overridable**: Instance
+//!   metadata services (169.254.169.254, metadata.google.internal, etc.) are
+//!   always denied regardless of allowlist configuration.
 //! - **Wildcard subdomain matching**: `*.googleapis.com` matches
 //!   `storage.googleapis.com` but not `googleapis.com` itself.
-
-use ipnet::IpNet;
-use std::net::IpAddr;
 
 /// Result of a host filter check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FilterResult {
     /// Host is allowed by the allowlist
     Allow,
-    /// Host is denied because it matches a CIDR deny range
-    DenyCidr {
-        /// The resolved IP that matched a deny range
-        ip: IpAddr,
-        /// The CIDR range that matched
-        cidr: IpNet,
-    },
     /// Host is denied because a specific hostname is in the deny list
     DenyHost {
         /// The hostname that was denied
@@ -55,9 +42,6 @@ impl FilterResult {
     pub fn reason(&self) -> String {
         match self {
             FilterResult::Allow => "allowed by host filter".to_string(),
-            FilterResult::DenyCidr { ip, cidr } => {
-                format!("resolved IP {} matches denied CIDR {}", ip, cidr)
-            }
             FilterResult::DenyHost { host } => {
                 format!("host {} is in the deny list", host)
             }
@@ -76,32 +60,11 @@ const DENY_HOSTS: &[&str] = &[
     "metadata.azure.internal",
 ];
 
-/// CIDR ranges that are always denied regardless of allowlist configuration.
-/// Includes RFC1918 private networks, link-local, loopback, and IPv6 equivalents.
-fn default_deny_cidrs() -> Vec<IpNet> {
-    // These are all well-known CIDR ranges; parse failures would be a programming error.
-    let ranges = [
-        "10.0.0.0/8",
-        "172.16.0.0/12",
-        "192.168.0.0/16",
-        "169.254.0.0/16",
-        "127.0.0.0/8",
-        "::1/128",
-        "fc00::/7",
-        "fe80::/10",
-    ];
-    ranges
-        .iter()
-        .filter_map(|s| s.parse::<IpNet>().ok())
-        .collect()
-}
-
 /// A filter for host-based network access control.
 ///
-/// Supports exact domain match, wildcard subdomains (`*.googleapis.com`),
-/// and CIDR deny ranges (RFC1918, link-local, cloud metadata).
+/// Supports exact domain match and wildcard subdomains (`*.googleapis.com`).
 ///
-/// The default deny list is always applied and cannot be overridden.
+/// Cloud metadata endpoints are always denied and cannot be overridden.
 /// The allowlist determines which hosts are permitted; everything else
 /// is denied by default.
 #[derive(Debug, Clone)]
@@ -110,8 +73,6 @@ pub struct HostFilter {
     allowed_hosts: Vec<String>,
     /// Allowed wildcard suffixes (e.g., ".googleapis.com", lowercased)
     allowed_suffixes: Vec<String>,
-    /// CIDR ranges that are always denied
-    deny_cidrs: Vec<IpNet>,
     /// Hostnames that are always denied
     deny_hosts: Vec<String>,
 }
@@ -119,8 +80,7 @@ pub struct HostFilter {
 impl HostFilter {
     /// Create a new host filter with the given allowed hosts.
     ///
-    /// The default deny list (cloud metadata, RFC1918, loopback, link-local)
-    /// is automatically included and cannot be removed.
+    /// Cloud metadata endpoints are automatically denied and cannot be removed.
     ///
     /// Hosts starting with `*.` are treated as wildcard subdomain patterns.
     /// All other entries are exact matches. Matching is case-insensitive.
@@ -142,40 +102,31 @@ impl HostFilter {
         Self {
             allowed_hosts: exact,
             allowed_suffixes: suffixes,
-            deny_cidrs: default_deny_cidrs(),
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
         }
     }
 
     /// Create a host filter that allows everything (no filtering).
     ///
-    /// The default deny list still applies — cloud metadata and private
-    /// networks are always blocked.
+    /// Cloud metadata endpoints are still blocked.
     #[must_use]
     pub fn allow_all() -> Self {
         Self {
             allowed_hosts: Vec::new(),
             allowed_suffixes: Vec::new(),
-            deny_cidrs: default_deny_cidrs(),
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
         }
     }
 
     /// Check a host against the filter.
     ///
-    /// `resolved_ips` should contain the DNS-resolved IP addresses for the host.
-    /// The caller is responsible for performing DNS resolution before calling this
-    /// method. This prevents DNS rebinding attacks: the proxy resolves once, checks
-    /// the resolved IPs here, then connects to the same resolved IP.
-    ///
     /// # Check Order
     ///
     /// 1. Deny hosts (exact match against cloud metadata hostnames)
-    /// 2. Deny CIDRs (resolved IPs against RFC1918, link-local, loopback)
-    /// 3. Allowlist (exact host match, then wildcard subdomain match)
-    /// 4. Default deny (if not in allowlist and allowlist is non-empty)
+    /// 2. Allowlist (exact host match, then wildcard subdomain match)
+    /// 3. Default deny (if not in allowlist and allowlist is non-empty)
     #[must_use]
-    pub fn check_host(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
+    pub fn check_host(&self, host: &str) -> FilterResult {
         let lower_host = host.to_lowercase();
 
         // 1. Check deny hosts
@@ -185,45 +136,27 @@ impl HostFilter {
             };
         }
 
-        // 2. Check resolved IPs against deny CIDRs
-        for ip in resolved_ips {
-            for cidr in &self.deny_cidrs {
-                if cidr.contains(ip) {
-                    return FilterResult::DenyCidr {
-                        ip: *ip,
-                        cidr: *cidr,
-                    };
-                }
-            }
-        }
-
-        // 3. If no allowlist is configured (allow_all mode), allow
+        // 2. If no allowlist is configured (allow_all mode), allow
         if self.allowed_hosts.is_empty() && self.allowed_suffixes.is_empty() {
             return FilterResult::Allow;
         }
 
-        // 4. Check exact host match
+        // 3. Check exact host match
         if self.allowed_hosts.contains(&lower_host) {
             return FilterResult::Allow;
         }
 
-        // 5. Check wildcard subdomain match
+        // 4. Check wildcard subdomain match
         for suffix in &self.allowed_suffixes {
             if lower_host.ends_with(suffix.as_str()) && lower_host.len() > suffix.len() {
                 return FilterResult::Allow;
             }
         }
 
-        // 6. Not in allowlist
+        // 5. Not in allowlist
         FilterResult::DenyNotAllowed {
             host: host.to_string(),
         }
-    }
-
-    /// Check if a single IP is in any deny CIDR range.
-    #[must_use]
-    pub fn is_denied_cidr(&self, ip: &IpAddr) -> bool {
-        self.deny_cidrs.iter().any(|cidr| cidr.contains(ip))
     }
 
     /// Number of allowed hosts (exact + wildcard)
@@ -239,30 +172,25 @@ impl HostFilter {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::net::{Ipv4Addr, Ipv6Addr};
-
-    fn public_ip() -> Vec<IpAddr> {
-        vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))]
-    }
 
     #[test]
     fn test_exact_host_allowed() {
         let filter = HostFilter::new(&["api.openai.com".to_string()]);
-        let result = filter.check_host("api.openai.com", &public_ip());
+        let result = filter.check_host("api.openai.com");
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_exact_host_case_insensitive() {
         let filter = HostFilter::new(&["API.OpenAI.COM".to_string()]);
-        let result = filter.check_host("api.openai.com", &public_ip());
+        let result = filter.check_host("api.openai.com");
         assert!(result.is_allowed());
     }
 
     #[test]
     fn test_host_not_in_allowlist() {
         let filter = HostFilter::new(&["api.openai.com".to_string()]);
-        let result = filter.check_host("evil.com", &public_ip());
+        let result = filter.check_host("evil.com");
         assert!(!result.is_allowed());
         assert!(matches!(result, FilterResult::DenyNotAllowed { .. }));
     }
@@ -272,11 +200,11 @@ mod tests {
         let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
 
         // Subdomain should match
-        let result = filter.check_host("storage.googleapis.com", &public_ip());
+        let result = filter.check_host("storage.googleapis.com");
         assert!(result.is_allowed());
 
         // Deep subdomain should match
-        let result = filter.check_host("us-central1-aiplatform.googleapis.com", &public_ip());
+        let result = filter.check_host("us-central1-aiplatform.googleapis.com");
         assert!(result.is_allowed());
     }
 
@@ -285,7 +213,7 @@ mod tests {
         let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
 
         // Bare domain should NOT match wildcard
-        let result = filter.check_host("googleapis.com", &public_ip());
+        let result = filter.check_host("googleapis.com");
         assert!(!result.is_allowed());
     }
 
@@ -294,7 +222,7 @@ mod tests {
         let filter = HostFilter::new(&["169.254.169.254".to_string()]);
 
         // Should be denied even if in allowlist
-        let result = filter.check_host("169.254.169.254", &public_ip());
+        let result = filter.check_host("169.254.169.254");
         assert!(!result.is_allowed());
         assert!(matches!(result, FilterResult::DenyHost { .. }));
     }
@@ -302,85 +230,23 @@ mod tests {
     #[test]
     fn test_deny_google_metadata() {
         let filter = HostFilter::new(&["metadata.google.internal".to_string()]);
-        let result = filter.check_host("metadata.google.internal", &public_ip());
+        let result = filter.check_host("metadata.google.internal");
         assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_deny_rfc1918_ip_via_cidr() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-
-        // Even if hostname matches allowlist, resolved IP in RFC1918 should be denied
-        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
-        let result = filter.check_host("api.example.com", &private_ip);
-        assert!(!result.is_allowed());
-        assert!(matches!(result, FilterResult::DenyCidr { .. }));
-    }
-
-    #[test]
-    fn test_deny_link_local_cidr() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-        let link_local = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))];
-        let result = filter.check_host("api.example.com", &link_local);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_deny_loopback_cidr() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-        let loopback = vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))];
-        let result = filter.check_host("api.example.com", &loopback);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_deny_ipv6_loopback() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-        let ipv6_loopback = vec![IpAddr::V6(Ipv6Addr::LOCALHOST)];
-        let result = filter.check_host("api.example.com", &ipv6_loopback);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_deny_ipv6_unique_local() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-        let ipv6_ula = vec![IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1))];
-        let result = filter.check_host("api.example.com", &ipv6_ula);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_dns_rebinding_protection() {
-        // Attacker's domain resolves to cloud metadata IP
-        let filter = HostFilter::new(&["attacker.com".to_string()]);
-        let metadata_ip = vec![IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))];
-        let result = filter.check_host("attacker.com", &metadata_ip);
-        assert!(!result.is_allowed());
-        assert!(matches!(result, FilterResult::DenyCidr { .. }));
     }
 
     #[test]
     fn test_allow_all_mode() {
         // No allowlist = allow all (except deny list)
         let filter = HostFilter::allow_all();
-        let result = filter.check_host("any-host.example.com", &public_ip());
+        let result = filter.check_host("any-host.example.com");
         assert!(result.is_allowed());
     }
 
     #[test]
-    fn test_allow_all_still_denies_private() {
+    fn test_allow_all_allows_private_networks() {
         let filter = HostFilter::allow_all();
-        let private_ip = vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))];
-        let result = filter.check_host("internal.corp.com", &private_ip);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_is_denied_cidr() {
-        let filter = HostFilter::new(&[]);
-        assert!(filter.is_denied_cidr(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
-        assert!(filter.is_denied_cidr(&IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
-        assert!(!filter.is_denied_cidr(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        let result = filter.check_host("internal.corp.com");
+        assert!(result.is_allowed());
     }
 
     #[test]
@@ -394,14 +260,6 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_resolved_ips_skips_cidr_check() {
-        let filter = HostFilter::new(&["api.openai.com".to_string()]);
-        // No resolved IPs = skip CIDR check, just check hostname
-        let result = filter.check_host("api.openai.com", &[]);
-        assert!(result.is_allowed());
-    }
-
-    #[test]
     fn test_filter_result_reason() {
         let allow = FilterResult::Allow;
         assert!(allow.reason().contains("allowed"));
@@ -410,30 +268,5 @@ mod tests {
             host: "evil.com".to_string(),
         };
         assert!(deny.reason().contains("evil.com"));
-    }
-
-    #[test]
-    fn test_multiple_ips_any_denied() {
-        let filter = HostFilter::new(&["multi.example.com".to_string()]);
-        // First IP is public, second is private
-        let ips = vec![
-            IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96)),
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-        ];
-        let result = filter.check_host("multi.example.com", &ips);
-        assert!(!result.is_allowed());
-    }
-
-    #[test]
-    fn test_172_16_range_denied() {
-        let filter = HostFilter::new(&["*.example.com".to_string()]);
-        let ip = vec![IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))];
-        let result = filter.check_host("api.example.com", &ip);
-        assert!(!result.is_allowed());
-
-        // 172.15.x.x should be allowed (outside the /12 range)
-        let ip = vec![IpAddr::V4(Ipv4Addr::new(172, 15, 255, 255))];
-        let result = filter.check_host("api.example.com", &ip);
-        assert!(result.is_allowed());
     }
 }

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -131,11 +131,24 @@ User profiles can specify a network profile in the `network` section:
 
 The following cloud metadata destinations are always blocked, regardless of configuration. These cannot be overridden.
 
+### Denied Hostnames
+
 | Host | Service |
 |------|---------|
 | 169.254.169.254 | AWS/GCP/Azure instance metadata |
 | metadata.google.internal | GCP metadata alias |
 | metadata.azure.internal | Azure metadata alias |
+
+### Link-Local IP Protection
+
+Resolved IPs in the link-local range are always blocked after DNS resolution to prevent DNS rebinding attacks targeting cloud metadata services:
+
+| Range | Description |
+|-------|-------------|
+| 169.254.0.0/16 | IPv4 link-local |
+| fe80::/10 | IPv6 link-local |
+
+Private network addresses (RFC1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) are allowed to support enterprise environments.
 
 ## Platform Behavior
 

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -81,7 +81,7 @@ For corporate environments with a mandatory outbound proxy:
 nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:3128 -- my-agent
 ```
 
-CONNECT requests are chained through the corporate proxy. The default deny list (cloud metadata, RFC1918) is still enforced as a floor.
+CONNECT requests are chained through the corporate proxy. Cloud metadata endpoints are still denied.
 
 ## Network Profiles
 
@@ -129,27 +129,13 @@ User profiles can specify a network profile in the `network` section:
 
 ## Default Deny List
 
-The following destinations are always blocked, regardless of configuration. These cannot be overridden.
+The following cloud metadata destinations are always blocked, regardless of configuration. These cannot be overridden.
 
-### Cloud Metadata
-
-| Host/CIDR | Service |
-|-----------|---------|
+| Host | Service |
+|------|---------|
 | 169.254.169.254 | AWS/GCP/Azure instance metadata |
 | metadata.google.internal | GCP metadata alias |
-
-### Private Networks
-
-| CIDR | Range |
-|------|-------|
-| 10.0.0.0/8 | RFC1918 Class A |
-| 172.16.0.0/12 | RFC1918 Class B |
-| 192.168.0.0/16 | RFC1918 Class C |
-| 169.254.0.0/16 | Link-local |
-| 127.0.0.0/8 | Loopback (except proxy port) |
-| ::1/128 | IPv6 loopback |
-| fc00::/7 | IPv6 unique local |
-| fe80::/10 | IPv6 link-local |
+| metadata.azure.internal | Azure metadata alias |
 
 ## Platform Behavior
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -232,13 +232,13 @@ Tokens are compared using constant-time equality to prevent timing attacks. This
 
 ### DNS Rebinding Protection
 
-The proxy resolves DNS itself and checks all resolved IP addresses against the deny list before connecting. This prevents attacks where:
+The proxy resolves DNS itself and checks all resolved IP addresses against the link-local range before connecting. This prevents attacks where:
 
 1. An attacker controls DNS for an allowed hostname
-2. DNS returns a cloud metadata address (e.g., `169.254.169.254`)
-3. The proxy would connect to the metadata service thinking it's an allowed external API
+2. DNS returns a link-local address (e.g., `169.254.169.254`)
+3. The proxy would connect to the cloud metadata service thinking it's an allowed external API
 
-Cloud metadata endpoints are hardcoded as denied and cannot be overridden by configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
+Link-local IPs (169.254.0.0/16, fe80::/10) are always blocked after DNS resolution. Cloud metadata hostnames are also hardcoded as denied. Private network addresses (RFC1918) are allowed to support enterprise environments.
 
 ### Credential Isolation
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -235,10 +235,10 @@ Tokens are compared using constant-time equality to prevent timing attacks. This
 The proxy resolves DNS itself and checks all resolved IP addresses against the deny list before connecting. This prevents attacks where:
 
 1. An attacker controls DNS for an allowed hostname
-2. DNS returns an RFC1918 address (e.g., `10.0.0.1`) or cloud metadata (`169.254.169.254`)
-3. The proxy would connect to an internal host thinking it's an allowed external API
+2. DNS returns a cloud metadata address (e.g., `169.254.169.254`)
+3. The proxy would connect to the metadata service thinking it's an allowed external API
 
-The deny list (cloud metadata, RFC1918, link-local, loopback) is hardcoded and cannot be overridden by configuration.
+Cloud metadata endpoints are hardcoded as denied and cannot be overridden by configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
 
 ### Credential Isolation
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -267,7 +267,7 @@ See [Credential Injection](/cli/features/credential-injection) for complete docu
 
 #### `--external-proxy`
 
-Chain outbound connections through an external (enterprise) proxy. The default deny list (cloud metadata, private networks) is still enforced.
+Chain outbound connections through an external (enterprise) proxy. Cloud metadata endpoints are still denied.
 
 ```bash
 nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:3128 -- my-agent


### PR DESCRIPTION
Private network addresses (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, link-local, loopback, IPv6 equivalents) were hardcoded as denied in the proxy host filter. This blocked legitimate enterprise use cases where agents need to reach internal services (Kerberos, internal APIs, etc.).

Cloud metadata endpoints (169.254.169.254, metadata.google.internal, metadata.azure.internal) remain hardcoded as denied — these are SSRF targets that should never be accessed by sandboxed agents.

Removes the ipnet dependency from both nono and nono-proxy crates.

Closes: #225