### PR TITLE
feat(cli): add pluggable theme system with 6 built-in palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ nono run --profile my-profile -- rm /tmp/old-file.txt
 > [!WARNING]
 > Command blocking is defense-in-depth layered on top of the kernel sandbox. Commands can bypass this via `sh -c '...'` or wrapper scripts — the sandbox filesystem restrictions are the real security boundary.
 
+### Themes
+
+nono ships with multiple color themes inspired by popular terminal palettes. The default is **Catppuccin Mocha**.
+
+| Theme | Description |
+|-------|-------------|
+| `mocha` | Catppuccin Mocha -- warm dark (default) |
+| `latte` | Catppuccin Latte -- clean light |
+| `frappe` | Catppuccin Frappe -- muted dark |
+| `macchiato` | Catppuccin Macchiato -- deep vivid dark |
+| `tokyo-night` | Tokyo Night -- cool blues and purples |
+| `minimal` | Grayscale with orange accent |
+
+```bash
+# Per invocation
+nono --theme tokyo-night run --allow-cwd -- my-agent
+
+# Via environment variable
+export NONO_THEME=latte
+
+# Via config file (~/.config/nono/config.toml)
+# [ui]
+# theme = "frappe"
+```
+
 ### Audit Trail
 
 Every supervised session automatically records command, timing, exit code, network events, and cryptographic snapshot commitments as structured JSON. Opt out with `--no-audit`.

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -58,6 +58,27 @@ nono why --path ~/.ssh/id_rsa --op read
 nono run --allow-cwd --dry-run -- command
 ```
 
+## Themes
+
+The CLI supports named output themes for banners, summaries, warnings, and status text.
+
+Available themes: `mocha`, `latte`, `frappe`, `macchiato`, `tokyo-night`, `minimal`
+
+```bash
+# Per invocation
+nono --theme tokyo-night run --allow-cwd -- claude
+
+# Environment variable
+export NONO_THEME=latte
+
+# Config file
+# ~/.config/nono/config.toml
+# [ui]
+# theme = "frappe"
+```
+
+Precedence is: CLI flag, then `NONO_THEME`, then config file, then the default `mocha`.
+
 ## Built-in Profiles
 
 | Profile | Command |

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -4,6 +4,7 @@
 
 use crate::cli::{AuditArgs, AuditCommands, AuditListArgs, AuditShowArgs};
 use crate::rollback_session::{discover_sessions, load_session, SessionInfo};
+use crate::theme;
 use colored::Colorize;
 use nono::undo::SnapshotManager;
 use nono::{NonoError, Result};
@@ -12,7 +13,8 @@ use std::path::{Path, PathBuf};
 
 /// Prefix used for all audit command output
 fn prefix() -> colored::ColoredString {
-    "[nono]".truecolor(204, 102, 0)
+    let t = theme::current();
+    "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold()
 }
 
 /// Dispatch to the appropriate audit subcommand.
@@ -65,7 +67,11 @@ fn cmd_list(args: AuditListArgs) -> Result<()> {
                 "    {} {} {}",
                 s.metadata.session_id,
                 status,
-                cmd.truecolor(150, 150, 150),
+                cmd.truecolor(
+                    theme::current().subtext.0,
+                    theme::current().subtext.1,
+                    theme::current().subtext.2
+                ),
             );
         }
         eprintln!();
@@ -208,7 +214,11 @@ fn cmd_show(args: AuditShowArgs) -> Result<()> {
     );
     eprintln!(
         "  Command:  {}",
-        session.metadata.command.join(" ").truecolor(150, 150, 150)
+        session.metadata.command.join(" ").truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2
+        )
     );
     eprintln!("  Started:  {}", session.metadata.started);
     if let Some(ref ended) = session.metadata.ended {
@@ -358,7 +368,11 @@ fn session_status_label(s: &SessionInfo) -> colored::ColoredString {
     } else if s.is_stale {
         "orphaned".yellow()
     } else {
-        "completed".truecolor(150, 150, 150)
+        "completed".truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2,
+        )
     }
 }
 
@@ -401,7 +415,11 @@ fn change_symbol(ct: &nono::undo::ChangeType) -> colored::ColoredString {
         nono::undo::ChangeType::Created => "+".green(),
         nono::undo::ChangeType::Modified => "~".yellow(),
         nono::undo::ChangeType::Deleted => "-".red(),
-        nono::undo::ChangeType::PermissionsChanged => "p".truecolor(150, 150, 150),
+        nono::undo::ChangeType::PermissionsChanged => "p".truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2,
+        ),
     }
 }
 

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 /// Prefix used for all audit command output
 fn prefix() -> colored::ColoredString {
     let t = theme::current();
-    "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold()
+    theme::fg("nono", t.brand).bold()
 }
 
 /// Dispatch to the appropriate audit subcommand.
@@ -67,11 +67,7 @@ fn cmd_list(args: AuditListArgs) -> Result<()> {
                 "    {} {} {}",
                 s.metadata.session_id,
                 status,
-                cmd.truecolor(
-                    theme::current().subtext.0,
-                    theme::current().subtext.1,
-                    theme::current().subtext.2
-                ),
+                theme::fg(&cmd, theme::current().subtext),
             );
         }
         eprintln!();
@@ -214,10 +210,9 @@ fn cmd_show(args: AuditShowArgs) -> Result<()> {
     );
     eprintln!(
         "  Command:  {}",
-        session.metadata.command.join(" ").truecolor(
-            theme::current().subtext.0,
-            theme::current().subtext.1,
-            theme::current().subtext.2
+        theme::fg(
+            &session.metadata.command.join(" "),
+            theme::current().subtext
         )
     );
     eprintln!("  Started:  {}", session.metadata.started);
@@ -368,11 +363,7 @@ fn session_status_label(s: &SessionInfo) -> colored::ColoredString {
     } else if s.is_stale {
         "orphaned".yellow()
     } else {
-        "completed".truecolor(
-            theme::current().subtext.0,
-            theme::current().subtext.1,
-            theme::current().subtext.2,
-        )
+        theme::fg("completed", theme::current().subtext)
     }
 }
 
@@ -415,11 +406,7 @@ fn change_symbol(ct: &nono::undo::ChangeType) -> colored::ColoredString {
         nono::undo::ChangeType::Created => "+".green(),
         nono::undo::ChangeType::Modified => "~".yellow(),
         nono::undo::ChangeType::Deleted => "-".red(),
-        nono::undo::ChangeType::PermissionsChanged => "p".truecolor(
-            theme::current().subtext.0,
-            theme::current().subtext.1,
-            theme::current().subtext.2,
-        ),
+        nono::undo::ChangeType::PermissionsChanged => theme::fg("p", theme::current().subtext),
     }
 }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -18,6 +18,10 @@ pub struct Cli {
     #[arg(long, short = 's', global = true)]
     pub silent: bool,
 
+    /// Color theme for output (mocha, latte, frappe, macchiato, tokyo-night, minimal)
+    #[arg(long, global = true, env = "NONO_THEME", value_name = "THEME")]
+    pub theme: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/crates/nono-cli/src/config/user.rs
+++ b/crates/nono-cli/src/config/user.rs
@@ -28,6 +28,16 @@ pub struct UserConfig {
     pub rollback: RollbackSettings,
     #[serde(default)]
     pub updates: UpdateSettings,
+    #[serde(default)]
+    pub ui: UiSettings,
+}
+
+/// UI display settings
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct UiSettings {
+    /// Color theme name (mocha, latte, frappe, macchiato, tokyo-night, minimal)
+    #[serde(default)]
+    pub theme: Option<String>,
 }
 
 /// Metadata for user config

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -830,7 +830,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
     if !silent {
         eprintln!("{}", {
             let t = theme::current();
-            "Exit the shell with Ctrl-D or 'exit'.".truecolor(t.subtext.0, t.subtext.1, t.subtext.2)
+            theme::fg("Exit the shell with Ctrl-D or 'exit'.", t.subtext)
         });
         eprintln!();
     }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -23,6 +23,7 @@ mod rollback_ui;
 mod sandbox_state;
 mod setup;
 mod terminal_approval;
+mod theme;
 mod trust_cmd;
 mod trust_intercept;
 mod trust_scan;
@@ -46,6 +47,7 @@ fn main() {
     normalize_legacy_flag_env_vars();
     let cli = Cli::parse();
     init_tracing(&cli);
+    init_theme(&cli);
 
     if let Err(e) = run(cli) {
         error!("{}", e);
@@ -67,6 +69,16 @@ fn copy_legacy_env_var(old: &str, new: &str) {
     if let Some(value) = std::env::var_os(old) {
         std::env::set_var(new, value);
     }
+}
+
+fn init_theme(cli: &Cli) {
+    // Try loading config theme (best-effort, don't fail on config errors)
+    let config_theme = config::user::load_user_config()
+        .ok()
+        .flatten()
+        .and_then(|c| c.ui.theme);
+
+    theme::init(cli.theme.as_deref(), config_theme.as_deref());
 }
 
 fn init_tracing(cli: &Cli) {
@@ -816,10 +828,10 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
     }
 
     if !silent {
-        eprintln!(
-            "{}",
-            "Exit the shell with Ctrl-D or 'exit'.".truecolor(150, 150, 150)
-        );
+        eprintln!("{}", {
+            let t = theme::current();
+            "Exit the shell with Ctrl-D or 'exit'.".truecolor(t.subtext.0, t.subtext.1, t.subtext.2)
+        });
         eprintln!();
     }
 

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -2,7 +2,7 @@
 //!
 //! All colors are drawn from the active theme via `theme::current()`.
 
-use crate::theme::{self, Rgb, badge, fg};
+use crate::theme::{self, badge, fg, Rgb};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
 use std::ffi::{OsStr, OsString};

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -2,7 +2,7 @@
 //!
 //! All colors are drawn from the active theme via `theme::current()`.
 
-use crate::theme::{self, Rgb};
+use crate::theme::{self, Rgb, badge, fg};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
 use std::ffi::{OsStr, OsString};
@@ -13,29 +13,13 @@ use std::path::Path;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Apply an Rgb color to text
-fn fg(s: &str, c: Rgb) -> colored::ColoredString {
-    s.truecolor(c.0, c.1, c.2)
-}
-
-/// Apply an Rgb background + foreground
-fn badge(label: &str, bg: Rgb, fg_color: Rgb) -> String {
-    format!(
-        "{}",
-        label
-            .on_truecolor(bg.0, bg.1, bg.2)
-            .truecolor(fg_color.0, fg_color.1, fg_color.2)
-            .bold()
-    )
-}
-
 /// Dark foreground for badge text (works on both light and dark bg colors)
 const BADGE_FG_DARK: Rgb = Rgb(30, 30, 46);
 
 /// Print a thin horizontal rule using overlay color
 fn rule() {
     let t = theme::current();
-    eprintln!("  {}", fg(&"\u{2500}".repeat(52), t.overlay));
+    eprintln!("  {}", theme::fg(&"\u{2500}".repeat(52), t.overlay));
 }
 
 // ---------------------------------------------------------------------------
@@ -54,8 +38,8 @@ pub fn print_banner(silent: bool) {
     eprintln!();
     eprintln!(
         "  {} {}",
-        fg("nono", t.brand).bold(),
-        fg(&format!("v{version}"), t.subtext),
+        theme::fg("nono", t.brand).bold(),
+        theme::fg(&format!("v{version}"), t.subtext),
     );
 }
 
@@ -101,15 +85,15 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
                 eprintln!(
                     "  {} {} {}",
                     access_badge,
-                    fg(&cap.resolved.display().to_string(), t.text),
-                    fg(&format!("({kind}) [{source_str}]"), t.subtext),
+                    theme::fg(&cap.resolved.display().to_string(), t.text),
+                    theme::fg(&format!("({kind}) [{source_str}]"), t.subtext),
                 );
             } else {
                 eprintln!(
                     "  {} {} {}",
                     access_badge,
-                    fg(&cap.resolved.display().to_string(), t.text),
-                    fg(&format!("({kind})"), t.subtext),
+                    theme::fg(&cap.resolved.display().to_string(), t.text),
+                    theme::fg(&format!("({kind})"), t.subtext),
                 );
             }
         }
@@ -117,7 +101,7 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         if other_count > 0 {
             eprintln!(
                 "       {}",
-                fg(
+                theme::fg(
                     &format!("+ {other_count} system/group paths (-v to show)"),
                     t.subtext
                 )
@@ -130,23 +114,23 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         NetworkMode::Blocked => {
             eprintln!(
                 "  {} {}",
-                badge(" net ", t.red, BADGE_FG_DARK),
-                fg("outbound blocked", t.subtext),
+                theme::badge(" net ", t.red, BADGE_FG_DARK),
+                theme::fg("outbound blocked", t.subtext),
             );
         }
         NetworkMode::ProxyOnly { port, bind_ports } => {
             if bind_ports.is_empty() {
                 eprintln!(
                     "  {} {}",
-                    badge(" net ", t.yellow, BADGE_FG_DARK),
-                    fg(&format!("proxy localhost:{port}"), t.subtext),
+                    theme::badge(" net ", t.yellow, BADGE_FG_DARK),
+                    theme::fg(&format!("proxy localhost:{port}"), t.subtext),
                 );
             } else {
                 let ports_str: Vec<String> = bind_ports.iter().map(|p| p.to_string()).collect();
                 eprintln!(
                     "  {} {}",
-                    badge(" net ", t.yellow, BADGE_FG_DARK),
-                    fg(
+                    theme::badge(" net ", t.yellow, BADGE_FG_DARK),
+                    theme::fg(
                         &format!("proxy localhost:{port}, bind: {}", ports_str.join(", ")),
                         t.subtext,
                     ),
@@ -156,8 +140,8 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         NetworkMode::AllowAll => {
             eprintln!(
                 "  {} {}",
-                badge(" net ", t.green, BADGE_FG_DARK),
-                fg("outbound allowed", t.subtext),
+                theme::badge(" net ", t.green, BADGE_FG_DARK),
+                theme::fg("outbound allowed", t.subtext),
             );
         }
     }
@@ -169,8 +153,8 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             .collect();
         eprintln!(
             "  {} {}",
-            badge(" ipc ", t.teal, BADGE_FG_DARK),
-            fg(&format!("localhost:{}", ports_str.join(", ")), t.subtext,),
+            theme::badge(" ipc ", t.teal, BADGE_FG_DARK),
+            theme::fg(&format!("localhost:{}", ports_str.join(", ")), t.subtext,),
         );
     }
 
@@ -182,9 +166,9 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
 fn format_access_badge(access: &AccessMode) -> String {
     let t = theme::current();
     match access {
-        AccessMode::Read => badge("  r  ", t.green, BADGE_FG_DARK),
-        AccessMode::Write => badge("  w  ", t.yellow, BADGE_FG_DARK),
-        AccessMode::ReadWrite => badge(" r+w ", t.brand, BADGE_FG_DARK),
+        AccessMode::Read => theme::badge("  r  ", t.green, BADGE_FG_DARK),
+        AccessMode::Write => theme::badge("  w  ", t.yellow, BADGE_FG_DARK),
+        AccessMode::ReadWrite => theme::badge(" r+w ", t.brand, BADGE_FG_DARK),
     }
 }
 
@@ -192,9 +176,9 @@ fn format_access_badge(access: &AccessMode) -> String {
 fn format_access_inline(access: &AccessMode) -> colored::ColoredString {
     let t = theme::current();
     match access {
-        AccessMode::Read => fg("read", t.green),
-        AccessMode::Write => fg("write", t.yellow),
-        AccessMode::ReadWrite => fg("read+write", t.brand),
+        AccessMode::Read => theme::fg("read", t.green),
+        AccessMode::Write => theme::fg("write", t.yellow),
+        AccessMode::ReadWrite => theme::fg("read+write", t.brand),
     }
 }
 

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -1,63 +1,69 @@
 //! CLI output styling for nono
+//!
+//! All colors are drawn from the active theme via `theme::current()`.
 
+use crate::theme::{self, Rgb};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
-use rand::prelude::IndexedRandom;
 use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, IsTerminal, Write};
 use std::path::Path;
 
-/// Hedgehog puns for the banner
-const QUOTES: &[&str] = &[
-    "¡Hola Nono!",
-    "Bonjour Nono !",
-    "Hallo Nono!",
-    "Ciao Nono!",
-    "Olá Nono!",
-    "こんにちは、Nono！",
-    "안녕하세요, Nono!",
-    "你好，Nono！",
-    "!مرحبًا نونو",
-    "नमस्ते नोनो!",
-    "Hej Nono!",
-    "Merhaba Nono!",
-    "Halo Nono!",
-    "Xin chào Nono!",
-    "Sawubona Nono!",
-    "Γεια σου Nono!",
-    "Привет, Nono!",
-    "Cześć Nono!",
-    "Shalom Nono!",
-    "Kamusta Nono!",
-];
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-/// Print the nono banner with hedgehog mascot
+/// Apply an Rgb color to text
+fn fg(s: &str, c: Rgb) -> colored::ColoredString {
+    s.truecolor(c.0, c.1, c.2)
+}
+
+/// Apply an Rgb background + foreground
+fn badge(label: &str, bg: Rgb, fg_color: Rgb) -> String {
+    format!(
+        "{}",
+        label
+            .on_truecolor(bg.0, bg.1, bg.2)
+            .truecolor(fg_color.0, fg_color.1, fg_color.2)
+            .bold()
+    )
+}
+
+/// Dark foreground for badge text (works on both light and dark bg colors)
+const BADGE_FG_DARK: Rgb = Rgb(30, 30, 46);
+
+/// Print a thin horizontal rule using overlay color
+fn rule() {
+    let t = theme::current();
+    eprintln!("  {}", fg(&"\u{2500}".repeat(52), t.overlay));
+}
+
+// ---------------------------------------------------------------------------
+// Banner
+// ---------------------------------------------------------------------------
+
+/// Print the nono banner
 pub fn print_banner(silent: bool) {
     if silent {
         return;
     }
 
-    let quote = QUOTES
-        .choose(&mut rand::rng())
-        .unwrap_or(&"The opposite of yolo");
-
+    let t = theme::current();
     let version = env!("CARGO_PKG_VERSION");
 
-    // Hedgehog in brown/tan - 2 lines, compact
-    let hog_line1 = " \u{2584}\u{2588}\u{2584}".truecolor(139, 90, 43); //  ▄█▄ (leading space to center)
-    let hog_line2 = "\u{2580}\u{2584}^\u{2584}\u{2580}".truecolor(139, 90, 43); // ▀▄^▄▀
-
-    // Title in orange
-    let title = "  nono".truecolor(204, 102, 0).bold();
-    let ver = format!("v{}", version).white();
-
     eprintln!();
-    eprintln!(" {} {} {}", hog_line1, title, ver);
-    eprintln!(" {}  - {}", hog_line2, quote.truecolor(150, 150, 150));
-    eprintln!();
+    eprintln!(
+        "  {} {}",
+        fg("nono", t.brand).bold(),
+        fg(&format!("v{version}"), t.subtext),
+    );
 }
 
-/// Print the capability summary with colors
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+/// Print the capability summary
 ///
 /// When `verbose` is 0, only user-specified capabilities are shown (CLI flags
 /// and profile filesystem entries). System paths and group-resolved paths are
@@ -67,16 +73,16 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         return;
     }
 
-    eprintln!("{}", "Capabilities:".white().bold());
+    let t = theme::current();
+
+    rule();
 
     // Filesystem capabilities
     let fs_caps = caps.fs_capabilities();
     if !fs_caps.is_empty() {
         let (user_caps, other_count) = if verbose > 0 {
-            // Show everything with source labels
             (fs_caps.to_vec(), 0)
         } else {
-            // Only show user-specified and profile capabilities
             let user: Vec<_> = fs_caps
                 .iter()
                 .filter(|c| c.source.is_user_intent())
@@ -86,65 +92,73 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             (user, hidden)
         };
 
-        eprintln!("  {}", "Filesystem:".white());
         for cap in &user_caps {
             let kind = if cap.is_file { "file" } else { "dir" };
-            let access_str = cap.access.to_string();
-            let access_colored = match cap.access {
-                AccessMode::Read => access_str.green(),
-                AccessMode::Write => access_str.yellow(),
-                AccessMode::ReadWrite => access_str.truecolor(204, 102, 0), // orange
-            };
+            let access_badge = format_access_badge(&cap.access);
 
             if verbose > 0 {
                 let source_str = format!("{}", cap.source);
                 eprintln!(
-                    "    {} [{}] ({}) [{}]",
-                    cap.resolved.display().to_string().white(),
-                    access_colored,
-                    kind.truecolor(150, 150, 150),
-                    source_str.truecolor(100, 100, 100),
+                    "  {} {} {}",
+                    access_badge,
+                    fg(&cap.resolved.display().to_string(), t.text),
+                    fg(&format!("({kind}) [{source_str}]"), t.subtext),
                 );
             } else {
                 eprintln!(
-                    "    {} [{}] ({})",
-                    cap.resolved.display().to_string().white(),
-                    access_colored,
-                    kind.truecolor(150, 150, 150)
+                    "  {} {} {}",
+                    access_badge,
+                    fg(&cap.resolved.display().to_string(), t.text),
+                    fg(&format!("({kind})"), t.subtext),
                 );
             }
         }
 
         if other_count > 0 {
             eprintln!(
-                "    {}",
-                format!("+ {} system/group paths (use -v to show)", other_count)
-                    .truecolor(100, 100, 100)
+                "       {}",
+                fg(
+                    &format!("+ {other_count} system/group paths (-v to show)"),
+                    t.subtext
+                )
             );
         }
     }
 
     // Network status
-    eprintln!("  {}", "Network:".white());
     match caps.network_mode() {
         NetworkMode::Blocked => {
-            eprintln!("    outbound: {}", "blocked".red());
+            eprintln!(
+                "  {} {}",
+                badge(" net ", t.red, BADGE_FG_DARK),
+                fg("outbound blocked", t.subtext),
+            );
         }
         NetworkMode::ProxyOnly { port, bind_ports } => {
             if bind_ports.is_empty() {
-                eprintln!("    outbound: {} (localhost:{})", "proxy".yellow(), port);
+                eprintln!(
+                    "  {} {}",
+                    badge(" net ", t.yellow, BADGE_FG_DARK),
+                    fg(&format!("proxy localhost:{port}"), t.subtext),
+                );
             } else {
                 let ports_str: Vec<String> = bind_ports.iter().map(|p| p.to_string()).collect();
                 eprintln!(
-                    "    outbound: {} (localhost:{}), bind: {}",
-                    "proxy".yellow(),
-                    port,
-                    ports_str.join(", ")
+                    "  {} {}",
+                    badge(" net ", t.yellow, BADGE_FG_DARK),
+                    fg(
+                        &format!("proxy localhost:{port}, bind: {}", ports_str.join(", ")),
+                        t.subtext,
+                    ),
                 );
             }
         }
         NetworkMode::AllowAll => {
-            eprintln!("    outbound: {}", "allowed".green());
+            eprintln!(
+                "  {} {}",
+                badge(" net ", t.green, BADGE_FG_DARK),
+                fg("outbound allowed", t.subtext),
+            );
         }
     }
     if !caps.localhost_ports().is_empty() {
@@ -153,11 +167,40 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             .iter()
             .map(|p| p.to_string())
             .collect();
-        eprintln!("    localhost IPC: {}", ports_str.join(", ").cyan());
+        eprintln!(
+            "  {} {}",
+            badge(" ipc ", t.teal, BADGE_FG_DARK),
+            fg(&format!("localhost:{}", ports_str.join(", ")), t.subtext,),
+        );
     }
 
+    rule();
     eprintln!();
 }
+
+/// Format an access mode as a fixed-width colored badge
+fn format_access_badge(access: &AccessMode) -> String {
+    let t = theme::current();
+    match access {
+        AccessMode::Read => badge("  r  ", t.green, BADGE_FG_DARK),
+        AccessMode::Write => badge("  w  ", t.yellow, BADGE_FG_DARK),
+        AccessMode::ReadWrite => badge(" r+w ", t.brand, BADGE_FG_DARK),
+    }
+}
+
+/// Format an access mode as inline colored text (for prompts)
+fn format_access_inline(access: &AccessMode) -> colored::ColoredString {
+    let t = theme::current();
+    match access {
+        AccessMode::Read => fg("read", t.green),
+        AccessMode::Write => fg("write", t.yellow),
+        AccessMode::ReadWrite => fg("read+write", t.brand),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kernel / ABI
+// ---------------------------------------------------------------------------
 
 /// Print Landlock ABI information (Linux only).
 ///
@@ -168,18 +211,23 @@ pub fn print_abi_info(silent: bool) {
     if silent {
         return;
     }
+    let t = theme::current();
     match nono::Sandbox::detect_abi() {
         Ok(detected) => {
             let features = detected.feature_names();
             let feature_summary: Vec<&str> = features.iter().skip(1).map(|s| s.as_str()).collect();
             if feature_summary.is_empty() {
-                eprintln!("  {} {}", "Sandbox:".white(), detected.to_string().green(),);
+                eprintln!(
+                    "  {} {}",
+                    badge(" kernel ", t.green, BADGE_FG_DARK),
+                    fg(&detected.to_string(), t.text),
+                );
             } else {
                 eprintln!(
-                    "  {} {} ({})",
-                    "Sandbox:".white(),
-                    detected.to_string().green(),
-                    feature_summary.join(", ").truecolor(150, 150, 150),
+                    "  {} {} {}",
+                    badge(" kernel ", t.green, BADGE_FG_DARK),
+                    fg(&detected.to_string(), t.text),
+                    fg(&format!("({})", feature_summary.join(", ")), t.subtext,),
                 );
             }
 
@@ -200,42 +248,50 @@ pub fn print_abi_info(silent: bool) {
                 .collect();
             if !missing.is_empty() {
                 eprintln!(
-                    "  {}",
-                    format!(
-                        "Degraded: {} (upgrade kernel for full support)",
-                        missing.join(", ")
-                    )
-                    .truecolor(180, 150, 50),
+                    "          {}",
+                    fg(
+                        &format!(
+                            "degraded: {} (upgrade kernel for full support)",
+                            missing.join(", "),
+                        ),
+                        t.yellow,
+                    ),
                 );
             }
         }
         Err(e) => {
             eprintln!(
                 "  {} {}",
-                "Sandbox:".white(),
-                format!("Landlock detection failed: {}", e).red(),
+                badge(" kernel ", t.red, BADGE_FG_DARK),
+                fg(&format!("Landlock detection failed: {e}"), t.red),
             );
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Status messages
+// ---------------------------------------------------------------------------
 
 /// Print supervised mode status
 pub fn print_supervised_info(silent: bool, rollback: bool, proxy_active: bool) {
     if silent {
         return;
     }
-    let detail = match (rollback, proxy_active) {
-        (true, true) => "rollback snapshots + network proxy + supervisor",
-        (true, false) => "rollback snapshots + supervisor",
-        (false, true) => "network proxy + supervisor",
-        (false, false) => "supervisor",
-    };
+    let t = theme::current();
+    let mut features = Vec::new();
+    if rollback {
+        features.push("snapshots");
+    }
+    if proxy_active {
+        features.push("proxy");
+    }
+    features.push("supervisor");
     eprintln!(
-        "{}",
-        format!("Supervised mode: child sandboxed, parent manages {detail}.")
-            .truecolor(150, 150, 150)
+        "  {} {}",
+        fg("mode", t.subtext),
+        fg(&format!("supervised ({})", features.join(", ")), t.subtext),
     );
-    eprintln!();
 }
 
 /// Print status message for applying sandbox
@@ -243,10 +299,10 @@ pub fn print_applying_sandbox(silent: bool) {
     if silent {
         return;
     }
-    eprintln!(
-        "{}",
-        "Applying Kernel sandbox protections.".truecolor(150, 150, 150)
-    );
+    let t = theme::current();
+    eprint!("  {}", fg("Applying sandbox...", t.subtext));
+    // Flush so it appears immediately (no newline yet)
+    std::io::stderr().flush().ok();
 }
 
 /// Print success message when sandbox is active
@@ -254,10 +310,9 @@ pub fn print_sandbox_active(silent: bool) {
     if silent {
         return;
     }
-    eprintln!(
-        "{}",
-        "Sandbox active. Restrictions are now in effect.".green()
-    );
+    let t = theme::current();
+    // Complete the "Applying sandbox..." line
+    eprintln!(" {}", fg("active", t.green).bold());
     eprintln!();
 }
 
@@ -266,6 +321,7 @@ pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
     if silent {
         return;
     }
+    let t = theme::current();
     let mut command = Vec::with_capacity(1 + cmd_args.len());
     command.push(program.to_string_lossy().into_owned());
     command.extend(
@@ -275,40 +331,44 @@ pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
     );
 
     eprintln!(
-        "{}",
-        "Dry run mode - sandbox would be applied with above capabilities".yellow()
+        "  {} {}",
+        fg("dry-run", t.yellow).bold(),
+        fg(
+            "sandbox would be applied with above capabilities",
+            t.subtext,
+        ),
     );
-    eprintln!("Command: {:?}", command);
+    eprintln!(
+        "  {} {}",
+        fg("$", t.subtext),
+        fg(&command.join(" "), t.text)
+    );
 }
+
+// ---------------------------------------------------------------------------
+// Rollback / Snapshots
+// ---------------------------------------------------------------------------
 
 /// Print rollback tracking status during session start
 pub fn print_rollback_tracking(paths: &[std::path::PathBuf], silent: bool) {
     if silent {
         return;
     }
-    eprintln!("{}", "Rollback snapshots enabled.".truecolor(150, 150, 150));
-    if paths.len() <= 3 {
-        for path in paths {
-            eprintln!(
-                "  {} {}",
-                "tracking:".truecolor(100, 100, 100),
-                path.display().to_string().white()
-            );
-        }
-    } else {
-        for path in &paths[..2] {
-            eprintln!(
-                "  {} {}",
-                "tracking:".truecolor(100, 100, 100),
-                path.display().to_string().white()
-            );
-        }
+    let t = theme::current();
+    let display_paths = if paths.len() <= 3 { paths } else { &paths[..2] };
+    for path in display_paths {
         eprintln!(
-            "  {}",
-            format!("+ {} more paths", paths.len() - 2).truecolor(100, 100, 100)
+            "  {} {}",
+            badge(" snap ", t.surface, t.subtext),
+            fg(&path.display().to_string(), t.subtext),
         );
     }
-    eprintln!();
+    if paths.len() > 3 {
+        eprintln!(
+            "         {}",
+            fg(&format!("+ {} more paths", paths.len() - 2), t.subtext),
+        );
+    }
 }
 
 /// Print post-exit summary of changes detected by the rollback system
@@ -316,6 +376,8 @@ pub fn print_rollback_session_summary(changes: &[nono::undo::Change], silent: bo
     if silent || changes.is_empty() {
         return;
     }
+
+    let t = theme::current();
 
     let created = changes
         .iter()
@@ -332,23 +394,27 @@ pub fn print_rollback_session_summary(changes: &[nono::undo::Change], silent: bo
 
     let mut parts = Vec::new();
     if created > 0 {
-        parts.push(format!("{created} created"));
+        parts.push(format!("{}", fg(&format!("{created} created"), t.green)));
     }
     if modified > 0 {
-        parts.push(format!("{modified} modified"));
+        parts.push(format!("{}", fg(&format!("{modified} modified"), t.yellow)));
     }
     if deleted > 0 {
-        parts.push(format!("{deleted} deleted"));
+        parts.push(format!("{}", fg(&format!("{deleted} deleted"), t.red)));
     }
 
     eprintln!();
     eprintln!(
-        "{} {} files changed. ({})",
-        "[nono]".truecolor(204, 102, 0),
+        "  {} {} files changed ({})",
+        fg("nono", t.brand).bold(),
         changes.len(),
-        parts.join(", ")
+        parts.join(", "),
     );
 }
+
+// ---------------------------------------------------------------------------
+// Update notification
+// ---------------------------------------------------------------------------
 
 /// Detect how nono was installed based on the binary's path.
 fn detect_install_command() -> &'static str {
@@ -418,61 +484,62 @@ pub fn print_update_notification(info: &crate::update_check::UpdateInfo, silent:
         return;
     }
 
+    let t = theme::current();
     let version = sanitize_terminal_output(&info.latest_version);
+    let install_cmd = detect_install_command();
     eprintln!(
-        "  {} nono {} is available (current: {})",
-        "Update:".yellow().bold(),
-        version.green(),
-        env!("CARGO_PKG_VERSION"),
+        "  {} {} {} {}",
+        fg("update", t.yellow).bold(),
+        fg(&version, t.green).bold(),
+        fg("available", t.subtext),
+        fg(
+            &format!("(current: {})", env!("CARGO_PKG_VERSION")),
+            t.subtext,
+        ),
     );
     if let Some(ref msg) = info.message {
         let safe_msg = sanitize_terminal_output(msg);
-        eprintln!("  {}", safe_msg.truecolor(150, 150, 150));
+        eprintln!("  {}", fg(&safe_msg, t.subtext));
     }
-    let install_cmd = detect_install_command();
-    eprintln!(
-        "  {}",
-        format!("Run: {install_cmd}").truecolor(150, 150, 150)
-    );
+    eprintln!("  {} {}", fg("$", t.subtext), fg(install_cmd, t.text));
     if let Some(ref url) = info.release_url {
         let safe_url = sanitize_terminal_output(url);
-        eprintln!("  {}", safe_url.truecolor(100, 100, 100));
+        eprintln!("  {}", fg(&safe_url, t.blue));
     }
     eprintln!();
 }
+
+// ---------------------------------------------------------------------------
+// Interactive prompts
+// ---------------------------------------------------------------------------
 
 /// Prompt the user to confirm sharing the current working directory.
 ///
 /// Returns `Ok(true)` if user confirms, `Ok(false)` if user declines.
 /// Returns `Ok(false)` with a hint if stdin is not a TTY.
 pub fn prompt_cwd_sharing(cwd: &Path, access: &AccessMode) -> Result<bool> {
+    let t = theme::current();
     let stdin = std::io::stdin();
     if !stdin.is_terminal() {
         eprintln!(
-            "{}",
-            "Skipping CWD prompt (non-interactive). Use --allow-cwd to include working directory."
-                .truecolor(150, 150, 150),
+            "  {}",
+            fg(
+                "Skipping CWD prompt (non-interactive). Use --allow-cwd to include working directory.",
+                t.subtext,
+            ),
         );
         return Ok(false);
     }
 
-    let access_str = access.to_string();
-    let access_colored = match access {
-        AccessMode::Read => access_str.green(),
-        AccessMode::Write => access_str.yellow(),
-        AccessMode::ReadWrite => access_str.truecolor(204, 102, 0),
-    };
+    let access_colored = format_access_inline(access);
 
     eprintln!(
-        "Current directory '{}' will be shared with {} access.",
-        cwd.display().to_string().white().bold(),
+        "  Share {} with {} access?",
+        fg(&cwd.display().to_string(), t.text).bold(),
         access_colored,
     );
-    eprintln!(
-        "{}",
-        "tip: use --allow-cwd to skip this prompt".truecolor(150, 150, 150),
-    );
-    eprint!("  {} ", "Proceed? [y/N]:".white());
+    eprintln!("  {}", fg("use --allow-cwd to skip this prompt", t.subtext),);
+    eprint!("  {} ", fg("[y/N]", t.text).bold());
     std::io::stderr().flush().ok();
 
     let mut input = String::new();

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -11,6 +11,7 @@ use crate::rollback_base_exclusions;
 use crate::rollback_session::{
     discover_sessions, format_bytes, load_session, remove_session, rollback_root, SessionInfo,
 };
+use crate::theme;
 use colored::Colorize;
 use nono::undo::{MerkleTree, ObjectStore, SnapshotManager};
 use nono::{NonoError, Result};
@@ -55,7 +56,8 @@ fn canonical_candidates(path: &Path) -> Vec<PathBuf> {
 
 /// Prefix used for all rollback command output
 fn prefix() -> colored::ColoredString {
-    "[nono]".truecolor(204, 102, 0)
+    let t = theme::current();
+    "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold()
 }
 
 /// Dispatch to the appropriate rollback subcommand.
@@ -206,7 +208,11 @@ fn print_session_line(s: &SessionInfo, created: usize, modified: usize, deleted:
         "    {}  {}  {}  {}",
         s.metadata.session_id.white().bold(),
         timestamp.truecolor(100, 100, 100),
-        cmd_name.truecolor(150, 150, 150),
+        cmd_name.truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2
+        ),
         change_summary,
     );
 }
@@ -309,7 +315,11 @@ fn cmd_show(args: RollbackShowArgs) -> Result<()> {
         "{} Session {} ({})\n",
         prefix(),
         session.metadata.session_id.white().bold(),
-        session.metadata.command.join(" ").truecolor(150, 150, 150)
+        session.metadata.command.join(" ").truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2
+        )
     );
 
     if args.diff {
@@ -871,8 +881,16 @@ fn cmd_cleanup(args: RollbackCleanupArgs) -> Result<()> {
             eprintln!(
                 "  {} {} ({})",
                 s.metadata.session_id,
-                s.metadata.command.join(" ").truecolor(150, 150, 150),
-                format_bytes(s.disk_size).truecolor(150, 150, 150),
+                s.metadata.command.join(" ").truecolor(
+                    theme::current().subtext.0,
+                    theme::current().subtext.1,
+                    theme::current().subtext.2
+                ),
+                format_bytes(s.disk_size).truecolor(
+                    theme::current().subtext.0,
+                    theme::current().subtext.1,
+                    theme::current().subtext.2
+                ),
             );
         }
         return Ok(());
@@ -1044,7 +1062,11 @@ fn change_symbol(ct: &nono::undo::ChangeType) -> colored::ColoredString {
         nono::undo::ChangeType::Created => "+".green(),
         nono::undo::ChangeType::Modified => "~".yellow(),
         nono::undo::ChangeType::Deleted => "-".red(),
-        nono::undo::ChangeType::PermissionsChanged => "p".truecolor(150, 150, 150),
+        nono::undo::ChangeType::PermissionsChanged => "p".truecolor(
+            theme::current().subtext.0,
+            theme::current().subtext.1,
+            theme::current().subtext.2,
+        ),
     }
 }
 

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -57,7 +57,7 @@ fn canonical_candidates(path: &Path) -> Vec<PathBuf> {
 /// Prefix used for all rollback command output
 fn prefix() -> colored::ColoredString {
     let t = theme::current();
-    "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold()
+    theme::fg("nono", t.brand).bold()
 }
 
 /// Dispatch to the appropriate rollback subcommand.
@@ -208,11 +208,7 @@ fn print_session_line(s: &SessionInfo, created: usize, modified: usize, deleted:
         "    {}  {}  {}  {}",
         s.metadata.session_id.white().bold(),
         timestamp.truecolor(100, 100, 100),
-        cmd_name.truecolor(
-            theme::current().subtext.0,
-            theme::current().subtext.1,
-            theme::current().subtext.2
-        ),
+        theme::fg(&cmd_name, theme::current().subtext),
         change_summary,
     );
 }
@@ -315,10 +311,9 @@ fn cmd_show(args: RollbackShowArgs) -> Result<()> {
         "{} Session {} ({})\n",
         prefix(),
         session.metadata.session_id.white().bold(),
-        session.metadata.command.join(" ").truecolor(
-            theme::current().subtext.0,
-            theme::current().subtext.1,
-            theme::current().subtext.2
+        theme::fg(
+            &session.metadata.command.join(" "),
+            theme::current().subtext
         )
     );
 

--- a/crates/nono-cli/src/rollback_ui.rs
+++ b/crates/nono-cli/src/rollback_ui.rs
@@ -28,8 +28,8 @@ pub fn review_and_restore(
 
     eprint!(
         "{} {}",
-        "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
-        "Restore to initial state? [y/N]: ".truecolor(t.text.0, t.text.1, t.text.2)
+        theme::fg("nono", t.brand).bold(),
+        theme::fg("Restore to initial state? [y/N]: ", t.text)
     );
     std::io::stderr().flush().ok();
 
@@ -43,23 +43,23 @@ pub fn review_and_restore(
     if answer == "y" || answer == "yes" {
         eprintln!(
             "{} {}",
-            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
-            "Restoring...".truecolor(t.text.0, t.text.1, t.text.2)
+            theme::fg("nono", t.brand).bold(),
+            theme::fg("Restoring...", t.text)
         );
 
         let applied = manager.restore_to(baseline)?;
 
         eprintln!(
             "{} Restored {} files.",
-            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
+            theme::fg("nono", t.brand).bold(),
             applied.len()
         );
         Ok(true)
     } else {
         eprintln!(
             "{} {}",
-            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
-            "Exiting without restoring.".truecolor(t.subtext.0, t.subtext.1, t.subtext.2)
+            theme::fg("nono", t.brand).bold(),
+            theme::fg("Exiting without restoring.", t.subtext)
         );
         Ok(false)
     }
@@ -70,16 +70,16 @@ fn print_change_details(changes: &[Change]) {
     let t = theme::current();
     eprintln!(
         "{} {}",
-        "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
-        "Changes:".truecolor(t.text.0, t.text.1, t.text.2).bold()
+        theme::fg("nono", t.brand).bold(),
+        theme::fg("Changes:", t.text).bold()
     );
 
     for change in changes {
         let symbol = match change.change_type {
-            ChangeType::Created => "+".truecolor(t.green.0, t.green.1, t.green.2),
-            ChangeType::Modified => "~".truecolor(t.yellow.0, t.yellow.1, t.yellow.2),
-            ChangeType::Deleted => "-".truecolor(t.red.0, t.red.1, t.red.2),
-            ChangeType::PermissionsChanged => "p".truecolor(t.subtext.0, t.subtext.1, t.subtext.2),
+            ChangeType::Created => theme::fg("+", t.green),
+            ChangeType::Modified => theme::fg("~", t.yellow),
+            ChangeType::Deleted => theme::fg("-", t.red),
+            ChangeType::PermissionsChanged => theme::fg("p", t.subtext),
         };
 
         let label = match change.change_type {
@@ -102,8 +102,8 @@ fn print_change_details(changes: &[Change]) {
             "  {} {} ({}){}",
             symbol,
             change.path.display(),
-            label.truecolor(t.subtext.0, t.subtext.1, t.subtext.2),
-            size_info.truecolor(t.overlay.0, t.overlay.1, t.overlay.2)
+            theme::fg(label, t.subtext),
+            theme::fg(&size_info, t.overlay)
         );
     }
     eprintln!();

--- a/crates/nono-cli/src/rollback_ui.rs
+++ b/crates/nono-cli/src/rollback_ui.rs
@@ -3,6 +3,7 @@
 //! Presents the user with a summary of changes made during the session
 //! and offers to restore to the initial state.
 
+use crate::theme;
 use colored::Colorize;
 use nono::undo::{Change, ChangeType, SnapshotManager, SnapshotManifest};
 use nono::Result;
@@ -17,6 +18,7 @@ pub fn review_and_restore(
     baseline: &SnapshotManifest,
     changes: &[Change],
 ) -> Result<bool> {
+    let t = theme::current();
     let stdin = std::io::stdin();
     if !stdin.is_terminal() {
         return Ok(false);
@@ -26,8 +28,8 @@ pub fn review_and_restore(
 
     eprint!(
         "{} {}",
-        "[nono]".truecolor(204, 102, 0),
-        "Restore to initial state? [y/N]: ".white()
+        "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
+        "Restore to initial state? [y/N]: ".truecolor(t.text.0, t.text.1, t.text.2)
     );
     std::io::stderr().flush().ok();
 
@@ -41,23 +43,23 @@ pub fn review_and_restore(
     if answer == "y" || answer == "yes" {
         eprintln!(
             "{} {}",
-            "[nono]".truecolor(204, 102, 0),
-            "Restoring...".white()
+            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
+            "Restoring...".truecolor(t.text.0, t.text.1, t.text.2)
         );
 
         let applied = manager.restore_to(baseline)?;
 
         eprintln!(
             "{} Restored {} files.",
-            "[nono]".truecolor(204, 102, 0),
+            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
             applied.len()
         );
         Ok(true)
     } else {
         eprintln!(
             "{} {}",
-            "[nono]".truecolor(204, 102, 0),
-            "Exiting without restoring.".truecolor(150, 150, 150)
+            "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
+            "Exiting without restoring.".truecolor(t.subtext.0, t.subtext.1, t.subtext.2)
         );
         Ok(false)
     }
@@ -65,18 +67,19 @@ pub fn review_and_restore(
 
 /// Print details of each change
 fn print_change_details(changes: &[Change]) {
+    let t = theme::current();
     eprintln!(
         "{} {}",
-        "[nono]".truecolor(204, 102, 0),
-        "Changes:".white().bold()
+        "nono".truecolor(t.brand.0, t.brand.1, t.brand.2).bold(),
+        "Changes:".truecolor(t.text.0, t.text.1, t.text.2).bold()
     );
 
     for change in changes {
         let symbol = match change.change_type {
-            ChangeType::Created => "+".green(),
-            ChangeType::Modified => "~".yellow(),
-            ChangeType::Deleted => "-".red(),
-            ChangeType::PermissionsChanged => "p".truecolor(150, 150, 150),
+            ChangeType::Created => "+".truecolor(t.green.0, t.green.1, t.green.2),
+            ChangeType::Modified => "~".truecolor(t.yellow.0, t.yellow.1, t.yellow.2),
+            ChangeType::Deleted => "-".truecolor(t.red.0, t.red.1, t.red.2),
+            ChangeType::PermissionsChanged => "p".truecolor(t.subtext.0, t.subtext.1, t.subtext.2),
         };
 
         let label = match change.change_type {
@@ -99,8 +102,8 @@ fn print_change_details(changes: &[Change]) {
             "  {} {} ({}){}",
             symbol,
             change.path.display(),
-            label.truecolor(150, 150, 150),
-            size_info.truecolor(100, 100, 100)
+            label.truecolor(t.subtext.0, t.subtext.1, t.subtext.2),
+            size_info.truecolor(t.overlay.0, t.overlay.1, t.overlay.2)
         );
     }
     eprintln!();

--- a/crates/nono-cli/src/theme.rs
+++ b/crates/nono-cli/src/theme.rs
@@ -1,0 +1,271 @@
+//! Theme system for nono CLI output
+//!
+//! Provides named color themes inspired by Catppuccin and other popular
+//! terminal palettes. Users select a theme via `--theme`, `NONO_THEME`
+//! env var, or `[ui] theme = "..."` in config.toml.
+
+use std::sync::OnceLock;
+
+/// RGB color tuple
+#[derive(Debug, Clone, Copy)]
+pub struct Rgb(pub u8, pub u8, pub u8);
+
+/// A complete color theme for CLI output
+#[derive(Debug, Clone)]
+pub struct Theme {
+    /// Theme display name
+    pub name: &'static str,
+
+    // -- Brand --
+    /// Primary brand accent (nono orange in default themes)
+    pub brand: Rgb,
+
+    // -- Semantic colors --
+    /// Success / read access / positive states
+    pub green: Rgb,
+    /// Warning / write access / caution states
+    pub yellow: Rgb,
+    /// Error / denied / destructive states
+    pub red: Rgb,
+    /// Network / informational highlights
+    pub blue: Rgb,
+    /// IPC / secondary informational
+    pub teal: Rgb,
+
+    // -- Surface colors --
+    /// Primary text (paths, values)
+    pub text: Rgb,
+    /// Secondary / muted text (labels, metadata)
+    pub subtext: Rgb,
+    /// Dim elements (borders, rules, separators)
+    pub overlay: Rgb,
+    /// Very dim elements (badge backgrounds for subtle items)
+    pub surface: Rgb,
+}
+
+// ---------------------------------------------------------------------------
+// Built-in themes
+// ---------------------------------------------------------------------------
+
+/// Catppuccin Mocha (dark) - warm and rich
+pub const MOCHA: Theme = Theme {
+    name: "mocha",
+    brand: Rgb(250, 179, 135),   // Peach
+    green: Rgb(166, 218, 149),   // Green
+    yellow: Rgb(249, 226, 175),  // Yellow
+    red: Rgb(243, 139, 168),     // Red
+    blue: Rgb(137, 180, 250),    // Blue
+    teal: Rgb(148, 226, 213),    // Teal
+    text: Rgb(205, 214, 244),    // Text
+    subtext: Rgb(147, 153, 178), // Subtext0
+    overlay: Rgb(108, 112, 134), // Overlay0
+    surface: Rgb(69, 71, 90),    // Surface1
+};
+
+/// Catppuccin Latte (light) - clean and bright
+pub const LATTE: Theme = Theme {
+    name: "latte",
+    brand: Rgb(254, 100, 11),    // Peach
+    green: Rgb(64, 160, 43),     // Green
+    yellow: Rgb(223, 142, 29),   // Yellow
+    red: Rgb(210, 15, 57),       // Red
+    blue: Rgb(30, 102, 245),     // Blue
+    teal: Rgb(23, 146, 153),     // Teal
+    text: Rgb(76, 79, 105),      // Text
+    subtext: Rgb(108, 111, 133), // Subtext0
+    overlay: Rgb(140, 143, 161), // Overlay0
+    surface: Rgb(188, 192, 204), // Surface1
+};
+
+/// Catppuccin Frappe (medium dark) - muted and sophisticated
+pub const FRAPPE: Theme = Theme {
+    name: "frappe",
+    brand: Rgb(239, 159, 118),   // Peach
+    green: Rgb(166, 209, 137),   // Green
+    yellow: Rgb(229, 200, 144),  // Yellow
+    red: Rgb(231, 130, 132),     // Red
+    blue: Rgb(140, 170, 238),    // Blue
+    teal: Rgb(129, 200, 190),    // Teal
+    text: Rgb(198, 208, 245),    // Text
+    subtext: Rgb(148, 156, 187), // Subtext0
+    overlay: Rgb(115, 121, 148), // Overlay0
+    surface: Rgb(65, 69, 89),    // Surface1
+};
+
+/// Catppuccin Macchiato (dark) - deep and vivid
+pub const MACCHIATO: Theme = Theme {
+    name: "macchiato",
+    brand: Rgb(245, 169, 127),   // Peach
+    green: Rgb(166, 218, 149),   // Green (same as mocha)
+    yellow: Rgb(238, 212, 159),  // Yellow
+    red: Rgb(237, 135, 150),     // Red
+    blue: Rgb(138, 173, 244),    // Blue
+    teal: Rgb(139, 213, 202),    // Teal
+    text: Rgb(202, 211, 245),    // Text
+    subtext: Rgb(148, 155, 187), // Subtext0
+    overlay: Rgb(110, 115, 141), // Overlay0
+    surface: Rgb(54, 58, 79),    // Surface1
+};
+
+/// Tokyo Night - cool blues and purples
+pub const TOKYO_NIGHT: Theme = Theme {
+    name: "tokyo-night",
+    brand: Rgb(255, 158, 100),   // Orange
+    green: Rgb(158, 206, 106),   // Green
+    yellow: Rgb(224, 175, 104),  // Yellow
+    red: Rgb(247, 118, 142),     // Red
+    blue: Rgb(122, 162, 247),    // Blue
+    teal: Rgb(115, 218, 202),    // Teal
+    text: Rgb(192, 202, 245),    // Foreground
+    subtext: Rgb(134, 150, 187), // Comment-ish
+    overlay: Rgb(86, 95, 137),   // LineNr
+    surface: Rgb(52, 59, 88),    // Surface
+};
+
+/// Minimal - plain ANSI-friendly grayscale with orange accent
+pub const MINIMAL: Theme = Theme {
+    name: "minimal",
+    brand: Rgb(204, 102, 0), // Classic nono orange
+    green: Rgb(80, 200, 80),
+    yellow: Rgb(220, 180, 50),
+    red: Rgb(220, 70, 70),
+    blue: Rgb(80, 150, 220),
+    teal: Rgb(80, 190, 190),
+    text: Rgb(220, 220, 220),
+    subtext: Rgb(140, 140, 140),
+    overlay: Rgb(80, 80, 80),
+    surface: Rgb(55, 55, 55),
+};
+
+// ---------------------------------------------------------------------------
+// Global theme state
+// ---------------------------------------------------------------------------
+
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+/// Initialize the global theme. Call once at startup.
+///
+/// Resolution order: CLI flag > env var > config file > default (mocha).
+pub fn init(cli_theme: Option<&str>, config_theme: Option<&str>) {
+    let chosen = if let Some(t) = cli_theme {
+        t
+    } else if let Ok(val) = std::env::var("NONO_THEME") {
+        // Leak the string so we get a &'static str - this runs once at startup
+        Box::leak(val.into_boxed_str())
+    } else {
+        config_theme.unwrap_or("mocha")
+    };
+
+    if !is_valid(chosen) {
+        tracing::warn!(
+            "unknown theme '{}', using mocha. available: {}",
+            chosen,
+            available_themes().join(", "),
+        );
+    }
+
+    let theme = resolve(chosen);
+    tracing::debug!("theme: {}", theme.name);
+    // Ignore error if already set (shouldn't happen)
+    let _ = THEME.set(theme);
+}
+
+/// Get the current theme. Falls back to Mocha if not initialized.
+pub fn current() -> &'static Theme {
+    THEME.get().unwrap_or(&MOCHA)
+}
+
+/// Resolve a theme name to a Theme value
+fn resolve(name: &str) -> Theme {
+    match name.to_lowercase().as_str() {
+        "mocha" | "catppuccin-mocha" | "catppuccin" => MOCHA,
+        "latte" | "catppuccin-latte" => LATTE,
+        "frappe" | "catppuccin-frappe" => FRAPPE,
+        "macchiato" | "catppuccin-macchiato" => MACCHIATO,
+        "tokyo-night" | "tokyo" | "tokyonight" => TOKYO_NIGHT,
+        "minimal" | "plain" => MINIMAL,
+        _ => MOCHA,
+    }
+}
+
+/// List available theme names
+pub fn available_themes() -> &'static [&'static str] {
+    &[
+        "mocha",
+        "latte",
+        "frappe",
+        "macchiato",
+        "tokyo-night",
+        "minimal",
+    ]
+}
+
+/// Check whether a theme name is recognized
+pub fn is_valid(name: &str) -> bool {
+    resolve(name).name != "mocha"
+        || name.to_lowercase() == "mocha"
+        || name.to_lowercase() == "catppuccin"
+        || name.to_lowercase() == "catppuccin-mocha"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_known_themes() {
+        assert_eq!(resolve("mocha").name, "mocha");
+        assert_eq!(resolve("latte").name, "latte");
+        assert_eq!(resolve("frappe").name, "frappe");
+        assert_eq!(resolve("macchiato").name, "macchiato");
+        assert_eq!(resolve("tokyo-night").name, "tokyo-night");
+        assert_eq!(resolve("minimal").name, "minimal");
+    }
+
+    #[test]
+    fn test_resolve_aliases() {
+        assert_eq!(resolve("catppuccin").name, "mocha");
+        assert_eq!(resolve("catppuccin-latte").name, "latte");
+        assert_eq!(resolve("tokyo").name, "tokyo-night");
+        assert_eq!(resolve("plain").name, "minimal");
+    }
+
+    #[test]
+    fn test_resolve_unknown_falls_back() {
+        assert_eq!(resolve("nonexistent").name, "mocha");
+    }
+
+    #[test]
+    fn test_current_before_init() {
+        // Should return mocha as default
+        assert_eq!(current().name, "mocha");
+    }
+
+    #[test]
+    fn test_available_themes_not_empty() {
+        let themes = available_themes();
+        assert!(!themes.is_empty());
+        // Every listed theme should resolve to a theme with a matching name
+        for name in themes {
+            let t = resolve(name);
+            assert_eq!(t.name, *name);
+        }
+    }
+
+    #[test]
+    fn test_all_color_slots_used() {
+        // Verify all theme fields are accessible (catches dead code)
+        let t = &MOCHA;
+        let _brand = t.brand;
+        let _green = t.green;
+        let _yellow = t.yellow;
+        let _red = t.red;
+        let _blue = t.blue;
+        let _teal = t.teal;
+        let _text = t.text;
+        let _subtext = t.subtext;
+        let _overlay = t.overlay;
+        let _surface = t.surface;
+        assert!(!t.name.is_empty());
+    }
+}

--- a/crates/nono-cli/src/theme.rs
+++ b/crates/nono-cli/src/theme.rs
@@ -4,11 +4,28 @@
 //! terminal palettes. Users select a theme via `--theme`, `NONO_THEME`
 //! env var, or `[ui] theme = "..."` in config.toml.
 
+use colored::Colorize;
 use std::sync::OnceLock;
 
 /// RGB color tuple
 #[derive(Debug, Clone, Copy)]
 pub struct Rgb(pub u8, pub u8, pub u8);
+
+/// Apply an Rgb color to text.
+pub fn fg(s: &str, c: Rgb) -> colored::ColoredString {
+    s.truecolor(c.0, c.1, c.2)
+}
+
+/// Apply an Rgb background + foreground.
+pub fn badge(label: &str, bg: Rgb, fg_color: Rgb) -> String {
+    format!(
+        "{}",
+        label
+            .on_truecolor(bg.0, bg.1, bg.2)
+            .truecolor(fg_color.0, fg_color.1, fg_color.2)
+            .bold()
+    )
+}
 
 /// A complete color theme for CLI output
 #[derive(Debug, Clone)]
@@ -202,10 +219,23 @@ pub fn available_themes() -> &'static [&'static str] {
 
 /// Check whether a theme name is recognized
 pub fn is_valid(name: &str) -> bool {
-    resolve(name).name != "mocha"
-        || name.to_lowercase() == "mocha"
-        || name.to_lowercase() == "catppuccin"
-        || name.to_lowercase() == "catppuccin-mocha"
+    matches!(
+        name.to_lowercase().as_str(),
+        "mocha"
+            | "catppuccin-mocha"
+            | "catppuccin"
+            | "latte"
+            | "catppuccin-latte"
+            | "frappe"
+            | "catppuccin-frappe"
+            | "macchiato"
+            | "catppuccin-macchiato"
+            | "tokyo-night"
+            | "tokyo"
+            | "tokyonight"
+            | "minimal"
+            | "plain"
+    )
 }
 
 #[cfg(test)]

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -18,6 +18,39 @@ nono -s run --allow-cwd -- my-agent
 nono --silent why --path ~/.ssh/id_rsa --op read
 ```
 
+### `--theme`
+
+Select the CLI color theme for banners, summaries, warnings, and other styled output.
+
+Available themes:
+- `mocha`
+- `latte`
+- `frappe`
+- `macchiato`
+- `tokyo-night`
+- `minimal`
+
+Resolution order:
+- `--theme <NAME>`
+- `NONO_THEME`
+- `[ui] theme = "<NAME>"` in `~/.config/nono/config.toml`
+- default: `mocha`
+
+```bash
+# Per invocation
+nono --theme tokyo-night run --allow-cwd -- claude
+
+# Via environment variable
+NONO_THEME=latte nono run --allow-cwd -- codex
+
+# Config file
+# ~/.config/nono/config.toml
+# [ui]
+# theme = "frappe"
+```
+
+If an unknown theme is supplied, nono falls back to `mocha`.
+
 ## Commands
 
 ### `nono run`


### PR DESCRIPTION
Implement a comprehensive theming system for nono CLI output with user-selectable
color schemes. Introduces new `theme` module with 6 built-in themes (Catppuccin
Mocha/Latte/Frappe/Macchiato, Tokyo Night, Minimal) and refactors all colored
output to use theme colors instead of hardcoded RGB values.

Features:
- Theme selection via `--theme` flag, `NONO_THEME` env var, or `[ui] theme`
  config setting (resolution order: CLI > env > config > default mocha)
- New `theme::Rgb` type and `Theme` struct with semantic color slots (brand,
  green/yellow/red/blue/teal, text/subtext/overlay/surface)
- Centralized `theme::current()` for all output modules to query active theme
- Refactored output.rs, audit_commands.rs, rollback_commands.rs, rollback_ui.rs
  to use theme colors; removed hardcoded RGB tuples
- Helper functions: `fg()` for foreground, `badge()` for fixed-width colored badges
- Added theme validation and alias support (e.g., "catppuccin" → mocha, "tokyo" →
  tokyo-night)
- README documentation with theme table and usage examples
- Theme tests: resolve, aliases, fallback, color slot coverage

Theme initialization added to main() before subcommand dispatch. All audit,
rollback, and interactive prompts now respect user theme preference.

Signed-off-by: Luke Hinds <lukehinds@gmail.com>