### PR TITLE
fix: add OAuth2 URL opening support via supervisor IPC

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -436,6 +436,15 @@
         ]
       }
     },
+    "codex_macos": {
+      "description": "Codex macOS-specific state and credential paths",
+      "platform": "macos",
+      "allow": {
+        "read": [
+          "$HOME/Library/Keychains/login.keychain-db"
+        ]
+      }
+    },
     "vscode_macos": {
       "description": "Visual Studio Code configuration and extension directories for macOS",
       "platform": "macos",
@@ -581,6 +590,13 @@
       },
       "network": { "block": false },
       "workdir": { "access": "readwrite" },
+      "open_urls": {
+        "allow_origins": [
+          "https://claude.ai"
+        ],
+        "allow_localhost": true
+      },
+      "allow_launch_services": true,
       "hooks": {
         "claude-code": {
           "event": "PostToolUseFailure",
@@ -603,6 +619,7 @@
       },
       "security": {
         "groups": [
+          "codex_macos",
           "node_runtime",
           "rust_runtime",
           "python_runtime",
@@ -616,6 +633,13 @@
       "filesystem": {
         "allow": ["$HOME/.codex"]
       },
+      "open_urls": {
+        "allow_origins": [
+          "https://auth.openai.com"
+        ],
+        "allow_localhost": true
+      },
+      "allow_launch_services": true,
       "network": { "block": false },
       "workdir": { "access": "readwrite" },
       "interactive": true

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -448,6 +448,7 @@ mod tests {
             env_credential_map: vec![],
             profile: None,
             allow_cwd: false,
+            allow_launch_services: false,
             workdir: None,
             config: None,
             verbose: 0,

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -212,6 +212,22 @@ PLATFORM NOTES:
     nono audit show 20260214-143022-12345 --json
 ")]
     Audit(AuditArgs),
+
+    /// Internal: open a URL via supervisor IPC
+    #[command(hide = true)]
+    OpenUrlHelper(OpenUrlHelperArgs),
+}
+
+/// Arguments for the hidden open-url-helper subcommand.
+///
+/// Invoked as `BROWSER=nono open-url-helper` on Linux, or via the `open`
+/// PATH shim on macOS. Reads `NONO_SUPERVISOR_FD` from the environment,
+/// sends an `OpenUrl` IPC message to the unsandboxed supervisor, and
+/// waits for a response.
+#[derive(Parser, Debug, Clone)]
+pub struct OpenUrlHelperArgs {
+    /// The URL to open
+    pub url: String,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -393,6 +409,11 @@ pub struct SandboxArgs {
     /// Access level determined by profile or defaults to read-only.
     #[arg(long)]
     pub allow_cwd: bool,
+
+    /// Allow direct LaunchServices opens on macOS for this session.
+    /// Requires profile opt-in and should be used only for temporary login/setup flows.
+    #[arg(long)]
+    pub allow_launch_services: bool,
 
     /// Working directory for $WORKDIR expansion in profiles (defaults to current dir)
     #[arg(long, value_name = "DIR")]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -199,6 +199,11 @@ pub struct SupervisorConfig<'a> {
     pub approval_backend: &'a dyn ApprovalBackend,
     /// Session identifier used for audit correlation.
     pub session_id: &'a str,
+    /// Allowed URL origins for supervisor-delegated browser opens (from profile).
+    /// Empty means no URLs are allowed.
+    pub open_url_origins: &'a [String],
+    /// Whether to allow http://localhost and http://127.0.0.1 URLs.
+    pub open_url_allow_localhost: bool,
 }
 
 /// Execute a command using the Direct strategy (exec, nono disappears).
@@ -346,6 +351,53 @@ pub fn execute_supervised(
         }
     }
 
+    // Delegate URL opens to the unsandboxed supervisor.
+    //
+    // On Linux, child processes inherit Landlock restrictions so the browser
+    // can't access its own config directories. xdg-open and the Node.js `open`
+    // package respect the BROWSER env var, so we set it to our helper.
+    //
+    // On macOS, the Node.js `open` package ignores BROWSER and always spawns
+    // `/usr/bin/open`. Seatbelt blocks that from launching URLs. Instead, we
+    // create a shim script named `open` in a temp directory and prepend it to
+    // PATH so the npm `open` package hits our shim first.
+    if supervisor.is_some() {
+        if let Ok(nono_exe) = std::env::current_exe() {
+            #[cfg(target_os = "linux")]
+            {
+                let exe_str = nono_exe.display().to_string();
+                let quoted_exe = shell_quote(&exe_str);
+                let browser_cmd = format!("BROWSER={quoted_exe} open-url-helper");
+                if let Ok(cstr) = CString::new(browser_cmd) {
+                    env_c.push(cstr);
+                }
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                // Create a shim `open` script that delegates to nono open-url-helper.
+                // The npm `open` package spawns `open <url>` on macOS; by placing our
+                // shim earlier in PATH, we intercept the call.
+                if let Some(shim) = create_open_shim(&nono_exe) {
+                    // Prepend shim dir to PATH and also set BROWSER for any tool
+                    // that does respect it.
+                    let current_path = std::env::var("PATH").unwrap_or_default();
+                    let new_path = format!("PATH={}:{current_path}", shim.dir.display());
+                    if let Ok(cstr) = CString::new(new_path) {
+                        // Remove existing PATH from env_c, then add our modified one
+                        env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
+                        env_c.push(cstr);
+                    }
+                    let quoted_helper = shell_quote(&shim.helper_exe.display().to_string());
+                    let browser_cmd = format!("BROWSER={quoted_helper} open-url-helper");
+                    if let Ok(cstr) = CString::new(browser_cmd) {
+                        env_c.push(cstr);
+                    }
+                }
+            }
+        }
+    }
+
     // Create null-terminated pointer arrays for execve
     let argv_ptrs: Vec<*const libc::c_char> = argv_c
         .iter()
@@ -453,6 +505,28 @@ pub fn execute_supervised(
             // Sandbox::apply() allocates (Seatbelt profile generation, Landlock
             // PathFd opens) but this is safe because we validated single-threaded
             // execution before fork, giving us a clean heap.
+
+            // The supervisor socket must survive exec into the sandboxed command,
+            // and later into any helper (`open-url-helper`) that needs to speak
+            // IPC back to the unsandboxed parent. `UnixStream::pair()` creates
+            // fds with close-on-exec set, so clear it on the child end here.
+            if let Some(fd) = child_sock_fd {
+                if let Err(e) = clear_close_on_exec(fd) {
+                    let detail = format!(
+                        "nono: failed to clear close-on-exec on supervisor socket: {}\n",
+                        e
+                    );
+                    let msg = detail.as_bytes();
+                    unsafe {
+                        libc::write(
+                            libc::STDERR_FILENO,
+                            msg.as_ptr().cast::<libc::c_void>(),
+                            msg.len(),
+                        );
+                        libc::_exit(126);
+                    }
+                }
+            }
 
             // Set up PTY slave as the child's controlling terminal (elevation only).
             // This gives the child its own terminal so TUI apps can freely
@@ -1566,6 +1640,162 @@ fn handle_supervisor_message(
             };
             sock.send_response(&response)?;
         }
+        SupervisorMessage::OpenUrl(url_request) => {
+            let request_id = url_request.request_id.clone();
+
+            match validate_and_open_url(&url_request.url, config) {
+                Ok(()) => {
+                    info!("Supervisor: opened URL {} for child", url_request.url);
+                    let response = SupervisorResponse::UrlOpened {
+                        request_id,
+                        success: true,
+                        error: None,
+                    };
+                    sock.send_response(&response)?;
+                }
+                Err(reason) => {
+                    warn!(
+                        "Supervisor: URL open denied for {}: {}",
+                        url_request.url, reason
+                    );
+                    let response = SupervisorResponse::UrlOpened {
+                        request_id,
+                        success: false,
+                        error: Some(reason),
+                    };
+                    sock.send_response(&response)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Maximum URL length to prevent abuse via oversized URLs.
+const MAX_URL_LENGTH: usize = 8192;
+
+/// Validate a URL against the profile's allowed origins, then open it in the user's browser.
+///
+/// The supervisor (unsandboxed parent) performs this operation so the browser
+/// launches outside the sandbox with full access to its own config files.
+fn validate_and_open_url(
+    url: &str,
+    config: &SupervisorConfig<'_>,
+) -> std::result::Result<(), String> {
+    validate_url(url, config)?;
+    open_url_in_browser(url)
+}
+
+/// Validate a URL against the profile's allowed origins and scheme rules.
+///
+/// Returns `Ok(())` if the URL passes all checks. Does not open the browser.
+fn validate_url(url: &str, config: &SupervisorConfig<'_>) -> std::result::Result<(), String> {
+    // Length check
+    if url.len() > MAX_URL_LENGTH {
+        return Err(format!(
+            "URL exceeds maximum length ({} > {})",
+            url.len(),
+            MAX_URL_LENGTH
+        ));
+    }
+
+    // Parse URL to extract origin
+    let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    let scheme = parsed.scheme();
+    let host = parsed.host_str().unwrap_or("");
+
+    // Check localhost first
+    let is_localhost = host == "localhost" || host == "127.0.0.1" || host == "::1";
+    if is_localhost {
+        if scheme != "http" && scheme != "https" {
+            return Err(format!(
+                "Localhost URL must use http or https scheme, got: {scheme}"
+            ));
+        }
+        if !config.open_url_allow_localhost {
+            return Err("Localhost URLs are not allowed by this profile".to_string());
+        }
+    } else {
+        // Non-localhost: must be https
+        if scheme != "https" {
+            return Err(format!(
+                "Only https:// URLs are allowed (got {scheme}://). \
+                 file://, javascript:, data:, and other schemes are blocked."
+            ));
+        }
+
+        // Check against allowed origins
+        let url_origin = parsed.origin().unicode_serialization();
+        let origin_allowed = config.open_url_origins.contains(&url_origin);
+
+        if !origin_allowed {
+            return Err(format!(
+                "Origin {url_origin} is not in the profile's open_urls.allow_origins list"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Open a URL in the user's default browser.
+///
+/// Uses `open` on macOS and `xdg-open` on Linux. Runs in the unsandboxed
+/// parent process so the browser has full system access.
+fn open_url_in_browser(url: &str) -> std::result::Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open")
+        .arg(url)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open")
+        .arg(url)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let result: std::result::Result<std::process::ExitStatus, std::io::Error> =
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "URL opening not supported on this platform",
+        ));
+
+    match result {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(format!("Browser opener exited with status: {status}")),
+        Err(e) => Err(format!("Failed to launch browser: {e}")),
+    }
+}
+
+/// Clear `FD_CLOEXEC` on a file descriptor so it survives `execve()`.
+fn clear_close_on_exec(fd: i32) -> Result<()> {
+    // SAFETY: `fcntl` is called with a valid fd owned by this process.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "fcntl(F_GETFD) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    let new_flags = flags & !libc::FD_CLOEXEC;
+    if new_flags != flags {
+        // SAFETY: `fcntl` is called with a valid fd and descriptor flags.
+        let rc = unsafe { libc::fcntl(fd, libc::F_SETFD, new_flags) };
+        if rc < 0 {
+            return Err(NonoError::SandboxInit(format!(
+                "fcntl(F_SETFD) failed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
     }
 
     Ok(())
@@ -1577,11 +1807,101 @@ pub(super) fn record_denial(denials: &mut Vec<DenialRecord>, record: DenialRecor
     }
 }
 
-/// Generate a unique request ID from timestamp + random component.
+/// Create a temporary directory containing an `open` shim script on macOS.
 ///
-/// Uses nanosecond timestamp for ordering plus random bytes for
-/// uniqueness under concurrency. Not cryptographically significant --
-/// used for audit correlation and replay detection, not security.
+/// The shim intercepts calls to `open` (which the Node.js `open` package
+/// uses on macOS) and routes URL arguments through `nono open-url-helper`.
+/// Non-URL arguments are passed through to `/usr/bin/open` so that
+/// non-browser `open` invocations (e.g. opening files) still work.
+///
+/// Returns the path to the shim directory, or `None` on failure.
+#[cfg(target_os = "macos")]
+struct OpenShim {
+    dir: std::path::PathBuf,
+    helper_exe: std::path::PathBuf,
+}
+
+#[cfg(target_os = "macos")]
+fn create_open_shim(nono_exe: &std::path::Path) -> Option<OpenShim> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let shim_dir = std::env::temp_dir().join(format!("nono-shim-{}", std::process::id()));
+    if std::fs::create_dir_all(&shim_dir).is_err() {
+        return None;
+    }
+
+    // Keep the helper inside the shim directory so it is always readable and
+    // executable under the sandbox's temp-dir allowlist, regardless of where
+    // the original `nono` binary was launched from.
+    let helper_path = shim_dir.join("nono-open-url-helper");
+    if std::fs::copy(nono_exe, &helper_path).is_err() {
+        return None;
+    }
+    if std::fs::set_permissions(&helper_path, std::fs::Permissions::from_mode(0o755)).is_err() {
+        return None;
+    }
+
+    let shim_path = shim_dir.join("open");
+    let quoted_helper = shell_quote(&helper_path.display().to_string());
+
+    // The shim script checks if the last argument looks like a URL (starts with
+    // http:// or https://). If so, delegate to nono open-url-helper. Otherwise
+    // fall through to /usr/bin/open for non-URL uses (opening files, apps, etc.).
+    let script = format!(
+        r#"#!/bin/sh
+# nono URL open shim — intercepts `open` calls for browser URL delegation
+# Get last argument (POSIX-compatible)
+for last_arg do :; done
+case "$last_arg" in
+    http://*|https://*)
+        exec {quoted_helper} open-url-helper "$last_arg"
+        ;;
+    *)
+        exec /usr/bin/open "$@"
+        ;;
+esac
+"#
+    );
+
+    if std::fs::write(&shim_path, script).is_err() {
+        return None;
+    }
+    if std::fs::set_permissions(&shim_path, std::fs::Permissions::from_mode(0o755)).is_err() {
+        return None;
+    }
+
+    Some(OpenShim {
+        dir: shim_dir,
+        helper_exe: helper_path,
+    })
+}
+
+/// Shell-quote a string for safe embedding in `sh -c` commands.
+/// If the string contains no special characters, returns it unchanged.
+/// Otherwise wraps it in single quotes, escaping embedded single quotes.
+fn shell_quote(s: &str) -> String {
+    // If the string is safe as-is, skip quoting
+    if !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/-_.".contains(&b))
+    {
+        return s.to_string();
+    }
+    // Single-quote the string, replacing ' with '\'' (end quote, escaped quote, start quote)
+    let mut quoted = String::with_capacity(s.len() + 2);
+    quoted.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+/// Generate a unique request ID from timestamp + monotonic counter.
 #[cfg(target_os = "linux")]
 fn unique_request_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -2148,6 +2468,8 @@ mod tests {
             never_grant: &never_grant,
             approval_backend: &backend,
             session_id: "test-session",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
         };
 
         // Fork a child that closes its socket end and exits immediately.
@@ -2194,5 +2516,194 @@ mod tests {
             }
             Err(e) => panic!("fork failed: {e}"),
         }
+    }
+
+    struct TestDenyBackend;
+    impl ApprovalBackend for TestDenyBackend {
+        fn request_capability(
+            &self,
+            _req: &nono::supervisor::CapabilityRequest,
+        ) -> nono::Result<ApprovalDecision> {
+            Ok(ApprovalDecision::Denied {
+                reason: "test".to_string(),
+            })
+        }
+        fn backend_name(&self) -> &str {
+            "test-deny"
+        }
+    }
+
+    #[test]
+    fn test_validate_url_allowed_origin() {
+        let never_grant =
+            NeverGrantChecker::new(&[]).expect("NeverGrantChecker::new failed in test");
+        let backend = TestDenyBackend;
+        let origins = vec!["https://claude.ai".to_string()];
+        let config = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &origins,
+            open_url_allow_localhost: false,
+        };
+
+        // Allowed origin: validation passes
+        let result = validate_url("https://claude.ai/oauth/authorize?state=xyz", &config);
+        assert!(result.is_ok(), "Expected validation to pass: {result:?}");
+
+        // Disallowed origin: must fail validation
+        let result = validate_url("https://evil.example.com/phishing", &config);
+        assert!(result.is_err());
+        assert!(result
+            .as_ref()
+            .err()
+            .map(|e| e.contains("not in the profile"))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn test_validate_url_blocks_non_https() {
+        let never_grant =
+            NeverGrantChecker::new(&[]).expect("NeverGrantChecker::new failed in test");
+        let backend = TestDenyBackend;
+        let config = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+        };
+
+        let result = validate_url("file:///etc/passwd", &config);
+        assert!(result.is_err());
+        assert!(result
+            .as_ref()
+            .err()
+            .map(|e| e.contains("Only https://"))
+            .unwrap_or(false));
+
+        let result = validate_url("javascript:alert(1)", &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_url_localhost() {
+        let never_grant =
+            NeverGrantChecker::new(&[]).expect("NeverGrantChecker::new failed in test");
+        let backend = TestDenyBackend;
+        let config_allow = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &[],
+            open_url_allow_localhost: true,
+        };
+        let config_deny = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+        };
+
+        // Localhost denied when not allowed
+        let result = validate_url("http://localhost:8080/callback", &config_deny);
+        assert!(result.is_err());
+        assert!(result
+            .as_ref()
+            .err()
+            .map(|e| e.contains("not allowed"))
+            .unwrap_or(false));
+
+        // Localhost allowed when configured
+        let result = validate_url("http://localhost:8080/callback", &config_allow);
+        assert!(
+            result.is_ok(),
+            "Expected localhost validation to pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_url_max_length() {
+        let never_grant =
+            NeverGrantChecker::new(&[]).expect("NeverGrantChecker::new failed in test");
+        let backend = TestDenyBackend;
+        let config = SupervisorConfig {
+            never_grant: &never_grant,
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+        };
+
+        let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
+        let result = validate_url(&long_url, &config);
+        assert!(result.is_err());
+        assert!(result
+            .as_ref()
+            .err()
+            .map(|e| e.contains("maximum length"))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn test_shell_quote_simple_path() {
+        assert_eq!(shell_quote("/usr/bin/nono"), "/usr/bin/nono");
+    }
+
+    #[test]
+    fn test_shell_quote_path_with_spaces() {
+        assert_eq!(shell_quote("/opt/my app/nono"), "'/opt/my app/nono'");
+    }
+
+    #[test]
+    fn test_shell_quote_path_with_single_quote() {
+        assert_eq!(shell_quote("/opt/it's/nono"), "'/opt/it'\\''s/nono'");
+    }
+
+    #[test]
+    fn test_shell_quote_empty_string() {
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn test_clear_close_on_exec_clears_flag() {
+        use std::os::fd::AsRawFd;
+        use std::os::unix::net::UnixStream;
+
+        let (a, _b) = UnixStream::pair().expect("socketpair");
+        let fd = a.as_raw_fd();
+
+        let before = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(before >= 0, "F_GETFD before failed");
+        assert_ne!(before & libc::FD_CLOEXEC, 0, "fd should start CLOEXEC");
+
+        clear_close_on_exec(fd).expect("clear cloexec");
+
+        let after = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(after >= 0, "F_GETFD after failed");
+        assert_eq!(after & libc::FD_CLOEXEC, 0, "fd should not be CLOEXEC");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_create_open_shim_installs_helper_in_shim_dir() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let shim = create_open_shim(&exe).expect("create shim");
+
+        assert!(shim.dir.join("open").exists(), "open shim should exist");
+        assert!(shim.helper_exe.exists(), "helper copy should exist");
+        assert_eq!(
+            shim.helper_exe.parent(),
+            Some(shim.dir.as_path()),
+            "helper should live inside shim dir"
+        );
+
+        let script = std::fs::read_to_string(shim.dir.join("open")).expect("read shim");
+        let helper = shell_quote(&shim.helper_exe.display().to_string());
+        assert!(
+            script.contains(&format!("exec {helper} open-url-helper \"$last_arg\"")),
+            "shim should exec the copied helper"
+        );
     }
 }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -310,6 +310,9 @@ pub fn execute_supervised(
     // Build environment: inherit current env + add our vars
     let mut env_c: Vec<CString> = Vec::new();
 
+    #[cfg(target_os = "macos")]
+    let mut open_shim: Option<OpenShim> = None;
+
     // Copy current environment, filtering dangerous and overridden vars
     for (key, value) in std::env::vars_os() {
         if let (Some(k), Some(v)) = (key.to_str(), value.to_str()) {
@@ -382,7 +385,8 @@ pub fn execute_supervised(
                     // Prepend shim dir to PATH and also set BROWSER for any tool
                     // that does respect it.
                     let current_path = std::env::var("PATH").unwrap_or_default();
-                    let new_path = format!("PATH={}:{current_path}", shim.dir.display());
+                    let new_path =
+                        format!("PATH={}:{current_path}", shim.dir.path().display());
                     if let Ok(cstr) = CString::new(new_path) {
                         // Remove existing PATH from env_c, then add our modified one
                         env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
@@ -393,10 +397,14 @@ pub fn execute_supervised(
                     if let Ok(cstr) = CString::new(browser_cmd) {
                         env_c.push(cstr);
                     }
+                    open_shim = Some(shim);
                 }
             }
         }
     }
+
+    #[cfg(target_os = "macos")]
+    let _keep_open_shim_alive = open_shim;
 
     // Create null-terminated pointer arrays for execve
     let argv_ptrs: Vec<*const libc::c_char> = argv_c
@@ -1817,7 +1825,7 @@ pub(super) fn record_denial(denials: &mut Vec<DenialRecord>, record: DenialRecor
 /// Returns the path to the shim directory, or `None` on failure.
 #[cfg(target_os = "macos")]
 struct OpenShim {
-    dir: std::path::PathBuf,
+    dir: tempfile::TempDir,
     helper_exe: std::path::PathBuf,
 }
 
@@ -1825,15 +1833,16 @@ struct OpenShim {
 fn create_open_shim(nono_exe: &std::path::Path) -> Option<OpenShim> {
     use std::os::unix::fs::PermissionsExt;
 
-    let shim_dir = std::env::temp_dir().join(format!("nono-shim-{}", std::process::id()));
-    if std::fs::create_dir_all(&shim_dir).is_err() {
-        return None;
-    }
+    let shim_dir = tempfile::Builder::new()
+        .prefix("nono-shim-")
+        .tempdir()
+        .ok()?;
+    let shim_dir_path = shim_dir.path();
 
     // Keep the helper inside the shim directory so it is always readable and
     // executable under the sandbox's temp-dir allowlist, regardless of where
     // the original `nono` binary was launched from.
-    let helper_path = shim_dir.join("nono-open-url-helper");
+    let helper_path = shim_dir_path.join("nono-open-url-helper");
     if std::fs::copy(nono_exe, &helper_path).is_err() {
         return None;
     }
@@ -1841,25 +1850,30 @@ fn create_open_shim(nono_exe: &std::path::Path) -> Option<OpenShim> {
         return None;
     }
 
-    let shim_path = shim_dir.join("open");
+    let shim_path = shim_dir_path.join("open");
     let quoted_helper = shell_quote(&helper_path.display().to_string());
 
-    // The shim script checks if the last argument looks like a URL (starts with
-    // http:// or https://). If so, delegate to nono open-url-helper. Otherwise
-    // fall through to /usr/bin/open for non-URL uses (opening files, apps, etc.).
+    // The shim script scans all arguments for the first URL-like value. If one
+    // is present, delegate to nono open-url-helper. Otherwise fall through to
+    // /usr/bin/open for non-URL uses (opening files, apps, etc.).
     let script = format!(
         r#"#!/bin/sh
 # nono URL open shim — intercepts `open` calls for browser URL delegation
-# Get last argument (POSIX-compatible)
-for last_arg do :; done
-case "$last_arg" in
-    http://*|https://*)
-        exec {quoted_helper} open-url-helper "$last_arg"
-        ;;
-    *)
-        exec /usr/bin/open "$@"
-        ;;
-esac
+url_arg=""
+for arg in "$@"; do
+    case "$arg" in
+        http://*|https://*)
+            url_arg="$arg"
+            break
+            ;;
+    esac
+done
+
+if [ -n "$url_arg" ]; then
+    exec {quoted_helper} open-url-helper "$url_arg"
+else
+    exec /usr/bin/open "$@"
+fi
 "#
     );
 
@@ -2691,19 +2705,38 @@ mod tests {
         let exe = std::env::current_exe().expect("current_exe");
         let shim = create_open_shim(&exe).expect("create shim");
 
-        assert!(shim.dir.join("open").exists(), "open shim should exist");
+        assert!(
+            shim.dir.path().join("open").exists(),
+            "open shim should exist"
+        );
         assert!(shim.helper_exe.exists(), "helper copy should exist");
         assert_eq!(
             shim.helper_exe.parent(),
-            Some(shim.dir.as_path()),
+            Some(shim.dir.path()),
             "helper should live inside shim dir"
         );
 
-        let script = std::fs::read_to_string(shim.dir.join("open")).expect("read shim");
+        let script = std::fs::read_to_string(shim.dir.path().join("open")).expect("read shim");
         let helper = shell_quote(&shim.helper_exe.display().to_string());
         assert!(
-            script.contains(&format!("exec {helper} open-url-helper \"$last_arg\"")),
+            script.contains("for arg in \"$@\"; do"),
+            "shim should scan all arguments for a URL"
+        );
+        assert!(
+            script.contains(&format!("exec {helper} open-url-helper \"$url_arg\"")),
             "shim should exec the copied helper"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_open_shim_drop_cleans_up_directory() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let shim = create_open_shim(&exe).expect("create shim");
+        let dir = shim.dir.path().to_path_buf();
+
+        assert!(dir.exists(), "shim dir should exist before drop");
+        drop(shim);
+        assert!(!dir.exists(), "shim dir should be removed on drop");
     }
 }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -385,8 +385,7 @@ pub fn execute_supervised(
                     // Prepend shim dir to PATH and also set BROWSER for any tool
                     // that does respect it.
                     let current_path = std::env::var("PATH").unwrap_or_default();
-                    let new_path =
-                        format!("PATH={}:{current_path}", shim.dir.path().display());
+                    let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
                     if let Ok(cstr) = CString::new(new_path) {
                         // Remove existing PATH from env_c, then add our modified one
                         env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -1818,11 +1818,10 @@ fn print_allow_launch_services_warning(silent: bool) {
     eprintln!(
         "  {}",
         "WARNING: --allow-launch-services permits the sandboxed process to ask macOS \
-         LaunchServices to open URLs, files, or apps.".yellow()
+         LaunchServices to open URLs, files, or apps."
+            .yellow()
     );
-    eprintln!(
-        "  Use this only for temporary login/setup flows, then exit and rerun without it."
-    );
+    eprintln!("  Use this only for temporary login/setup flows, then exit and rerun without it.");
     eprintln!("  Prefer using it from a trusted directory, not inside an untrusted project.");
 }
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -31,12 +31,14 @@ mod update_check;
 use capability_ext::CapabilitySetExt;
 use clap::Parser;
 use cli::{
-    Cli, Commands, LearnArgs, RunArgs, SandboxArgs, SetupArgs, ShellArgs, WhyArgs, WhyOp, WrapArgs,
+    Cli, Commands, LearnArgs, OpenUrlHelperArgs, RunArgs, SandboxArgs, SetupArgs, ShellArgs,
+    WhyArgs, WhyOp, WrapArgs,
 };
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
 use profile::WorkdirAccess;
 use std::ffi::OsString;
+use std::os::unix::io::FromRawFd;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
@@ -102,7 +104,11 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         Commands::Shell(args) => args.sandbox.verbose,
         Commands::Wrap(args) => args.sandbox.verbose,
         Commands::Setup(args) => args.verbose,
-        Commands::Why(_) | Commands::Rollback(_) | Commands::Trust(_) | Commands::Audit(_) => 0,
+        Commands::Why(_)
+        | Commands::Rollback(_)
+        | Commands::Trust(_)
+        | Commands::Audit(_)
+        | Commands::OpenUrlHelper(_) => 0,
     }
 }
 
@@ -151,6 +157,7 @@ fn run(cli: Cli) -> Result<()> {
             show_update_notification(&mut update_handle, cli.silent);
             audit_commands::run_audit(args)
         }
+        Commands::OpenUrlHelper(args) => run_open_url_helper(args),
     }
 }
 
@@ -160,6 +167,60 @@ fn show_update_notification(handle: &mut Option<update_check::UpdateCheckHandle>
         if let Some(info) = h.take_result() {
             output::print_update_notification(&info, silent);
         }
+    }
+}
+
+/// Internal helper invoked via BROWSER env var (Linux) or PATH shim (macOS).
+///
+/// Reads the supervisor socket fd from `NONO_SUPERVISOR_FD`, sends an
+/// `OpenUrl` IPC message, waits for the response, and exits with the
+/// appropriate exit code.
+fn run_open_url_helper(args: OpenUrlHelperArgs) -> Result<()> {
+    use nono::supervisor::types::{SupervisorMessage, SupervisorResponse};
+    use nono::supervisor::{SupervisorSocket, UrlOpenRequest};
+    use std::os::unix::net::UnixStream;
+
+    let fd_str = std::env::var("NONO_SUPERVISOR_FD").map_err(|_| {
+        NonoError::SandboxInit(
+            "NONO_SUPERVISOR_FD not set. open-url-helper must be invoked inside a nono sandbox."
+                .to_string(),
+        )
+    })?;
+
+    let fd: i32 = fd_str.parse().map_err(|_| {
+        NonoError::SandboxInit(format!("Invalid NONO_SUPERVISOR_FD value: {fd_str}"))
+    })?;
+
+    // SAFETY: The fd was inherited from the parent process via fork+exec.
+    // It is a valid Unix domain socket created by the supervisor.
+    let stream = unsafe { UnixStream::from(std::os::unix::io::OwnedFd::from_raw_fd(fd)) };
+    let mut sock = SupervisorSocket::from_stream(stream);
+
+    let request = UrlOpenRequest {
+        request_id: format!("url-{}", std::process::id()),
+        url: args.url.clone(),
+        child_pid: std::process::id(),
+        session_id: String::new(),
+    };
+
+    sock.send_message(&SupervisorMessage::OpenUrl(request))?;
+
+    let response = sock.recv_response()?;
+    match response {
+        SupervisorResponse::UrlOpened { success: true, .. } => Ok(()),
+        SupervisorResponse::UrlOpened {
+            success: false,
+            error,
+            ..
+        } => {
+            let msg = error.unwrap_or_else(|| "Unknown error".to_string());
+            Err(NonoError::SandboxInit(format!(
+                "Supervisor denied URL open: {msg}"
+            )))
+        }
+        other => Err(NonoError::SandboxInit(format!(
+            "Unexpected supervisor response: {other:?}"
+        ))),
     }
 }
 
@@ -370,6 +431,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             env_credential_map: vec![],
             profile: None,
             allow_cwd: false,
+            allow_launch_services: false,
             workdir: args.workdir.clone(),
             config: None,
             verbose: 0,
@@ -407,6 +469,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             env_credential_map: vec![],
             profile: None,
             allow_cwd: false,
+            allow_launch_services: false,
             workdir: args.workdir.clone(),
             config: None,
             verbose: 0,
@@ -486,6 +549,10 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     }
 
     let mut prepared = prepare_sandbox(&args, silent)?;
+
+    if prepared.allow_launch_services_active {
+        print_allow_launch_services_warning(silent);
+    }
 
     // CLI --capability-elevation overrides profile setting
     if run_args.capability_elevation {
@@ -698,6 +765,8 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             external_proxy_bypass: effective_bypass,
             allow_bind_ports: args.allow_bind,
             proxy_port: args.proxy_port,
+            open_url_origins: prepared.open_url_origins,
+            open_url_allow_localhost: prepared.open_url_allow_localhost,
         },
     )
 }
@@ -741,6 +810,10 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
     }
 
     let prepared = prepare_sandbox(&args.sandbox, silent)?;
+
+    if prepared.allow_launch_services_active {
+        print_allow_launch_services_warning(silent);
+    }
 
     if !silent {
         eprintln!(
@@ -823,6 +896,10 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
         ));
     }
 
+    if prepared.allow_launch_services_active {
+        print_allow_launch_services_warning(silent);
+    }
+
     execute_sandboxed(
         program,
         cmd_args,
@@ -883,6 +960,10 @@ struct ExecutionFlags {
     allow_bind_ports: Vec<u16>,
     /// Fixed port for the credential proxy (from --proxy-port)
     proxy_port: Option<u16>,
+    /// Allowed URL origins for supervisor-delegated browser opens
+    open_url_origins: Vec<String>,
+    /// Whether to allow http://localhost URL opens
+    open_url_allow_localhost: bool,
 }
 
 impl ExecutionFlags {
@@ -917,6 +998,8 @@ impl ExecutionFlags {
             external_proxy_bypass: Vec::new(),
             allow_bind_ports: Vec::new(),
             proxy_port: None,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
         })
     }
 }
@@ -1465,6 +1548,8 @@ fn execute_sandboxed(
                 never_grant: &never_grant_checker,
                 approval_backend: &approval_backend,
                 session_id: &supervisor_session_id,
+                open_url_origins: &flags.open_url_origins,
+                open_url_allow_localhost: flags.open_url_allow_localhost,
             };
 
             let trust_interceptor = if flags.trust_interception_active {
@@ -1635,6 +1720,12 @@ struct PreparedSandbox {
     external_proxy_bypass: Vec<String>,
     /// Whether the profile enables runtime capability elevation (seccomp-notify + PTY)
     capability_elevation: bool,
+    /// Whether direct LaunchServices opens are enabled for this session.
+    allow_launch_services_active: bool,
+    /// Allowed URL origins for supervisor-delegated browser opens
+    open_url_origins: Vec<String>,
+    /// Whether to allow http://localhost URL opens
+    open_url_allow_localhost: bool,
 }
 
 fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, String)>> {
@@ -1667,6 +1758,72 @@ fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, Strin
     }
 
     Ok(pairs)
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_enable_macos_launch_services(
+    caps: &mut CapabilitySet,
+    cli_requested: bool,
+    profile_allowed: bool,
+    open_url_origins: &[String],
+    open_url_allow_localhost: bool,
+) -> Result<bool> {
+    if !cli_requested {
+        return Ok(false);
+    }
+
+    if !profile_allowed {
+        return Err(NonoError::ConfigParse(
+            "--allow-launch-services requires a profile that opts into allow_launch_services"
+                .to_string(),
+        ));
+    }
+
+    if open_url_origins.is_empty() && !open_url_allow_localhost {
+        return Err(NonoError::ConfigParse(
+            "--allow-launch-services requires the selected profile to configure open_urls"
+                .to_string(),
+        ));
+    }
+
+    // Allow LaunchServices URL opening directly from inside the Seatbelt sandbox.
+    // This bypasses supervisor URL validation on macOS, so it must be gated by
+    // both profile opt-in and an explicit CLI flag.
+    caps.add_platform_rule("(allow lsopen)")?;
+    warn!("--allow-launch-services enabled: allowing direct LaunchServices opens on macOS");
+    Ok(true)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn maybe_enable_macos_launch_services(
+    _caps: &mut CapabilitySet,
+    cli_requested: bool,
+    _profile_allowed: bool,
+    _open_url_origins: &[String],
+    _open_url_allow_localhost: bool,
+) -> Result<bool> {
+    if cli_requested {
+        return Err(NonoError::ConfigParse(
+            "--allow-launch-services is only supported on macOS".to_string(),
+        ));
+    }
+    Ok(false)
+}
+
+fn print_allow_launch_services_warning(silent: bool) {
+    if silent {
+        return;
+    }
+
+    eprintln!(
+        "  {}",
+        "WARNING: --allow-launch-services permits the sandboxed process to ask macOS \
+         LaunchServices to open URLs, files, or apps.".yellow()
+    );
+    eprintln!(
+        "  Use this only for temporary login/setup flows, then exit and rerun without it."
+    );
+    eprintln!("  Prefer using it from a trusted directory, not inside an untrusted project.");
 }
 
 fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> {
@@ -1768,6 +1925,20 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .as_ref()
         .map(|p| p.network.external_proxy_bypass.clone())
         .unwrap_or_default();
+    let open_url_origins = loaded_profile
+        .as_ref()
+        .and_then(|p| p.open_urls.as_ref())
+        .map(|u| u.allow_origins.clone())
+        .unwrap_or_default();
+    let open_url_allow_localhost = loaded_profile
+        .as_ref()
+        .and_then(|p| p.open_urls.as_ref())
+        .map(|u| u.allow_localhost)
+        .unwrap_or(false);
+    let profile_allow_launch_services = loaded_profile
+        .as_ref()
+        .and_then(|p| p.allow_launch_services)
+        .unwrap_or(false);
 
     // On Linux, pre-create paths that the claude-code profile grants but
     // may not exist yet. Non-existent paths are skipped during capability
@@ -1809,6 +1980,14 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
     } else {
         CapabilitySet::from_args(args)?
     };
+
+    let allow_launch_services_active = maybe_enable_macos_launch_services(
+        &mut caps,
+        args.allow_launch_services,
+        profile_allow_launch_services,
+        &open_url_origins,
+        open_url_allow_localhost,
+    )?;
 
     // Auto-include CWD based on profile [workdir] config or default behavior
     let cwd_access = if let Some(ref access) = profile_workdir_access {
@@ -1984,6 +2163,9 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         external_proxy: profile_external_proxy,
         external_proxy_bypass: profile_external_proxy_bypass,
         capability_elevation,
+        allow_launch_services_active,
+        open_url_origins,
+        open_url_allow_localhost,
     })
 }
 
@@ -2203,6 +2385,7 @@ mod tests {
             env_credential_map: vec![],
             profile: None,
             allow_cwd: false,
+            allow_launch_services: false,
             workdir: None,
             config: None,
             verbose: 0,
@@ -2308,6 +2491,9 @@ mod tests {
             external_proxy: None,
             external_proxy_bypass: Vec::new(),
             capability_elevation: false,
+            allow_launch_services_active: false,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -2342,6 +2528,9 @@ mod tests {
             external_proxy: None,
             external_proxy_bypass: Vec::new(),
             capability_elevation: false,
+            allow_launch_services_active: false,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -2435,5 +2624,60 @@ mod tests {
         assert!(!is_claude_command(&OsString::from("bash")));
         assert!(!is_claude_command(&OsString::from("/usr/bin/python3")));
         assert!(!is_claude_command(&OsString::from("claude-code")));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_maybe_enable_macos_launch_services_adds_rule_when_enabled() {
+        let mut caps = CapabilitySet::new();
+
+        let enabled = maybe_enable_macos_launch_services(
+            &mut caps,
+            true,
+            true,
+            &["https://claude.ai".to_string()],
+            false,
+        )
+        .expect("launch services gate should apply");
+
+        assert!(enabled, "launch services should be active");
+        assert!(
+            caps.platform_rules().iter().any(|r| r == "(allow lsopen)"),
+            "lsopen platform rule should be present"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_maybe_enable_macos_launch_services_rejects_without_profile_opt_in() {
+        let mut caps = CapabilitySet::new();
+
+        let err = maybe_enable_macos_launch_services(
+            &mut caps,
+            true,
+            false,
+            &["https://claude.ai".to_string()],
+            false,
+        )
+        .expect_err("missing profile opt-in should fail");
+
+        assert!(
+            err.to_string().contains("requires a profile"),
+            "error should mention profile opt-in"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_maybe_enable_macos_launch_services_rejects_without_open_urls() {
+        let mut caps = CapabilitySet::new();
+
+        let err = maybe_enable_macos_launch_services(&mut caps, true, true, &[], false)
+            .expect_err("missing open_urls should fail");
+
+        assert!(
+            err.to_string().contains("configure open_urls"),
+            "error should mention open_urls"
+        );
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -121,6 +121,10 @@ pub struct ProfileDef {
     #[serde(default, alias = "undo")]
     pub rollback: profile::RollbackConfig,
     #[serde(default)]
+    pub open_urls: Option<profile::OpenUrlConfig>,
+    #[serde(default)]
+    pub allow_launch_services: Option<bool>,
+    #[serde(default)]
     pub interactive: bool,
 }
 
@@ -157,6 +161,8 @@ impl ProfileDef {
             workdir: self.workdir.clone(),
             hooks: self.hooks.clone(),
             rollback: self.rollback.clone(),
+            open_urls: self.open_urls.clone(),
+            allow_launch_services: self.allow_launch_services,
             interactive: self.interactive,
         })
     }

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -83,15 +83,15 @@ mod tests {
             .filesystem
             .allow
             .contains(&"$HOME/.codex".to_string()));
-        assert!(profile
-            .security
-            .groups
-            .contains(&"codex_macos".to_string()));
+        assert!(profile.security.groups.contains(&"codex_macos".to_string()));
         assert!(profile
             .security
             .groups
             .contains(&"node_runtime".to_string()));
-        assert!(profile.security.groups.contains(&"rust_runtime".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"rust_runtime".to_string()));
         assert!(profile
             .security
             .groups

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -86,11 +86,12 @@ mod tests {
         assert!(profile
             .security
             .groups
-            .contains(&"node_runtime".to_string()));
+            .contains(&"codex_macos".to_string()));
         assert!(profile
             .security
             .groups
-            .contains(&"rust_runtime".to_string()));
+            .contains(&"node_runtime".to_string()));
+        assert!(profile.security.groups.contains(&"rust_runtime".to_string()));
         assert!(profile
             .security
             .groups

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -710,6 +710,23 @@ pub struct RollbackConfig {
     pub exclude_globs: Vec<String>,
 }
 
+/// Configuration for supervisor-delegated URL opening.
+///
+/// Controls which URLs the sandboxed child can request the supervisor to
+/// open in the user's browser. Used for OAuth2 login flows and similar
+/// operations where the sandboxed process cannot launch a browser directly.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OpenUrlConfig {
+    /// Allowed URL origins (scheme + host, e.g., "https://console.anthropic.com").
+    /// The supervisor validates each URL open request against this list.
+    /// An empty list means no URLs are allowed.
+    #[serde(default)]
+    pub allow_origins: Vec<String>,
+    /// Allow opening http://localhost and http://127.0.0.1 URLs (for OAuth2 callbacks).
+    #[serde(default)]
+    pub allow_localhost: bool,
+}
+
 /// A complete profile definition
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Profile {
@@ -732,6 +749,17 @@ pub struct Profile {
     pub hooks: HooksConfig,
     #[serde(default, alias = "undo")]
     pub rollback: RollbackConfig,
+    /// Supervisor-delegated URL opening (e.g., for OAuth2 login flows).
+    /// When `None` (absent from JSON), inherits from the base profile.
+    /// When `Some`, replaces the base profile's config entirely, allowing
+    /// derived profiles to narrow permissions.
+    #[serde(default)]
+    pub open_urls: Option<OpenUrlConfig>,
+    /// Opt-in gate for temporary direct LaunchServices opens on macOS.
+    /// Must be paired with the CLI flag `--allow-launch-services`.
+    /// When `None`, inherits from the base profile.
+    #[serde(default)]
+    pub allow_launch_services: Option<bool>,
     /// Deprecated: Parsed for backward compatibility but ignored.
     /// Supervised mode preserves TTY by default, making this unnecessary.
     #[serde(default)]
@@ -932,6 +960,8 @@ fn load_base_profile_raw(name: &str) -> Result<Profile> {
             workdir: def.workdir.clone(),
             hooks: def.hooks.clone(),
             rollback: def.rollback.clone(),
+            open_urls: def.open_urls.clone(),
+            allow_launch_services: def.allow_launch_services,
             interactive: def.interactive,
         });
     }
@@ -1031,6 +1061,11 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &child.rollback.exclude_globs,
             ),
         },
+        open_urls: match child.open_urls {
+            Some(child_urls) => Some(child_urls),
+            None => base.open_urls,
+        },
+        allow_launch_services: child.allow_launch_services.or(base.allow_launch_services),
         interactive: base.interactive || child.interactive,
     }
 }
@@ -2051,6 +2086,11 @@ mod tests {
                 exclude_patterns: vec!["node_modules".to_string()],
                 exclude_globs: vec!["*.pyc".to_string()],
             },
+            open_urls: Some(OpenUrlConfig {
+                allow_origins: vec!["https://base.example.com".to_string()],
+                allow_localhost: false,
+            }),
+            allow_launch_services: Some(false),
             interactive: false,
         }
     }
@@ -2104,6 +2144,11 @@ mod tests {
                 exclude_patterns: vec![],
                 exclude_globs: vec![],
             },
+            open_urls: Some(OpenUrlConfig {
+                allow_origins: vec!["https://child.example.com".to_string()],
+                allow_localhost: true,
+            }),
+            allow_launch_services: Some(true),
             interactive: false,
         }
     }
@@ -2679,6 +2724,54 @@ mod tests {
             merged.extends.is_none(),
             "extends should be consumed after merge"
         );
+    }
+
+    #[test]
+    fn test_merge_profiles_open_urls_child_replaces_base() {
+        // When child has open_urls, it replaces base entirely
+        let merged = merge_profiles(base_profile(), child_profile());
+        let urls = merged.open_urls.expect("should have open_urls");
+        assert_eq!(urls.allow_origins, vec!["https://child.example.com"]);
+        assert!(!urls
+            .allow_origins
+            .contains(&"https://base.example.com".to_string()));
+        assert!(urls.allow_localhost);
+    }
+
+    #[test]
+    fn test_merge_profiles_open_urls_child_absent_inherits_base() {
+        // When child has no open_urls, base is inherited
+        let mut child = child_profile();
+        child.open_urls = None;
+        let merged = merge_profiles(base_profile(), child);
+        let urls = merged.open_urls.expect("should inherit base open_urls");
+        assert_eq!(urls.allow_origins, vec!["https://base.example.com"]);
+        assert!(!urls.allow_localhost);
+    }
+
+    #[test]
+    fn test_merge_profiles_open_urls_child_narrows() {
+        // A derived profile can restrict to fewer origins than base
+        let mut child = child_profile();
+        child.open_urls = Some(OpenUrlConfig {
+            allow_origins: vec![],
+            allow_localhost: false,
+        });
+        let merged = merge_profiles(base_profile(), child);
+        let urls = merged.open_urls.expect("should have open_urls");
+        assert!(urls.allow_origins.is_empty());
+        assert!(!urls.allow_localhost);
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_launch_services_child_overrides_base() {
+        let merged = merge_profiles(base_profile(), child_profile());
+        assert_eq!(merged.allow_launch_services, Some(true));
+
+        let mut child = child_profile();
+        child.allow_launch_services = Some(false);
+        let merged = merge_profiles(base_profile(), child);
+        assert_eq!(merged.allow_launch_services, Some(false));
     }
 
     #[test]

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -78,6 +78,7 @@ pub use sandbox::{Sandbox, SupportInfo};
 pub use state::SandboxState;
 pub use supervisor::{
     ApprovalBackend, ApprovalDecision, CapabilityRequest, NeverGrantChecker, SupervisorSocket,
+    UrlOpenRequest,
 };
 pub use trust::{
     Enforcement, InstructionPatterns, Publisher, SignerIdentity, TrustPolicy, VerificationOutcome,

--- a/crates/nono/src/supervisor/mod.rs
+++ b/crates/nono/src/supervisor/mod.rs
@@ -38,6 +38,7 @@ pub use never_grant::{NeverGrantChecker, NeverGrantResult};
 pub use socket::SupervisorSocket;
 pub use types::{
     ApprovalDecision, AuditEntry, CapabilityRequest, SupervisorMessage, SupervisorResponse,
+    UrlOpenRequest,
 };
 
 use crate::error::Result;

--- a/crates/nono/src/supervisor/socket.rs
+++ b/crates/nono/src/supervisor/socket.rs
@@ -495,6 +495,7 @@ mod tests {
                 assert_eq!(req.path, PathBuf::from("/tmp/test"));
                 assert_eq!(req.child_pid, 12345);
             }
+            other => panic!("Expected Request, got {:?}", other),
         }
 
         // Supervisor sends response
@@ -516,6 +517,64 @@ mod tests {
                 assert_eq!(request_id, "req-001");
                 assert!(decision.is_granted());
             }
+            other => panic!("Expected Decision, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_url_open_roundtrip() {
+        use crate::supervisor::types::UrlOpenRequest;
+
+        let (mut supervisor, mut child) =
+            SupervisorSocket::pair().expect("Failed to create socket pair");
+
+        let url_request = UrlOpenRequest {
+            request_id: "url-001".to_string(),
+            url: "https://console.anthropic.com/oauth/authorize".to_string(),
+            child_pid: 12345,
+            session_id: "sess-001".to_string(),
+        };
+
+        // Child sends URL open request
+        child
+            .send_message(&SupervisorMessage::OpenUrl(url_request))
+            .expect("Failed to send message");
+
+        // Supervisor receives it
+        let msg = supervisor
+            .recv_message()
+            .expect("Failed to receive message");
+        match msg {
+            SupervisorMessage::OpenUrl(req) => {
+                assert_eq!(req.request_id, "url-001");
+                assert_eq!(req.url, "https://console.anthropic.com/oauth/authorize");
+            }
+            other => panic!("Expected OpenUrl, got {:?}", other),
+        }
+
+        // Supervisor sends response
+        let response = SupervisorResponse::UrlOpened {
+            request_id: "url-001".to_string(),
+            success: true,
+            error: None,
+        };
+        supervisor
+            .send_response(&response)
+            .expect("Failed to send response");
+
+        // Child receives it
+        let resp = child.recv_response().expect("Failed to receive response");
+        match resp {
+            SupervisorResponse::UrlOpened {
+                request_id,
+                success,
+                error,
+            } => {
+                assert_eq!(request_id, "url-001");
+                assert!(success);
+                assert!(error.is_none());
+            }
+            other => panic!("Expected UrlOpened, got {:?}", other),
         }
     }
 

--- a/crates/nono/src/supervisor/types.rs
+++ b/crates/nono/src/supervisor/types.rs
@@ -75,11 +75,31 @@ pub struct AuditEntry {
     pub duration_ms: u64,
 }
 
+/// A request from the sandboxed child to open a URL in the user's browser.
+///
+/// Sent over the supervisor Unix socket when the child needs to launch a
+/// browser (e.g., for OAuth2 login). The unsandboxed supervisor validates
+/// the URL against the profile's allowed origins and opens it outside the
+/// sandbox, where the browser can access its own config files freely.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UrlOpenRequest {
+    /// Unique identifier for this request (for replay protection and audit)
+    pub request_id: String,
+    /// The URL to open in the user's browser
+    pub url: String,
+    /// PID of the requesting child process
+    pub child_pid: u32,
+    /// Session identifier for correlating requests within a single run
+    pub session_id: String,
+}
+
 /// IPC message envelope sent from child to supervisor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SupervisorMessage {
     /// A capability expansion request (explicit, from SDK clients)
     Request(CapabilityRequest),
+    /// A request to open a URL in the user's browser (e.g., OAuth2 login)
+    OpenUrl(UrlOpenRequest),
 }
 
 /// IPC message envelope sent from supervisor to child.
@@ -91,5 +111,14 @@ pub enum SupervisorResponse {
         request_id: String,
         /// The approval decision
         decision: ApprovalDecision,
+    },
+    /// Response to a URL open request
+    UrlOpened {
+        /// The request_id this responds to
+        request_id: String,
+        /// Whether the URL was opened successfully
+        success: bool,
+        /// Error message if the open failed
+        error: Option<String>,
     },
 }

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -37,6 +37,7 @@ The built-in profile provides:
 - **Network access** enabled (required for Anthropic API)
 - **Interactive mode** enabled (preserves TTY for Claude's terminal UI)
 - **Automatic hook installation** for sandbox-aware error handling
+- **OAuth2 login support** via supervised URL opening (allows `claude /login` to work)
 
 ## Custom Profile
 
@@ -145,6 +146,57 @@ nono run --profile claude-code --allow-net -- claude
 ```
 
 This also disables any proxy-based credential injection configured by the profile for that run.
+
+## OAuth2 Login
+
+Running `claude /login` inside a sandbox requires the browser to open outside the sandboxed process. On Linux (Landlock), `nono` can delegate approved URLs to the unsandboxed parent process. On macOS (Seatbelt), Claude's login flow needs a temporary LaunchServices permission to open the browser.
+
+The built-in `claude-code` profile includes an origin allowlist that controls which URLs may be opened during supervised login flows:
+
+- `https://claude.ai` (OAuth2 authorize endpoint)
+- `localhost` callbacks (for the OAuth2 redirect)
+
+On Linux, no additional flags are needed:
+
+```bash
+nono run --profile claude-code -- claude
+```
+
+On macOS, enable LaunchServices temporarily for the login session:
+
+```bash
+nono run --profile claude-code --allow-launch-services -- claude
+```
+
+After login completes, exit and rerun without `--allow-launch-services`.
+
+<Warning>
+`--allow-launch-services` lets the sandboxed Claude process ask macOS LaunchServices to open URLs, files, or apps for that session. Use it only for temporary login or setup flows, and prefer running it from a trusted directory.
+</Warning>
+
+### Adding Custom OAuth2 Origins
+
+If your organization uses a custom identity provider for Claude Code authentication, add its origin to your profile:
+
+```json
+{
+  "meta": { "name": "claude-code-custom-auth" },
+  "extends": "claude-code",
+  "open_urls": {
+    "allow_origins": [
+      "https://claude.ai",
+      "https://sso.example.com"
+    ],
+    "allow_localhost": true
+  }
+}
+```
+
+When a derived profile specifies `open_urls`, it replaces the base profile's config entirely. Include all origins you need, including `https://claude.ai` if you still want the standard OAuth2 flow. Omit `open_urls` to inherit the base profile's settings unchanged.
+
+<Note>
+The origin allowlist is enforced by the supervisor when `nono` delegates browser opening itself. On macOS, `--allow-launch-services` bypasses that supervisor path for the duration of the session in exchange for login compatibility.
+</Note>
 
 ## Enabling LSPs, Linters, and Dev Tools
 

--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -26,6 +26,7 @@ The built-in profile provides:
 - **Read+write access** to the current working directory
 - **Read+write access** to `~/.codex` (config, auth state, sessions, caches, and local metadata)
 - **Read access** to common user-local runtime paths for Rust, Node.js, Python, and Nix toolchains
+- **OAuth login support** via supervised URL opening on Linux and a temporary LaunchServices flag on macOS
 - **Network access** enabled
 - **Interactive mode** enabled for the terminal UI
 
@@ -55,6 +56,33 @@ Custom profiles with the same name override the built-in profile. Remove or rena
 </Note>
 
 ## Security Tips
+
+### OAuth Login
+
+Codex login opens `https://auth.openai.com` during the OAuth flow.
+
+The built-in profile includes the required browser-open allowlist:
+
+- `https://auth.openai.com`
+- `localhost` callbacks for the OAuth redirect
+
+On Linux, no additional flags are needed:
+
+```bash
+nono run --profile codex -- codex
+```
+
+On macOS, enable LaunchServices temporarily for the login session:
+
+```bash
+nono run --profile codex --allow-launch-services -- codex
+```
+
+After login completes, exit and rerun without `--allow-launch-services`.
+
+<Warning>
+`--allow-launch-services` lets the sandboxed Codex process ask macOS LaunchServices to open URLs, files, or apps for that session. Use it only for temporary login or setup flows, and prefer running it from a trusted directory.
+</Warning>
 
 ### Restrict to a Specific Project
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -570,6 +570,18 @@ nono run --profile claude-code --allow-cwd -- claude
 nono -s run --profile claude-code --allow-cwd -- claude
 ```
 
+#### `--allow-launch-services`
+
+Allow direct LaunchServices opens on macOS for this session. This is intended for temporary login or setup flows that need to open a browser from inside the sandbox.
+
+```bash
+nono run --profile claude-code --allow-launch-services -- claude
+```
+
+<Note>
+  `--allow-launch-services` is only supported on macOS. It requires the selected profile to opt into `allow_launch_services` and configure `open_urls`; otherwise nono fails closed with an error.
+</Note>
+
 ### Execution Mode Flags
 
 #### `--rollback`

--- a/scripts/diagnose-macos-browser-open.sh
+++ b/scripts/diagnose-macos-browser-open.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Diagnose browser-opening behavior on macOS outside and inside nono.
+#
+# This runs a small matrix of increasingly sandboxed `open` invocations and
+# records:
+# - the exact command
+# - the exit status
+# - whether nono's macOS URL debug log was touched
+#
+# It intentionally uses `open -g` to avoid focusing the browser window.
+
+set -euo pipefail
+
+if [[ "${OSTYPE:-}" != darwin* ]]; then
+    echo "This script is macOS-only." >&2
+    exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NONO_BIN="${NONO_BIN:-$ROOT_DIR/target/debug/nono}"
+URL="${1:-https://claude.ai}"
+TMP_BASE="${TMPDIR:-/tmp}"
+LOG_FILE="$TMP_BASE/nono-macos-open-diagnose.log"
+DEBUG_LOG="$TMP_BASE/nono-open-url-debug.log"
+
+if [[ ! -x "$NONO_BIN" ]]; then
+    echo "nono binary not found or not executable: $NONO_BIN" >&2
+    echo "Build it first with: cargo build -p nono-cli" >&2
+    exit 1
+fi
+
+timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+log() {
+    printf '[%s] %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE"
+}
+
+clear_logs() {
+    rm -f "$DEBUG_LOG"
+}
+
+show_debug_log() {
+    if [[ -f "$DEBUG_LOG" ]]; then
+        log "debug-log: present at $DEBUG_LOG"
+        while IFS= read -r line; do
+            log "debug-log: $line"
+        done <"$DEBUG_LOG"
+    else
+        log "debug-log: not created"
+    fi
+}
+
+run_step() {
+    local name="$1"
+    shift
+
+    clear_logs
+    log "===== $name ====="
+    log "command: $*"
+
+    set +e
+    "$@" >>"$LOG_FILE" 2>&1
+    local rc=$?
+    set -e
+
+    log "exit-status: $rc"
+    show_debug_log
+    log ""
+}
+
+log "Starting macOS browser-open diagnostics"
+log "root-dir: $ROOT_DIR"
+log "nono-bin: $NONO_BIN"
+log "url: $URL"
+log "tmp-base: $TMP_BASE"
+log ""
+
+run_step \
+    "outside-sandbox absolute-open" \
+    /usr/bin/open -g "$URL"
+
+run_step \
+    "outside-sandbox path-open" \
+    open -g "$URL"
+
+run_step \
+    "nono no-profile absolute-open" \
+    "$NONO_BIN" run --allow-cwd --net-allow -- /usr/bin/open -g "$URL"
+
+run_step \
+    "nono claude-profile absolute-open" \
+    "$NONO_BIN" run --profile claude-code --allow-cwd -- /usr/bin/open -g "$URL"
+
+run_step \
+    "nono claude-profile path-open" \
+    "$NONO_BIN" run --profile claude-code --allow-cwd -- open -g "$URL"
+
+run_step \
+    "nono claude-profile absolute-open with lsopen" \
+    "$NONO_BIN" run --profile claude-code --allow-cwd --allow-launch-services -- \
+    /usr/bin/open -g "$URL"
+
+run_step \
+    "nono claude-profile path-open with lsopen" \
+    "$NONO_BIN" run --profile claude-code --allow-cwd --allow-launch-services -- \
+    open -g "$URL"
+
+log "Completed diagnostics. Full log: $LOG_FILE"

--- a/scripts/probe-claude-open-path.sh
+++ b/scripts/probe-claude-open-path.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run Claude with a PATH-prepended `open` wrapper to determine whether the
+# login flow resolves `open` via PATH or calls `/usr/bin/open` directly.
+#
+# Usage:
+#   ./scripts/probe-claude-open-path.sh
+# Then trigger login inside Claude. After exiting, inspect the printed log path.
+
+set -euo pipefail
+
+if [[ "${OSTYPE:-}" != darwin* ]]; then
+    echo "This script is macOS-only." >&2
+    exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NONO_BIN="${NONO_BIN:-$ROOT_DIR/target/debug/nono}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || true)}"
+TMP_BASE="${TMPDIR:-/tmp}"
+PROBE_DIR="$(mktemp -d "$TMP_BASE/nono-open-probe.XXXXXX")"
+WRAPPER_LOG="$PROBE_DIR/open-wrapper.log"
+OPEN_WRAPPER="$PROBE_DIR/open"
+
+cleanup() {
+    echo
+    echo "Probe directory: $PROBE_DIR"
+    echo "Wrapper log: $WRAPPER_LOG"
+}
+trap cleanup EXIT
+
+if [[ ! -x "$NONO_BIN" ]]; then
+    echo "nono binary not found or not executable: $NONO_BIN" >&2
+    echo "Build it first with: cargo build -p nono-cli" >&2
+    exit 1
+fi
+
+if [[ -z "$CLAUDE_BIN" || ! -x "$CLAUDE_BIN" ]]; then
+    echo "claude binary not found or not executable: ${CLAUDE_BIN:-<empty>}" >&2
+    echo "Set CLAUDE_BIN=/absolute/path/to/claude and retry." >&2
+    exit 1
+fi
+
+cat >"$OPEN_WRAPPER" <<'EOF'
+#!/bin/sh
+log_file="${NONO_OPEN_WRAPPER_LOG:-/tmp/nono-open-wrapper.log}"
+{
+    printf 'pid=%s argc=%s\n' "$$" "$#"
+    i=1
+    for arg in "$@"; do
+        printf 'arg[%s]=%s\n' "$i" "$arg"
+        i=$((i + 1))
+    done
+    printf '\n'
+} >>"$log_file"
+exec /usr/bin/open "$@"
+EOF
+
+chmod 755 "$OPEN_WRAPPER"
+
+echo "Starting Claude with PATH wrapper."
+echo "Trigger login, then exit Claude."
+echo "If the wrapper log stays empty, Claude is not resolving \`open\` through PATH."
+echo "Claude binary: $CLAUDE_BIN"
+echo
+
+env \
+    PATH="$PROBE_DIR:$PATH" \
+    NONO_OPEN_WRAPPER_LOG="$WRAPPER_LOG" \
+    "$NONO_BIN" run --profile claude-code --allow-cwd --allow-launch-services \
+    --read-file "$CLAUDE_BIN" -- \
+    "$CLAUDE_BIN"

--- a/scripts/stream-macos-sandbox-logs.sh
+++ b/scripts/stream-macos-sandbox-logs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Stream macOS unified logs relevant to nono/claude browser-open failures.
+#
+# Run this in one terminal, reproduce the failing login in another terminal,
+# then Ctrl+C and send back the captured log file.
+
+set -euo pipefail
+
+if [[ "${OSTYPE:-}" != darwin* ]]; then
+    echo "This script is macOS-only." >&2
+    exit 1
+fi
+
+TMP_BASE="${TMPDIR:-/tmp}"
+OUT_FILE="${1:-$TMP_BASE/nono-macos-sandbox-stream.log}"
+PREDICATE='subsystem == "com.apple.sandbox" OR process == "claude" OR process == "nono" OR process == "open"'
+
+echo "Writing live unified logs to: $OUT_FILE"
+echo "Start the failing login flow in another terminal, then Ctrl+C here."
+echo
+
+/usr/bin/log stream \
+    --style compact \
+    --predicate "$PREDICATE" | tee "$OUT_FILE"


### PR DESCRIPTION
Profiles can now opt in to OAuth2 and similar browser-based login flows by specifying allowed URL origins and enabling localhost callbacks. When enabled, the sandboxed process requests the unsandboxed supervisor to open URLs in the user's browser, where authentication can complete without sandbox restrictions.

The implementation adds a new IPC message type (OpenUrl) to the supervisor protocol, with validation against profile-defined allowed origins. On Linux, the BROWSER env var points to the nono open-url-helper subcommand; on macOS, a shim script in PATH intercepts calls to the system open command. This allows both xdg-open and the Node.js open package to delegate to the supervisor without requiring direct browser access inside the sandbox.

Profiles declare opt-in via open_urls config (allowed origins + localhost flag) and allow_launch_services flag. Built-in profiles (claude-code, codex) are configured with
appropriate origins for their respective authentication flows.