### PR TITLE
feat: add port_allow to profile JSON NetworkConfig (#254)

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -265,6 +265,11 @@ impl CapabilitySetExt for CapabilitySet {
             });
         }
 
+        // Localhost IPC ports from profile
+        for port in &profile.network.port_allow {
+            caps.add_localhost_port(*port);
+        }
+
         // Apply allowed commands from profile
         for cmd in &profile.security.allowed_commands {
             caps.add_allowed_command(cmd.as_str());

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -488,6 +488,10 @@ pub struct NetworkConfig {
     /// Credential services to enable via reverse proxy
     #[serde(default)]
     pub proxy_credentials: Vec<String>,
+    /// Localhost TCP ports to allow bidirectional IPC (connect + bind).
+    /// Equivalent to `--allow-port` CLI flag.
+    #[serde(default)]
+    pub port_allow: Vec<u16>,
     /// Custom credential definitions for services not in network-policy.json.
     /// Keys are service names (used with --proxy-credential), values define
     /// how to route and inject credentials for that service.
@@ -898,6 +902,25 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 .network_profile
                 .merge(base.network.network_profile),
             proxy_allow: dedup_append(&base.network.proxy_allow, &child.network.proxy_allow),
+            port_allow: {
+                let mut seen = std::collections::HashSet::with_capacity(
+                    base.network.port_allow.len() + child.network.port_allow.len(),
+                );
+                let mut result = Vec::with_capacity(
+                    base.network.port_allow.len() + child.network.port_allow.len(),
+                );
+                for port in base
+                    .network
+                    .port_allow
+                    .iter()
+                    .chain(child.network.port_allow.iter())
+                {
+                    if seen.insert(port) {
+                        result.push(*port);
+                    }
+                }
+                result
+            },
             proxy_credentials: dedup_append(
                 &base.network.proxy_credentials,
                 &child.network.proxy_credentials,
@@ -1882,6 +1905,7 @@ mod tests {
                 block: false,
                 network_profile: InheritableValue::Set("base-net".to_string()),
                 proxy_allow: vec!["base.example.com".to_string()],
+                port_allow: vec![3000],
                 proxy_credentials: vec!["base_cred".to_string()],
                 custom_credentials: HashMap::new(),
             },
@@ -1932,6 +1956,7 @@ mod tests {
                 block: false,
                 network_profile: InheritableValue::Inherit,
                 proxy_allow: vec!["child.example.com".to_string()],
+                port_allow: vec![3000, 5000],
                 proxy_credentials: vec![],
                 custom_credentials: HashMap::new(),
             },
@@ -1968,6 +1993,13 @@ mod tests {
             .filesystem
             .read_file
             .contains(&"/base/file.txt".to_string()));
+    }
+
+    #[test]
+    fn test_merge_profiles_deduplicates_port_allow() {
+        let merged = merge_profiles(base_profile(), child_profile());
+        // base has [3000], child has [3000, 5000] — merged should dedup to [3000, 5000]
+        assert_eq!(merged.network.port_allow, vec![3000, 5000]);
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -902,25 +902,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 .network_profile
                 .merge(base.network.network_profile),
             proxy_allow: dedup_append(&base.network.proxy_allow, &child.network.proxy_allow),
-            port_allow: {
-                let mut seen = std::collections::HashSet::with_capacity(
-                    base.network.port_allow.len() + child.network.port_allow.len(),
-                );
-                let mut result = Vec::with_capacity(
-                    base.network.port_allow.len() + child.network.port_allow.len(),
-                );
-                for port in base
-                    .network
-                    .port_allow
-                    .iter()
-                    .chain(child.network.port_allow.iter())
-                {
-                    if seen.insert(port) {
-                        result.push(*port);
-                    }
-                }
-                result
-            },
+            port_allow: dedup_append(&base.network.port_allow, &child.network.port_allow),
             proxy_credentials: dedup_append(
                 &base.network.proxy_credentials,
                 &child.network.proxy_credentials,
@@ -968,7 +950,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
 }
 
 /// Append child items after base items, deduplicating while preserving order.
-fn dedup_append(base: &[String], child: &[String]) -> Vec<String> {
+fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &[T]) -> Vec<T> {
     let mut seen = std::collections::HashSet::with_capacity(base.len() + child.len());
     let mut result = Vec::with_capacity(base.len() + child.len());
     for item in base.iter().chain(child.iter()) {

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -113,6 +113,7 @@ The `network` section controls network access and credential injection:
     "block": false,
     "network_profile": "claude-code",
     "proxy_allow": ["my-internal-api.example.com"],
+    "port_allow": [3000],
     "proxy_credentials": ["openai", "anthropic"],
     "custom_credentials": {
       "telegram": {
@@ -131,6 +132,7 @@ The `network` section controls network access and credential injection:
 | `block` | Block all network access (default: `false`) |
 | `network_profile` | Network profile name for host filtering (e.g., `minimal`, `claude-code`, `enterprise`). Set to `null` in a child profile to clear an inherited value. |
 | `proxy_allow` | Additional hosts to allow through the proxy |
+| `port_allow` | Localhost TCP ports to allow bidirectional IPC (equivalent to `--allow-port`) |
 | `proxy_credentials` | Credential services to enable via reverse proxy (e.g., `openai`, `anthropic`) |
 | `custom_credentials` | Custom credential service definitions for APIs not in the built-in list |
 


### PR DESCRIPTION
Expose --allow-port functionality in profile JSON via a new
network.port_allow field, with dedup merging for profile inheritance.

Resolves: #254 

Signed-off-by: Luke Hinds <lukehinds@gmail.com>