### PR TITLE
fix: resolve dirfd-relative paths in seccomp-notify handler (#262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ nono run --profile pydantic-ai-agent --allow logs/ -- uv run my_agent.py
 nono run --profile custom-profile -- node agent.js
 
 # Rollback snapshots — undo everything the agent did
-nono run --rollback --allow-cwd -- claude
+nono run --rollback --profile claude-code --allow-cwd -- claude
 
 # Combine rollback, network filtering, and port binding
 nono run --rollback --proxy-allow api.anthropic.ai --allow-port 8000 -- uv run uvicorn myagent.main:app --port 8000
@@ -68,6 +68,15 @@ nono run --no-audit --allow-cwd -- npm test
 
 # Direct exec for scripts and piping (no parent process)
 nono wrap --read ./src --write ./output -- cargo build
+
+# Need a profile automatically applied for a specific client?
+nono learn -- new-cool-coding-agent
+
+# Why did you block that command? 
+nono why --path ~/.ssh/id_rsa
+DENIED
+  Reason: sensitive_path
+  Details: Path matches sensitive pattern 'Block access to cryptographic keys, tokens, and cloud credentials'. Access blocked by security policy.
 ```
 
 Built-in profiles for [Claude Code](https://docs.nono.sh/clients/claude-code), [OpenCode](https://docs.nono.sh/clients/opencode), and [OpenClaw](https://docs.nono.sh/clients/openclaw) — or define your own with custom permissions.

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -100,15 +100,31 @@ pub(super) fn handle_seccomp_notification(
 ) -> Result<()> {
     use nono::sandbox::{
         classify_access_from_flags, deny_notif, inject_fd, notif_id_valid, read_notif_path,
-        read_open_how, recv_notif, validate_openat2_size, SYS_OPENAT, SYS_OPENAT2,
+        read_open_how, recv_notif, resolve_notif_path, validate_openat2_size, SYS_OPENAT,
+        SYS_OPENAT2,
     };
 
     // 1. Receive the notification
     let notif = recv_notif(notify_fd)?;
 
     // 2. Read the path from the child's memory (args[1] = pathname for openat/openat2)
+    //    Then resolve dirfd-relative paths using /proc/PID/fd/DIRFD or /proc/PID/cwd.
     let path = match read_notif_path(notif.pid, notif.data.args[1]) {
-        Ok(p) => p,
+        Ok(raw_path) => {
+            // args[0] is dirfd for both openat and openat2
+            match resolve_notif_path(notif.pid, notif.data.args[0], &raw_path) {
+                Ok(resolved) => resolved,
+                Err(e) => {
+                    debug!(
+                        "Failed to resolve dirfd-relative path '{}': {}",
+                        raw_path.display(),
+                        e
+                    );
+                    let _ = deny_notif(notify_fd, notif.id);
+                    return Ok(());
+                }
+            }
+        }
         Err(e) => {
             debug!("Failed to read path from seccomp notification: {}", e);
             let _ = deny_notif(notify_fd, notif.id);
@@ -216,11 +232,26 @@ pub(super) fn handle_seccomp_notification(
         match open_path_for_access(&canonicalized, &access, config.never_grant, None) {
             Ok(file) => {
                 if notif_id_valid(notify_fd, notif.id)? {
-                    inject_fd(notify_fd, notif.id, file.as_raw_fd())?;
+                    if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
+                        debug!(
+                            "inject_fd failed for initial-set path {}: {}",
+                            path.display(),
+                            e
+                        );
+                        let _ = deny_notif(notify_fd, notif.id);
+                    }
                 }
             }
             Err(e) => {
                 debug!("Failed to open initial-set path {}: {}", path.display(), e);
+                record_denial(
+                    denials,
+                    DenialRecord {
+                        path: canonicalized.clone(),
+                        access,
+                        reason: DenialReason::PolicyBlocked,
+                    },
+                );
                 let _ = deny_notif(notify_fd, notif.id);
             }
         }
@@ -336,7 +367,14 @@ pub(super) fn handle_seccomp_notification(
             verified_digest.as_deref(),
         ) {
             Ok(file) => {
-                inject_fd(notify_fd, notif.id, file.as_raw_fd())?;
+                if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
+                    debug!(
+                        "inject_fd failed for approved path {}: {}",
+                        canonicalized.display(),
+                        e
+                    );
+                    let _ = deny_notif(notify_fd, notif.id);
+                }
             }
             Err(e) => {
                 warn!(

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -648,6 +648,61 @@ pub fn read_notif_path(pid: u32, addr: u64) -> Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(path_str))
 }
 
+/// Resolve a path from a seccomp notification, accounting for dirfd-relative paths.
+///
+/// When the child uses `openat(dirfd, "relative/path", ...)`, the raw pathname
+/// read from memory is relative. This function resolves it to an absolute path
+/// using `/proc/PID/fd/DIRFD` (or `/proc/PID/cwd` when dirfd is `AT_FDCWD`).
+///
+/// If the path is already absolute, it is returned unchanged.
+///
+/// # Arguments
+///
+/// * `pid` - The child process ID
+/// * `dirfd` - The dirfd argument from the openat/openat2 syscall (args[0])
+/// * `raw_path` - The pathname read from the child's memory via `read_notif_path`
+///
+/// # Errors
+///
+/// Returns an error if the `/proc` symlink cannot be read.
+pub fn resolve_notif_path(
+    pid: u32,
+    dirfd: u64,
+    raw_path: &std::path::Path,
+) -> Result<std::path::PathBuf> {
+    // Absolute paths need no resolution
+    if raw_path.is_absolute() {
+        return Ok(raw_path.to_path_buf());
+    }
+
+    // AT_FDCWD (-100 as i32, but stored as u64 in seccomp args via sign extension)
+    let at_fdcwd_u64 = libc::AT_FDCWD as i32 as u32 as u64;
+    // Also handle sign-extended 64-bit representation
+    let at_fdcwd_u64_extended = libc::AT_FDCWD as i64 as u64;
+
+    let base_dir = if dirfd == at_fdcwd_u64 || dirfd == at_fdcwd_u64_extended {
+        // Use the child's current working directory
+        let cwd_link = format!("/proc/{}/cwd", pid);
+        std::fs::read_link(&cwd_link).map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "Failed to read {} for dirfd-relative path resolution: {}",
+                cwd_link, e
+            ))
+        })?
+    } else {
+        // Read the directory path from /proc/PID/fd/DIRFD
+        let fd_link = format!("/proc/{}/fd/{}", pid, dirfd);
+        std::fs::read_link(&fd_link).map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "Failed to read {} for dirfd-relative path resolution: {}",
+                fd_link, e
+            ))
+        })?
+    };
+
+    Ok(base_dir.join(raw_path))
+}
+
 /// Read the open_how struct from a seccomp notification for openat2 syscalls.
 ///
 /// For openat2, args[2] is a pointer to `struct open_how`, NOT the flags integer.
@@ -1011,5 +1066,69 @@ mod tests {
     fn test_validate_openat2_size_rejects_unreasonably_large() {
         assert!(!validate_openat2_size(4097));
         assert!(!validate_openat2_size(usize::MAX));
+    }
+
+    #[test]
+    fn test_resolve_notif_path_absolute_unchanged() {
+        // Absolute paths should be returned unchanged regardless of dirfd
+        let abs_path = std::path::PathBuf::from("/usr/lib/libc.so.6");
+        let result = resolve_notif_path(1, 42, &abs_path);
+        let path = match result {
+            Ok(p) => p,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(path, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_notif_path_absolute_with_at_fdcwd() {
+        // Absolute paths should be returned unchanged even with AT_FDCWD
+        let abs_path = std::path::PathBuf::from("/etc/passwd");
+        let at_fdcwd = libc::AT_FDCWD as i64 as u64;
+        let path = match resolve_notif_path(1, at_fdcwd, &abs_path) {
+            Ok(p) => p,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(path, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_notif_path_relative_with_invalid_pid_fails() {
+        // Relative path with non-existent PID should fail (can't read /proc/PID/cwd)
+        let rel_path = std::path::PathBuf::from("relative/path.so");
+        let at_fdcwd = libc::AT_FDCWD as i64 as u64;
+        let result = resolve_notif_path(u32::MAX, at_fdcwd, &rel_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_notif_path_relative_with_invalid_fd_fails() {
+        // Relative path with non-existent PID/fd should fail
+        let rel_path = std::path::PathBuf::from("some_lib.so");
+        let result = resolve_notif_path(u32::MAX, 999, &rel_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_notif_path_at_fdcwd_both_representations() {
+        // AT_FDCWD is -100. When stored as u64 in seccomp args, it may be
+        // sign-extended to 0xFFFFFFFFFFFFFF9C or truncated to 0xFFFFFF9C.
+        // Both should be recognized.
+        let abs_path = std::path::PathBuf::from("/absolute");
+        let at_fdcwd_32 = libc::AT_FDCWD as i32 as u32 as u64; // 0xFFFFFF9C
+        let at_fdcwd_64 = libc::AT_FDCWD as i64 as u64; // 0xFFFFFFFFFFFFFF9C
+
+        // Both should work for absolute paths (early return)
+        let path_32 = match resolve_notif_path(1, at_fdcwd_32, &abs_path) {
+            Ok(p) => p,
+            Err(e) => panic!("unexpected error for 32-bit AT_FDCWD: {e}"),
+        };
+        assert_eq!(path_32, abs_path);
+
+        let path_64 = match resolve_notif_path(1, at_fdcwd_64, &abs_path) {
+            Ok(p) => p,
+            Err(e) => panic!("unexpected error for 64-bit AT_FDCWD: {e}"),
+        };
+        assert_eq!(path_64, abs_path);
     }
 }

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -675,9 +675,12 @@ pub fn resolve_notif_path(
         return Ok(raw_path.to_path_buf());
     }
 
-    // AT_FDCWD (-100 as i32, but stored as u64 in seccomp args via sign extension)
+    // AT_FDCWD (-100, but stored as u64 in seccomp args via sign extension).
+    // Two representations: 32-bit zero-extended (0xFFFFFF9C) and 64-bit sign-extended
+    // (0xFFFFFFFFFFFFFF9C). We must check both.
+    #[allow(clippy::unnecessary_cast)]
     let at_fdcwd_u64 = libc::AT_FDCWD as i32 as u32 as u64;
-    // Also handle sign-extended 64-bit representation
+    #[allow(clippy::unnecessary_cast)]
     let at_fdcwd_u64_extended = libc::AT_FDCWD as i64 as u64;
 
     let base_dir = if dirfd == at_fdcwd_u64 || dirfd == at_fdcwd_u64_extended {
@@ -1115,6 +1118,7 @@ mod tests {
         // sign-extended to 0xFFFFFFFFFFFFFF9C or truncated to 0xFFFFFF9C.
         // Both should be recognized.
         let abs_path = std::path::PathBuf::from("/absolute");
+        #[allow(clippy::unnecessary_cast)]
         let at_fdcwd_32 = libc::AT_FDCWD as i32 as u32 as u64; // 0xFFFFFF9C
         let at_fdcwd_64 = libc::AT_FDCWD as i64 as u64; // 0xFFFFFFFFFFFFFF9C
 

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -22,8 +22,8 @@ pub use macos::{extension_consume, extension_issue_file, extension_release};
 #[cfg(target_os = "linux")]
 pub use linux::{
     classify_access_from_flags, deny_notif, inject_fd, install_seccomp_notify, notif_id_valid,
-    read_notif_path, read_open_how, recv_notif, validate_openat2_size, OpenHow, SeccompData,
-    SeccompNotif, SYS_OPENAT, SYS_OPENAT2,
+    read_notif_path, read_open_how, recv_notif, resolve_notif_path, validate_openat2_size, OpenHow,
+    SeccompData, SeccompNotif, SYS_OPENAT, SYS_OPENAT2,
 };
 
 /// Information about sandbox support on this platform


### PR DESCRIPTION
The seccomp-notify supervisor handler ignored the dirfd argument (args[0]) from openat/openat2 syscalls. When programs use openat(dirfd, "relative_name", ...) instead of absolute paths, the handler failed to resolve the path and denied with EPERM.

Three fixes:
- Add resolve_notif_path() to resolve relative paths via /proc/PID/fd/DIRFD (or /proc/PID/cwd for AT_FDCWD)
- Record DenialRecord when open_path_for_access fails on the fast-path (was silently denied)
- Handle inject_fd failures with deny_notif fallback instead of ? propagation (prevents child hanging on pending notification)

Fixes #262
Fixes #205