### PR TITLE
feat: add `--external-proxy-bypass` for routing domains direct

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -432,6 +432,7 @@ mod tests {
             proxy_allow: vec![],
             proxy_credential: vec![],
             external_proxy: None,
+            external_proxy_bypass: vec![],
             override_deny: vec![],
             allow_command: vec![],
             block_command: vec![],

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -274,6 +274,7 @@ pub struct SandboxArgs {
             "proxy_allow",
             "proxy_credential",
             "external_proxy",
+            "external_proxy_bypass",
             "proxy_port"
         ]
     )]
@@ -315,8 +316,19 @@ pub struct SandboxArgs {
 
     /// Chain through an external (enterprise) proxy.
     /// Format: host:port (e.g., squid.corp.internal:3128)
-    #[arg(long, value_name = "HOST:PORT")]
+    #[arg(long, value_name = "HOST:PORT", env = "NONO_EXTERNAL_PROXY")]
     pub external_proxy: Option<String>,
+
+    /// Domains to route directly instead of through the external proxy.
+    /// Supports exact hostnames and wildcards (e.g., *.internal.corp).
+    /// Can be specified multiple times. Requires --external-proxy (or profile equivalent).
+    #[arg(
+        long,
+        value_name = "HOST",
+        env = "NONO_EXTERNAL_PROXY_BYPASS",
+        value_delimiter = ','
+    )]
+    pub external_proxy_bypass: Vec<String>,
 
     /// Fixed port for the credential injection proxy (default: OS-assigned).
     /// Use this when the sandboxed application requires a known proxy port
@@ -386,6 +398,7 @@ impl SandboxArgs {
         self.network_profile.is_some()
             || !self.proxy_allow.is_empty()
             || !self.proxy_credential.is_empty()
+            || self.external_proxy.is_some()
     }
 }
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -346,6 +346,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             proxy_allow: vec![],
             proxy_credential: vec![],
             external_proxy: None,
+            external_proxy_bypass: vec![],
             override_deny: vec![],
             allow_command: vec![],
             block_command: vec![],
@@ -381,6 +382,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             proxy_allow: vec![],
             proxy_credential: vec![],
             external_proxy: None,
+            external_proxy_bypass: vec![],
             override_deny: vec![],
             allow_command: vec![],
             block_command: vec![],
@@ -454,6 +456,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     // Dry run mode - just show what would happen
     if args.dry_run {
         let prepared = prepare_sandbox(&args, silent)?;
+        validate_external_proxy_bypass(&args, &prepared)?;
         if !prepared.secrets.is_empty() && !silent {
             eprintln!(
                 "  Would inject {} credential(s) as environment variables",
@@ -564,6 +567,32 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     let proxy_allow_hosts = effective_proxy.proxy_allow_hosts;
     let proxy_credentials = effective_proxy.proxy_credentials;
 
+    // Resolve effective external proxy: --net-allow clears it (same as other
+    // proxy settings), otherwise CLI overrides profile.
+    let effective_external_proxy = if args.net_allow {
+        None
+    } else {
+        args.external_proxy
+            .clone()
+            .or_else(|| prepared.external_proxy.clone())
+    };
+
+    // Resolve effective bypass hosts: cleared by --net-allow, otherwise
+    // CLI --external-proxy wins (use CLI bypass only), otherwise merge
+    // profile + CLI bypass hosts.
+    let effective_bypass = if args.net_allow {
+        Vec::new()
+    } else if args.external_proxy.is_some() {
+        args.external_proxy_bypass.clone()
+    } else {
+        let mut bypass = prepared.external_proxy_bypass.clone();
+        bypass.extend(args.external_proxy_bypass.clone());
+        bypass
+    };
+
+    // Validate: bypass hosts require an external proxy (from CLI or profile)
+    validate_external_proxy_bypass(&args, &prepared)?;
+
     // The proxy is needed when the network mode is ProxyOnly OR when there are
     // credential routes to inject. However, --net-block takes precedence: if
     // network is explicitly blocked, the proxy must NOT activate since that
@@ -572,6 +601,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
         if !proxy_credentials.is_empty()
             || network_profile.is_some()
             || !proxy_allow_hosts.is_empty()
+            || effective_external_proxy.is_some()
         {
             warn!(
                 "--net-block is active; ignoring proxy configuration \
@@ -592,6 +622,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
         ) || !proxy_credentials.is_empty()
             || network_profile.is_some()
             || !proxy_allow_hosts.is_empty()
+            || effective_external_proxy.is_some()
     };
 
     // Split --rollback-exclude values: glob metacharacters route to filename
@@ -646,7 +677,8 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             proxy_allow_hosts,
             proxy_credentials,
             custom_credentials: prepared.custom_credentials,
-            external_proxy: args.external_proxy.clone(),
+            external_proxy: effective_external_proxy,
+            external_proxy_bypass: effective_bypass,
             allow_bind_ports: args.allow_bind,
             proxy_port: args.proxy_port,
         },
@@ -713,10 +745,12 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
         || !args.proxy_allow.is_empty()
         || !args.proxy_credential.is_empty()
         || args.external_proxy.is_some()
+        || !args.external_proxy_bypass.is_empty()
     {
         return Err(NonoError::ConfigParse(
             "nono wrap does not support proxy flags (--network-profile, --proxy-allow, \
-             --proxy-credential, --external-proxy). Use `nono run` instead."
+             --proxy-credential, --external-proxy, --external-proxy-bypass). \
+             Use `nono run` instead."
                 .to_string(),
         ));
     }
@@ -742,6 +776,22 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
     }
 
     let prepared = prepare_sandbox(&args, silent)?;
+
+    // Also reject proxy flags that came from the profile (not just CLI).
+    // Profile-provided external_proxy / network settings activate ProxyOnly
+    // mode, which requires a parent process that wrap doesn't provide.
+    if prepared.external_proxy.is_some()
+        || matches!(
+            prepared.caps.network_mode(),
+            nono::NetworkMode::ProxyOnly { .. }
+        )
+    {
+        return Err(NonoError::ConfigParse(
+            "nono wrap does not support proxy mode (activated by profile network settings). \
+             Use `nono run` instead."
+                .to_string(),
+        ));
+    }
 
     execute_sandboxed(
         program,
@@ -797,6 +847,8 @@ struct ExecutionFlags {
     custom_credentials: std::collections::HashMap<String, profile::CustomCredentialDef>,
     /// External proxy address (from --external-proxy)
     external_proxy: Option<String>,
+    /// Hosts to bypass the external proxy (from --external-proxy-bypass)
+    external_proxy_bypass: Vec<String>,
     /// Ports the sandboxed process is allowed to bind (from --allow-bind)
     allow_bind_ports: Vec<u16>,
     /// Fixed port for the credential proxy (from --proxy-port)
@@ -832,6 +884,7 @@ impl ExecutionFlags {
             proxy_credentials: Vec::new(),
             custom_credentials: std::collections::HashMap::new(),
             external_proxy: None,
+            external_proxy_bypass: Vec::new(),
             allow_bind_ports: Vec::new(),
             proxy_port: None,
         })
@@ -875,6 +928,23 @@ fn resolve_effective_proxy_settings(
         proxy_allow_hosts,
         proxy_credentials,
     }
+}
+
+/// Validate that bypass hosts are not specified without an external proxy.
+/// Called from both the dry-run and live execution paths.
+fn validate_external_proxy_bypass(args: &SandboxArgs, prepared: &PreparedSandbox) -> Result<()> {
+    let has_bypass =
+        !args.external_proxy_bypass.is_empty() || !prepared.external_proxy_bypass.is_empty();
+    let has_external_proxy = args.external_proxy.is_some() || prepared.external_proxy.is_some();
+
+    if has_bypass && !has_external_proxy {
+        return Err(NonoError::ConfigParse(
+            "--external-proxy-bypass requires --external-proxy \
+             (or external_proxy in profile network config)"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Apply sandbox pre-fork for Direct mode (both parent+child confined).
@@ -943,6 +1013,7 @@ fn build_proxy_config_from_flags(
         proxy_config.external_proxy = Some(nono_proxy::config::ExternalProxyConfig {
             address: addr.clone(),
             auth: None,
+            bypass_hosts: flags.external_proxy_bypass.clone(),
         });
     }
 
@@ -1494,6 +1565,10 @@ struct PreparedSandbox {
     proxy_credentials: Vec<String>,
     /// Custom credential definitions from profile config
     custom_credentials: std::collections::HashMap<String, profile::CustomCredentialDef>,
+    /// External proxy address from profile config (if any)
+    external_proxy: Option<String>,
+    /// Bypass hosts for external proxy from profile config
+    external_proxy_bypass: Vec<String>,
     /// Whether the profile enables runtime capability elevation (seccomp-notify + PTY)
     capability_elevation: bool,
 }
@@ -1584,6 +1659,13 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
     let profile_custom_credentials = loaded_profile
         .as_ref()
         .map(|p| p.network.custom_credentials.clone())
+        .unwrap_or_default();
+    let profile_external_proxy = loaded_profile
+        .as_ref()
+        .and_then(|p| p.network.external_proxy.clone());
+    let profile_external_proxy_bypass = loaded_profile
+        .as_ref()
+        .map(|p| p.network.external_proxy_bypass.clone())
         .unwrap_or_default();
 
     // On Linux, pre-create paths that the claude-code profile grants but
@@ -1784,6 +1866,8 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         proxy_allow_hosts: profile_proxy_allow,
         proxy_credentials: profile_proxy_credentials,
         custom_credentials: profile_custom_credentials,
+        external_proxy: profile_external_proxy,
+        external_proxy_bypass: profile_external_proxy_bypass,
         capability_elevation,
     })
 }
@@ -1919,6 +2003,7 @@ mod tests {
             proxy_allow: vec![],
             proxy_credential: vec![],
             external_proxy: None,
+            external_proxy_bypass: vec![],
             override_deny: vec![],
             allow_command: vec![],
             block_command: vec![],
@@ -2027,6 +2112,8 @@ mod tests {
             proxy_allow_hosts: vec!["docs.python.org".to_string()],
             proxy_credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
+            external_proxy: None,
+            external_proxy_bypass: Vec::new(),
             capability_elevation: false,
         };
 
@@ -2059,6 +2146,8 @@ mod tests {
             proxy_allow_hosts: vec!["docs.python.org".to_string()],
             proxy_credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
+            external_proxy: None,
+            external_proxy_bypass: Vec::new(),
             capability_elevation: false,
         };
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -497,6 +497,13 @@ pub struct NetworkConfig {
     /// how to route and inject credentials for that service.
     #[serde(default)]
     pub custom_credentials: HashMap<String, CustomCredentialDef>,
+    /// External proxy address (host:port) for enterprise proxy passthrough.
+    #[serde(default)]
+    pub external_proxy: Option<String>,
+    /// Hosts to bypass the external proxy and route directly.
+    /// Supports exact hostnames and `*.` wildcard suffixes.
+    #[serde(default)]
+    pub external_proxy_bypass: Vec<String>,
 }
 
 impl NetworkConfig {
@@ -509,6 +516,7 @@ impl NetworkConfig {
         self.resolved_network_profile().is_some()
             || !self.proxy_allow.is_empty()
             || !self.proxy_credentials.is_empty()
+            || self.external_proxy.is_some()
     }
 }
 
@@ -923,6 +931,12 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 merged.extend(child.network.custom_credentials);
                 merged
             },
+            // Child overrides base external proxy; if child has None, inherit base
+            external_proxy: child.network.external_proxy.or(base.network.external_proxy),
+            external_proxy_bypass: dedup_append(
+                &base.network.external_proxy_bypass,
+                &child.network.external_proxy_bypass,
+            ),
         },
         env_credentials: SecretsConfig {
             mappings: {
@@ -1911,6 +1925,8 @@ mod tests {
                 port_allow: vec![3000],
                 proxy_credentials: vec!["base_cred".to_string()],
                 custom_credentials: HashMap::new(),
+                external_proxy: None,
+                external_proxy_bypass: Vec::new(),
             },
             env_credentials: SecretsConfig {
                 mappings: {
@@ -1962,6 +1978,8 @@ mod tests {
                 port_allow: vec![3000, 5000],
                 proxy_credentials: vec![],
                 custom_credentials: HashMap::new(),
+                external_proxy: None,
+                external_proxy_bypass: Vec::new(),
             },
             env_credentials: SecretsConfig {
                 mappings: {

--- a/crates/nono-cli/tests/env_vars.rs
+++ b/crates/nono-cli/tests/env_vars.rs
@@ -116,6 +116,109 @@ fn cli_flag_overrides_env_var() {
 }
 
 #[test]
+fn env_nono_external_proxy() {
+    let output = nono_bin()
+        .env("NONO_EXTERNAL_PROXY", "squid.corp:3128")
+        .args(["run", "--allow", "/tmp", "--dry-run", "echo"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "NONO_EXTERNAL_PROXY should be accepted, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn env_nono_external_proxy_bypass_comma_separated() {
+    let output = nono_bin()
+        .env("NONO_EXTERNAL_PROXY", "squid.corp:3128")
+        .env("NONO_EXTERNAL_PROXY_BYPASS", "internal.corp,*.private.net")
+        .args(["run", "--allow", "/tmp", "--dry-run", "echo"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "NONO_EXTERNAL_PROXY_BYPASS should be accepted, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn env_nono_external_proxy_bypass_requires_external_proxy() {
+    // NONO_EXTERNAL_PROXY_BYPASS without NONO_EXTERNAL_PROXY should fail
+    let output = nono_bin()
+        .env("NONO_EXTERNAL_PROXY_BYPASS", "internal.corp")
+        .args(["run", "--allow", "/tmp", "--dry-run", "echo"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        !output.status.success(),
+        "NONO_EXTERNAL_PROXY_BYPASS without NONO_EXTERNAL_PROXY should fail"
+    );
+}
+
+#[test]
+fn env_net_allow_conflicts_with_external_proxy() {
+    // NONO_NET_ALLOW + NONO_EXTERNAL_PROXY should conflict at the clap level.
+    let output = nono_bin()
+        .env("NONO_EXTERNAL_PROXY", "squid.corp:3128")
+        .env("NONO_NET_ALLOW", "true")
+        .args(["run", "--allow", "/tmp", "--dry-run", "echo"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        !output.status.success(),
+        "NONO_NET_ALLOW + NONO_EXTERNAL_PROXY should conflict"
+    );
+}
+
+#[test]
+fn net_allow_overrides_profile_external_proxy() {
+    // A profile with external_proxy should be overridden by --net-allow,
+    // resulting in unrestricted network (no proxy mode activation).
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let profile_path = dir.path().join("ext-proxy-profile.json");
+    std::fs::write(
+        &profile_path,
+        r#"{
+            "meta": { "name": "ext-proxy-test" },
+            "network": { "external_proxy": "squid.corp:3128" }
+        }"#,
+    )
+    .expect("write profile");
+
+    let output = nono_bin()
+        .args([
+            "run",
+            "--profile",
+            profile_path.to_str().expect("valid utf8"),
+            "--net-allow",
+            "--allow",
+            "/tmp",
+            "--dry-run",
+            "echo",
+        ])
+        .output()
+        .expect("failed to run nono");
+
+    let text = combined_output(&output);
+    assert!(
+        output.status.success(),
+        "--net-allow should override profile external_proxy, stderr: {text}"
+    );
+    // Should show "allowed" network, not proxy mode
+    assert!(
+        text.contains("allowed"),
+        "expected unrestricted network in dry-run output, got:\n{text}"
+    );
+}
+
+#[test]
 fn env_conflict_net_allow_and_net_block() {
     let output = nono_bin()
         .env("NONO_NET_ALLOW", "true")

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -141,6 +141,12 @@ pub struct ExternalProxyConfig {
 
     /// Optional authentication for the external proxy.
     pub auth: Option<ExternalProxyAuth>,
+
+    /// Hosts to bypass the external proxy and route directly.
+    /// Supports exact hostnames and `*.` wildcard suffixes (case-insensitive).
+    /// Empty = all traffic goes through the external proxy.
+    #[serde(default)]
+    pub bypass_hosts: Vec<String>,
 }
 
 /// Authentication for an external proxy.
@@ -182,5 +188,31 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: ProxyConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.allowed_hosts, vec!["api.openai.com"]);
+    }
+
+    #[test]
+    fn test_external_proxy_config_with_bypass_hosts() {
+        let config = ProxyConfig {
+            external_proxy: Some(ExternalProxyConfig {
+                address: "squid.corp:3128".to_string(),
+                auth: None,
+                bypass_hosts: vec!["internal.corp".to_string(), "*.private.net".to_string()],
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ProxyConfig = serde_json::from_str(&json).unwrap();
+        let ext = deserialized.external_proxy.unwrap();
+        assert_eq!(ext.address, "squid.corp:3128");
+        assert_eq!(ext.bypass_hosts.len(), 2);
+        assert_eq!(ext.bypass_hosts[0], "internal.corp");
+        assert_eq!(ext.bypass_hosts[1], "*.private.net");
+    }
+
+    #[test]
+    fn test_external_proxy_config_bypass_hosts_default_empty() {
+        let json = r#"{"address": "proxy:3128", "auth": null}"#;
+        let ext: ExternalProxyConfig = serde_json::from_str(json).unwrap();
+        assert!(ext.bypass_hosts.is_empty());
     }
 }

--- a/crates/nono-proxy/src/external.rs
+++ b/crates/nono-proxy/src/external.rs
@@ -14,6 +14,76 @@ use tokio::net::TcpStream;
 use tracing::debug;
 use zeroize::Zeroizing;
 
+/// Matcher for hosts that should bypass the external proxy.
+///
+/// Supports exact hostname match and `*.` wildcard suffix match,
+/// both case-insensitive. Uses the same `*`-prefix parsing pattern
+/// as `HostFilter::new()`.
+#[derive(Debug, Clone)]
+pub struct BypassMatcher {
+    /// Exact hostnames (lowercased)
+    exact: Vec<String>,
+    /// Wildcard suffixes (e.g., ".internal.corp", lowercased)
+    suffixes: Vec<String>,
+}
+
+impl BypassMatcher {
+    /// Create a new bypass matcher from a list of host patterns.
+    ///
+    /// Entries starting with `*.` are wildcard patterns matching any subdomain.
+    /// All other entries are exact matches. Matching is case-insensitive.
+    ///
+    /// Only the `*.domain` form is accepted for wildcards. Bare `*` and
+    /// patterns like `*corp` (without the dot) are treated as exact hostnames
+    /// to prevent accidental over-broad matching.
+    #[must_use]
+    pub fn new(hosts: &[String]) -> Self {
+        let mut exact = Vec::new();
+        let mut suffixes = Vec::new();
+
+        for host in hosts {
+            let lower = host.to_lowercase();
+            if let Some(suffix) = lower.strip_prefix("*.") {
+                // *.example.com -> .example.com
+                if !suffix.is_empty() {
+                    suffixes.push(format!(".{suffix}"));
+                }
+                // Bare "*." with nothing after is silently ignored (no valid domain)
+            } else {
+                exact.push(lower);
+            }
+        }
+
+        Self { exact, suffixes }
+    }
+
+    /// Check whether a host should bypass the external proxy.
+    #[must_use]
+    pub fn matches(&self, host: &str) -> bool {
+        let lower = host.to_lowercase();
+
+        // Exact match
+        if self.exact.contains(&lower) {
+            return true;
+        }
+
+        // Wildcard suffix match
+        for suffix in &self.suffixes {
+            if lower.ends_with(suffix.as_str()) && lower.len() > suffix.len() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Whether any bypass hosts are configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.exact.is_empty() && self.suffixes.is_empty()
+    }
+}
+
 /// Handle a CONNECT request by chaining it to an external proxy.
 ///
 /// 1. Validate session token
@@ -235,5 +305,87 @@ mod tests {
     #[test]
     fn test_parse_status_code_malformed() {
         assert!(parse_status_code("garbage").is_err());
+    }
+
+    #[test]
+    fn test_bypass_matcher_exact() {
+        let matcher = BypassMatcher::new(&["internal.corp".to_string()]);
+        assert!(matcher.matches("internal.corp"));
+        assert!(!matcher.matches("other.corp"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_case_insensitive() {
+        let matcher = BypassMatcher::new(&["Internal.Corp".to_string()]);
+        assert!(matcher.matches("internal.corp"));
+        assert!(matcher.matches("INTERNAL.CORP"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_wildcard() {
+        let matcher = BypassMatcher::new(&["*.internal.corp".to_string()]);
+        assert!(matcher.matches("app.internal.corp"));
+        assert!(matcher.matches("deep.sub.internal.corp"));
+        // Bare domain should NOT match wildcard
+        assert!(!matcher.matches("internal.corp"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_wildcard_case_insensitive() {
+        let matcher = BypassMatcher::new(&["*.Internal.Corp".to_string()]);
+        assert!(matcher.matches("APP.INTERNAL.CORP"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_no_match() {
+        let matcher =
+            BypassMatcher::new(&["internal.corp".to_string(), "*.private.net".to_string()]);
+        assert!(!matcher.matches("api.openai.com"));
+        assert!(!matcher.matches("evil.com"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_empty() {
+        let matcher = BypassMatcher::new(&[]);
+        assert!(matcher.is_empty());
+        assert!(!matcher.matches("anything.com"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_mixed() {
+        let matcher =
+            BypassMatcher::new(&["exact.host.com".to_string(), "*.wildcard.com".to_string()]);
+        assert!(matcher.matches("exact.host.com"));
+        assert!(matcher.matches("sub.wildcard.com"));
+        assert!(!matcher.matches("wildcard.com"));
+        assert!(!matcher.matches("other.com"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_bare_star_is_not_wildcard() {
+        // Bare "*" must NOT bypass everything — it should be treated as
+        // a literal (non-matching) hostname, not a universal wildcard.
+        let matcher = BypassMatcher::new(&["*".to_string()]);
+        assert!(!matcher.matches("anything.com"));
+        assert!(!matcher.matches("internal.corp"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_star_without_dot_is_literal() {
+        // "*corp" (no dot) must NOT be treated as a wildcard suffix.
+        // Only "*.corp" is a valid wildcard pattern.
+        let matcher = BypassMatcher::new(&["*corp".to_string()]);
+        assert!(!matcher.matches("internal.corp"));
+        assert!(!matcher.matches("subcorp"));
+        // It's treated as the literal hostname "*corp"
+        assert!(matcher.matches("*corp"));
+    }
+
+    #[test]
+    fn test_bypass_matcher_star_dot_only_is_ignored() {
+        // "*." with nothing after is not a valid domain pattern.
+        let matcher = BypassMatcher::new(&["*.".to_string()]);
+        assert!(matcher.is_empty());
+        assert!(!matcher.matches("anything.com"));
     }
 }

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -141,6 +141,9 @@ struct ProxyState {
     active_connections: AtomicUsize,
     /// Shared network audit log for this proxy session.
     audit_log: audit::SharedAuditLog,
+    /// Matcher for hosts that bypass the external proxy and route direct.
+    /// Built once at startup from `ExternalProxyConfig.bypass_hosts`.
+    bypass_matcher: external::BypassMatcher,
 }
 
 /// Start the proxy server.
@@ -200,6 +203,13 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     .with_no_client_auth();
     let tls_connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
 
+    // Build bypass matcher from external proxy config (once, not per-request)
+    let bypass_matcher = config
+        .external_proxy
+        .as_ref()
+        .map(|ext| external::BypassMatcher::new(&ext.bypass_hosts))
+        .unwrap_or_else(|| external::BypassMatcher::new(&[]));
+
     // Shutdown channel
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let audit_log = audit::new_audit_log();
@@ -212,6 +222,7 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
         tls_connector,
         active_connections: AtomicUsize::new(0),
         audit_log: Arc::clone(&audit_log),
+        bypass_matcher,
     });
 
     // Spawn accept loop as a task within the current runtime.
@@ -321,8 +332,34 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
 
     // Dispatch by method
     if first_line.starts_with("CONNECT ") {
-        // Check if external proxy is configured
-        if let Some(ref ext_config) = state.config.external_proxy {
+        // Check if external proxy is configured and host is not bypassed
+        let use_external = if let Some(ref ext_config) = state.config.external_proxy {
+            if state.bypass_matcher.is_empty() {
+                Some(ext_config)
+            } else {
+                // Parse host from CONNECT line to check bypass
+                let host = first_line
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|authority| {
+                        authority
+                            .rsplit_once(':')
+                            .map(|(h, _)| h)
+                            .or(Some(authority))
+                    })
+                    .unwrap_or("");
+                if state.bypass_matcher.matches(host) {
+                    debug!("Bypassing external proxy for {}", host);
+                    None
+                } else {
+                    Some(ext_config)
+                }
+            }
+        } else {
+            None
+        };
+
+        if let Some(ext_config) = use_external {
             external::handle_external_proxy(
                 first_line,
                 &mut stream,
@@ -330,6 +367,21 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                 &state.filter,
                 &state.session_token,
                 ext_config,
+                Some(&state.audit_log),
+            )
+            .await
+        } else if state.config.external_proxy.is_some() {
+            // Bypass route: enforce strict session token validation before
+            // routing direct. Without this, bypassed hosts would inherit
+            // connect::handle_connect()'s lenient auth (which tolerates
+            // missing Proxy-Authorization for Node.js undici compat).
+            token::validate_proxy_auth(&header_bytes, &state.session_token)?;
+            connect::handle_connect(
+                first_line,
+                &mut stream,
+                &state.filter,
+                &state.session_token,
+                &header_bytes,
                 Some(&state.audit_log),
             )
             .await

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -92,6 +92,39 @@ nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:31
 
 CONNECT requests are chained through the corporate proxy. Cloud metadata endpoints are still denied.
 
+#### Bypassing the External Proxy
+
+Some domains may need to bypass the enterprise proxy and connect directly (e.g., internal services that are not reachable through the proxy, or services that the proxy interferes with):
+
+```bash
+nono run --allow-cwd --network-profile enterprise \
+  --external-proxy squid.corp:3128 \
+  --external-proxy-bypass git.internal.corp \
+  --external-proxy-bypass "*.dev.local" \
+  -- my-agent
+```
+
+Bypass patterns support exact hostnames and `*.` wildcard suffixes (case-insensitive). Matching hosts are routed directly via a CONNECT tunnel; everything else goes through the enterprise proxy.
+
+This can also be configured in a profile:
+
+```json
+{
+  "network": {
+    "external_proxy": "squid.corp:3128",
+    "external_proxy_bypass": ["git.internal.corp", "*.dev.local"]
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export NONO_EXTERNAL_PROXY=squid.corp:3128
+export NONO_EXTERNAL_PROXY_BYPASS=git.internal.corp,*.dev.local
+nono run --allow-cwd -- my-agent
+```
+
 ## Network Profiles
 
 Network profiles are composable groups of allowed hosts, similar to filesystem policy groups. They're defined in `network-policy.json` (embedded in the binary).
@@ -133,6 +166,22 @@ User profiles can specify a network profile in the `network` section:
   "network": {
     "network_profile": "claude-code",
     "proxy_allow": ["my-internal-api.example.com"]
+  }
+}
+```
+
+Enterprise profiles can include external proxy and bypass configuration:
+
+```json
+{
+  "meta": { "name": "corp-agent" },
+  "filesystem": {
+    "allow": ["$WORKDIR"]
+  },
+  "network": {
+    "network_profile": "enterprise",
+    "external_proxy": "squid.corp:3128",
+    "external_proxy_bypass": ["git.internal.corp", "*.dev.local"]
   }
 }
 ```

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -115,6 +115,8 @@ The `network` section controls network access and credential injection:
     "proxy_allow": ["my-internal-api.example.com"],
     "port_allow": [3000],
     "proxy_credentials": ["openai", "anthropic"],
+    "external_proxy": "squid.corp:3128",
+    "external_proxy_bypass": ["git.internal.corp", "*.dev.local"],
     "custom_credentials": {
       "telegram": {
         "upstream": "https://api.telegram.org",
@@ -135,6 +137,8 @@ The `network` section controls network access and credential injection:
 | `port_allow` | Localhost TCP ports to allow bidirectional IPC (equivalent to `--allow-port`) |
 | `proxy_credentials` | Credential services to enable via reverse proxy (e.g., `openai`, `anthropic`) |
 | `custom_credentials` | Custom credential service definitions for APIs not in the built-in list |
+| `external_proxy` | External (enterprise) proxy address, e.g., `squid.corp:3128` |
+| `external_proxy_bypass` | Domains to bypass the external proxy (exact hostnames and `*.` wildcards) |
 
 #### Custom Credentials
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -45,7 +45,7 @@ nono wrap [OPTIONS] -- <COMMAND> [ARGS...]
 ```
 
 <Note>
-  `nono wrap` does not support proxy flags (`--network-profile`, `--proxy-allow`, `--proxy-credential`, `--external-proxy`). The network proxy requires a parent process. Use `nono run` instead.
+  `nono wrap` does not support proxy flags (`--network-profile`, `--proxy-allow`, `--proxy-credential`, `--external-proxy`, `--external-proxy-bypass`). The network proxy requires a parent process. Use `nono run` instead.
 </Note>
 
 ### `nono why`
@@ -225,7 +225,7 @@ nono run --profile claude-code --net-allow -- claude
 ```
 
 <Note>
-  `--net-allow` disables proxy mode for that run, so it also disables proxy-based credential injection. It conflicts with `--net-block`, `--network-profile`, `--proxy-allow`, `--proxy-credential`, `--external-proxy`, and `--proxy-port`.
+  `--net-allow` disables proxy mode for that run, so it also disables proxy-based credential injection. It conflicts with `--net-block`, `--network-profile`, `--proxy-allow`, `--proxy-credential`, `--external-proxy`, `--external-proxy-bypass`, and `--proxy-port`.
 </Note>
 
 #### `--network-profile`
@@ -297,6 +297,30 @@ Chain outbound connections through an external (enterprise) proxy. Cloud metadat
 ```bash
 nono run --allow-cwd --network-profile enterprise --external-proxy squid.corp:3128 -- my-agent
 ```
+
+#### `--external-proxy-bypass`
+
+Route specific domains directly instead of through the external proxy. Supports exact hostnames and `*.` wildcard suffixes (case-insensitive). Requires `--external-proxy`.
+
+```bash
+# Bypass the enterprise proxy for internal services
+nono run --allow-cwd --network-profile enterprise \
+  --external-proxy squid.corp:3128 \
+  --external-proxy-bypass internal.corp \
+  --external-proxy-bypass "*.private.net" \
+  -- my-agent
+
+# Multiple bypass patterns
+nono run --allow-cwd \
+  --external-proxy squid.corp:3128 \
+  --external-proxy-bypass git.internal.corp \
+  --external-proxy-bypass "*.dev.local" \
+  -- my-agent
+```
+
+Bypass hosts are checked before routing. Matching hosts use a direct CONNECT tunnel (same as Mode 1); non-matching hosts chain through the external proxy.
+
+Can be specified multiple times.
 
 #### `--proxy-port`
 
@@ -926,6 +950,8 @@ CLI flags always take precedence over environment variables.
 | `--network-profile` | `NONO_NETWORK_PROFILE` | `NONO_NETWORK_PROFILE=claude-code` |
 | `--env-credential` | `NONO_ENV_CREDENTIAL` | `NONO_ENV_CREDENTIAL=key1,key2` |
 | `--capability-elevation` | `NONO_CAPABILITY_ELEVATION` | `NONO_CAPABILITY_ELEVATION=true` |
+| `--external-proxy` | `NONO_EXTERNAL_PROXY` | `NONO_EXTERNAL_PROXY=squid.corp:3128` |
+| `--external-proxy-bypass` | `NONO_EXTERNAL_PROXY_BYPASS` | `NONO_EXTERNAL_PROXY_BYPASS=internal.corp,*.private.net` (comma-separated) |
 
 Boolean variables accept `true`, `false`, `yes`, `no`, `1`, `0`.
 


### PR DESCRIPTION
Add a bypass mechanism so that specific domains skip the enterprise proxy and connect directly. Supports exact hostnames and `*.` wildcard suffixes (case-insensitive), configurable via CLI flag, environment variable (`NONO_EXTERNAL_PROXY_BYPASS`), or profile JSON.

The bypass matcher is built once at startup in ProxyState and checked per-CONNECT before routing. Bypassed connections enforce strict session token validation and go through the standard host filter, preserving the same security guarantees as external-proxy mode.