### PR TITLE
feat: inject nono sandbox instructions via Claude Code system prompt

### DIFF
--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -64,6 +64,7 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5.8"
+tempfile = "3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }
@@ -80,4 +81,3 @@ toml = "1.0"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-tempfile = "3"

--- a/crates/nono-cli/src/hooks.rs
+++ b/crates/nono-cli/src/hooks.rs
@@ -125,10 +125,6 @@ fn install_claude_code_hook(config: &HookConfig) -> Result<HookInstallResult> {
     // Update settings.json to register the hook
     let settings_modified = update_claude_settings(&settings_path, config)?;
 
-    // Update CLAUDE.md with nono sandbox instructions
-    let claude_md_path = home.join(".claude").join("CLAUDE.md");
-    update_claude_md(&claude_md_path)?;
-
     // Determine result based on what changed
     let result = if needs_install && !script_existed {
         HookInstallResult::Installed
@@ -236,106 +232,54 @@ fn update_claude_settings(settings_path: &PathBuf, config: &HookConfig) -> Resul
     }
 }
 
-/// Nono sandbox section marker for CLAUDE.md
-const NONO_SECTION_START: &str = "<!-- nono-sandbox-start -->";
-const NONO_SECTION_END: &str = "<!-- nono-sandbox-end -->";
-
-/// Content for the nono sandbox section in CLAUDE.md
-const NONO_CLAUDE_MD_CONTENT: &str = r#"## Nono Sandbox - CRITICAL
-
-**You are running inside the nono security sandbox.** This is a capability-based sandbox that CANNOT be bypassed or modified from within the session.
-
-### On ANY "operation not permitted" or "EPERM" error:
-
-**IMMEDIATELY tell the user:**
-> This path is not accessible in the current nono sandbox session. You need to exit and restart with:
-> `nono run --allow /path/to/needed -- claude`
-
-**NEVER attempt:**
-- Alternative file paths or locations
-- Copying files to accessible directories
-- Using sudo or permission changes
-- Manual workarounds for the user to try
-- ANY other approach besides restarting nono
-
-The sandbox is a hard security boundary. Once applied, it cannot be expanded. The ONLY solution is to restart the session with additional --allow flags.
-"#;
-
-/// Update ~/.claude/CLAUDE.md with nono sandbox instructions
+/// Remove legacy nono sandbox section from ~/.claude/CLAUDE.md.
 ///
-/// Adds or updates a nono-managed section in CLAUDE.md. This provides
-/// upfront context to Claude about the sandbox restrictions.
-fn update_claude_md(claude_md_path: &PathBuf) -> Result<()> {
-    let nono_section = format!(
-        "{}\n{}{}",
-        NONO_SECTION_START, NONO_CLAUDE_MD_CONTENT, NONO_SECTION_END
-    );
+/// Earlier versions of nono injected sandbox instructions directly into CLAUDE.md
+/// between `<!-- nono-sandbox-start -->` and `<!-- nono-sandbox-end -->` markers.
+/// This caused stale instructions to persist when Claude was run without nono.
+/// The instructions are now injected via `--append-system-prompt-file` instead.
+pub fn remove_legacy_claude_md_section() {
+    let home = match xdg_home::home_dir() {
+        Some(h) => h,
+        None => return,
+    };
+    let claude_md_path = home.join(".claude").join("CLAUDE.md");
+    if !claude_md_path.exists() {
+        return;
+    }
 
-    let content = if claude_md_path.exists() {
-        let existing = fs::read_to_string(claude_md_path).map_err(|e| {
-            NonoError::HookInstall(format!(
-                "Failed to read {}: {}",
-                claude_md_path.display(),
-                e
-            ))
-        })?;
-
-        // Check if nono section already exists
-        if existing.contains(NONO_SECTION_START) {
-            // Replace existing section
-            let start_idx = existing.find(NONO_SECTION_START);
-            let end_idx = existing.find(NONO_SECTION_END);
-
-            // Validate: both markers exist and end comes after start
-            if let (Some(start), Some(end)) = (start_idx, end_idx) {
-                if end > start {
-                    let end_of_section = end + NONO_SECTION_END.len();
-                    let before = &existing[..start];
-                    let after = &existing[end_of_section..];
-                    format!("{}\n\n{}{}", before.trim_end(), nono_section, after)
-                } else {
-                    // Markers in wrong order - malformed, append fresh
-                    tracing::warn!("Malformed nono section markers in CLAUDE.md (end before start), appending fresh");
-                    format!("{}\n\n{}", existing.trim_end(), nono_section)
-                }
-            } else {
-                // Only one marker present - malformed, append fresh
-                tracing::warn!(
-                    "Malformed nono section in CLAUDE.md (missing marker), appending fresh"
-                );
-                format!("{}\n\n{}", existing.trim_end(), nono_section)
-            }
-        } else {
-            // Append section
-            format!("{}\n\n{}", existing.trim_end(), nono_section)
-        }
-    } else {
-        // Create new file with just the nono section
-        nono_section
+    let existing = match fs::read_to_string(&claude_md_path) {
+        Ok(content) => content,
+        Err(_) => return,
     };
 
-    // Atomic write: write to temp file, then rename
-    let temp_path = claude_md_path.with_extension("md.tmp");
-    fs::write(&temp_path, &content).map_err(|e| {
-        NonoError::HookInstall(format!(
-            "Failed to write temp file {}: {}",
-            temp_path.display(),
-            e
-        ))
-    })?;
+    const START_MARKER: &str = "<!-- nono-sandbox-start -->";
+    const END_MARKER: &str = "<!-- nono-sandbox-end -->";
 
-    fs::rename(&temp_path, claude_md_path).map_err(|e| {
-        // Clean up temp file on rename failure
-        let _ = fs::remove_file(&temp_path);
-        NonoError::HookInstall(format!(
-            "Failed to rename temp file to {}: {}",
-            claude_md_path.display(),
-            e
-        ))
-    })?;
+    if !existing.contains(START_MARKER) {
+        return;
+    }
 
-    tracing::info!("Updated {}", claude_md_path.display());
-    Ok(())
+    let start_idx = existing.find(START_MARKER);
+    let end_idx = existing.find(END_MARKER);
+
+    if let (Some(start), Some(end)) = (start_idx, end_idx) {
+        if end > start {
+            let end_of_section = end + END_MARKER.len();
+            let before = &existing[..start];
+            let after = &existing[end_of_section..];
+            let cleaned = format!("{}{}", before.trim_end(), after);
+            let cleaned = cleaned.trim().to_string();
+
+            if cleaned.is_empty() {
+                // File only contained the nono section — remove it entirely
+                let _ = fs::remove_file(&claude_md_path);
+            } else {
+                let _ = fs::write(&claude_md_path, format!("{}\n", cleaned));
+            }
+            tracing::info!("Removed legacy nono section from CLAUDE.md");
+        }
+    }
 }
 
 /// Install all hooks from a profile's hooks configuration

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -1006,9 +1006,27 @@ fn execute_sandboxed(
         });
     }
 
+    // Detect if we're launching Claude Code and inject system prompt
+    let prompt_file_path = if is_claude_command(&program) {
+        write_system_prompt_file(flags.silent)
+    } else {
+        None
+    };
+
+    // Build extra args for Claude Code (--append-system-prompt-file)
+    let extra_args: Vec<OsString> = if let Some(ref prompt_path) = prompt_file_path {
+        vec![
+            OsString::from("--append-system-prompt-file"),
+            OsString::from(prompt_path),
+        ]
+    } else {
+        vec![]
+    };
+
     // Convert OsString command to String for exec_strategy
     let command: Vec<String> = std::iter::once(program.to_string_lossy().into_owned())
         .chain(cmd_args.iter().map(|s| s.to_string_lossy().into_owned()))
+        .chain(extra_args.iter().map(|s| s.to_string_lossy().into_owned()))
         .collect();
 
     if command.is_empty() {
@@ -1460,6 +1478,9 @@ fn execute_sandboxed(
             }
 
             cleanup_capability_state_file(&cap_file_path);
+            if let Some(ref prompt_path) = prompt_file_path {
+                cleanup_capability_state_file(prompt_path);
+            }
             drop(config);
             drop(loaded_secrets);
             std::process::exit(exit_code);
@@ -1564,6 +1585,11 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
     // Load profile once if specified (used for both capabilities and secrets)
     let loaded_profile = if let Some(ref profile_name) = args.profile {
         let prof = profile::load_profile(profile_name)?;
+
+        // Remove legacy nono section from CLAUDE.md (one-time migration).
+        // Earlier versions injected instructions directly into CLAUDE.md which
+        // persisted when Claude was run without nono. Now uses --append-system-prompt-file.
+        hooks::remove_legacy_claude_md_section();
 
         // Install hooks defined in the profile (idempotent - only installs if needed)
         if !prof.hooks.hooks.is_empty() {
@@ -1952,6 +1978,59 @@ fn enforce_rollback_limits(silent: bool) {
     }
 }
 
+/// Check if the command being executed is Claude Code.
+///
+/// Matches the binary name "claude" regardless of path (e.g. /usr/bin/claude,
+/// ~/.npm/bin/claude, claude).
+fn is_claude_command(program: &OsString) -> bool {
+    std::path::Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name == "claude")
+        .unwrap_or(false)
+}
+
+/// System prompt content injected into Claude Code sessions via --append-system-prompt-file.
+///
+/// This is ephemeral — it only exists for the duration of the nono session.
+/// Unlike CLAUDE.md injection, it leaves no persistent state to clean up.
+const NONO_SYSTEM_PROMPT: &str = "\
+You are running inside the nono security sandbox. This is a capability-based \
+sandbox that CANNOT be bypassed or modified from within the session.
+
+On ANY \"operation not permitted\" or \"EPERM\" error:
+
+IMMEDIATELY tell the user:
+> This path is not accessible in the current nono sandbox session. You need to \
+exit and restart with:
+> `nono run --allow /path/to/needed -- claude`
+
+NEVER attempt:
+- Alternative file paths or locations
+- Copying files to accessible directories
+- Using sudo or permission changes
+- Manual workarounds for the user to try
+- ANY other approach besides restarting nono
+
+The sandbox is a hard security boundary. Once applied, it cannot be expanded. \
+The ONLY solution is to restart the session with additional --allow flags.";
+
+/// Write the system prompt file for Claude Code.
+///
+/// Returns the path to the temp file, or None if writing failed.
+fn write_system_prompt_file(silent: bool) -> Option<std::path::PathBuf> {
+    let prompt_file = std::env::temp_dir().join(format!(".nono-prompt-{}.txt", std::process::id()));
+    if let Err(e) = std::fs::write(&prompt_file, NONO_SYSTEM_PROMPT) {
+        error!("Failed to write system prompt file: {}", e);
+        if !silent {
+            eprintln!("  WARNING: System prompt file could not be written.");
+        }
+        None
+    } else {
+        Some(prompt_file)
+    }
+}
+
 fn write_capability_state_file(caps: &CapabilitySet, silent: bool) -> Option<std::path::PathBuf> {
     // Write sandbox state for `nono why --self`.
     let cap_file = std::env::temp_dir().join(format!(".nono-{}.json", std::process::id()));
@@ -2203,5 +2282,29 @@ mod tests {
             select_exec_strategy(false, false, false, true),
             exec_strategy::ExecStrategy::Supervised
         );
+    }
+
+    #[test]
+    fn test_is_claude_command_bare_name() {
+        assert!(is_claude_command(&OsString::from("claude")));
+    }
+
+    #[test]
+    fn test_is_claude_command_absolute_path() {
+        assert!(is_claude_command(&OsString::from("/usr/local/bin/claude")));
+    }
+
+    #[test]
+    fn test_is_claude_command_home_path() {
+        assert!(is_claude_command(&OsString::from(
+            "/home/user/.npm/bin/claude"
+        )));
+    }
+
+    #[test]
+    fn test_is_claude_command_not_claude() {
+        assert!(!is_claude_command(&OsString::from("bash")));
+        assert!(!is_claude_command(&OsString::from("/usr/bin/python3")));
+        assert!(!is_claude_command(&OsString::from("claude-code")));
     }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -2019,15 +2019,39 @@ The ONLY solution is to restart the session with additional --allow flags.";
 ///
 /// Returns the path to the temp file, or None if writing failed.
 fn write_system_prompt_file(silent: bool) -> Option<std::path::PathBuf> {
-    let prompt_file = std::env::temp_dir().join(format!(".nono-prompt-{}.txt", std::process::id()));
-    if let Err(e) = std::fs::write(&prompt_file, NONO_SYSTEM_PROMPT) {
-        error!("Failed to write system prompt file: {}", e);
-        if !silent {
-            eprintln!("  WARNING: System prompt file could not be written.");
+    use std::io::Write;
+
+    // SECURITY: Use tempfile crate to create file with O_EXCL and random name,
+    // preventing symlink attacks (CWE-377) on predictable paths in /tmp.
+    match tempfile::Builder::new()
+        .prefix(".nono-prompt-")
+        .suffix(".txt")
+        .tempfile()
+    {
+        Ok(mut file) => {
+            if let Err(e) = file.write_all(NONO_SYSTEM_PROMPT.as_bytes()) {
+                error!("Failed to write system prompt file: {}", e);
+                if !silent {
+                    eprintln!("  WARNING: System prompt file could not be written.");
+                }
+                return None;
+            }
+            // Persist the file so it outlives this scope (cleaned up manually after child exits)
+            match file.into_temp_path().keep() {
+                Ok(path) => Some(path),
+                Err(e) => {
+                    error!("Failed to persist system prompt file: {}", e);
+                    None
+                }
+            }
         }
-        None
-    } else {
-        Some(prompt_file)
+        Err(e) => {
+            error!("Failed to create system prompt file: {}", e);
+            if !silent {
+                eprintln!("  WARNING: System prompt file could not be written.");
+            }
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Replace persistent CLAUDE.md injection with ephemeral --append-system-prompt-file. Remove legacy nono section from CLAUDE.md on profile load (one-time migration). Add is_claude_command() detector and write_system_prompt_file() to main.rs. Update hooks.rs to only remove stale sections, no longer inject instructions.

Resolves: #316 #250

@josephgimenez  / @sporkmonger - this also cleans up the claude.md of the old nono stuff
