### PR TITLE
chore: migrate Homebrew distribution from tap to homebrew-core

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding_issue.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding_issue.yml
@@ -44,7 +44,7 @@ body:
     id: install-method
     attributes:
       label: How did you install nono?
-      placeholder: "e.g. Homebrew tap, cargo install, downloaded binary from GitHub releases..."
+      placeholder: "e.g. Homebrew, cargo install, downloaded binary from GitHub releases..."
     validations:
       required: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,50 +156,17 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  update-homebrew:
-    name: Update Homebrew Formula
+  update-homebrew-core:
+    name: Bump Homebrew Core Formula
     needs: release
     runs-on: ubuntu-latest
-    # Only update stable formula for non-prerelease versions
     if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
     steps:
-      - name: Checkout homebrew-nono
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Bump homebrew-core formula
+        uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3.6
         with:
-          repository: always-further/homebrew-nono
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-nono
-
-      - name: Download macOS artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          pattern: nono-*-apple-darwin
-          path: artifacts
-
-      - name: Update formula
-        run: |
-          VERSION="${{ env.RELEASE_TAG }}"
-          VERSION="${VERSION#v}"
-
-          # Calculate SHA256 for both architectures
-          ARM64_SHA=$(sha256sum artifacts/nono-aarch64-apple-darwin/nono-*-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
-          X64_SHA=$(sha256sum artifacts/nono-x86_64-apple-darwin/nono-*-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)
-
-          # Update formula version and checksums
-          cd homebrew-nono
-          sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/nono.rb
-          # Update URLs (both directory path and filename)
-          sed -i "s|releases/download/v[^/]*/nono-v[^-]*-|releases/download/v${VERSION}/nono-v${VERSION}-|g" Formula/nono.rb
-          # Update ARM64 SHA (first sha256 in on_arm block)
-          sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${ARM64_SHA}\"/}" Formula/nono.rb
-          # Update x64 SHA (sha256 in on_intel block)
-          sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${X64_SHA}\"/}" Formula/nono.rb
-
-      - name: Commit and push
-        run: |
-          cd homebrew-nono
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/nono.rb
-          git diff --staged --quiet || git commit -m "Update nono to ${{ env.RELEASE_TAG }}"
-          git push
+          formula-name: nono
+          tag-name: ${{ env.RELEASE_TAG }}
+          download-url: "https://github.com/always-further/nono/archive/refs/tags/${{ env.RELEASE_TAG }}.tar.gz"
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_CORE_TOKEN }}

--- a/.github/workflows/sign-instruction-files.yml
+++ b/.github/workflows/sign-instruction-files.yml
@@ -30,4 +30,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: always-further/nono-attest@v0.0.3
+      - uses: always-further/nono-attest@6b5bd8fbf7e1946e8711338eff11646ecdff87d3 # v0.0.3

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ nono audit show 20260216-193311-20751 --json
 ### macOS
 
 ```bash
-brew tap always-further/nono
 brew install nono
 ```
 

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -7,7 +7,6 @@ CLI for capability-based sandboxing using Landlock (Linux) and Seatbelt (macOS).
 ### Homebrew (macOS)
 
 ```bash
-brew tap always-further/nono
 brew install nono
 ```
 

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -6,7 +6,6 @@ description: How to install nono on your system
 ## Homebrew (macOS)
 
 ```bash
-brew tap always-further/nono
 brew install nono
 ```
 


### PR DESCRIPTION
Replace the custom tap update job with mislav/bump-homebrew-formula-action to open PRs against Homebrew/homebrew-core on release. Remove brew tap instructions from README, CLI docs, and installation guide.