### PR TITLE
feat: context-aware diagnostic banner for sandbox failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #   make check        Run clippy and format check
 #   make release      Build release binaries
 
-.PHONY: all build build-lib build-cli build-ffi test test-lib test-cli test-ffi check clippy clippy-ci fmt clean install audit help
+.PHONY: all build build-lib build-cli build-ffi test test-lib test-cli test-ffi check clippy fmt clean install audit help
 
 # Default target
 all: build
@@ -48,13 +48,10 @@ test-doc:
 	cargo test --doc
 
 # Check targets (lint + format)
-check: clippy-ci fmt-check
+check: clippy fmt-check
 
 clippy:
-	cargo clippy -- -D warnings -D clippy::unwrap_used
-
-clippy-ci:
-	cargo clippy --workspace --all-targets -- -D warnings
+	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used
 
 clippy-fix:
 	cargo clippy --fix --allow-dirty
@@ -126,7 +123,6 @@ help:
 	@echo "Check:"
 	@echo "  make check          Run clippy and format check"
 	@echo "  make clippy         Run clippy linter"
-	@echo "  make clippy-ci      Run strict workspace clippy (all targets)"
 	@echo "  make fmt            Format code"
 	@echo "  make fmt-check      Check formatting"
 	@echo ""

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -642,10 +642,16 @@ pub fn execute_supervised(
                 } else {
                     DiagnosticMode::Standard
                 };
-                let formatter = DiagnosticFormatter::new(config.caps)
+                let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
                     .with_denials(&denials)
                     .with_protected_paths(config.protected_paths);
+                if let Some(program) = config.command.first() {
+                    formatter = formatter.with_command(nono::diagnostic::CommandContext {
+                        program: program.clone(),
+                        resolved_path: config.resolved_program.to_path_buf(),
+                    });
+                }
                 let footer = formatter.format_footer(exit_code);
                 eprintln!("\n{}", footer);
             }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1241,7 +1241,7 @@ mod tests {
     fn test_exit_sigsys_platform_correct() {
         let caps = make_test_caps();
         let formatter = DiagnosticFormatter::new(&caps);
-        let output = formatter.format_footer(128 + libc::SIGSYS as i32);
+        let output = formatter.format_footer(128 + libc::SIGSYS);
 
         assert!(output.contains("SIGSYS"));
         assert!(output.contains("blocked system call"));

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -50,6 +50,18 @@ pub enum DiagnosticMode {
     Supervised,
 }
 
+/// Context about the command that was executed.
+///
+/// Used to generate more specific diagnostic messages when a
+/// sandboxed command fails.
+#[derive(Debug, Clone)]
+pub struct CommandContext {
+    /// The program name as the user typed it (e.g. "ps", "./script.sh")
+    pub program: String,
+    /// The resolved absolute path to the binary
+    pub resolved_path: PathBuf,
+}
+
 /// Formats diagnostic information about sandbox policy.
 ///
 /// This is library code that can be used by any parent process
@@ -62,6 +74,8 @@ pub struct DiagnosticFormatter<'a> {
     protected_paths: &'a [PathBuf],
     /// Name of a protected file that was detected in the error output
     blocked_protected_file: Option<String>,
+    /// Command that was executed (for context-aware diagnostics)
+    command: Option<CommandContext>,
 }
 
 impl<'a> DiagnosticFormatter<'a> {
@@ -74,6 +88,7 @@ impl<'a> DiagnosticFormatter<'a> {
             denials: &[],
             protected_paths: &[],
             blocked_protected_file: None,
+            command: None,
         }
     }
 
@@ -111,6 +126,13 @@ impl<'a> DiagnosticFormatter<'a> {
         self
     }
 
+    /// Set command context for more specific diagnostics.
+    #[must_use]
+    pub fn with_command(mut self, command: CommandContext) -> Self {
+        self.command = Some(command);
+        self
+    }
+
     /// Check if an error line mentions any protected file and return the filename.
     ///
     /// This is used by the output processor to detect when a permission error
@@ -139,6 +161,253 @@ impl<'a> DiagnosticFormatter<'a> {
         }
     }
 
+    /// Check whether the resolved binary path falls under any allowed read path.
+    fn is_binary_path_readable(&self) -> bool {
+        let cmd = match &self.command {
+            Some(c) => c,
+            None => return true, // no context, assume readable
+        };
+        let binary_path = &cmd.resolved_path;
+        for cap in self.caps.fs_capabilities() {
+            if cap.access == AccessMode::Read || cap.access == AccessMode::ReadWrite {
+                if binary_path.starts_with(&cap.resolved) {
+                    return true;
+                }
+                if cap.is_file && *binary_path == cap.resolved {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Check whether the binary's parent directory is readable in the sandbox.
+    fn is_binary_dir_readable(&self) -> bool {
+        let cmd = match &self.command {
+            Some(c) => c,
+            None => return true,
+        };
+        let binary_dir = match cmd.resolved_path.parent() {
+            Some(d) => d,
+            None => return false,
+        };
+        for cap in self.caps.fs_capabilities() {
+            if (cap.access == AccessMode::Read || cap.access == AccessMode::ReadWrite)
+                && (binary_dir.starts_with(&cap.resolved) || cap.resolved == binary_dir)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Format context-aware explanation for the exit code.
+    ///
+    /// Returns a vec of `[nono]`-prefixed lines explaining what likely
+    /// happened and what the user can do about it.
+    fn format_exit_explanation(&self, exit_code: i32) -> Vec<String> {
+        let mut lines = Vec::new();
+
+        match exit_code {
+            127 => {
+                // 127 = command not found (shell convention) or execve failed
+                lines.push(
+                    "[nono] Command not found (exit code 127).".to_string(),
+                );
+                lines.push("[nono]".to_string());
+
+                if let Some(ref cmd) = self.command {
+                    if !self.is_binary_path_readable() {
+                        // The binary exists (we resolved it) but the sandbox
+                        // can't read it.
+                        lines.push(format!(
+                            "[nono] The binary '{}' was found at:",
+                            cmd.program,
+                        ));
+                        lines.push(format!(
+                            "[nono]   {}",
+                            cmd.resolved_path.display(),
+                        ));
+                        lines.push(
+                            "[nono] but its directory is not readable inside the sandbox."
+                                .to_string(),
+                        );
+                        lines.push("[nono]".to_string());
+
+                        if let Some(parent) = cmd.resolved_path.parent() {
+                            lines.push("[nono] Fix: grant read access to the binary's directory:".to_string());
+                            lines.push(format!(
+                                "[nono]   nono run --read {} ...",
+                                parent.display(),
+                            ));
+                        }
+                    } else if !self.is_binary_dir_readable() {
+                        // Binary itself is allowed but its directory isn't
+                        // (unlikely but possible with file-level grants)
+                        lines.push(format!(
+                            "[nono] '{}' resolved to {} but the directory",
+                            cmd.program,
+                            cmd.resolved_path.display(),
+                        ));
+                        lines.push(
+                            "[nono] may not be accessible. The sandbox needs read access to"
+                                .to_string(),
+                        );
+                        lines.push(
+                            "[nono] the directory containing the binary.".to_string(),
+                        );
+                    } else {
+                        // Binary path is readable — the command may depend on
+                        // a dynamic linker, shared libraries, or shell that
+                        // isn't accessible.
+                        lines.push(format!(
+                            "[nono] '{}' resolved to {} which is readable,",
+                            cmd.program,
+                            cmd.resolved_path.display(),
+                        ));
+                        lines.push(
+                            "[nono] but the command still failed to execute. Common causes:"
+                                .to_string(),
+                        );
+                        lines.push(
+                            "[nono]   - A shared library or dynamic linker path is not accessible"
+                                .to_string(),
+                        );
+                        lines.push(
+                            "[nono]   - The binary is a script whose interpreter is not accessible"
+                                .to_string(),
+                        );
+                        lines.push(
+                            "[nono]   - The binary depends on a path not in the sandbox"
+                                .to_string(),
+                        );
+                        lines.push("[nono]".to_string());
+                        lines.push(
+                            "[nono] Run with -v to see all allowed paths and check if"
+                                .to_string(),
+                        );
+                        lines.push(
+                            "[nono] required system directories are included.".to_string(),
+                        );
+                    }
+                } else {
+                    lines.push(
+                        "[nono] The command binary could not be found or executed inside"
+                            .to_string(),
+                    );
+                    lines.push(
+                        "[nono] the sandbox. Ensure the binary's directory is readable."
+                            .to_string(),
+                    );
+                }
+            }
+            126 => {
+                // 126 = command found but not executable
+                lines.push(
+                    "[nono] Permission denied (exit code 126).".to_string(),
+                );
+                lines.push("[nono]".to_string());
+
+                if let Some(ref cmd) = self.command {
+                    lines.push(format!(
+                        "[nono] '{}' was found at {} but could not be executed.",
+                        cmd.program,
+                        cmd.resolved_path.display(),
+                    ));
+                    lines.push(
+                        "[nono] The file may not have execute permission, or the sandbox"
+                            .to_string(),
+                    );
+                    lines.push(
+                        "[nono] may be blocking execution of binaries in that directory."
+                            .to_string(),
+                    );
+                } else {
+                    lines.push(
+                        "[nono] The command was found but could not be executed.".to_string(),
+                    );
+                    lines.push(
+                        "[nono] Check file permissions and sandbox access to the binary's directory."
+                            .to_string(),
+                    );
+                }
+            }
+            1 => {
+                // Generic error - could be anything
+                lines.push(format!(
+                    "[nono] Command exited with code {}. This may be due to sandbox restrictions.",
+                    exit_code,
+                ));
+            }
+            code if (129..=192).contains(&code) => {
+                // Signal-based exit: 128 + signal number
+                let sig = code - 128;
+                // SIGSYS is platform-dependent: 31 on Linux, 12 on macOS
+                let sigsys: i32 = libc::SIGSYS;
+                let sig_name = match sig {
+                    1 => "SIGHUP",
+                    2 => "SIGINT",
+                    4 => "SIGILL",
+                    6 => "SIGABRT",
+                    9 => "SIGKILL",
+                    11 => "SIGSEGV",
+                    13 => "SIGPIPE",
+                    15 => "SIGTERM",
+                    s if s == sigsys => "SIGSYS",
+                    _ => "",
+                };
+
+                if sig == sigsys {
+                    // SIGSYS = seccomp/sandbox killed it
+                    lines.push(format!(
+                        "[nono] Command killed by {} (exit code {}).",
+                        sig_name, code,
+                    ));
+                    lines.push("[nono]".to_string());
+                    lines.push(
+                        "[nono] SIGSYS typically means a blocked system call. The command tried"
+                            .to_string(),
+                    );
+                    lines.push(
+                        "[nono] an operation that the sandbox does not permit."
+                            .to_string(),
+                    );
+                } else if sig == 9 {
+                    lines.push(format!(
+                        "[nono] Command killed by {} (exit code {}).",
+                        sig_name, code,
+                    ));
+                    lines.push("[nono]".to_string());
+                    lines.push(
+                        "[nono] The process was forcefully terminated. This is usually not"
+                            .to_string(),
+                    );
+                    lines.push(
+                        "[nono] caused by sandbox restrictions.".to_string(),
+                    );
+                } else if !sig_name.is_empty() {
+                    lines.push(format!(
+                        "[nono] Command killed by signal {} / {} (exit code {}).",
+                        sig, sig_name, code,
+                    ));
+                } else {
+                    lines.push(format!(
+                        "[nono] Command killed by signal {} (exit code {}).",
+                        sig, code,
+                    ));
+                }
+            }
+            code => {
+                lines.push(format!(
+                    "[nono] Command exited with code {}. This may be due to sandbox restrictions.",
+                    code,
+                ));
+            }
+        }
+
+        lines
+    }
+
     /// Standard mode footer: concise policy summary with --allow suggestions.
     fn format_standard_footer(&self, exit_code: i32) -> String {
         let mut lines = Vec::new();
@@ -156,10 +425,7 @@ impl<'a> DiagnosticFormatter<'a> {
             lines.push("[nono]".to_string());
             lines.push(format!("[nono] Command exited with code {}.", exit_code));
         } else {
-            lines.push(format!(
-                "[nono] Command exited with code {}. This may be due to sandbox restrictions.",
-                exit_code
-            ));
+            lines.extend(self.format_exit_explanation(exit_code));
         }
         lines.push("[nono]".to_string());
 
@@ -191,10 +457,7 @@ impl<'a> DiagnosticFormatter<'a> {
     fn format_supervised_footer(&self, exit_code: i32) -> String {
         let mut lines = Vec::new();
 
-        lines.push(format!(
-            "[nono] Command exited with code {}. This may be due to sandbox restrictions.",
-            exit_code
-        ));
+        lines.extend(self.format_exit_explanation(exit_code));
         lines.push("[nono]".to_string());
 
         if self.denials.is_empty() && !self.caps.extensions_enabled() {
@@ -853,5 +1116,167 @@ mod tests {
 
         assert!(output.contains("Write-protected"));
         assert!(output.contains("config.json"));
+    }
+
+    // --- Exit code explanation tests ---
+
+    fn make_command_context(program: &str, path: &str) -> CommandContext {
+        CommandContext {
+            program: program.to_string(),
+            resolved_path: PathBuf::from(path),
+        }
+    }
+
+    #[test]
+    fn test_exit_127_binary_not_readable() {
+        // Binary resolved to /opt/bin/foo but sandbox has no read access there
+        let caps = make_test_caps(); // only /test/project
+        let cmd = make_command_context("foo", "/opt/bin/foo");
+        let formatter = DiagnosticFormatter::new(&caps).with_command(cmd);
+        let output = formatter.format_footer(127);
+
+        assert!(output.contains("Command not found (exit code 127)"));
+        assert!(output.contains("'foo' was found at:"));
+        assert!(output.contains("/opt/bin/foo"));
+        assert!(output.contains("not readable inside the sandbox"));
+        assert!(output.contains("nono run --read /opt/bin"));
+    }
+
+    #[test]
+    fn test_exit_127_binary_readable_but_exec_fails() {
+        // Binary at /usr/bin/ps, sandbox has /usr/bin readable
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/usr/bin"),
+            resolved: PathBuf::from("/usr/bin"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("system_read".to_string()),
+        });
+        let cmd = make_command_context("ps", "/usr/bin/ps");
+        let formatter = DiagnosticFormatter::new(&caps).with_command(cmd);
+        let output = formatter.format_footer(127);
+
+        assert!(output.contains("'ps' resolved to /usr/bin/ps which is readable"));
+        assert!(output.contains("Common causes:"));
+        assert!(output.contains("shared library"));
+        assert!(output.contains("Run with -v"));
+    }
+
+    #[test]
+    fn test_exit_127_file_level_grant_dir_not_readable() {
+        // Binary granted as a file-level read, but parent dir not readable
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/opt/custom/mybin"),
+            resolved: PathBuf::from("/opt/custom/mybin"),
+            access: AccessMode::Read,
+            is_file: true,
+            source: CapabilitySource::User,
+        });
+        let cmd = make_command_context("mybin", "/opt/custom/mybin");
+        let formatter = DiagnosticFormatter::new(&caps).with_command(cmd);
+        let output = formatter.format_footer(127);
+
+        // is_binary_path_readable returns true (file-level match)
+        // is_binary_dir_readable returns false (/opt/custom not granted)
+        assert!(output.contains("'mybin' resolved to /opt/custom/mybin but the directory"));
+        assert!(output.contains("read access to"));
+    }
+
+    #[test]
+    fn test_exit_127_no_command_context() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(127);
+
+        assert!(output.contains("Command not found (exit code 127)"));
+        assert!(output.contains("could not be found or executed"));
+    }
+
+    #[test]
+    fn test_exit_126_permission_denied() {
+        let caps = make_test_caps();
+        let cmd = make_command_context("script.sh", "/test/project/script.sh");
+        let formatter = DiagnosticFormatter::new(&caps).with_command(cmd);
+        let output = formatter.format_footer(126);
+
+        assert!(output.contains("Permission denied (exit code 126)"));
+        assert!(output.contains("'script.sh' was found at /test/project/script.sh"));
+        assert!(output.contains("execute permission"));
+    }
+
+    #[test]
+    fn test_exit_126_no_command_context() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(126);
+
+        assert!(output.contains("Permission denied (exit code 126)"));
+        assert!(output.contains("found but could not be executed"));
+    }
+
+    #[test]
+    fn test_exit_1_generic() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains("exited with code 1"));
+        assert!(output.contains("may be due to sandbox restrictions"));
+    }
+
+    #[test]
+    fn test_exit_sigkill() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(128 + 9);
+
+        assert!(output.contains("SIGKILL"));
+        assert!(output.contains("forcefully terminated"));
+        assert!(output.contains("usually not"));
+    }
+
+    #[test]
+    fn test_exit_sigsys_platform_correct() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(128 + libc::SIGSYS as i32);
+
+        assert!(output.contains("SIGSYS"));
+        assert!(output.contains("blocked system call"));
+    }
+
+    #[test]
+    fn test_exit_sigterm() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(128 + 15);
+
+        assert!(output.contains("SIGTERM"));
+        // SIGTERM gets the generic signal line, not a special explanation
+        assert!(!output.contains("blocked system call"));
+        assert!(!output.contains("forcefully terminated"));
+    }
+
+    #[test]
+    fn test_exit_unknown_signal() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(128 + 33);
+
+        assert!(output.contains("killed by signal 33"));
+        assert!(!output.contains("SIGKILL"));
+        assert!(!output.contains("SIGSYS"));
+    }
+
+    #[test]
+    fn test_exit_other_code() {
+        let caps = make_test_caps();
+        let formatter = DiagnosticFormatter::new(&caps);
+        let output = formatter.format_footer(42);
+
+        assert!(output.contains("exited with code 42"));
+        assert!(output.contains("may be due to sandbox restrictions"));
     }
 }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -62,6 +62,34 @@ pub struct CommandContext {
     pub resolved_path: PathBuf,
 }
 
+/// Strip control characters and ANSI escape sequences from a string.
+///
+/// Prevents terminal injection from attacker-controlled program names
+/// or paths appearing in diagnostic output.
+fn sanitize_for_diagnostic(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip ESC and the entire escape sequence
+            if let Some(next) = chars.next() {
+                if next == '[' {
+                    for seq_char in chars.by_ref() {
+                        if seq_char.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                }
+            }
+        } else if c.is_control() {
+            // Strip all control characters
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 /// Formats diagnostic information about sandbox policy.
 ///
 /// This is library code that can be used by any parent process
@@ -170,10 +198,11 @@ impl<'a> DiagnosticFormatter<'a> {
         let binary_path = &cmd.resolved_path;
         for cap in self.caps.fs_capabilities() {
             if cap.access == AccessMode::Read || cap.access == AccessMode::ReadWrite {
-                if binary_path.starts_with(&cap.resolved) {
-                    return true;
-                }
-                if cap.is_file && *binary_path == cap.resolved {
+                if cap.is_file {
+                    if *binary_path == cap.resolved {
+                        return true;
+                    }
+                } else if binary_path.starts_with(&cap.resolved) {
                     return true;
                 }
             }
@@ -192,8 +221,9 @@ impl<'a> DiagnosticFormatter<'a> {
             None => return false,
         };
         for cap in self.caps.fs_capabilities() {
-            if (cap.access == AccessMode::Read || cap.access == AccessMode::ReadWrite)
-                && (binary_dir.starts_with(&cap.resolved) || cap.resolved == binary_dir)
+            if !cap.is_file
+                && (cap.access == AccessMode::Read || cap.access == AccessMode::ReadWrite)
+                && binary_dir.starts_with(&cap.resolved)
             {
                 return true;
             }
@@ -211,23 +241,17 @@ impl<'a> DiagnosticFormatter<'a> {
         match exit_code {
             127 => {
                 // 127 = command not found (shell convention) or execve failed
-                lines.push(
-                    "[nono] Command not found (exit code 127).".to_string(),
-                );
+                lines.push("[nono] Command not found (exit code 127).".to_string());
                 lines.push("[nono]".to_string());
 
                 if let Some(ref cmd) = self.command {
+                    let program = sanitize_for_diagnostic(&cmd.program);
+                    let path = sanitize_for_diagnostic(&cmd.resolved_path.display().to_string());
                     if !self.is_binary_path_readable() {
                         // The binary exists (we resolved it) but the sandbox
                         // can't read it.
-                        lines.push(format!(
-                            "[nono] The binary '{}' was found at:",
-                            cmd.program,
-                        ));
-                        lines.push(format!(
-                            "[nono]   {}",
-                            cmd.resolved_path.display(),
-                        ));
+                        lines.push(format!("[nono] The binary '{}' was found at:", program,));
+                        lines.push(format!("[nono]   {}", path));
                         lines.push(
                             "[nono] but its directory is not readable inside the sandbox."
                                 .to_string(),
@@ -235,35 +259,33 @@ impl<'a> DiagnosticFormatter<'a> {
                         lines.push("[nono]".to_string());
 
                         if let Some(parent) = cmd.resolved_path.parent() {
-                            lines.push("[nono] Fix: grant read access to the binary's directory:".to_string());
-                            lines.push(format!(
-                                "[nono]   nono run --read {} ...",
-                                parent.display(),
-                            ));
+                            let parent_path =
+                                sanitize_for_diagnostic(&parent.display().to_string());
+                            lines.push(
+                                "[nono] Fix: grant read access to the binary's directory:"
+                                    .to_string(),
+                            );
+                            lines.push(format!("[nono]   nono run --read {} ...", parent_path,));
                         }
                     } else if !self.is_binary_dir_readable() {
                         // Binary itself is allowed but its directory isn't
                         // (unlikely but possible with file-level grants)
                         lines.push(format!(
                             "[nono] '{}' resolved to {} but the directory",
-                            cmd.program,
-                            cmd.resolved_path.display(),
+                            program, path,
                         ));
                         lines.push(
                             "[nono] may not be accessible. The sandbox needs read access to"
                                 .to_string(),
                         );
-                        lines.push(
-                            "[nono] the directory containing the binary.".to_string(),
-                        );
+                        lines.push("[nono] the directory containing the binary.".to_string());
                     } else {
                         // Binary path is readable — the command may depend on
                         // a dynamic linker, shared libraries, or shell that
                         // isn't accessible.
                         lines.push(format!(
                             "[nono] '{}' resolved to {} which is readable,",
-                            cmd.program,
-                            cmd.resolved_path.display(),
+                            program, path,
                         ));
                         lines.push(
                             "[nono] but the command still failed to execute. Common causes:"
@@ -283,12 +305,9 @@ impl<'a> DiagnosticFormatter<'a> {
                         );
                         lines.push("[nono]".to_string());
                         lines.push(
-                            "[nono] Run with -v to see all allowed paths and check if"
-                                .to_string(),
+                            "[nono] Run with -v to see all allowed paths and check if".to_string(),
                         );
-                        lines.push(
-                            "[nono] required system directories are included.".to_string(),
-                        );
+                        lines.push("[nono] required system directories are included.".to_string());
                     }
                 } else {
                     lines.push(
@@ -303,16 +322,15 @@ impl<'a> DiagnosticFormatter<'a> {
             }
             126 => {
                 // 126 = command found but not executable
-                lines.push(
-                    "[nono] Permission denied (exit code 126).".to_string(),
-                );
+                lines.push("[nono] Permission denied (exit code 126).".to_string());
                 lines.push("[nono]".to_string());
 
                 if let Some(ref cmd) = self.command {
+                    let program = sanitize_for_diagnostic(&cmd.program);
+                    let path = sanitize_for_diagnostic(&cmd.resolved_path.display().to_string());
                     lines.push(format!(
                         "[nono] '{}' was found at {} but could not be executed.",
-                        cmd.program,
-                        cmd.resolved_path.display(),
+                        program, path,
                     ));
                     lines.push(
                         "[nono] The file may not have execute permission, or the sandbox"
@@ -331,13 +349,6 @@ impl<'a> DiagnosticFormatter<'a> {
                             .to_string(),
                     );
                 }
-            }
-            1 => {
-                // Generic error - could be anything
-                lines.push(format!(
-                    "[nono] Command exited with code {}. This may be due to sandbox restrictions.",
-                    exit_code,
-                ));
             }
             code if (129..=192).contains(&code) => {
                 // Signal-based exit: 128 + signal number
@@ -368,10 +379,7 @@ impl<'a> DiagnosticFormatter<'a> {
                         "[nono] SIGSYS typically means a blocked system call. The command tried"
                             .to_string(),
                     );
-                    lines.push(
-                        "[nono] an operation that the sandbox does not permit."
-                            .to_string(),
-                    );
+                    lines.push("[nono] an operation that the sandbox does not permit.".to_string());
                 } else if sig == 9 {
                     lines.push(format!(
                         "[nono] Command killed by {} (exit code {}).",
@@ -382,9 +390,7 @@ impl<'a> DiagnosticFormatter<'a> {
                         "[nono] The process was forcefully terminated. This is usually not"
                             .to_string(),
                     );
-                    lines.push(
-                        "[nono] caused by sandbox restrictions.".to_string(),
-                    );
+                    lines.push("[nono] caused by sandbox restrictions.".to_string());
                 } else if !sig_name.is_empty() {
                     lines.push(format!(
                         "[nono] Command killed by signal {} / {} (exit code {}).",

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -61,7 +61,9 @@ pub mod undo;
 pub use capability::{
     AccessMode, CapabilitySet, CapabilitySource, FsCapability, NetworkMode, SignalMode,
 };
-pub use diagnostic::{DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode};
+pub use diagnostic::{
+    CommandContext, DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode,
+};
 pub use error::{NonoError, Result};
 pub use keystore::{
     is_env_uri, is_op_uri, load_secret_by_ref, load_secrets, redact_op_uri,


### PR DESCRIPTION
Replace the generic "Command exited with code N" message with specific guidance based on exit code and sandbox state:

- Exit 127: detect whether the binary path is readable in the sandbox and suggest the exact --read flag needed
- Exit 126: explain permission denied with binary path context
- Signals: name the signal (SIGKILL, SIGSYS, etc.) and explain what it means — SIGSYS uses libc::SIGSYS for correct platform-specific signal number (12 on macOS, 31 on Linux)
- Generic codes: retain the existing "may be due to sandbox restrictions" fallback

Adds CommandContext to DiagnosticFormatter so the footer can reference the program name and resolved binary path. The CLI passes this context from ExecConfig when building the formatter.