### PR TITLE
feat: add env:// credential scheme and GitHub token proxy support

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -101,6 +101,16 @@
     }
   },
   "profiles": {
+    "opencode": {
+      "groups": [
+        "llm_apis",
+        "package_registries",
+        "github",
+        "sigstore",
+        "documentation"
+      ],
+      "credentials": ["google-ai", "github"]
+    },
     "developer": {
       "groups": [
         "llm_apis",
@@ -108,7 +118,18 @@
         "github",
         "sigstore",
         "documentation"
-      ]
+      ],
+      "credentials": ["github"]
+    },
+    "claude-code": {
+      "groups": [
+        "llm_apis",
+        "package_registries",
+        "github",
+        "sigstore",
+        "documentation"
+      ],
+      "credentials": ["github"]
     },
     "minimal": {
       "groups": [
@@ -148,6 +169,13 @@
       "upstream": "https://generativelanguage.googleapis.com",
       "inject_header": "x-goog-api-key",
       "credential_format": "{}"
+    },
+    "github": {
+      "upstream": "https://api.github.com",
+      "credential_key": "env://GITHUB_TOKEN",
+      "inject_header": "Authorization",
+      "credential_format": "token {}",
+      "env_var": "GITHUB_TOKEN"
     }
   }
 }

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -69,6 +69,13 @@ pub struct CredentialDef {
     pub inject_header: String,
     #[serde(default = "default_credential_format")]
     pub credential_format: String,
+    /// Explicit environment variable name for the phantom token.
+    ///
+    /// Required when `credential_key` is an `env://` or `op://` URI, since
+    /// uppercasing those produces nonsensical env var names. When `None`,
+    /// the proxy derives the env var from `credential_key.to_uppercase()`.
+    #[serde(default)]
+    pub env_var: Option<String>,
 }
 
 fn default_inject_header() -> String {
@@ -226,7 +233,7 @@ pub fn resolve_credentials(
                 path_pattern: None,
                 path_replacement: None,
                 query_param_name: None,
-                env_var: None,
+                env_var: cred.env_var.clone(),
             });
         }
         // We already validated existence above, so this else branch won't be hit
@@ -685,8 +692,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_credentials_builtin_has_no_env_var() {
-        // Built-in credentials should always have env_var = None
+    fn test_resolve_credentials_builtin_without_env_var() {
+        // Built-in credentials without explicit env_var should have env_var = None
         // (they use the cred_key.to_uppercase() fallback)
         let json = embedded_network_policy_json();
         let policy = load_network_policy(json).expect("policy should load");
@@ -697,7 +704,58 @@ mod tests {
         assert_eq!(routes.len(), 1);
         assert_eq!(
             routes[0].env_var, None,
-            "Built-in credentials should not have env_var set"
+            "Built-in credentials without env_var field should have None"
+        );
+    }
+
+    #[test]
+    fn test_resolve_github_credential() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).expect("policy should load");
+
+        let custom = HashMap::new();
+        let routes =
+            resolve_credentials(&policy, &["github".to_string()], &custom).expect("should resolve");
+        assert_eq!(routes.len(), 1);
+
+        let github = &routes[0];
+        assert_eq!(github.prefix, "github");
+        assert_eq!(github.upstream, "https://api.github.com");
+        assert_eq!(
+            github.credential_key,
+            Some("env://GITHUB_TOKEN".to_string())
+        );
+        assert_eq!(github.credential_format, "token {}");
+        assert_eq!(
+            github.env_var,
+            Some("GITHUB_TOKEN".to_string()),
+            "github credential must have explicit env_var for phantom token"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_profile_includes_github_credential() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).expect("policy should load");
+
+        let resolved = resolve_network_profile(&policy, "claude-code").expect("should resolve");
+        assert!(
+            resolved.profile_credentials.contains(&"github".to_string()),
+            "claude-code profile should include github credential, got: {:?}",
+            resolved.profile_credentials
+        );
+    }
+
+    #[test]
+    fn test_developer_profile_includes_github_credential() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).expect("policy should load");
+
+        let resolved = resolve_network_profile(&policy, "developer").expect("should resolve");
+        assert!(
+            resolved.profile_credentials.contains(&"github".to_string()),
+            "developer profile should include github credential, got: {:?}",
+            resolved.profile_credentials
         );
     }
 }

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -207,6 +207,15 @@ pub fn resolve_credentials(
         // in profile/mod.rs::validate_profile_custom_credentials(), so we don't
         // need to re-validate here.
         if let Some(cred) = custom_credentials.get(name) {
+            // Validate env_var against dangerous variable blocklist
+            if let Some(ref env_var) = cred.env_var {
+                nono::validate_destination_env_var(env_var).map_err(|e| {
+                    NonoError::ConfigParse(format!(
+                        "custom credential '{}' has invalid env_var: {}",
+                        name, e
+                    ))
+                })?;
+            }
             routes.push(RouteConfig {
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
@@ -220,6 +229,15 @@ pub fn resolve_credentials(
                 env_var: cred.env_var.clone(),
             });
         } else if let Some(cred) = policy.credentials.get(name) {
+            // Validate env_var against dangerous variable blocklist
+            if let Some(ref env_var) = cred.env_var {
+                nono::validate_destination_env_var(env_var).map_err(|e| {
+                    NonoError::ConfigParse(format!(
+                        "credential '{}' has invalid env_var: {}",
+                        name, e
+                    ))
+                })?;
+            }
             // Built-in credentials always use header mode.
             // credential_key defaults to the service name if not set.
             let key = cred.credential_key.clone().unwrap_or_else(|| name.clone());
@@ -743,6 +761,39 @@ mod tests {
             resolved.profile_credentials.contains(&"github".to_string()),
             "claude-code profile should include github credential, got: {:?}",
             resolved.profile_credentials
+        );
+    }
+
+    #[test]
+    fn test_resolve_credentials_rejects_dangerous_env_var() {
+        use crate::profile::CustomCredentialDef;
+
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let mut custom = HashMap::new();
+        custom.insert(
+            "evil".to_string(),
+            CustomCredentialDef {
+                upstream: "https://api.example.com".to_string(),
+                credential_key: "safe_key".to_string(),
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: Some("LD_PRELOAD".to_string()),
+            },
+        );
+
+        let result = resolve_credentials(&policy, &["evil".to_string()], &custom);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("blocklist"),
+            "should mention blocklist, got: {}",
+            err
         );
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -399,14 +399,18 @@ fn validate_profile_custom_credentials(profile: &Profile) -> Result<()> {
 
 /// Validate env_credentials keys in a profile.
 ///
-/// Keys can be either keyring account names or `op://` URIs.
+/// Keys can be keyring account names, `op://` URIs, or `env://` URIs.
 /// Keyring account names are validated at load time by the keyring crate itself,
-/// but `op://` URIs need structural validation upfront.
+/// but `op://` and `env://` URIs need structural validation upfront.
 fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
     for key in profile.env_credentials.mappings.keys() {
         if nono::keystore::is_op_uri(key) {
             nono::keystore::validate_op_uri(key).map_err(|e| {
                 NonoError::ProfileParse(format!("invalid 1Password URI in env_credentials: {}", e))
+            })?;
+        } else if nono::keystore::is_env_uri(key) {
+            nono::keystore::validate_env_uri(key).map_err(|e| {
+                NonoError::ProfileParse(format!("invalid env:// URI in env_credentials: {}", e))
             })?;
         }
     }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -403,7 +403,7 @@ fn validate_profile_custom_credentials(profile: &Profile) -> Result<()> {
 /// Keyring account names are validated at load time by the keyring crate itself,
 /// but `op://` and `env://` URIs need structural validation upfront.
 fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
-    for key in profile.env_credentials.mappings.keys() {
+    for (key, value) in &profile.env_credentials.mappings {
         if nono::keystore::is_op_uri(key) {
             nono::keystore::validate_op_uri(key).map_err(|e| {
                 NonoError::ProfileParse(format!("invalid 1Password URI in env_credentials: {}", e))
@@ -413,6 +413,13 @@ fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
                 NonoError::ProfileParse(format!("invalid env:// URI in env_credentials: {}", e))
             })?;
         }
+        // Validate destination env var name against dangerous blocklist
+        nono::validate_destination_env_var(value).map_err(|e| {
+            NonoError::ProfileParse(format!(
+                "invalid destination env var '{}' in env_credentials: {}",
+                value, e
+            ))
+        })?;
     }
     Ok(())
 }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -9,7 +9,7 @@ use crate::config::{InjectMode, RouteConfig};
 use crate::error::{ProxyError, Result};
 use base64::Engine;
 use std::collections::HashMap;
-use tracing::debug;
+use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
 /// A loaded credential ready for injection.
@@ -66,7 +66,12 @@ impl CredentialStore {
     /// Load credentials for all configured routes from the system keystore.
     ///
     /// Routes without a `credential_key` are skipped (no credential injection).
-    /// Returns an error if any configured credential fails to load.
+    /// Routes whose credential is not found (e.g. unset env var) are skipped
+    /// with a warning — this allows profiles to declare optional credentials
+    /// without failing when they are unavailable.
+    ///
+    /// Returns an error only for hard failures (keystore access errors,
+    /// config parse errors, non-UTF-8 values).
     pub fn load(routes: &[RouteConfig]) -> Result<Self> {
         let mut credentials = HashMap::new();
 
@@ -77,8 +82,17 @@ impl CredentialStore {
                     route.prefix, route.inject_mode
                 );
 
-                let secret = nono::keystore::load_secret_by_ref(KEYRING_SERVICE, key)
-                    .map_err(|e| ProxyError::Credential(e.to_string()))?;
+                let secret = match nono::keystore::load_secret_by_ref(KEYRING_SERVICE, key) {
+                    Ok(s) => s,
+                    Err(nono::NonoError::SecretNotFound(msg)) => {
+                        warn!(
+                            "Credential '{}' not available, skipping route: {}",
+                            route.prefix, msg
+                        );
+                        continue;
+                    }
+                    Err(e) => return Err(ProxyError::Credential(e.to_string())),
+                };
 
                 // Format header value based on mode
                 let header_value = match route.inject_mode {

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -1,11 +1,14 @@
-//! Secure credential loading from system keystore and 1Password
+//! Secure credential loading from system keystore, 1Password, and environment
 //!
 //! This module provides functionality to load secrets from the system keystore
-//! (macOS Keychain / Linux Secret Service) or 1Password (via the `op` CLI) and
-//! return them as zeroized strings.
+//! (macOS Keychain / Linux Secret Service), 1Password (via the `op` CLI), or
+//! environment variables (via the `env://` scheme) and return them as zeroized
+//! strings.
 //!
-//! Credential references starting with `op://` are loaded via the 1Password CLI.
-//! All other references are loaded from the system keyring.
+//! Credential references are dispatched by URI scheme:
+//! - `env://VAR_NAME` — reads from the current process environment
+//! - `op://vault/item/field` — loaded via the 1Password CLI
+//! - Everything else — loaded from the system keyring
 //!
 //! All secrets are wrapped in `Zeroizing<String>` to ensure they are securely
 //! cleared from memory after use.
@@ -32,6 +35,46 @@ pub const DEFAULT_SERVICE: &str = "nono";
 
 /// The `op://` URI scheme prefix, indicating 1Password CLI backend.
 const OP_URI_PREFIX: &str = "op://";
+
+/// The `env://` URI scheme prefix, indicating environment variable backend.
+const ENV_URI_PREFIX: &str = "env://";
+
+/// Environment variable names that must never be loaded via `env://`.
+///
+/// These control linker, interpreter, or shell behavior. Allowing them as
+/// credential sources would let an `env://` URI act as an injection vector.
+const DANGEROUS_ENV_VAR_NAMES: &[&str] = &[
+    // Linker injection
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    // Shell injection
+    "BASH_ENV",
+    "ENV",
+    "IFS",
+    "CDPATH",
+    "PROMPT_COMMAND",
+    // Interpreter injection
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "PYTHONSTARTUP",
+    "PYTHONPATH",
+    "PERL5OPT",
+    "PERL5LIB",
+    "RUBYOPT",
+    "RUBYLIB",
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "DOTNET_STARTUP_HOOKS",
+    "GOFLAGS",
+    // Process-critical
+    "PATH",
+    "HOME",
+    "SHELL",
+];
 
 /// Characters forbidden in `op://` URIs to prevent argument/shell injection.
 const FORBIDDEN_URI_CHARS: &[char] = &[
@@ -86,12 +129,14 @@ pub fn load_secrets(
 
 /// Load a single secret, dispatching to the appropriate backend.
 ///
-/// If `credential_ref` starts with `op://`, delegates to the 1Password CLI.
-/// Otherwise, loads from the system keyring under the given service name.
+/// Dispatch order:
+/// 1. `env://VAR` — reads from the process environment
+/// 2. `op://vault/item/field` — delegates to the 1Password CLI
+/// 3. Everything else — loads from the system keyring
 ///
 /// # Arguments
 /// * `service` - Keyring service name (only used for keyring backend)
-/// * `credential_ref` - Either a keyring account name or an `op://` URI
+/// * `credential_ref` - A keyring account name, `op://` URI, or `env://` URI
 ///
 /// # Security
 /// The returned value is wrapped in `Zeroizing<String>`. For `op://` URIs,
@@ -100,7 +145,9 @@ pub fn load_secrets(
 /// is the same class of limitation as the keyring crate's internal buffers.
 #[must_use = "loaded secret should be used or explicitly dropped"]
 pub fn load_secret_by_ref(service: &str, credential_ref: &str) -> Result<Zeroizing<String>> {
-    if credential_ref.starts_with(OP_URI_PREFIX) {
+    if credential_ref.starts_with(ENV_URI_PREFIX) {
+        load_from_env(credential_ref)
+    } else if credential_ref.starts_with(OP_URI_PREFIX) {
         load_from_op(credential_ref)
     } else {
         load_single_secret(service, credential_ref)
@@ -165,6 +212,93 @@ pub fn validate_op_uri(uri: &str) -> Result<()> {
 #[must_use]
 pub fn is_op_uri(credential_ref: &str) -> bool {
     credential_ref.starts_with(OP_URI_PREFIX)
+}
+
+/// Returns true if the credential reference is an `env://` URI.
+#[must_use]
+pub fn is_env_uri(credential_ref: &str) -> bool {
+    credential_ref.starts_with(ENV_URI_PREFIX)
+}
+
+/// Validate an `env://VAR_NAME` URI.
+///
+/// Accepts variable names containing only ASCII alphanumeric characters and
+/// underscores (`[A-Za-z0-9_]+`). This is stricter than POSIX (which allows
+/// any byte except `=` and NUL) but matches real-world conventions and
+/// prevents injection through crafted variable names.
+///
+/// Rejects:
+/// - Empty variable name
+/// - Names containing non-alphanumeric/underscore characters
+/// - Dangerous variable names that control linker/interpreter/shell behavior
+pub fn validate_env_uri(uri: &str) -> Result<()> {
+    let var_name = uri.strip_prefix(ENV_URI_PREFIX).ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "credential reference '{}' does not start with '{}'",
+            uri, ENV_URI_PREFIX
+        ))
+    })?;
+
+    if var_name.is_empty() {
+        return Err(NonoError::ConfigParse(
+            "env:// URI has empty variable name".to_string(),
+        ));
+    }
+
+    if let Some(bad) = var_name
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
+    {
+        return Err(NonoError::ConfigParse(format!(
+            "env:// variable name contains invalid character {:?}: {}",
+            bad, uri
+        )));
+    }
+
+    if DANGEROUS_ENV_VAR_NAMES.contains(&var_name) {
+        return Err(NonoError::ConfigParse(format!(
+            "env:// cannot read dangerous environment variable: {}",
+            var_name
+        )));
+    }
+
+    Ok(())
+}
+
+/// Load a secret from an environment variable.
+///
+/// Reads from the current process environment (before sandbox application).
+/// The value is wrapped in `Zeroizing<String>` to minimize plaintext lifetime.
+///
+/// # Errors
+///
+/// Returns `SecretNotFound` if the variable is unset or empty.
+/// Returns `KeystoreAccess` if the variable contains non-UTF-8 data.
+fn load_from_env(uri: &str) -> Result<Zeroizing<String>> {
+    validate_env_uri(uri)?;
+
+    let var_name = uri
+        .strip_prefix(ENV_URI_PREFIX)
+        .ok_or_else(|| NonoError::ConfigParse(format!("invalid env:// URI: {}", uri)))?;
+
+    match std::env::var(var_name) {
+        Ok(value) if value.is_empty() => Err(NonoError::SecretNotFound(format!(
+            "environment variable '{}' is set but empty",
+            var_name
+        ))),
+        Ok(value) => {
+            tracing::debug!("Loaded secret from environment variable '{}'", var_name);
+            Ok(Zeroizing::new(value))
+        }
+        Err(std::env::VarError::NotPresent) => Err(NonoError::SecretNotFound(format!(
+            "environment variable '{}' is not set",
+            var_name
+        ))),
+        Err(std::env::VarError::NotUnicode(_)) => Err(NonoError::KeystoreAccess(format!(
+            "environment variable '{}' contains non-UTF-8 data",
+            var_name
+        ))),
+    }
 }
 
 /// Load a single secret from the keystore.
@@ -359,17 +493,22 @@ fn wait_with_timeout(
 
 /// Build secret mappings from a comma-separated list of credential entries.
 ///
-/// Supports two formats:
+/// Supports three formats:
 /// - **Keyring names**: `openai_api_key` → env var `OPENAI_API_KEY` (auto-uppercased)
 /// - **1Password URIs with explicit var**: `op://vault/item/field=MY_VAR` → env var `MY_VAR`
+/// - **Environment URIs**: `env://GITHUB_TOKEN` → env var `GITHUB_TOKEN` (auto-derived)
+///   or `env://GITHUB_TOKEN=GH_TOKEN` → env var `GH_TOKEN` (explicit)
 ///
 /// 1Password URIs (`op://...`) **must** include `=VAR_NAME` because uppercasing a URI
-/// produces a meaningless env var name. Bare `op://` URIs without `=` are rejected
-/// and return an error.
+/// produces a meaningless env var name. Bare `op://` URIs without `=` are rejected.
+///
+/// Environment URIs (`env://...`) auto-derive the target variable name from the source
+/// when `=` is omitted: `env://GITHUB_TOKEN` maps to env var `GITHUB_TOKEN`.
 ///
 /// # Errors
 ///
-/// Returns an error if an `op://` URI is provided without an `=VAR_NAME` suffix.
+/// Returns an error if an `op://` URI is provided without an `=VAR_NAME` suffix,
+/// or if any URI fails validation.
 ///
 /// # Example
 ///
@@ -389,7 +528,30 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
             continue;
         }
 
-        if entry.starts_with(OP_URI_PREFIX) {
+        if entry.starts_with(ENV_URI_PREFIX) {
+            // env:// URI: auto-derive target var or use explicit =VAR_NAME
+            if let Some(eq_pos) = entry.rfind('=') {
+                let uri = &entry[..eq_pos];
+                let var_name = &entry[eq_pos + 1..];
+
+                if var_name.is_empty() {
+                    return Err(NonoError::ConfigParse(format!(
+                        "env:// credential '{}' has '=' but no variable name",
+                        uri
+                    )));
+                }
+
+                validate_env_uri(uri)?;
+                mappings.insert(uri.to_string(), var_name.to_string());
+            } else {
+                // Auto-derive: env://GITHUB_TOKEN -> target GITHUB_TOKEN
+                validate_env_uri(entry)?;
+                let source_var = entry
+                    .strip_prefix(ENV_URI_PREFIX)
+                    .ok_or_else(|| NonoError::ConfigParse("invalid env:// URI".to_string()))?;
+                mappings.insert(entry.to_string(), source_var.to_string());
+            }
+        } else if entry.starts_with(OP_URI_PREFIX) {
             // 1Password URI: must have =VAR_NAME suffix
             // Find the last '=' that separates the URI from the var name.
             // op:// URIs don't contain '=', so the last '=' is unambiguous.
@@ -833,6 +995,216 @@ mod tests {
             err.contains("1Password") || err.contains("op"),
             "expected 1Password error, got: {}",
             err
+        );
+    }
+
+    // =========================================================================
+    // env:// URI tests
+    // =========================================================================
+
+    #[test]
+    fn test_is_env_uri_positive() {
+        assert!(is_env_uri("env://GITHUB_TOKEN"));
+        assert!(is_env_uri("env://MY_KEY_123"));
+    }
+
+    #[test]
+    fn test_is_env_uri_negative() {
+        assert!(!is_env_uri("openai_api_key"));
+        assert!(!is_env_uri("op://vault/item/field"));
+        assert!(!is_env_uri("ENV://UPPER_SCHEME"));
+    }
+
+    #[test]
+    fn test_validate_env_uri_valid() {
+        assert!(validate_env_uri("env://GITHUB_TOKEN").is_ok());
+        assert!(validate_env_uri("env://MY_API_KEY_123").is_ok());
+        assert!(validate_env_uri("env://x").is_ok());
+        assert!(validate_env_uri("env://A").is_ok());
+    }
+
+    #[test]
+    fn test_validate_env_uri_empty_name() {
+        let err = validate_env_uri("env://").expect_err("should reject");
+        assert!(
+            err.to_string().contains("empty variable name"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_env_uri_invalid_chars() {
+        // Spaces
+        let err = validate_env_uri("env://MY VAR").expect_err("should reject");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "got: {}",
+            err
+        );
+
+        // Dashes
+        let err = validate_env_uri("env://MY-VAR").expect_err("should reject");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "got: {}",
+            err
+        );
+
+        // Dots
+        let err = validate_env_uri("env://MY.VAR").expect_err("should reject");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "got: {}",
+            err
+        );
+
+        // Shell metacharacters
+        let err = validate_env_uri("env://$(whoami)").expect_err("should reject");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_env_uri_dangerous_ld_preload() {
+        let err = validate_env_uri("env://LD_PRELOAD").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_env_uri_dangerous_dyld() {
+        let err = validate_env_uri("env://DYLD_INSERT_LIBRARIES").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_env_uri_dangerous_node_options() {
+        let err = validate_env_uri("env://NODE_OPTIONS").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_env_uri_dangerous_path() {
+        let err = validate_env_uri("env://PATH").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_env_uri_missing_prefix() {
+        let err = validate_env_uri("GITHUB_TOKEN").expect_err("should reject");
+        assert!(
+            err.to_string().contains("does not start with"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_load_from_env_set() {
+        // Set a test variable, load it, verify value
+        let test_var = "NONO_TEST_ENV_SECRET_12345";
+        unsafe { std::env::set_var(test_var, "secret_value_42") };
+
+        let result = load_from_env(&format!("env://{}", test_var));
+        assert!(result.is_ok(), "should load: {:?}", result.err());
+        assert_eq!(*result.expect("should load"), "secret_value_42");
+
+        unsafe { std::env::remove_var(test_var) };
+    }
+
+    #[test]
+    fn test_load_from_env_not_set() {
+        let result = load_from_env("env://NONO_NONEXISTENT_VAR_XYZZY");
+        assert!(result.is_err());
+        let err = result.expect_err("should fail").to_string();
+        assert!(err.contains("not set"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_load_from_env_empty() {
+        let test_var = "NONO_TEST_ENV_EMPTY_12345";
+        unsafe { std::env::set_var(test_var, "") };
+
+        let result = load_from_env(&format!("env://{}", test_var));
+        assert!(result.is_err());
+        let err = result.expect_err("should fail").to_string();
+        assert!(err.contains("empty"), "got: {}", err);
+
+        unsafe { std::env::remove_var(test_var) };
+    }
+
+    #[test]
+    fn test_load_secret_by_ref_dispatches_env() {
+        let test_var = "NONO_TEST_REF_DISPATCH_12345";
+        unsafe { std::env::set_var(test_var, "dispatched_ok") };
+
+        let result = load_secret_by_ref("nono", &format!("env://{}", test_var));
+        assert!(
+            result.is_ok(),
+            "should dispatch to env backend: {:?}",
+            result.err()
+        );
+        assert_eq!(*result.expect("should load"), "dispatched_ok");
+
+        unsafe { std::env::remove_var(test_var) };
+    }
+
+    // --- env:// in build_mappings_from_list ---
+
+    #[test]
+    fn test_build_mappings_env_uri_auto_derive() {
+        let mappings = build_mappings_from_list("env://GITHUB_TOKEN").expect("should parse");
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(
+            mappings.get("env://GITHUB_TOKEN"),
+            Some(&"GITHUB_TOKEN".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_mappings_env_uri_with_explicit_var() {
+        let mappings =
+            build_mappings_from_list("env://GITHUB_TOKEN=GH_TOKEN").expect("should parse");
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(
+            mappings.get("env://GITHUB_TOKEN"),
+            Some(&"GH_TOKEN".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_mappings_env_uri_empty_var_rejected() {
+        let err =
+            build_mappings_from_list("env://GITHUB_TOKEN=").expect_err("should reject empty var");
+        assert!(err.to_string().contains("no variable name"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_build_mappings_env_uri_dangerous_rejected() {
+        let err =
+            build_mappings_from_list("env://LD_PRELOAD").expect_err("should reject dangerous var");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_build_mappings_mixed_keyring_op_env() {
+        let mappings = build_mappings_from_list(
+            "my_api_key,op://vault/item/field=SECRET_VAR,env://GITHUB_TOKEN",
+        )
+        .expect("should parse");
+
+        assert_eq!(mappings.len(), 3);
+        assert_eq!(mappings.get("my_api_key"), Some(&"MY_API_KEY".to_string()));
+        assert_eq!(
+            mappings.get("op://vault/item/field"),
+            Some(&"SECRET_VAR".to_string())
+        );
+        assert_eq!(
+            mappings.get("env://GITHUB_TOKEN"),
+            Some(&"GITHUB_TOKEN".to_string())
         );
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -255,9 +255,50 @@ pub fn validate_env_uri(uri: &str) -> Result<()> {
         )));
     }
 
-    if DANGEROUS_ENV_VAR_NAMES.contains(&var_name) {
+    if DANGEROUS_ENV_VAR_NAMES
+        .iter()
+        .any(|&d| d.eq_ignore_ascii_case(var_name))
+    {
         return Err(NonoError::ConfigParse(format!(
             "env:// cannot read dangerous environment variable: {}",
+            var_name
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate a destination environment variable name.
+///
+/// Ensures the target variable name is not on the dangerous blocklist and
+/// follows standard naming conventions (`[A-Za-z0-9_]+`). This prevents
+/// Environment Variable Injection where an attacker specifies a dangerous
+/// target like `LD_PRELOAD` or `PATH` via explicit `=TARGET` syntax.
+///
+/// The check is case-insensitive to prevent bypass via `ld_preload` etc.
+pub fn validate_destination_env_var(var_name: &str) -> Result<()> {
+    if var_name.is_empty() {
+        return Err(NonoError::ConfigParse(
+            "destination environment variable name cannot be empty".to_string(),
+        ));
+    }
+
+    if let Some(bad) = var_name
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
+    {
+        return Err(NonoError::ConfigParse(format!(
+            "destination environment variable name contains invalid character {:?}: {}",
+            bad, var_name
+        )));
+    }
+
+    if DANGEROUS_ENV_VAR_NAMES
+        .iter()
+        .any(|&d| d.eq_ignore_ascii_case(var_name))
+    {
+        return Err(NonoError::ConfigParse(format!(
+            "destination environment variable '{}' is on the blocklist of dangerous variables",
             var_name
         )));
     }
@@ -542,13 +583,18 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
                 }
 
                 validate_env_uri(uri)?;
+                validate_destination_env_var(var_name)?;
                 mappings.insert(uri.to_string(), var_name.to_string());
             } else {
                 // Auto-derive: env://GITHUB_TOKEN -> target GITHUB_TOKEN
                 validate_env_uri(entry)?;
-                let source_var = entry
-                    .strip_prefix(ENV_URI_PREFIX)
-                    .ok_or_else(|| NonoError::ConfigParse("invalid env:// URI".to_string()))?;
+                // Safe: validate_env_uri confirmed the prefix exists
+                let source_var = match entry.strip_prefix(ENV_URI_PREFIX) {
+                    Some(v) => v,
+                    None => {
+                        return Err(NonoError::ConfigParse("invalid env:// URI".to_string()));
+                    }
+                };
                 mappings.insert(entry.to_string(), source_var.to_string());
             }
         } else if entry.starts_with(OP_URI_PREFIX) {
@@ -569,6 +615,7 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
 
                 // Validate the URI portion
                 validate_op_uri(uri)?;
+                validate_destination_env_var(var_name)?;
 
                 mappings.insert(uri.to_string(), var_name.to_string());
             } else {
@@ -581,6 +628,7 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
         } else {
             // Keyring name: auto-uppercase to env var name
             let env_var = entry.to_uppercase();
+            validate_destination_env_var(&env_var)?;
             mappings.insert(entry.to_string(), env_var);
         }
     }
@@ -1206,5 +1254,95 @@ mod tests {
             mappings.get("env://GITHUB_TOKEN"),
             Some(&"GITHUB_TOKEN".to_string())
         );
+    }
+
+    // =========================================================================
+    // Case-insensitive dangerous env var bypass prevention
+    // =========================================================================
+
+    #[test]
+    fn test_validate_env_uri_dangerous_case_insensitive() {
+        // Lowercase must be caught (case-insensitive check)
+        let err = validate_env_uri("env://ld_preload").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+
+        // Mixed case must be caught
+        let err = validate_env_uri("env://Ld_Preload").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+
+        let err = validate_env_uri("env://path").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+
+        let err = validate_env_uri("env://Node_Options").expect_err("should reject");
+        assert!(err.to_string().contains("dangerous"), "got: {}", err);
+    }
+
+    // =========================================================================
+    // Destination env var validation
+    // =========================================================================
+
+    #[test]
+    fn test_validate_destination_env_var_valid() {
+        assert!(validate_destination_env_var("GITHUB_TOKEN").is_ok());
+        assert!(validate_destination_env_var("MY_API_KEY").is_ok());
+        assert!(validate_destination_env_var("x").is_ok());
+    }
+
+    #[test]
+    fn test_validate_destination_env_var_empty() {
+        let err = validate_destination_env_var("").expect_err("should reject");
+        assert!(err.to_string().contains("empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_destination_env_var_invalid_chars() {
+        let err = validate_destination_env_var("MY-VAR").expect_err("should reject");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_destination_env_var_dangerous() {
+        let err = validate_destination_env_var("LD_PRELOAD").expect_err("should reject");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_destination_env_var_dangerous_case_insensitive() {
+        let err = validate_destination_env_var("ld_preload").expect_err("should reject");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+
+        let err = validate_destination_env_var("Path").expect_err("should reject");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+
+        let err = validate_destination_env_var("DYLD_INSERT_LIBRARIES").expect_err("should reject");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_build_mappings_env_uri_explicit_dangerous_target_rejected() {
+        // env://SAFE_VAR=LD_PRELOAD must be rejected
+        let err = build_mappings_from_list("env://SAFE_VAR=LD_PRELOAD")
+            .expect_err("should reject dangerous target");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_build_mappings_op_uri_dangerous_target_rejected() {
+        // op://vault/item/field=PATH must be rejected
+        let err = build_mappings_from_list("op://vault/item/field=PATH")
+            .expect_err("should reject dangerous target");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_build_mappings_keyring_dangerous_autoderived_rejected() {
+        // A keyring name that uppercases to a dangerous var must be rejected
+        let err =
+            build_mappings_from_list("ld_preload").expect_err("should reject dangerous target");
+        assert!(err.to_string().contains("blocklist"), "got: {}", err);
     }
 }

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -62,7 +62,8 @@ pub use capability::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, 
 pub use diagnostic::{DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode};
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_op_uri, load_secret_by_ref, load_secrets, redact_op_uri, validate_op_uri, LoadedSecret,
+    is_env_uri, is_op_uri, load_secret_by_ref, load_secrets, redact_op_uri, validate_env_uri,
+    validate_op_uri, LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
 pub use sandbox::{Sandbox, SupportInfo};

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -62,8 +62,8 @@ pub use capability::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, 
 pub use diagnostic::{DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode};
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_env_uri, is_op_uri, load_secret_by_ref, load_secrets, redact_op_uri, validate_env_uri,
-    validate_op_uri, LoadedSecret,
+    is_env_uri, is_op_uri, load_secret_by_ref, load_secrets, redact_op_uri,
+    validate_destination_env_var, validate_env_uri, validate_op_uri, LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
 pub use sandbox::{Sandbox, SupportInfo};


### PR DESCRIPTION
Add env:// URI scheme to keystore for loading credentials from
environment variables in CI environments where no system keyring
is available. Includes validation against dangerous env vars
(`LD_PRELOAD, DYLD_INSERT_LIBRARIES`, etc.) and constant-time
token comparison.

Add GitHub credential definition to `network-policy.json` with
phantom token proxy support, enabling nono to intercept and
protect `GITHUB_TOKEN` from exfiltration in fork-based CI attacks.

- keystore: `env://` dispatch in `load_secret_by_ref()`, `auto-derive`
  target var name, dangerous var blocklist
- network_policy: `env_var` field on `CredentialDef`, github credential
  added to claude-code/developer/opencode profiles
- profile validation: `env://` URI validation alongside `op://`