### PR TITLE
fix: enforce macOS signal isolation via Seatbelt

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -425,6 +425,9 @@
           "su",
           "doas",
           "pip",
+          "kill",
+          "killall",
+          "pkill",
           "shutdown",
           "reboot",
           "halt",
@@ -481,7 +484,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "node_runtime", "rust_runtime", "python_runtime", "vscode", "unlink_protection"]
+        "groups": ["user_caches_macos", "node_runtime", "rust_runtime", "python_runtime", "vscode", "unlink_protection"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {
@@ -513,7 +517,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["node_runtime"]
+        "groups": ["node_runtime"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {
@@ -539,7 +544,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "node_runtime", "unlink_protection"]
+        "groups": ["user_caches_macos", "node_runtime", "unlink_protection"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {
@@ -564,7 +570,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["python_runtime"]
+        "groups": ["python_runtime"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {},
@@ -580,7 +587,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["node_runtime"]
+        "groups": ["node_runtime"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {},
@@ -596,7 +604,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["go_runtime"]
+        "groups": ["go_runtime"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {},
@@ -612,7 +621,8 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["rust_runtime"]
+        "groups": ["rust_runtime"],
+        "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {},

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -270,6 +270,16 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_allowed_command(cmd.as_str());
         }
 
+        // Apply signal mode from profile (None defaults to Isolated)
+        caps = match profile.security.signal_mode {
+            Some(crate::profile::ProfileSignalMode::AllowAll) => {
+                caps.set_signal_mode(nono::SignalMode::AllowAll)
+            }
+            Some(crate::profile::ProfileSignalMode::Isolated) | None => {
+                caps.set_signal_mode(nono::SignalMode::Isolated)
+            }
+        };
+
         // Apply CLI overrides (CLI args take precedence)
         add_cli_overrides(&mut caps, args)?;
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -271,14 +271,12 @@ impl CapabilitySetExt for CapabilitySet {
         }
 
         // Apply signal mode from profile (None defaults to Isolated)
-        caps = match profile.security.signal_mode {
-            Some(crate::profile::ProfileSignalMode::AllowAll) => {
-                caps.set_signal_mode(nono::SignalMode::AllowAll)
-            }
-            Some(crate::profile::ProfileSignalMode::Isolated) | None => {
-                caps.set_signal_mode(nono::SignalMode::Isolated)
-            }
-        };
+        let mode = profile
+            .security
+            .signal_mode
+            .map(nono::SignalMode::from)
+            .unwrap_or_default();
+        caps = caps.set_signal_mode(mode);
 
         // Apply CLI overrides (CLI args take precedence)
         add_cli_overrides(&mut caps, args)?;

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -147,6 +147,7 @@ impl ProfileDef {
                 groups,
                 trust_groups: self.trust_groups.clone(),
                 allowed_commands: self.security.allowed_commands.clone(),
+                signal_mode: self.security.signal_mode,
             },
             filesystem: self.filesystem.clone(),
             network: self.network.clone(),

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -551,6 +551,19 @@ pub struct HooksConfig {
 /// Controls whether and how the current working directory is automatically
 /// shared with the sandboxed process. This is profile-driven so each
 /// application can declare its own CWD requirements.
+/// Signal isolation mode as specified in a profile.
+///
+/// Maps to `nono::SignalMode` when building the `CapabilitySet`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProfileSignalMode {
+    /// Signals restricted to the current process only
+    Isolated,
+    /// Signals allowed to any process
+    #[serde(alias = "allow_all")]
+    AllowAll,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkdirAccess {
@@ -589,6 +602,11 @@ pub struct SecurityConfig {
     /// Applied before CLI `--allow-command` overrides.
     #[serde(default)]
     pub allowed_commands: Vec<String>,
+    /// Signal isolation mode. Controls whether the sandboxed process can signal
+    /// other processes. When `None`, inherits from the base profile during merge
+    /// (defaults to `Isolated` if no base sets it).
+    #[serde(default)]
+    pub signal_mode: Option<ProfileSignalMode>,
 }
 
 /// Rollback snapshot configuration in a profile
@@ -820,6 +838,7 @@ fn load_base_profile_raw(name: &str) -> Result<Profile> {
                 groups: def.security.groups.clone(),
                 trust_groups: def.trust_groups.clone(),
                 allowed_commands: def.security.allowed_commands.clone(),
+                signal_mode: def.security.signal_mode,
             },
             filesystem: def.filesystem.clone(),
             network: def.network.clone(),
@@ -852,6 +871,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.security.allowed_commands,
                 &child.security.allowed_commands,
             ),
+            signal_mode: child.security.signal_mode.or(base.security.signal_mode),
         },
         filesystem: FilesystemConfig {
             allow: dedup_append(&base.filesystem.allow, &child.filesystem.allow),

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -564,6 +564,15 @@ pub enum ProfileSignalMode {
     AllowAll,
 }
 
+impl From<ProfileSignalMode> for nono::SignalMode {
+    fn from(val: ProfileSignalMode) -> Self {
+        match val {
+            ProfileSignalMode::Isolated => nono::SignalMode::Isolated,
+            ProfileSignalMode::AllowAll => nono::SignalMode::AllowAll,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkdirAccess {

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -338,6 +338,31 @@ fn tokenize_sexp(input: &str) -> Result<Vec<String>> {
 ///
 /// Determines how network traffic is filtered at the OS level.
 /// `ProxyOnly` restricts outbound connections to a single localhost port,
+/// Signal isolation mode for the sandbox.
+///
+/// Controls whether the sandboxed process can send signals to processes
+/// outside its own sandbox.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignalMode {
+    /// Signals restricted to the current process only.
+    ///
+    /// On macOS: `(allow signal (target self))` in Seatbelt — restricts
+    /// `kill()` to the calling process's own PID. Forked children within
+    /// the same sandbox are **not** included; the parent cannot signal
+    /// them via `kill()`. Terminal-generated signals (e.g., Ctrl+C
+    /// delivering SIGINT to the foreground process group) are delivered
+    /// by the kernel and bypass the sandbox filter.
+    ///
+    /// On Linux: **not yet enforced.** Landlock V6 scoping
+    /// (`LANDLOCK_SCOPE_SIGNAL`) will provide equivalent isolation once
+    /// implemented (see issue #255). Until then, sandboxed processes on
+    /// Linux can still call `kill(2)`/`tkill(2)`/`tgkill(2)` freely.
+    #[default]
+    Isolated,
+    /// Signals allowed to any process (no filtering).
+    AllowAll,
+}
+
 /// forcing all traffic through the nono proxy.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NetworkMode {
@@ -427,6 +452,8 @@ pub struct CapabilitySet {
     /// Raw platform-specific rules injected verbatim into the sandbox profile.
     /// On macOS these are Seatbelt S-expression strings; ignored on Linux.
     platform_rules: Vec<String>,
+    /// Signal isolation mode (default: Isolated).
+    signal_mode: SignalMode,
     /// Enable sandbox extension support for runtime capability expansion.
     /// On macOS, adds extension filter rules to the Seatbelt profile so that
     /// `sandbox_extension_consume()` tokens can expand the sandbox dynamically.
@@ -553,6 +580,26 @@ impl CapabilitySet {
         self.allow_tcp_connect(443).allow_tcp_connect(8443)
     }
 
+    /// Set signal isolation mode (builder pattern)
+    ///
+    /// By default, signals are isolated to the sandbox's own process subtree.
+    /// Use `SignalMode::AllowAll` to permit signaling any process.
+    #[must_use]
+    pub fn set_signal_mode(mut self, mode: SignalMode) -> Self {
+        self.signal_mode = mode;
+        self
+    }
+
+    /// Allow signals to any process (builder pattern)
+    ///
+    /// Disables signal isolation. By default, sandboxed processes can only
+    /// signal their own process subtree.
+    #[must_use]
+    pub fn allow_signals(mut self) -> Self {
+        self.signal_mode = SignalMode::AllowAll;
+        self
+    }
+
     /// Enable sandbox extensions for runtime capability expansion (builder pattern)
     ///
     /// On macOS, this adds extension filter rules to the Seatbelt profile so that
@@ -622,6 +669,11 @@ impl CapabilitySet {
         self.network_mode = mode;
     }
 
+    /// Set signal isolation mode (mutable)
+    pub fn set_signal_mode_mut(&mut self, mode: SignalMode) {
+        self.signal_mode = mode;
+    }
+
     /// Add a TCP connect port to the allowlist (mutable)
     pub fn add_tcp_connect_port(&mut self, port: u16) {
         self.tcp_connect_ports.push(port);
@@ -680,6 +732,12 @@ impl CapabilitySet {
             self.network_mode,
             NetworkMode::Blocked | NetworkMode::ProxyOnly { .. }
         )
+    }
+
+    /// Get the signal isolation mode
+    #[must_use]
+    pub fn signal_mode(&self) -> SignalMode {
+        self.signal_mode
     }
 
     /// Get the network mode

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -58,7 +58,9 @@ pub mod trust;
 pub mod undo;
 
 // Re-exports for convenience
-pub use capability::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NetworkMode};
+pub use capability::{
+    AccessMode, CapabilitySet, CapabilitySource, FsCapability, NetworkMode, SignalMode,
+};
 pub use diagnostic::{DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode};
 pub use error::{NonoError, Result};
 pub use keystore::{

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -344,7 +344,21 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     profile.push_str("(allow ipc-posix-shm-write-data)\n");
     profile.push_str("(allow ipc-posix-shm-write-create)\n");
 
-    profile.push_str("(allow signal)\n");
+    // Signal isolation: (target self) restricts kill() to the calling process's
+    // own PID only. This blocks signals to external processes but also blocks
+    // the parent from signaling forked children via kill(). Terminal-generated
+    // signals (Ctrl+C → SIGINT to foreground process group) are delivered by
+    // the kernel and bypass this restriction, so interactive use is unaffected.
+    // In monitor mode, the parent's signal forwarding handler will get EPERM
+    // when trying to forward to the child — this is tolerated silently.
+    match caps.signal_mode() {
+        crate::capability::SignalMode::Isolated => {
+            profile.push_str("(allow signal (target self))\n");
+        }
+        crate::capability::SignalMode::AllowAll => {
+            profile.push_str("(allow signal)\n");
+        }
+    }
     profile.push_str("(allow system-socket)\n");
     profile.push_str("(allow system-fsctl)\n");
     profile.push_str("(allow system-info)\n");

--- a/tests/integration/test_exec_strategy.sh
+++ b/tests/integration/test_exec_strategy.sh
@@ -70,12 +70,13 @@ run_test "direct mode preserves exit code 1" 1 \
 echo ""
 echo "--- Signal Forwarding ---"
 
-# Test SIGTERM forwarding: use timeout to cap the entire test at 10 seconds.
-# Start nono with a long sleep, send SIGTERM, verify it exits promptly.
+# Test SIGTERM forwarding: use supervised mode so the unsandboxed parent can
+# forward signals to the sandboxed child. Monitor mode cannot forward signals
+# on macOS because Seatbelt (target self) restricts kill() to the caller's PID.
 TESTS_RUN=$((TESTS_RUN + 1))
 
 SIGNAL_RESULT=$(
-    "$NONO_BIN" run --allow "$TMPDIR" -- sleep 60 </dev/null >/dev/null 2>&1 &
+    "$NONO_BIN" run --supervised --allow "$TMPDIR" -- sleep 60 </dev/null >/dev/null 2>&1 &
     NONO_PID=$!
     sleep 1
 


### PR DESCRIPTION
Replace `(allow signal)` with `(allow signal (target self))` in the generated Seatbelt profile when SignalMode::Isolated is active. This blocks sandboxed processes from sending signals to any process outside themselves at the kernel level.

Add SignalMode enum to the library with Isolated (default) and AllowAll variants, wired through profiles (with proper Option-based inheritance) and a `--allow-signal` CLI override.

Remove kill/killall/pkill from dangerous_commands — the Seatbelt syscall-level block makes command deny redundant on macOS.

Linux signal isolation is not yet enforced and will follow via Landlock V6 scoping (#255).