### PR TITLE
feat: add capability_elevation profile field and OS-aware groups

### DIFF
--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -52,13 +52,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.31", features = ["process", "signal", "fs", "user"] }
+nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }
 landlock = "0.4"
 dns-lookup = "2"
 keyring = { version = "3", features = ["sync-secret-service"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nix = { version = "0.31", features = ["process", "signal", "fs", "user"] }
+nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }
 keyring = { version = "3", features = ["apple-native"] }
 
 [build-dependencies]

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -319,6 +319,27 @@
         ]
       }
     },
+    "user_caches_linux": {
+      "description": "User cache and log directories for Linux programs (XDG)",
+      "platform": "linux",
+      "allow": {
+        "readwrite": [
+          "~/.cache"
+        ],
+        "read": [
+          "~/.local/state"
+        ]
+      }
+    },
+    "claude_cache_linux": {
+      "description": "Claude Code CLI cache and MCP log directories on Linux",
+      "platform": "linux",
+      "allow": {
+        "readwrite": [
+          "~/.cache/claude-cli-nodejs"
+        ]
+      }
+    },
     "user_tools": {
       "description": "User-local executables, .desktop files, man pages, and shell completions",
       "allow": {
@@ -408,7 +429,7 @@
       "description": "Visual Studio Code configuration and extension directories for macOS",
       "platform": "macos",
       "allow": {
-        "write": [
+        "readwrite": [
           "$HOME/.vscode",
           "$HOME/Library/Application Support/Code"
         ]
@@ -418,9 +439,22 @@
       "description": "Visual Studio Code configuration and extension directories for Linux",
       "platform": "linux",
       "allow": {
-        "write": [
+        "readwrite": [
           "$HOME/.vscode",
           "$HOME/.config/Code"
+        ]
+      }
+    },
+    "nix_runtime": {
+      "description": "Nix package manager runtime paths",
+      "platform": "linux",
+      "allow": {
+        "read": [
+          "~/.nix-profile",
+          "~/.nix-defexpr",
+          "/run/current-system/sw",
+          "/etc/profiles/per-user",
+          "/nix/var/nix/profiles"
         ]
       }
     },
@@ -516,14 +550,17 @@
           "claude_code_macos",
           "claude_code_linux",
           "user_caches_macos",
+          "claude_cache_linux",
           "node_runtime",
           "rust_runtime",
           "python_runtime",
           "vscode_macos",
           "vscode_linux",
+          "nix_runtime",
           "unlink_protection"
         ],
-        "signal_mode": "isolated"
+        "signal_mode": "isolated",
+        "capability_elevation": false
       },
       "trust_groups": [],
       "filesystem": {
@@ -581,7 +618,7 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "node_runtime", "unlink_protection"],
+        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "unlink_protection"],
         "signal_mode": "isolated"
       },
       "trust_groups": [],

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -449,6 +449,13 @@ pub struct RunArgs {
     #[arg(long)]
     pub trust_override: bool,
 
+    /// Enable runtime capability elevation (seccomp-notify + approval prompts).
+    /// Overrides the profile's capability_elevation setting.
+    /// When enabled, the supervisor can grant access to paths not in the
+    /// initial capability set via interactive prompts.
+    #[arg(long, env = "NONO_CAPABILITY_ELEVATION")]
+    pub capability_elevation: bool,
+
     /// Command to run inside the sandbox
     #[arg(required = true)]
     pub command: Vec<String>,

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -11,6 +11,7 @@
 //! allocation is safe) and uses only raw libc calls in the child.
 
 mod env_sanitization;
+mod pty_mux;
 #[cfg(target_os = "linux")]
 mod supervisor_linux;
 
@@ -82,6 +83,19 @@ impl ProcfsAccessContext {
             thread_pid,
         }
     }
+}
+
+/// PTY relay state passed to supervisor loops.
+///
+/// The supervisor poll loop uses these fds to relay I/O between the real
+/// terminal and the PTY master (which is connected to the child's PTY slave).
+struct PtyRelay<'a> {
+    /// PTY master fd (connected to child's stdin/stdout/stderr)
+    master_fd: std::os::fd::RawFd,
+    /// Real terminal fd (/dev/tty)
+    real_tty_fd: std::os::fd::RawFd,
+    /// Real terminal state (for save/restore during prompts)
+    real_term: &'a pty_mux::RealTerminal,
 }
 
 /// Threading context for fork safety validation.
@@ -163,6 +177,11 @@ pub struct ExecConfig<'a> {
     pub threading: ThreadingContext,
     /// Paths that are write-protected (signed instruction files).
     pub protected_paths: &'a [std::path::PathBuf],
+    /// Whether runtime capability elevation is enabled.
+    /// When true, the child installs seccomp-notify and the parent sets up
+    /// a PTY mux for terminal isolation during approval prompts.
+    /// When false, the child runs with static capabilities only.
+    pub capability_elevation: bool,
 }
 
 /// Configuration for supervisor IPC in supervised execution mode.
@@ -391,8 +410,26 @@ pub fn execute_supervised(
     // sandbox apply (see child branch below).
     // The parent sets itself non-dumpable immediately after fork.
 
-    // Compute child's FD keep list: supervisor socket fd if IPC is enabled
-    let child_keep_fds: Vec<i32> = child_sock_fd.into_iter().collect();
+    // Create PTY pair for terminal isolation, only when capability elevation
+    // is enabled. The PTY gives the child its own terminal so TUI apps can set
+    // raw mode without affecting the supervisor's approval prompts.
+    // Without elevation there are no prompts, so the child inherits the parent's
+    // terminal directly (simpler, avoids PTY relay complexity).
+    let pty_pair = if config.capability_elevation {
+        Some(pty_mux::create_pty_pair()?)
+    } else {
+        None
+    };
+    let pty_slave_fd = pty_pair.as_ref().map(|p| p.slave.as_raw_fd());
+
+    // Compute child's FD keep list: PTY slave (if elevation) + supervisor socket fd
+    let mut child_keep_fds: Vec<i32> = Vec::new();
+    if let Some(fd) = pty_slave_fd {
+        child_keep_fds.push(fd);
+    }
+    if let Some(fd) = child_sock_fd {
+        child_keep_fds.push(fd);
+    }
 
     let effective_caps: &CapabilitySet = config.caps;
 
@@ -409,16 +446,20 @@ pub fn execute_supervised(
 
     match fork_result {
         Ok(ForkResult::Child) => {
-            // CHILD: Apply sandbox, then exec.
+            // CHILD: Set up PTY, apply sandbox, then exec.
             //
             // The child applies the sandbox itself before exec.
             // Sandbox::apply() allocates (Seatbelt profile generation, Landlock
             // PathFd opens) but this is safe because we validated single-threaded
             // execution before fork, giving us a clean heap.
-            //
-            // The child inherits the parent's stdin/stdout/stderr directly
-            // (no pipe redirection). This preserves TTY semantics for
-            // interactive programs like Claude Code.
+
+            // Set up PTY slave as the child's controlling terminal (elevation only).
+            // This gives the child its own terminal so TUI apps can freely
+            // change terminal modes without affecting the supervisor.
+            // SAFETY: We are in the child after fork, slave_fd is valid.
+            if let Some(slave_fd) = pty_slave_fd {
+                unsafe { pty_mux::setup_child_pty(slave_fd) };
+            }
 
             // Apply Landlock FIRST. Landlock's restrict_self() opens path fds
             // for rule creation, so it must run before seccomp-notify is installed.
@@ -437,24 +478,47 @@ pub fn execute_supervised(
                 }
             }
 
-            // On Linux with supervisor enabled: install seccomp-notify filter
+            // On Linux with capability elevation: install seccomp-notify filter
             // AFTER Landlock. The kernel evaluates seccomp before LSM hooks
             // regardless of installation order, so the security properties are
             // identical. All openat/openat2 from exec'd child are routed to
             // the supervisor, which can inject fds for approved paths.
+            // Without elevation, seccomp is not installed — the child runs
+            // with static Landlock capabilities only.
             #[cfg(target_os = "linux")]
             {
-                if let Some(fd) = child_sock_fd {
-                    match nono::sandbox::install_seccomp_notify() {
-                        Ok(notify_fd) => {
-                            // Send the notify fd to the parent via SCM_RIGHTS
-                            // SAFETY: We own the child socket end and the notify fd
-                            // is valid. from_stream is safe with our inherited fd.
-                            let child_sock =
-                                unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
-                            let tmp_sock = SupervisorSocket::from_stream(child_sock);
-                            if let Err(_e) = tmp_sock.send_fd(notify_fd.as_raw_fd()) {
-                                let msg = b"nono: failed to send seccomp notify fd to supervisor\n";
+                if config.capability_elevation {
+                    if let Some(fd) = child_sock_fd {
+                        match nono::sandbox::install_seccomp_notify() {
+                            Ok(notify_fd) => {
+                                // Send the notify fd to the parent via SCM_RIGHTS
+                                // SAFETY: We own the child socket end and the notify fd
+                                // is valid. from_stream is safe with our inherited fd.
+                                let child_sock =
+                                    unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+                                let tmp_sock = SupervisorSocket::from_stream(child_sock);
+                                if let Err(_e) = tmp_sock.send_fd(notify_fd.as_raw_fd()) {
+                                    let msg =
+                                        b"nono: failed to send seccomp notify fd to supervisor\n";
+                                    unsafe {
+                                        libc::write(
+                                            libc::STDERR_FILENO,
+                                            msg.as_ptr().cast::<libc::c_void>(),
+                                            msg.len(),
+                                        );
+                                    }
+                                }
+                                // Leak the socket wrapper so it doesn't close the fd
+                                // (the fd is still needed for supervisor IPC)
+                                std::mem::forget(tmp_sock);
+                            }
+                            Err(e) => {
+                                // seccomp not available -- proceed without transparent expansion
+                                let detail = format!(
+                                    "nono: seccomp-notify not available, expansion disabled: {}\n",
+                                    e
+                                );
+                                let msg = detail.as_bytes();
                                 unsafe {
                                     libc::write(
                                         libc::STDERR_FILENO,
@@ -463,37 +527,18 @@ pub fn execute_supervised(
                                     );
                                 }
                             }
-                            // Leak the socket wrapper so it doesn't close the fd
-                            // (the fd is still needed for supervisor IPC)
-                            std::mem::forget(tmp_sock);
-                        }
-                        Err(e) => {
-                            // seccomp not available -- proceed without transparent expansion
-                            let detail = format!(
-                                "nono: seccomp-notify not available, expansion disabled: {}\n",
-                                e
-                            );
-                            let msg = detail.as_bytes();
-                            unsafe {
-                                libc::write(
-                                    libc::STDERR_FILENO,
-                                    msg.as_ptr().cast::<libc::c_void>(),
-                                    msg.len(),
-                                );
-                            }
                         }
                     }
                 }
             }
 
-            // In rollback-only mode (no supervisor IPC), make the child
-            // non-dumpable to prevent ptrace attachment from same-UID
-            // processes. When supervisor IPC is active, the child must stay
-            // dumpable so the parent can read /proc/CHILD/mem for
-            // seccomp-notify path extraction.
+            // When capability elevation is off, make the child non-dumpable
+            // to prevent ptrace attachment from same-UID processes. When
+            // elevation is active, the child must stay dumpable so the parent
+            // can read /proc/CHILD/mem for seccomp-notify path extraction.
             #[cfg(target_os = "linux")]
             {
-                if child_sock_fd.is_none() {
+                if !config.capability_elevation {
                     // No supervisor IPC — safe to drop dumpable
                     unsafe {
                         libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0);
@@ -521,6 +566,14 @@ pub fn execute_supervised(
             unsafe { libc::_exit(127) }
         }
         Ok(ForkResult::Parent { child }) => {
+            // Close the PTY slave in the parent (only the child uses it).
+            // The master stays open for relay. Destructure to take ownership
+            // of master and drop slave.
+            let pty_master = pty_pair.map(|p| {
+                drop(p.slave);
+                p.master
+            });
+
             // Destructure socket pair: close child's end, keep supervisor's end
             let supervisor_sock = if let Some((sup, child_end)) = socket_pair {
                 drop(child_end);
@@ -568,11 +621,12 @@ pub fn execute_supervised(
                 }
             }
 
-            // On Linux with supervisor enabled: receive the seccomp notify fd
+            // On Linux with capability elevation: receive the seccomp notify fd
             // from the child. The child installed a seccomp-notify filter and
             // sent the fd via SCM_RIGHTS on the supervisor socket.
+            // Only attempt recv when elevation is active (child sends the fd).
             #[cfg(target_os = "linux")]
-            let seccomp_notify_fd: Option<OwnedFd> = if supervisor.is_some() {
+            let seccomp_notify_fd: Option<OwnedFd> = if config.capability_elevation {
                 if let Some(ref sup_sock) = supervisor_sock {
                     match sup_sock.recv_fd() {
                         Ok(fd) => {
@@ -592,9 +646,29 @@ pub fn execute_supervised(
             };
 
             // Set up signal forwarding.
-            // No output piping needed - child inherits the terminal directly.
             setup_signal_forwarding(child);
             let _signal_forwarding_guard = SignalForwardingGuard;
+
+            // Set up PTY relay when capability elevation is enabled.
+            // The real terminal is put into raw mode so keystrokes pass through
+            // to the child transparently. When the supervisor needs to prompt,
+            // it restores the terminal, prompts, then re-enters raw mode.
+            // Without elevation, the child inherits the parent's terminal directly.
+            let real_term = if pty_master.is_some() {
+                Some(pty_mux::RealTerminal::open()?)
+            } else {
+                None
+            };
+            let pty_master_fd = pty_master.as_ref().map(|m| m.as_raw_fd());
+            let real_tty_fd = real_term.as_ref().map(|t| t.as_raw_fd());
+
+            if let (Some(master_fd), Some(tty_fd)) = (pty_master_fd, real_tty_fd) {
+                pty_mux::set_nonblocking(master_fd)?;
+                pty_mux::setup_sigwinch_forwarding(tty_fd, master_fd);
+                if let Some(ref rt) = real_term {
+                    rt.enter_raw_mode()?;
+                }
+            }
 
             // NOTE: peer_pid() is NOT called here. For socketpair() created
             // before fork, LOCAL_PEERPID/SO_PEERCRED return the parent's own PID
@@ -615,7 +689,23 @@ pub fn execute_supervised(
                 .map(|cap| (cap.resolved.clone(), cap.is_file))
                 .collect();
 
-            // Run IPC event loop if supervisor is configured, otherwise just wait
+            // Build optional PTY relay (only when capability elevation allocates a PTY).
+            let relay = if let (Some(mfd), Some(tfd), Some(ref rt)) =
+                (pty_master_fd, real_tty_fd, &real_term)
+            {
+                Some(PtyRelay {
+                    master_fd: mfd,
+                    real_tty_fd: tfd,
+                    real_term: rt,
+                })
+            } else {
+                None
+            };
+
+            // Run supervisor IPC loop when configured, with or without PTY relay.
+            // Trust interception runs over the IPC socket regardless of
+            // capability_elevation. The PTY relay is only present when
+            // elevation is active (seccomp-notify + interactive prompts).
             let (status, denials) =
                 if let (Some(sup_cfg), Some(mut sup_sock)) = (supervisor, supervisor_sock) {
                     #[cfg(target_os = "linux")]
@@ -627,16 +717,38 @@ pub fn execute_supervised(
                             seccomp_notify_fd.as_ref(),
                             &initial_caps,
                             trust_interceptor,
+                            relay.as_ref(),
                         )?
                     }
                     #[cfg(not(target_os = "linux"))]
                     {
-                        run_supervisor_loop(child, &mut sup_sock, sup_cfg, trust_interceptor)?
+                        run_supervisor_loop(
+                            child,
+                            &mut sup_sock,
+                            sup_cfg,
+                            trust_interceptor,
+                            relay.as_ref(),
+                        )?
                     }
+                } else if let Some(ref r) = relay {
+                    // PTY relay active but no supervisor — just relay I/O.
+                    let status = wait_for_child_with_relay(child, r)?;
+                    (status, Vec::new())
                 } else {
+                    // No supervisor, no PTY — simple wait.
                     let status = wait_for_child(child)?;
                     (status, Vec::new())
                 };
+
+            // Restore real terminal and clean up PTY state
+            if real_term.is_some() {
+                pty_mux::clear_sigwinch_forwarding();
+            }
+            if let Some(ref rt) = real_term {
+                let _ = rt.restore();
+            }
+            // Drop PTY master to send EOF to child (if still alive)
+            drop(pty_master);
 
             let exit_code = match status {
                 WaitStatus::Exited(_, code) => {
@@ -654,8 +766,6 @@ pub fn execute_supervised(
             };
 
             // Print diagnostic footer on non-zero exit.
-            // Supervised mode inherits the terminal directly, so the footer is
-            // printed here after the child exits.
             if exit_code != 0 && !config.no_diagnostics {
                 let mode = if supervisor.is_some() {
                     DiagnosticMode::Supervised
@@ -712,6 +822,59 @@ fn get_max_fd() -> i32 {
         std::cmp::min(max as i32, 65536)
     } else {
         1024
+    }
+}
+
+/// Wait for child process while relaying PTY I/O.
+///
+/// Used when no supervisor IPC is configured but we still need to relay
+/// the PTY for terminal isolation.
+fn wait_for_child_with_relay(child: Pid, relay: &PtyRelay<'_>) -> Result<WaitStatus> {
+    loop {
+        // Poll: real_tty (user input) + pty_master (child output)
+        let mut pfds = [
+            libc::pollfd {
+                fd: relay.real_tty_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: relay.master_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+
+        // SAFETY: pfds is a valid array on the stack
+        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), 2, 200) };
+
+        if ret > 0 {
+            // User input -> PTY master (child's stdin)
+            if pfds[0].revents & libc::POLLIN != 0 {
+                pty_mux::relay_bytes(relay.real_tty_fd, relay.master_fd);
+            }
+            // Child output -> real terminal
+            if pfds[1].revents & libc::POLLIN != 0 {
+                pty_mux::relay_bytes(relay.master_fd, relay.real_tty_fd);
+            }
+        }
+
+        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::StillAlive) => continue,
+            Ok(status) => {
+                // Drain any remaining output from PTY master
+                loop {
+                    if pty_mux::relay_bytes(relay.master_fd, relay.real_tty_fd) == 0 {
+                        break;
+                    }
+                }
+                return Ok(status);
+            }
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(e) => {
+                return Err(NonoError::SandboxInit(format!("waitpid() failed: {}", e)));
+            }
+        }
     }
 }
 
@@ -871,7 +1034,7 @@ fn get_thread_count() -> Result<usize> {
 
 /// Supervisor IPC event loop (non-Linux).
 ///
-/// Polls the supervisor socket for messages from the sandboxed child.
+/// Polls the supervisor socket and PTY relay fds for activity.
 /// Uses `poll(2)` with a 200ms timeout to periodically check child status.
 /// Returns the child's wait status and any denial records collected.
 #[cfg(not(target_os = "linux"))]
@@ -880,28 +1043,51 @@ fn run_supervisor_loop(
     sock: &mut SupervisorSocket,
     config: &SupervisorConfig<'_>,
     mut trust_interceptor: Option<crate::trust_intercept::TrustInterceptor>,
+    relay: Option<&PtyRelay<'_>>,
 ) -> Result<(WaitStatus, Vec<DenialRecord>)> {
     let _ = config.session_id;
     let sock_fd = sock.as_raw_fd();
     let mut denials = Vec::new();
     let mut seen_request_ids = HashSet::new();
 
-    loop {
-        let mut pfd = libc::pollfd {
-            fd: sock_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
+    // PTY relay fds: -1 when no relay (supervisor-only mode, no PTY mux)
+    let relay_tty_fd = relay.map_or(-1, |r| r.real_tty_fd);
+    let relay_master_fd = relay.map_or(-1, |r| r.master_fd);
 
-        // SAFETY: pfd is a valid pollfd struct on the stack, nfds=1 is correct.
-        let ret = unsafe { libc::poll(&mut pfd, 1, 200) };
+    loop {
+        // Poll: [0] supervisor socket, [1] real_tty (user input), [2] pty_master (child output)
+        let mut pfds = [
+            libc::pollfd {
+                fd: sock_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: relay_tty_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: relay_master_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+
+        // SAFETY: pfds is a valid array on the stack
+        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), 3, 200) };
 
         if ret > 0 {
-            if pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+            // Supervisor socket
+            if pfds[0].revents & (libc::POLLHUP | libc::POLLERR) != 0 {
                 debug!("Supervisor socket closed by child");
                 break;
             }
-            if pfd.revents & libc::POLLIN != 0 {
+            if pfds[0].revents & libc::POLLIN != 0 {
+                // Pause relay if active: restore terminal for interactive prompt
+                if let Some(r) = relay {
+                    let _ = r.real_term.restore();
+                }
                 match sock.recv_message() {
                     Ok(msg) => {
                         if let Err(e) = handle_supervisor_message(
@@ -921,6 +1107,19 @@ fn run_supervisor_loop(
                         break;
                     }
                 }
+                // Resume relay if active: re-enter raw mode
+                if let Some(r) = relay {
+                    let _ = r.real_term.enter_raw_mode();
+                }
+            }
+
+            // PTY relay: user input -> child
+            if relay.is_some() && pfds[1].revents & libc::POLLIN != 0 {
+                pty_mux::relay_bytes(relay_tty_fd, relay_master_fd);
+            }
+            // PTY relay: child output -> user
+            if relay.is_some() && pfds[2].revents & libc::POLLIN != 0 {
+                pty_mux::relay_bytes(relay_master_fd, relay_tty_fd);
             }
         } else if ret < 0 {
             let err = std::io::Error::last_os_error();
@@ -932,7 +1131,17 @@ fn run_supervisor_loop(
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => continue,
-            Ok(status) => return Ok((status, denials)),
+            Ok(status) => {
+                // Drain remaining child output
+                if relay.is_some() {
+                    loop {
+                        if pty_mux::relay_bytes(relay_master_fd, relay_tty_fd) == 0 {
+                            break;
+                        }
+                    }
+                }
+                return Ok((status, denials));
+            }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(nix::errno::Errno::ECHILD) => {
                 warn!("Child already reaped in supervisor loop");
@@ -956,14 +1165,16 @@ fn run_supervisor_loop(
 /// Multiplexes between:
 /// - seccomp notify fd (openat/openat2 interceptions from the child)
 /// - supervisor socket (explicit capability requests from SDK clients)
+/// - PTY relay (real terminal <-> PTY master), when present
 /// - child process exit via non-blocking `waitpid()`
 ///
-/// Seccomp notifications for paths in the initial capability set are handled
-/// immediately (fast-path). Other paths go through the approval backend.
+/// When a seccomp notification requires interactive approval, the relay is
+/// paused (terminal restored to canonical mode) so the user can type a response.
+/// After the prompt, raw mode is re-entered and relay resumes.
 ///
-/// The initial_caps parameter contains (path, is_file) tuples:
-/// - For files (is_file=true): only exact path matches are allowed
-/// - For directories (is_file=false): subpath matches via starts_with are allowed
+/// The relay is optional: when `capability_elevation` is off, no PTY is
+/// allocated but the supervisor loop still runs for trust interception over
+/// the IPC socket.
 ///
 /// Returns the child's wait status and any denial records collected.
 #[cfg(target_os = "linux")]
@@ -974,43 +1185,55 @@ fn run_supervisor_loop(
     seccomp_fd: Option<&OwnedFd>,
     initial_caps: &[(std::path::PathBuf, bool)],
     mut trust_interceptor: Option<crate::trust_intercept::TrustInterceptor>,
+    relay: Option<&PtyRelay<'_>>,
 ) -> Result<(WaitStatus, Vec<DenialRecord>)> {
     let sock_fd = sock.as_raw_fd();
     let notify_raw_fd = seccomp_fd.map(|fd| fd.as_raw_fd());
     let mut rate_limiter = supervisor_linux::RateLimiter::new(10, 5);
     let mut denials = Vec::new();
     let mut seen_request_ids = HashSet::new();
-    // Track whether the supervisor socket is still alive. After exec,
-    // CLOEXEC closes the child's socket end, causing POLLHUP. We stop
-    // polling the dead socket but continue handling seccomp notifications.
     let mut sock_fd_active = true;
 
+    // PTY relay fds: -1 when no relay (supervisor-only mode, no PTY mux)
+    let relay_tty_fd = relay.map_or(-1, |r| r.real_tty_fd);
+    let relay_master_fd = relay.map_or(-1, |r| r.master_fd);
+
     loop {
-        // Build poll array: supervisor socket (if alive) + seccomp fd (if present)
-        let mut pfds: Vec<libc::pollfd> = vec![libc::pollfd {
-            // poll ignores negative fds, so set to -1 when socket is dead
-            fd: if sock_fd_active { sock_fd } else { -1 },
-            events: libc::POLLIN,
-            revents: 0,
-        }];
-        if let Some(nfd) = notify_raw_fd {
-            pfds.push(libc::pollfd {
-                fd: nfd,
+        // Build poll array:
+        // [0] supervisor socket (or -1 if dead)
+        // [1] seccomp notify fd (or -1 if absent)
+        // [2] real_tty (user input for relay, or -1 if no relay)
+        // [3] pty_master (child output for relay, or -1 if no relay)
+        let mut pfds = [
+            libc::pollfd {
+                fd: if sock_fd_active { sock_fd } else { -1 },
                 events: libc::POLLIN,
                 revents: 0,
-            });
-        }
+            },
+            libc::pollfd {
+                fd: notify_raw_fd.unwrap_or(-1),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: relay_tty_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: relay_master_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
 
-        // SAFETY: pfds is a valid array of pollfd structs on the stack.
-        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as libc::nfds_t, 200) };
+        // SAFETY: pfds is a valid array on the stack
+        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), 4, 200) };
 
         match ret.cmp(&0) {
             std::cmp::Ordering::Greater => {
-                // Check supervisor socket (only if still active)
+                // [0] Supervisor socket
                 if sock_fd_active && pfds[0].revents & (libc::POLLHUP | libc::POLLERR) != 0 {
-                    // Supervisor socket closed (CLOEXEC closes child's end after exec).
-                    // If we have a seccomp notify fd, keep looping to handle
-                    // seccomp notifications -- just stop polling the dead socket.
                     if notify_raw_fd.is_some() {
                         debug!("Supervisor socket closed, continuing for seccomp notifications");
                         sock_fd_active = false;
@@ -1020,6 +1243,10 @@ fn run_supervisor_loop(
                     }
                 }
                 if sock_fd_active && pfds[0].revents & libc::POLLIN != 0 {
+                    // Pause relay if active: restore terminal for interactive prompt
+                    if let Some(r) = relay {
+                        let _ = r.real_term.restore();
+                    }
                     match sock.recv_message() {
                         Ok(msg) => {
                             if let Err(e) = handle_supervisor_message(
@@ -1037,16 +1264,28 @@ fn run_supervisor_loop(
                         Err(e) => {
                             debug!("Error receiving supervisor message: {}", e);
                             if notify_raw_fd.is_none() {
+                                if let Some(r) = relay {
+                                    let _ = r.real_term.enter_raw_mode();
+                                }
                                 break;
                             }
                             sock_fd_active = false;
                         }
                     }
+                    // Resume relay if active
+                    if let Some(r) = relay {
+                        let _ = r.real_term.enter_raw_mode();
+                    }
                 }
 
-                // Check seccomp notify fd (if present)
-                if pfds.len() > 1 && pfds[1].revents & libc::POLLIN != 0 {
+                // [1] Seccomp notify fd
+                if pfds[1].revents & libc::POLLIN != 0 {
                     if let Some(nfd) = notify_raw_fd {
+                        if let Some(r) = relay {
+                            if let Err(e) = r.real_term.restore() {
+                                warn!("Failed to restore terminal before seccomp prompt: {}", e);
+                            }
+                        }
                         if let Err(e) = supervisor_linux::handle_seccomp_notification(
                             nfd,
                             child,
@@ -1058,7 +1297,19 @@ fn run_supervisor_loop(
                         ) {
                             debug!("Error handling seccomp notification: {}", e);
                         }
+                        if let Some(r) = relay {
+                            let _ = r.real_term.enter_raw_mode();
+                        }
                     }
+                }
+
+                // [2] PTY relay: user input -> child
+                if relay.is_some() && pfds[2].revents & libc::POLLIN != 0 {
+                    pty_mux::relay_bytes(relay_tty_fd, relay_master_fd);
+                }
+                // [3] PTY relay: child output -> user
+                if relay.is_some() && pfds[3].revents & libc::POLLIN != 0 {
+                    pty_mux::relay_bytes(relay_master_fd, relay_tty_fd);
                 }
             }
             std::cmp::Ordering::Less => {
@@ -1073,7 +1324,17 @@ fn run_supervisor_loop(
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => continue,
-            Ok(status) => return Ok((status, denials)),
+            Ok(status) => {
+                // Drain remaining child output
+                if relay.is_some() {
+                    loop {
+                        if pty_mux::relay_bytes(relay_master_fd, relay_tty_fd) == 0 {
+                            break;
+                        }
+                    }
+                }
+                return Ok((status, denials));
+            }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(nix::errno::Errno::ECHILD) => {
                 warn!("Child already reaped in supervisor loop");
@@ -1846,5 +2107,91 @@ mod tests {
             Some(ProcfsAccessContext::new(4242, Some(4343))),
         );
         assert!(result.is_ok());
+    }
+
+    /// Verify that the supervisor loop runs and exits cleanly without a PTY relay.
+    ///
+    /// This tests the `capability_elevation = false` code path where no PTY is
+    /// allocated but the supervisor loop must still service the IPC socket for
+    /// trust interception. The child fork closes its socket end and exits,
+    /// causing the loop to see POLLHUP and return.
+    #[test]
+    fn test_supervisor_loop_runs_without_pty_relay() {
+        use nono::NeverGrantChecker;
+        use std::os::unix::net::UnixStream;
+
+        struct DenyAll;
+        impl ApprovalBackend for DenyAll {
+            fn request_capability(
+                &self,
+                _req: &nono::supervisor::CapabilityRequest,
+            ) -> nono::Result<ApprovalDecision> {
+                Ok(ApprovalDecision::Denied {
+                    reason: "test".to_string(),
+                })
+            }
+            fn backend_name(&self) -> &str {
+                "deny-all-test"
+            }
+        }
+
+        let (parent_stream, child_stream) = UnixStream::pair()
+            .map_err(|e| format!("socketpair: {e}"))
+            .expect("socketpair failed in test");
+
+        let never_grant = NeverGrantChecker::new(&[])
+            .map_err(|e| format!("never_grant: {e}"))
+            .expect("NeverGrantChecker::new failed in test");
+        let backend = DenyAll;
+        let sup_cfg = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test-session",
+        };
+
+        // Fork a child that closes its socket end and exits immediately.
+        // SAFETY: We are in a test; the child does minimal work and _exit()s.
+        match unsafe { fork() } {
+            Ok(ForkResult::Child) => {
+                drop(child_stream);
+                drop(parent_stream);
+                unsafe { libc::_exit(42) };
+            }
+            Ok(ForkResult::Parent { child }) => {
+                drop(child_stream);
+                let mut sock = SupervisorSocket::from_stream(parent_stream);
+
+                // Run supervisor loop with relay: None (the capability_elevation=false path).
+                // It should poll the socket, see POLLHUP when child exits, and return.
+                #[cfg(target_os = "linux")]
+                let result = run_supervisor_loop(
+                    child,
+                    &mut sock,
+                    &sup_cfg,
+                    None, // no seccomp
+                    &[],  // no initial caps
+                    None, // no trust interceptor
+                    None, // no PTY relay — this is what we're testing
+                );
+
+                #[cfg(not(target_os = "linux"))]
+                let result = run_supervisor_loop(
+                    child, &mut sock, &sup_cfg, None, // no trust interceptor
+                    None, // no PTY relay
+                );
+
+                let (status, denials) = result
+                    .map_err(|e| format!("supervisor loop: {e}"))
+                    .expect("supervisor loop failed");
+                assert!(denials.is_empty(), "no denials expected");
+
+                // Child exited with code 42
+                match status {
+                    WaitStatus::Exited(_, code) => assert_eq!(code, 42),
+                    other => panic!("unexpected wait status: {other:?}"),
+                }
+            }
+            Err(e) => panic!("fork failed: {e}"),
+        }
     }
 }

--- a/crates/nono-cli/src/exec_strategy/pty_mux.rs
+++ b/crates/nono-cli/src/exec_strategy/pty_mux.rs
@@ -186,22 +186,42 @@ pub(crate) fn forward_winsize(real_tty_fd: RawFd, master_fd: RawFd) {
 /// This is a non-blocking single-pass relay (call within a poll loop).
 pub(crate) fn relay_bytes(src_fd: RawFd, dst_fd: RawFd) -> usize {
     let mut buf = [0u8; 4096];
-    // SAFETY: read/write on valid fds with valid buffer
-    let n = unsafe { libc::read(src_fd, buf.as_mut_ptr().cast(), buf.len()) };
-    if n <= 0 {
+    // SAFETY: read on valid fd with valid buffer
+    let n = loop {
+        let res = unsafe { libc::read(src_fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if res < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return 0;
+        }
+        break res as usize;
+    };
+
+    if n == 0 {
         return 0;
     }
-    let n = n as usize;
+
     let mut written = 0;
     while written < n {
         // SAFETY: write on valid fd with valid buffer slice
         let w = unsafe { libc::write(dst_fd, buf[written..n].as_ptr().cast(), n - written) };
-        if w <= 0 {
+        if w < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            // EAGAIN/EWOULDBLOCK or fatal write error — return what we wrote.
+            // The caller's poll loop will retry when the fd is writable.
+            break;
+        }
+        if w == 0 {
             break;
         }
         written += w as usize;
     }
-    n
+    written
 }
 
 /// Set a file descriptor to non-blocking mode.

--- a/crates/nono-cli/src/exec_strategy/pty_mux.rs
+++ b/crates/nono-cli/src/exec_strategy/pty_mux.rs
@@ -1,0 +1,257 @@
+//! PTY multiplexer for supervised mode.
+//!
+//! Gives the sandboxed child its own PTY so that TUI programs (Claude Code, vim, etc.)
+//! can set raw mode without interfering with the supervisor's terminal prompts.
+//!
+//! Layout:
+//! ```text
+//! ┌─────────────┐         ┌──────────────┐         ┌──────────────┐
+//! │ Real TTY    │ <-----> │  Supervisor   │ <-----> │ PTY master   │
+//! │ (user sees) │         │  (relay loop) │         │              │
+//! └─────────────┘         └──────────────┘         └──────┬───────┘
+//!                                                         │ kernel
+//!                                                  ┌──────┴───────┐
+//!                                                  │ PTY slave    │
+//!                                                  │ (child's     │
+//!                                                  │  stdin/out/  │
+//!                                                  │  err)        │
+//!                                                  └──────────────┘
+//! ```
+//!
+//! The relay loop copies bytes between the real terminal and the PTY master.
+//! When the supervisor needs to display a prompt (seccomp approval, IPC message),
+//! it pauses the relay, interacts directly with the real terminal, then resumes.
+
+use nix::libc;
+use nix::pty::openpty;
+use nix::sys::termios;
+use nono::{NonoError, Result};
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use tracing::debug;
+
+/// PTY pair for supervised mode.
+///
+/// `master` stays with the supervisor (parent).
+/// `slave` is dup2'd onto the child's stdin/stdout/stderr after fork.
+pub(crate) struct PtyPair {
+    pub master: OwnedFd,
+    pub slave: OwnedFd,
+}
+
+/// State for the real terminal, saved before entering relay mode.
+pub(crate) struct RealTerminal {
+    /// File descriptor for /dev/tty (the real controlling terminal)
+    tty_fd: OwnedFd,
+    /// Original termios settings, restored on drop
+    original_termios: termios::Termios,
+}
+
+impl RealTerminal {
+    /// Open the real terminal and save its settings.
+    pub fn open() -> Result<Self> {
+        let tty = std::fs::File::open("/dev/tty").map_err(|e| {
+            NonoError::SandboxInit(format!("Failed to open /dev/tty for PTY relay: {e}"))
+        })?;
+        let tty_fd: OwnedFd = tty.into();
+        let original_termios = termios::tcgetattr(&tty_fd).map_err(|e| {
+            NonoError::SandboxInit(format!("Failed to get terminal attributes: {e}"))
+        })?;
+        Ok(Self {
+            tty_fd,
+            original_termios,
+        })
+    }
+
+    /// Put the real terminal into raw mode for transparent relay.
+    ///
+    /// Raw mode disables line buffering and echo so that every keystroke
+    /// is forwarded immediately to the PTY master (and thus to the child).
+    pub fn enter_raw_mode(&self) -> Result<()> {
+        let mut raw = self.original_termios.clone();
+        termios::cfmakeraw(&mut raw);
+        termios::tcsetattr(&self.tty_fd, termios::SetArg::TCSADRAIN, &raw).map_err(|e| {
+            NonoError::SandboxInit(format!("Failed to set raw mode on real terminal: {e}"))
+        })?;
+        Ok(())
+    }
+
+    /// Restore the real terminal to its original (canonical) mode.
+    ///
+    /// Called when the supervisor needs to display a prompt, and on exit.
+    /// Explicitly ensures ICANON, ECHO, ISIG, and ICRNL are set so that
+    /// line-buffered input works correctly for the approval prompt.
+    pub fn restore(&self) -> Result<()> {
+        let mut restored = self.original_termios.clone();
+        // Ensure canonical mode flags are set even if the original termios
+        // was somehow missing them (defensive)
+        restored.local_flags |=
+            termios::LocalFlags::ICANON | termios::LocalFlags::ECHO | termios::LocalFlags::ISIG;
+        restored.input_flags |= termios::InputFlags::ICRNL;
+        termios::tcsetattr(&self.tty_fd, termios::SetArg::TCSADRAIN, &restored).map_err(|e| {
+            NonoError::SandboxInit(format!("Failed to restore terminal attributes: {e}"))
+        })?;
+        Ok(())
+    }
+
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.tty_fd.as_raw_fd()
+    }
+}
+
+impl Drop for RealTerminal {
+    fn drop(&mut self) {
+        // Best-effort restore on drop
+        let _ = termios::tcsetattr(
+            &self.tty_fd,
+            termios::SetArg::TCSADRAIN,
+            &self.original_termios,
+        );
+    }
+}
+
+/// Create a PTY pair, copying the real terminal's size to the slave.
+pub(crate) fn create_pty_pair() -> Result<PtyPair> {
+    let result = openpty(None, None)
+        .map_err(|e| NonoError::SandboxInit(format!("openpty() failed: {e}")))?;
+
+    let master = result.master;
+    let slave = result.slave;
+
+    // Copy terminal size from real terminal to PTY slave
+    if let Ok(tty) = std::fs::File::open("/dev/tty") {
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        // SAFETY: ioctl TIOCGWINSZ reads terminal size into ws, valid pointer
+        let ret = unsafe { libc::ioctl(tty.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) };
+        if ret == 0 {
+            // SAFETY: ioctl TIOCSWINSZ sets terminal size from ws, valid pointer
+            unsafe { libc::ioctl(slave.as_raw_fd(), libc::TIOCSWINSZ, &ws) };
+        }
+    }
+
+    debug!(
+        "Created PTY pair: master={}, slave={}",
+        master.as_raw_fd(),
+        slave.as_raw_fd()
+    );
+
+    Ok(PtyPair { master, slave })
+}
+
+/// Set up the PTY slave as the child's controlling terminal.
+///
+/// Must be called in the child process after fork, before exec.
+/// This is async-signal-safe (only raw libc calls).
+///
+/// # Safety
+/// Must be called after fork() in the child process only.
+/// `slave_fd` must be a valid open file descriptor for the PTY slave.
+pub(crate) unsafe fn setup_child_pty(slave_fd: RawFd) {
+    // Create a new session so the child gets its own controlling terminal.
+    // setsid() detaches from the parent's controlling terminal.
+    libc::setsid();
+
+    // Make the PTY slave the controlling terminal for this session.
+    // TIOCSCTTY with arg 0 means "make this my controlling terminal".
+    libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0i32);
+
+    // Redirect stdin/stdout/stderr to the PTY slave
+    libc::dup2(slave_fd, libc::STDIN_FILENO);
+    libc::dup2(slave_fd, libc::STDOUT_FILENO);
+    libc::dup2(slave_fd, libc::STDERR_FILENO);
+
+    // Close the original slave fd if it's not one of 0/1/2
+    if slave_fd > 2 {
+        libc::close(slave_fd);
+    }
+}
+
+/// Forward the current terminal window size to the PTY master.
+///
+/// Called from the SIGWINCH handler to keep the child's terminal size in sync.
+pub(crate) fn forward_winsize(real_tty_fd: RawFd, master_fd: RawFd) {
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: ioctl reads/writes winsize struct, both fds are valid
+    unsafe {
+        if libc::ioctl(real_tty_fd, libc::TIOCGWINSZ, &mut ws) == 0 {
+            libc::ioctl(master_fd, libc::TIOCSWINSZ, &ws);
+        }
+    }
+}
+
+/// Relay bytes between the real terminal and the PTY master.
+///
+/// Reads from `src_fd` and writes to `dst_fd`. Returns the number of bytes
+/// relayed, or 0 on EOF/EAGAIN.
+///
+/// This is a non-blocking single-pass relay (call within a poll loop).
+pub(crate) fn relay_bytes(src_fd: RawFd, dst_fd: RawFd) -> usize {
+    let mut buf = [0u8; 4096];
+    // SAFETY: read/write on valid fds with valid buffer
+    let n = unsafe { libc::read(src_fd, buf.as_mut_ptr().cast(), buf.len()) };
+    if n <= 0 {
+        return 0;
+    }
+    let n = n as usize;
+    let mut written = 0;
+    while written < n {
+        // SAFETY: write on valid fd with valid buffer slice
+        let w = unsafe { libc::write(dst_fd, buf[written..n].as_ptr().cast(), n - written) };
+        if w <= 0 {
+            break;
+        }
+        written += w as usize;
+    }
+    n
+}
+
+/// Set a file descriptor to non-blocking mode.
+pub(crate) fn set_nonblocking(fd: RawFd) -> Result<()> {
+    // SAFETY: fcntl on valid fd
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "fcntl(F_GETFL) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if ret < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "fcntl(F_SETFL, O_NONBLOCK) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+// Global storage for SIGWINCH forwarding (same pattern as CHILD_PID)
+static REAL_TTY_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+static PTY_MASTER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+/// Install SIGWINCH handler that forwards window size changes to the PTY.
+pub(crate) fn setup_sigwinch_forwarding(real_tty_fd: RawFd, master_fd: RawFd) {
+    REAL_TTY_FD.store(real_tty_fd, std::sync::atomic::Ordering::SeqCst);
+    PTY_MASTER_FD.store(master_fd, std::sync::atomic::Ordering::SeqCst);
+
+    // SAFETY: signal handler only calls async-signal-safe ioctl()
+    unsafe {
+        let _ = nix::sys::signal::signal(
+            nix::sys::signal::Signal::SIGWINCH,
+            nix::sys::signal::SigHandler::Handler(handle_sigwinch),
+        );
+    }
+}
+
+extern "C" fn handle_sigwinch(_sig: libc::c_int) {
+    let tty = REAL_TTY_FD.load(std::sync::atomic::Ordering::SeqCst);
+    let master = PTY_MASTER_FD.load(std::sync::atomic::Ordering::SeqCst);
+    if tty >= 0 && master >= 0 {
+        forward_winsize(tty, master);
+    }
+}
+
+/// Clear SIGWINCH forwarding state.
+pub(crate) fn clear_sigwinch_forwarding() {
+    REAL_TTY_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+    PTY_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -1568,25 +1568,28 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         let home = config::validated_home()?;
         let home_path = std::path::Path::new(&home);
 
+        let precreate = |path: &std::path::Path, is_dir: bool| {
+            if !path.exists() {
+                let result = if is_dir {
+                    std::fs::create_dir_all(path)
+                } else {
+                    std::fs::File::create(path).map(|_| ())
+                };
+                if let Err(e) = result {
+                    warn!("Failed to pre-create {}: {}", path.display(), e);
+                }
+            }
+        };
+
         // ~/.claude.json.lock — Claude Code's saveConfigWithLock creates this
         // next to ~/.claude.json. Landlock cannot grant permission to create
         // new files in ~/ without opening the entire directory.
-        let lock_path = home_path.join(".claude.json.lock");
-        if !lock_path.exists() {
-            if let Err(e) = std::fs::File::create(&lock_path) {
-                warn!("Failed to pre-create {}: {}", lock_path.display(), e);
-            }
-        }
+        precreate(&home_path.join(".claude.json.lock"), false);
 
         // ~/.cache/claude-cli-nodejs — MCP server logs and CLI cache.
         // The claude_cache_linux group grants this directory, but it may
         // not exist on a fresh system.
-        let cache_dir = home_path.join(".cache/claude-cli-nodejs");
-        if !cache_dir.exists() {
-            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
-                warn!("Failed to pre-create {}: {}", cache_dir.display(), e);
-            }
-        }
+        precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
     }
 
     // Build capabilities from profile or arguments.

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -434,6 +434,11 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
 
     let mut prepared = prepare_sandbox(&args, silent)?;
 
+    // CLI --capability-elevation overrides profile setting
+    if run_args.capability_elevation {
+        prepared.capability_elevation = true;
+    }
+
     // Compute scan root for trust policy discovery and instruction file scanning.
     let scan_root = args
         .workdir
@@ -506,11 +511,13 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     };
     let _ = &scan_result; // suppress unused warning on non-macOS
 
-    // Enable sandbox extensions for transparent capability expansion in supervised mode.
-    // On Linux, seccomp-notify intercepts syscalls at the kernel level -- this flag is
-    // informational only (seccomp is installed separately in the child process).
+    // Enable sandbox extensions for transparent capability expansion in supervised mode,
+    // but only when the profile opts into capability elevation. Without elevation,
+    // supervised mode runs with static capabilities (no seccomp, no PTY, no prompts).
     #[cfg(target_os = "linux")]
-    prepared.caps.set_extensions_enabled(true);
+    if prepared.capability_elevation {
+        prepared.caps.set_extensions_enabled(true);
+    }
 
     let trust_scan_verified = scan_result.as_ref().is_some_and(|r| r.verified > 0);
 
@@ -588,6 +595,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             protected_paths: verified_protected_paths,
             rollback_exclude_patterns: merged_patterns,
             rollback_exclude_globs: merged_globs,
+            capability_elevation: prepared.capability_elevation,
             proxy_active,
             network_profile,
             proxy_allow_hosts,
@@ -642,6 +650,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         prepared.secrets,
         ExecutionFlags {
             no_diagnostics: true,
+            capability_elevation: prepared.capability_elevation,
             ..ExecutionFlags::defaults(silent)?
         },
     )
@@ -727,6 +736,9 @@ struct ExecutionFlags {
     rollback_exclude_patterns: Vec<String>,
     /// Profile-specific rollback exclusion globs (filename matching)
     rollback_exclude_globs: Vec<String>,
+    /// Whether runtime capability elevation is enabled (seccomp-notify + PTY mux).
+    /// When false, supervised mode runs with static capabilities only.
+    capability_elevation: bool,
     /// Whether proxy-based network filtering is active (forces Supervised mode)
     proxy_active: bool,
     /// Network profile name for proxy filtering (from --network-profile or profile config)
@@ -767,6 +779,7 @@ impl ExecutionFlags {
             protected_paths: Vec::new(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
+            capability_elevation: false,
             proxy_active: false,
             network_profile: None,
             proxy_allow_hosts: Vec::new(),
@@ -1059,6 +1072,7 @@ fn execute_sandboxed(
         no_diagnostics: flags.no_diagnostics || flags.silent,
         threading,
         protected_paths: &flags.protected_paths,
+        capability_elevation: flags.capability_elevation,
     };
 
     // Execute based on strategy
@@ -1436,6 +1450,8 @@ struct PreparedSandbox {
     proxy_credentials: Vec<String>,
     /// Custom credential definitions from profile config
     custom_credentials: std::collections::HashMap<String, profile::CustomCredentialDef>,
+    /// Whether the profile enables runtime capability elevation (seccomp-notify + PTY)
+    capability_elevation: bool,
 }
 
 fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> {
@@ -1512,6 +1528,10 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .unwrap_or_else(|| std::path::PathBuf::from("."));
 
     // Extract config before profile is consumed for secrets
+    let capability_elevation = loaded_profile
+        .as_ref()
+        .and_then(|p| p.security.capability_elevation)
+        .unwrap_or(false);
     let profile_workdir_access = loaded_profile.as_ref().map(|p| p.workdir.access.clone());
     let profile_rollback_patterns = loaded_profile
         .as_ref()
@@ -1539,18 +1559,32 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .map(|p| p.network.custom_credentials.clone())
         .unwrap_or_default();
 
-    // On Linux, pre-create the Claude Code config lock file before building
-    // capabilities. Claude Code's saveConfigWithLock creates ~/.claude.json.lock
-    // next to ~/.claude.json. Landlock cannot grant permission to create new
-    // files in ~/ without opening the entire directory, so we pre-create the
-    // lock file and grant access to it via the profile's allow_file list.
+    // On Linux, pre-create paths that the claude-code profile grants but
+    // may not exist yet. Non-existent paths are skipped during capability
+    // construction (capability_ext.rs:14), so they must exist before we
+    // build the CapabilitySet.
     #[cfg(target_os = "linux")]
     if args.profile.as_deref() == Some("claude-code") {
         let home = config::validated_home()?;
-        let lock_path = std::path::Path::new(&home).join(".claude.json.lock");
+        let home_path = std::path::Path::new(&home);
+
+        // ~/.claude.json.lock — Claude Code's saveConfigWithLock creates this
+        // next to ~/.claude.json. Landlock cannot grant permission to create
+        // new files in ~/ without opening the entire directory.
+        let lock_path = home_path.join(".claude.json.lock");
         if !lock_path.exists() {
             if let Err(e) = std::fs::File::create(&lock_path) {
                 warn!("Failed to pre-create {}: {}", lock_path.display(), e);
+            }
+        }
+
+        // ~/.cache/claude-cli-nodejs — MCP server logs and CLI cache.
+        // The claude_cache_linux group grants this directory, but it may
+        // not exist on a fresh system.
+        let cache_dir = home_path.join(".cache/claude-cli-nodejs");
+        if !cache_dir.exists() {
+            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+                warn!("Failed to pre-create {}: {}", cache_dir.display(), e);
             }
         }
     }
@@ -1720,6 +1754,7 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         proxy_allow_hosts: profile_proxy_allow,
         proxy_credentials: profile_proxy_credentials,
         custom_credentials: profile_custom_credentials,
+        capability_elevation,
     })
 }
 
@@ -1982,6 +2017,7 @@ mod tests {
             proxy_allow_hosts: vec!["docs.python.org".to_string()],
             proxy_credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
+            capability_elevation: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -2013,6 +2049,7 @@ mod tests {
             proxy_allow_hosts: vec!["docs.python.org".to_string()],
             proxy_credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
+            capability_elevation: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -148,6 +148,7 @@ impl ProfileDef {
                 trust_groups: self.trust_groups.clone(),
                 allowed_commands: self.security.allowed_commands.clone(),
                 signal_mode: self.security.signal_mode,
+                capability_elevation: self.security.capability_elevation,
             },
             filesystem: self.filesystem.clone(),
             network: self.network.clone(),
@@ -1162,7 +1163,7 @@ mod tests {
             .allow
             .as_ref()
             .expect("vscode_macos allow missing")
-            .write;
+            .readwrite;
         assert!(vscode_macos_paths.contains(&"$HOME/.vscode".to_string()));
         assert!(vscode_macos_paths.contains(&"$HOME/Library/Application Support/Code".to_string()));
 
@@ -1175,7 +1176,7 @@ mod tests {
             .allow
             .as_ref()
             .expect("vscode_linux allow missing")
-            .write;
+            .readwrite;
         assert!(vscode_linux_paths.contains(&"$HOME/.vscode".to_string()));
         assert!(vscode_linux_paths.contains(&"$HOME/.config/Code".to_string()));
     }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -620,6 +620,12 @@ pub struct SecurityConfig {
     /// (defaults to `Isolated` if no base sets it).
     #[serde(default)]
     pub signal_mode: Option<ProfileSignalMode>,
+    /// Enable runtime capability elevation via seccomp-notify (Linux).
+    /// When true, the supervisor intercepts file opens and can grant access
+    /// to paths not in the initial capability set. When false (default),
+    /// the sandbox is static — no seccomp interception, no PTY mux, no prompts.
+    #[serde(default)]
+    pub capability_elevation: Option<bool>,
 }
 
 /// Rollback snapshot configuration in a profile
@@ -853,6 +859,7 @@ fn load_base_profile_raw(name: &str) -> Result<Profile> {
                 trust_groups: def.trust_groups.clone(),
                 allowed_commands: def.security.allowed_commands.clone(),
                 signal_mode: def.security.signal_mode,
+                capability_elevation: def.security.capability_elevation,
             },
             filesystem: def.filesystem.clone(),
             network: def.network.clone(),
@@ -886,6 +893,10 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &child.security.allowed_commands,
             ),
             signal_mode: child.security.signal_mode.or(base.security.signal_mode),
+            capability_elevation: child
+                .security
+                .capability_elevation
+                .or(base.security.capability_elevation),
         },
         filesystem: FilesystemConfig {
             allow: dedup_append(&base.filesystem.allow, &child.filesystem.allow),

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -612,6 +612,22 @@ Suppress the diagnostic footer when the command exits non-zero. Useful for scrip
 nono run --no-diagnostics --allow-cwd -- my-command
 ```
 
+#### `--capability-elevation`
+
+Enable runtime capability elevation for this session. When active, the sandbox installs a seccomp-notify filter (Linux) and a PTY multiplexer so that file access beyond the initial capability set can be approved interactively at runtime.
+
+```bash
+nono run --capability-elevation --allow-cwd -- my-agent
+```
+
+Without this flag (the default), the sandbox runs with static capabilities only — no interactive approval prompts, no seccomp interception, and no PTY mux. The supervisor still runs for trust interception and rollback support.
+
+Profiles can set this via `capability_elevation` in their security config. The CLI flag overrides the profile setting.
+
+| Environment Variable | `NONO_CAPABILITY_ELEVATION` |
+|---------------------|---------------------------|
+| Example | `NONO_CAPABILITY_ELEVATION=true` |
+
 ### Operational Flags
 
 #### `--dry-run`
@@ -909,6 +925,7 @@ CLI flags always take precedence over environment variables.
 | `--profile` | `NONO_PROFILE` | `NONO_PROFILE=developer` |
 | `--network-profile` | `NONO_NETWORK_PROFILE` | `NONO_NETWORK_PROFILE=claude-code` |
 | `--env-credential` | `NONO_ENV_CREDENTIAL` | `NONO_ENV_CREDENTIAL=key1,key2` |
+| `--capability-elevation` | `NONO_CAPABILITY_ELEVATION` | `NONO_CAPABILITY_ELEVATION=true` |
 
 Boolean variables accept `true`, `false`, `yes`, `no`, `1`, `0`.
 


### PR DESCRIPTION
Add Linux-equivalent policy groups (user_caches_linux, claude_cache_linux, nix_runtime) and fix vscode groups to use readwrite access. Add capability_elevation field to profiles controlling whether seccomp-notify and PTY mux are enabled in supervised mode.

Key changes:
- Supervisor loop runs with or without PTY relay, ensuring trust interception works regardless of capability_elevation setting
- claude-code profile uses narrow claude_cache_linux instead of broad user_caches_linux
- nono shell propagates profile's capability_elevation flag
- Supervisor config always passed to execute_supervised; only seccomp install, recv_fd, and PR_SET_DUMPABLE gated on elevation flag