### PR TITLE
feat: add --allow-port for bidirectional localhost IPC between sandboxes

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -153,6 +153,11 @@ impl CapabilitySetExt for CapabilitySet {
             });
         }
 
+        // Localhost IPC ports
+        for port in &args.allow_port {
+            caps.add_localhost_port(*port);
+        }
+
         // Command allow/block lists
         for cmd in &args.allow_command {
             caps.add_allowed_command(cmd.clone());
@@ -382,6 +387,11 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
         });
     }
 
+    // Localhost IPC ports from CLI
+    for port in &args.allow_port {
+        caps.add_localhost_port(*port);
+    }
+
     // Command allow/block from CLI
     for cmd in &args.allow_command {
         caps.add_allowed_command(cmd.clone());
@@ -426,6 +436,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -459,6 +470,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -491,6 +503,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -527,6 +540,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -577,6 +591,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -621,6 +636,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -710,6 +726,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -777,6 +794,7 @@ mod tests {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -255,8 +255,9 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "PORT")]
     pub allow_bind: Vec<u16>,
 
-    /// Allow bidirectional localhost TCP on a specific port.
-    /// The sandboxed process can both connect to and listen on 127.0.0.1:PORT.
+    /// Allow bidirectional TCP on a specific port (connect + bind).
+    /// On macOS, scoped to localhost. On Linux, port-only (use with
+    /// --net-block or proxy mode to restrict to localhost).
     /// Use for IPC between sandboxed processes (e.g., MCP servers).
     /// Can be specified multiple times for multiple ports.
     #[arg(long, value_name = "PORT")]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -255,6 +255,13 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "PORT")]
     pub allow_bind: Vec<u16>,
 
+    /// Allow bidirectional localhost TCP on a specific port.
+    /// The sandboxed process can both connect to and listen on 127.0.0.1:PORT.
+    /// Use for IPC between sandboxed processes (e.g., MCP servers).
+    /// Can be specified multiple times for multiple ports.
+    #[arg(long, value_name = "PORT")]
+    pub allow_port: Vec<u16>,
+
     /// Chain through an external (enterprise) proxy.
     /// Format: host:port (e.g., squid.corp.internal:3128)
     #[arg(long, value_name = "HOST:PORT")]
@@ -1283,6 +1290,27 @@ mod tests {
         match cli.command {
             Commands::Run(args) => {
                 assert_eq!(args.sandbox.override_deny.len(), 2);
+            }
+            _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_allow_port_parsing() {
+        let cli = Cli::parse_from([
+            "nono",
+            "run",
+            "--allow-port",
+            "3000",
+            "--allow-port",
+            "5000",
+            "--allow",
+            ".",
+            "echo",
+        ]);
+        match cli.command {
+            Commands::Run(args) => {
+                assert_eq!(args.sandbox.allow_port, vec![3000, 5000]);
             }
             _ => panic!("Expected Run command"),
         }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -435,7 +435,10 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     // network is explicitly blocked, the proxy must NOT activate since that
     // would re-enable network access through the proxy's localhost listener.
     let proxy_active = if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
-        if !proxy_credentials.is_empty() || network_profile.is_some() {
+        if !proxy_credentials.is_empty()
+            || network_profile.is_some()
+            || !proxy_allow_hosts.is_empty()
+        {
             warn!(
                 "--net-block is active; ignoring proxy configuration \
                  that would re-enable network access"
@@ -454,6 +457,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             nono::NetworkMode::ProxyOnly { .. }
         ) || !proxy_credentials.is_empty()
             || network_profile.is_some()
+            || !proxy_allow_hosts.is_empty()
     };
 
     // Split --rollback-exclude values: glob metacharacters route to filename

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -223,6 +223,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 
@@ -256,6 +257,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             verbose: 0,
             dry_run: false,
             allow_bind: vec![],
+            allow_port: vec![],
             proxy_port: None,
         };
 

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -147,6 +147,14 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             eprintln!("    outbound: {}", "allowed".green());
         }
     }
+    if !caps.localhost_ports().is_empty() {
+        let ports_str: Vec<String> = caps
+            .localhost_ports()
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        eprintln!("    localhost IPC: {}", ports_str.join(", ").cyan());
+    }
 
     eprintln!();
 }

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -531,6 +531,7 @@ mod tests {
         let handle = ProxyHandle {
             port: 12345,
             token: Zeroizing::new("test_token".to_string()),
+            audit_log: audit::new_audit_log(),
             shutdown_tx,
             // Only "openai" was loaded; "github" credential was unavailable
             loaded_routes: ["openai".to_string()].into_iter().collect(),

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -412,6 +412,9 @@ pub struct CapabilitySet {
     tcp_connect_ports: Vec<u16>,
     /// Per-port TCP bind allowlist (Linux Landlock V4+ only).
     tcp_bind_ports: Vec<u16>,
+    /// Localhost TCP ports allowed for bidirectional IPC (connect + bind).
+    /// These apply regardless of NetworkMode, scoped to 127.0.0.1 only.
+    localhost_ports: Vec<u16>,
     /// Commands explicitly allowed (overrides blocklists - for CLI use)
     allowed_commands: Vec<String>,
     /// Additional commands to block (extends blocklists - for CLI use)
@@ -523,6 +526,20 @@ impl CapabilitySet {
         self
     }
 
+    /// Allow bidirectional localhost TCP on a specific port (builder pattern).
+    ///
+    /// The sandboxed process can both connect to and bind/listen on
+    /// `127.0.0.1:port`. Works across all network modes.
+    ///
+    /// On macOS: outbound is per-port via Seatbelt; bind/inbound is blanket
+    /// (same tradeoff as `--allow-bind`).
+    /// On Linux: per-port ConnectTcp + BindTcp via Landlock.
+    #[must_use]
+    pub fn allow_localhost_port(mut self, port: u16) -> Self {
+        self.localhost_ports.push(port);
+        self
+    }
+
     /// Allow TCP connect to standard HTTPS ports (443, 8443)
     ///
     /// Convenience method. Linux Landlock V4+ only.
@@ -610,6 +627,11 @@ impl CapabilitySet {
         self.tcp_bind_ports.push(port);
     }
 
+    /// Add a localhost IPC port (mutable)
+    pub fn add_localhost_port(&mut self, port: u16) {
+        self.localhost_ports.push(port);
+    }
+
     /// Set sandbox extensions state
     pub fn set_extensions_enabled(&mut self, enabled: bool) {
         self.extensions_enabled = enabled;
@@ -671,6 +693,12 @@ impl CapabilitySet {
     #[must_use]
     pub fn tcp_bind_ports(&self) -> &[u16] {
         &self.tcp_bind_ports
+    }
+
+    /// Get localhost IPC ports
+    #[must_use]
+    pub fn localhost_ports(&self) -> &[u16] {
+        &self.localhost_ports
     }
 
     /// Check if sandbox extensions are enabled for runtime capability expansion
@@ -1395,6 +1423,22 @@ mod tests {
         caps.add_tcp_bind_port(8080);
         assert_eq!(caps.tcp_connect_ports(), &[443]);
         assert_eq!(caps.tcp_bind_ports(), &[8080]);
+    }
+
+    #[test]
+    fn test_localhost_port_builder() {
+        let caps = CapabilitySet::new()
+            .allow_localhost_port(3000)
+            .allow_localhost_port(5000);
+        assert_eq!(caps.localhost_ports(), &[3000, 5000]);
+    }
+
+    #[test]
+    fn test_localhost_port_mutable() {
+        let mut caps = CapabilitySet::new();
+        caps.add_localhost_port(8080);
+        caps.add_localhost_port(9090);
+        assert_eq!(caps.localhost_ports(), &[8080, 9090]);
     }
 
     #[test]

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -412,8 +412,13 @@ pub struct CapabilitySet {
     tcp_connect_ports: Vec<u16>,
     /// Per-port TCP bind allowlist (Linux Landlock V4+ only).
     tcp_bind_ports: Vec<u16>,
-    /// Localhost TCP ports allowed for bidirectional IPC (connect + bind).
-    /// These apply regardless of NetworkMode, scoped to 127.0.0.1 only.
+    /// TCP ports allowed for bidirectional IPC (connect + bind).
+    /// These apply regardless of NetworkMode.
+    ///
+    /// On macOS (Seatbelt), outbound is scoped to localhost per-port.
+    /// On Linux (Landlock), ConnectTcp/BindTcp filter by port only, not
+    /// by destination IP. Use with `--net-block` or proxy mode to ensure
+    /// only localhost is reachable.
     localhost_ports: Vec<u16>,
     /// Commands explicitly allowed (overrides blocklists - for CLI use)
     allowed_commands: Vec<String>,

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -178,6 +178,32 @@ pub fn apply(caps: &CapabilitySet) -> Result<()> {
             })?;
     }
 
+    // Add localhost IPC port rules (connect + bind per port).
+    // Only meaningful in Blocked/ProxyOnly modes. In AllowAll mode, all ports are
+    // already reachable and adding Landlock network handling would restrict them.
+    if !matches!(caps.network_mode(), NetworkMode::AllowAll) {
+        for port in caps.localhost_ports() {
+            debug!("Adding localhost TCP connect rule for port {}", port);
+            ruleset = ruleset
+                .add_rule(NetPort::new(*port, AccessNet::ConnectTcp))
+                .map_err(|e| {
+                    NonoError::SandboxInit(format!(
+                        "Cannot add TCP connect rule for localhost port {}: {}",
+                        port, e
+                    ))
+                })?;
+            debug!("Adding localhost TCP bind rule for port {}", port);
+            ruleset = ruleset
+                .add_rule(NetPort::new(*port, AccessNet::BindTcp))
+                .map_err(|e| {
+                    NonoError::SandboxInit(format!(
+                        "Cannot add TCP bind rule for localhost port {}: {}",
+                        port, e
+                    ))
+                })?;
+        }
+    }
+
     // Add rules for each filesystem capability
     // These MUST succeed - caller explicitly requested these capabilities
     // Failing silently would violate the principle of least surprise and fail-secure design

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -443,9 +443,28 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     }
 
     // Network rules
+    let localhost_ports = caps.localhost_ports();
     match caps.network_mode() {
         NetworkMode::Blocked => {
             profile.push_str("(deny network*)\n");
+            if !localhost_ports.is_empty() {
+                // Allow system-socket for TCP (required for connect/bind)
+                profile.push_str(
+                    "(allow system-socket (socket-domain AF_INET) (socket-type SOCK_STREAM))\n",
+                );
+                profile.push_str(
+                    "(allow system-socket (socket-domain AF_INET6) (socket-type SOCK_STREAM))\n",
+                );
+                for lp in localhost_ports {
+                    profile.push_str(&format!(
+                        "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
+                        lp
+                    ));
+                }
+                // Seatbelt cannot filter bind/inbound by port
+                profile.push_str("(allow network-bind)\n");
+                profile.push_str("(allow network-inbound)\n");
+            }
         }
         NetworkMode::ProxyOnly { port, bind_ports } => {
             // Block all network, then allow only localhost TCP to the proxy port.
@@ -455,6 +474,12 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                 "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
                 port
             ));
+            for lp in localhost_ports {
+                profile.push_str(&format!(
+                    "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
+                    lp
+                ));
+            }
             // Scope system-socket to TCP only. Without this restriction,
             // the child could create Unix domain sockets for local IPC.
             profile.push_str(
@@ -463,10 +488,10 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             profile.push_str(
                 "(allow system-socket (socket-domain AF_INET6) (socket-type SOCK_STREAM))\n",
             );
-            // If bind ports are specified, allow network-bind and network-inbound.
-            // Seatbelt cannot filter bind/inbound by port, so this is a blanket allow.
-            // The user accepts this tradeoff for apps that need to listen (e.g., OpenClaw).
-            if !bind_ports.is_empty() {
+            // If bind ports or localhost IPC ports are specified, allow network-bind
+            // and network-inbound. Seatbelt cannot filter bind/inbound by port,
+            // so this is a blanket allow.
+            if !bind_ports.is_empty() || !localhost_ports.is_empty() {
                 profile.push_str("(allow network-bind)\n");
                 profile.push_str("(allow network-inbound)\n");
             }
@@ -947,5 +972,50 @@ mod tests {
         let caps = CapabilitySet::new().allow_tcp_bind(8080);
         let result = generate_profile(&caps);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_generate_profile_blocked_with_localhost_ports() {
+        let caps = CapabilitySet::new()
+            .block_network()
+            .allow_localhost_port(3000)
+            .allow_localhost_port(5000);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(deny network*)"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3000\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:5000\"))"));
+        assert!(profile.contains("(allow network-bind)"));
+        assert!(profile.contains("(allow network-inbound)"));
+        assert!(profile.contains("(allow system-socket"));
+    }
+
+    #[test]
+    fn test_generate_profile_proxy_with_localhost_ports() {
+        let caps = CapabilitySet::new()
+            .proxy_only(54321)
+            .allow_localhost_port(3000);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(deny network*)"));
+        // Proxy port
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:54321\"))"));
+        // Localhost IPC port
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3000\"))"));
+        // Bind/inbound enabled because localhost_ports is non-empty
+        assert!(profile.contains("(allow network-bind)"));
+        assert!(profile.contains("(allow network-inbound)"));
+    }
+
+    #[test]
+    fn test_generate_profile_allow_all_with_localhost_ports() {
+        // AllowAll is unchanged by localhost ports — all network already allowed
+        let caps = CapabilitySet::new().allow_localhost_port(3000);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(allow network-outbound)"));
+        assert!(profile.contains("(allow network-inbound)"));
+        assert!(profile.contains("(allow network-bind)"));
+        assert!(!profile.contains("(deny network*)"));
     }
 }

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -127,6 +127,29 @@ User profiles can specify a network profile in the `network` section:
 }
 ```
 
+## Localhost IPC Between Sandboxes
+
+When running multiple sandboxed processes that need to communicate (e.g., an MCP server in one sandbox, an AI agent in another), use `--allow-port` to open a specific localhost TCP port for bidirectional communication.
+
+```bash
+# Terminal 1: MCP server listening on port 3000
+nono run --net-block --allow-port 3000 --allow ./mcp-server -- node server.js
+
+# Terminal 2: Agent connecting to the MCP server
+nono run --net-block --allow-port 3000 --allow ./client -- claude
+```
+
+`--allow-port` works alongside the proxy. Outbound to allowed hosts goes through the proxy; IPC stays on localhost:
+
+```bash
+# Proxy filters outbound + localhost IPC on port 3000
+nono run --network-profile claude-code --allow-port 3000 --allow-cwd -- claude
+```
+
+This generates Seatbelt rules (macOS) or Landlock rules (Linux) that allow both `connect()` and `bind()` on the specified port, in addition to the proxy port.
+
+See [CLI Reference](/cli/usage/flags#--allow-port) for full details and platform limitations.
+
 ## Default Deny List
 
 The following cloud metadata destinations are always blocked, regardless of configuration. These cannot be overridden.

--- a/docs/cli/getting_started/quickstart.mdx
+++ b/docs/cli/getting_started/quickstart.mdx
@@ -68,9 +68,17 @@ Network is **allowed by default**. Use `--net-block` to disable outbound connect
 nono run --allow-cwd --net-block -- cargo build
 ```
 
-<Note>
-  Network access is currently all-or-nothing. You can either allow all network access (default) or block it entirely with `--net-block`.
-</Note>
+For granular control, use `--network-profile` for host-level filtering or `--allow-port` for localhost IPC between sandboxes:
+
+```bash
+# Host-level filtering via proxy
+nono run --allow-cwd --network-profile claude-code -- claude
+
+# Localhost IPC (e.g., MCP server on port 3000)
+nono run --net-block --allow-port 3000 --allow-cwd -- my-agent
+```
+
+See [Network Filtering](/cli/features/network-proxy) and [CLI Reference](/cli/usage/flags) for details.
 
 ## Interactive Shell (`nono shell`)
 

--- a/docs/cli/usage/examples.mdx
+++ b/docs/cli/usage/examples.mdx
@@ -322,3 +322,18 @@ nono run \
   --net-block \
   -- make release
 ```
+
+### IPC Between Sandboxed Processes
+
+Run an MCP server and a client in separate sandboxes, communicating over localhost:
+
+```bash
+# Terminal 1: MCP server on port 3000 (network blocked except IPC port)
+nono run --net-block --allow-port 3000 --allow ./mcp-server -- node server.js
+
+# Terminal 2: Agent connects to the MCP server on port 3000
+nono run --net-block --allow-port 3000 --allow ./agent -- my-agent
+
+# With proxy filtering + localhost IPC
+nono run --network-profile claude-code --allow-port 3000 --allow-cwd -- claude
+```

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -318,6 +318,35 @@ On Linux with Landlock ABI v4+, per-port filtering is enforced and only the spec
 `--allow-bind` only has effect in proxy mode (when `--network-profile` or `--proxy-allow` is active). Without proxy mode, network operations use the default OS-level allow/deny and bind is not restricted.
 </Note>
 
+#### `--allow-port`
+
+Allow bidirectional localhost TCP on a specific port. The sandboxed process can both **connect to** and **bind/listen on** `127.0.0.1:<PORT>`. Use this for IPC between sandboxed processes (e.g., MCP servers, dev tools, AI agents running in separate sandboxes).
+
+```bash
+# MCP server in one sandbox, client in another — both can use port 3000
+nono run --net-block --allow-port 3000 --allow ./mcp-server -- node server.js
+nono run --net-block --allow-port 3000 --allow ./client -- claude
+
+# Multiple IPC ports
+nono run --net-block --allow-port 3000 --allow-port 5000 --allow-cwd -- my-agent
+
+# Combine with proxy mode — outbound filtered + localhost IPC on port 4000
+nono run --network-profile claude-code --allow-port 4000 --allow-cwd -- claude
+```
+
+Works across all network modes:
+- **`--net-block`**: The port becomes an exception to the block (localhost only)
+- **Proxy mode**: The port is allowed in addition to the proxy port
+- **Default (AllowAll)**: No-op — all ports are already reachable
+
+Can be specified multiple times for multiple ports.
+
+<Warning>
+**macOS limitation:** Seatbelt cannot filter bind/inbound by port number. When `--allow-port` is specified on macOS, the sandbox permits binding to **any** port (same tradeoff as `--allow-bind`). Outbound connections are still restricted to only the specified localhost ports.
+
+On Linux with Landlock ABI v4+, both connect and bind are enforced per-port.
+</Warning>
+
 ## `nono shell` Options
 
 `nono shell` supports the same permission, profile, secrets, and dry-run flags as `nono run`, plus:

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -344,7 +344,7 @@ Can be specified multiple times for multiple ports.
 <Warning>
 **macOS limitation:** Seatbelt cannot filter bind/inbound by port number. When `--allow-port` is specified on macOS, the sandbox permits binding to **any** port (same tradeoff as `--allow-bind`). Outbound connections are still restricted to only the specified localhost ports.
 
-On Linux with Landlock ABI v4+, both connect and bind are enforced per-port.
+**Linux limitation:** Landlock ABI v4+ enforces both connect and bind per-port, but **cannot filter by destination IP**. The ConnectTcp rule allows connecting to the specified port on any IP, not just localhost. In practice this is mitigated by using `--net-block` (which blocks all outbound except the allowed ports) or proxy mode (which routes outbound through the localhost proxy). Only the `--allow-port` + default AllowAll combination (a no-op) would theoretically permit non-localhost connections on the port.
 </Warning>
 
 ## `nono shell` Options


### PR DESCRIPTION
feat: add --allow-port for bidirectional localhost IPC between sandboxes
    
Allow sandboxed processes to communicate over specific localhost TCP
ports. The sandboxed process can both connect to and bind/listen on
127.0.0.1:<port>, regardless of network mode (Blocked, ProxyOnly,
AllowAll)

Use case: running AI agents, MCP servers, and dev tools in separate
nono sandboxes that need to talk to each other.
    
Platform behavior:
- Linux: per-port ConnectTcp + BindTcp via Landlock
- macOS: per-port outbound via Seatbelt, blanket bind/inbound
(same tradeoff as --allow-bind)
    
 Signed-off-by: Luke Hinds <lukehinds@gmail.com>