### PR TITLE
feat(policy): deprecate security.trust_groups in favor of policy.exclude_groups

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -590,7 +590,6 @@
         "groups": [],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {},
       "network": { "block": false },
       "workdir": { "access": "none" },
@@ -621,7 +620,6 @@
         "signal_mode": "isolated",
         "capability_elevation": false
       },
-      "trust_groups": [],
       "filesystem": {
         "allow": ["$HOME/.claude"],
         "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"],
@@ -669,7 +667,6 @@
         "signal_mode": "isolated",
         "capability_elevation": false
       },
-      "trust_groups": [],
       "filesystem": {
         "allow": ["$HOME/.codex"]
       },
@@ -696,7 +693,6 @@
         "groups": ["node_runtime"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {
         "allow": [
           "$HOME/.openclaw",
@@ -724,7 +720,6 @@
         "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "unlink_protection"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {
         "allow": [
           "$HOME/.config/opencode",
@@ -752,7 +747,6 @@
         "groups": ["python_runtime"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {},
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
@@ -770,7 +764,6 @@
         "groups": ["node_runtime"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {},
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
@@ -788,7 +781,6 @@
         "groups": ["go_runtime"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {},
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
@@ -806,7 +798,6 @@
         "groups": ["rust_runtime"],
         "signal_mode": "isolated"
       },
-      "trust_groups": [],
       "filesystem": {},
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
@@ -831,7 +822,6 @@
         "signal_mode": "isolated",
         "capability_elevation": false
       },
-      "trust_groups": [],
       "filesystem": {
         "allow": [
           "$HOME/.config/swival",

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -202,15 +202,15 @@ impl CapabilitySetExt for CapabilitySet {
         // Resolve policy groups from profile
         // All profiles must have groups; if empty, use the built-in default profile
         let loaded_policy = policy::load_embedded_policy()?;
-        policy::validate_group_exclusions(&loaded_policy, &profile.policy.exclude_groups)?;
+        let group_exclusions = crate::profile::effective_group_exclusions(profile);
+        policy::validate_group_exclusions(&loaded_policy, &group_exclusions)?;
         let mut groups = if profile.security.groups.is_empty() {
             default_profile_groups()?
         } else {
             profile.security.groups.clone()
         };
-        if !profile.policy.exclude_groups.is_empty() {
-            let exclude_set: std::collections::HashSet<&String> =
-                profile.policy.exclude_groups.iter().collect();
+        if !group_exclusions.is_empty() {
+            let exclude_set: std::collections::HashSet<&String> = group_exclusions.iter().collect();
             groups.retain(|g| !exclude_set.contains(g));
         }
         let mut resolved = policy::resolve_groups(&loaded_policy, &groups, &mut caps)?;

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -199,20 +199,9 @@ impl CapabilitySetExt for CapabilitySet {
         let mut caps = CapabilitySet::new();
         let protected_roots = ProtectedRoots::from_defaults()?;
 
-        // Resolve policy groups from profile
-        // All profiles must have groups; if empty, use the built-in default profile
+        // Resolve policy groups from the already-finalized profile.
         let loaded_policy = policy::load_embedded_policy()?;
-        let group_exclusions = crate::profile::effective_group_exclusions(profile);
-        policy::validate_group_exclusions(&loaded_policy, &group_exclusions)?;
-        let mut groups = if profile.security.groups.is_empty() {
-            default_profile_groups()?
-        } else {
-            profile.security.groups.clone()
-        };
-        if !group_exclusions.is_empty() {
-            let exclude_set: std::collections::HashSet<&String> = group_exclusions.iter().collect();
-            groups.retain(|g| !exclude_set.contains(g));
-        }
+        let groups = profile.security.groups.clone();
         let mut resolved = policy::resolve_groups(&loaded_policy, &groups, &mut caps)?;
         debug!("Resolved {} policy groups", resolved.names.len());
 

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -49,7 +49,7 @@ pub struct Group {
     /// If set, this group only applies on the specified platform
     #[serde(default)]
     pub platform: Option<String>,
-    /// If true, this group cannot be removed via trust_groups
+    /// If true, this group cannot be removed via group exclusions
     #[serde(default)]
     pub required: bool,
     /// Allow operations
@@ -94,11 +94,11 @@ pub struct DenyOps {
     pub commands: Vec<String>,
 }
 
-/// Profile definition as stored in policy.json
+/// Profile definition as stored in policy.json.
 ///
-/// Separate from `profile::Profile` because in JSON `trust_groups` lives at the
-/// profile level and `security.groups` means "additional groups on top of base",
-/// not the complete merged list.
+/// Separate from `profile::Profile` because built-in policy profiles allow
+/// profile-level group exclusion fields, while `security.groups` means
+/// "additional groups on top of base", not the complete merged list.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ProfileDef {
     #[serde(default)]
@@ -107,7 +107,10 @@ pub struct ProfileDef {
     pub meta: profile::ProfileMeta,
     #[serde(default)]
     pub security: profile::SecurityConfig,
-    /// Base groups to exclude for this profile
+    /// Preferred built-in profile exclusions.
+    #[serde(default)]
+    pub exclude_groups: Vec<String>,
+    /// Deprecated legacy built-in profile exclusions.
     #[serde(default)]
     pub trust_groups: Vec<String>,
     #[serde(default)]
@@ -135,19 +138,25 @@ pub struct ProfileDef {
 impl ProfileDef {
     /// Convert to a raw Profile without merging base_groups.
     pub fn to_raw_profile(&self) -> profile::Profile {
+        let mut policy = self.policy.clone();
+        policy.exclude_groups = combine_group_exclusions(
+            &self.exclude_groups,
+            &self.trust_groups,
+            &self.policy.exclude_groups,
+        );
         profile::Profile {
             extends: self.extends.clone(),
             meta: self.meta.clone(),
             security: profile::SecurityConfig {
                 groups: self.security.groups.clone(),
-                trust_groups: self.trust_groups.clone(),
+                trust_groups: Vec::new(),
                 allowed_commands: self.security.allowed_commands.clone(),
                 signal_mode: self.security.signal_mode,
                 process_info_mode: self.security.process_info_mode,
                 capability_elevation: self.security.capability_elevation,
             },
             filesystem: self.filesystem.clone(),
-            policy: self.policy.clone(),
+            policy,
             network: self.network.clone(),
             env_credentials: self.env_credentials.clone(),
             workdir: self.workdir.clone(),
@@ -158,6 +167,21 @@ impl ProfileDef {
             interactive: self.interactive,
         }
     }
+}
+
+fn combine_group_exclusions(
+    primary: &[String],
+    legacy: &[String],
+    additional: &[String],
+) -> Vec<String> {
+    let mut combined = Vec::new();
+    let mut seen = HashSet::new();
+    for group in primary.iter().chain(legacy.iter()).chain(additional.iter()) {
+        if seen.insert(group.clone()) {
+            combined.push(group.clone());
+        }
+    }
+    combined
 }
 
 // ============================================================================
@@ -979,14 +1003,9 @@ pub fn validate_group_exclusions(policy: &Policy, excluded_groups: &[String]) ->
         .join(", ");
 
     Err(NonoError::ConfigParse(format!(
-        "Cannot exclude required groups via trust_groups: {}",
+        "Cannot exclude required groups: {}",
         names
     )))
-}
-
-/// Backward-compatible validator name for existing trust_groups callers.
-pub fn validate_trust_groups(policy: &Policy, trust_groups: &[String]) -> Result<()> {
-    validate_group_exclusions(policy, trust_groups)
 }
 
 /// Get a built-in profile from embedded policy.json.
@@ -1695,16 +1714,16 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_trust_groups_allows_non_required() {
+    fn test_validate_group_exclusions_allows_non_required() {
         let policy = load_policy(sample_policy_json()).expect("parse failed");
-        let result = validate_trust_groups(&policy, &["test_read".to_string()]);
+        let result = validate_group_exclusions(&policy, &["test_read".to_string()]);
         assert!(result.is_ok(), "Non-required group should be removable");
     }
 
     #[test]
-    fn test_validate_trust_groups_rejects_required() {
+    fn test_validate_group_exclusions_rejects_required() {
         let policy = load_policy(sample_policy_json()).expect("parse failed");
-        let result = validate_trust_groups(&policy, &["test_required".to_string()]);
+        let result = validate_group_exclusions(&policy, &["test_required".to_string()]);
         assert!(result.is_err(), "Required group must not be removable");
         let err = result.expect_err("expected error");
         assert!(
@@ -1715,13 +1734,38 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_trust_groups_ignores_unknown() {
+    fn test_validate_group_exclusions_ignores_unknown() {
         let policy = load_policy(sample_policy_json()).expect("parse failed");
-        let result = validate_trust_groups(&policy, &["nonexistent_group".to_string()]);
+        let result = validate_group_exclusions(&policy, &["nonexistent_group".to_string()]);
         assert!(
             result.is_ok(),
             "Unknown groups should not trigger required check"
         );
+    }
+
+    #[test]
+    fn test_profile_def_to_raw_profile_combines_exclude_groups() {
+        let def = ProfileDef {
+            exclude_groups: vec!["preferred".to_string()],
+            trust_groups: vec!["legacy".to_string()],
+            policy: profile::PolicyPatchConfig {
+                exclude_groups: vec!["policy".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let raw = def.to_raw_profile();
+
+        assert_eq!(
+            raw.policy.exclude_groups,
+            vec![
+                "preferred".to_string(),
+                "legacy".to_string(),
+                "policy".to_string()
+            ]
+        );
+        assert!(raw.security.trust_groups.is_empty());
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -111,6 +111,8 @@ pub struct ProfileDef {
     #[serde(default)]
     pub exclude_groups: Vec<String>,
     /// Deprecated legacy built-in profile exclusions.
+    /// Kept for backward-compatible deserialization of embedded/user-authored
+    /// policy JSON that still uses `trust_groups`.
     #[serde(default)]
     pub trust_groups: Vec<String>,
     #[serde(default)]
@@ -139,11 +141,8 @@ impl ProfileDef {
     /// Convert to a raw Profile without merging base_groups.
     pub fn to_raw_profile(&self) -> profile::Profile {
         let mut policy = self.policy.clone();
-        policy.exclude_groups = combine_group_exclusions(
-            &self.exclude_groups,
-            &self.trust_groups,
-            &self.policy.exclude_groups,
-        );
+        let combined = profile::dedup_append(&self.exclude_groups, &self.trust_groups);
+        policy.exclude_groups = profile::dedup_append(&combined, &self.policy.exclude_groups);
         profile::Profile {
             extends: self.extends.clone(),
             meta: self.meta.clone(),
@@ -167,21 +166,6 @@ impl ProfileDef {
             interactive: self.interactive,
         }
     }
-}
-
-fn combine_group_exclusions(
-    primary: &[String],
-    legacy: &[String],
-    additional: &[String],
-) -> Vec<String> {
-    let mut combined = Vec::new();
-    let mut seen = HashSet::new();
-    for group in primary.iter().chain(legacy.iter()).chain(additional.iter()) {
-        if seen.insert(group.clone()) {
-            combined.push(group.clone());
-        }
-    }
-    combined
 }
 
 // ============================================================================

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -195,15 +195,14 @@ mod tests {
     }
 
     #[test]
-    fn test_trust_groups_exclusion() {
-        // Verify that trust_groups mechanism works by checking openclaw
-        // doesn't have groups it shouldn't (trust_groups is empty for all
-        // current profiles, but the merging path is exercised)
+    fn test_profile_exclusion_mechanism() {
+        // Verify that built-in profiles resolve exclusions through the shared
+        // group-exclusion path. Current embedded profiles do not exclude any.
         let profile = get_builtin("openclaw").expect("Profile not found");
         let base = crate::policy::load_embedded_policy()
             .expect("load embedded policy")
             .base_groups;
-        // All base groups should be present since trust_groups is empty
+        // All base groups should be present since embedded exclusions are empty.
         for group in &base {
             assert!(
                 profile.security.groups.contains(group),

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -689,8 +689,8 @@ pub struct SecurityConfig {
     #[serde(default)]
     pub groups: Vec<String>,
     /// Deprecated legacy exclusions. Prefer `policy.exclude_groups`.
+    /// Kept for backward-compatible deserialization and merge behavior.
     #[serde(default)]
-    #[allow(dead_code)]
     pub trust_groups: Vec<String>,
     /// Commands to allow even when blocked by default policy (e.g. `["rm"]`).
     /// Applied before CLI `--allow-command` overrides.
@@ -872,6 +872,10 @@ pub(crate) fn resolve_and_finalize_profile(profile: Profile) -> Result<Profile> 
 /// `security.groups`. Built-in profiles also resolve through the same raw
 /// profile pipeline before base_groups are merged.
 /// This function applies: `((base_groups + profile.groups) - effective_exclusions)`.
+///
+/// This means exclusions win even if the same group is also added explicitly in
+/// `security.groups`. That is an intentional shift toward a single, consistent
+/// exclusion model as `trust_groups` is deprecated.
 fn merge_base_groups(profile: &mut Profile) -> Result<()> {
     let policy = crate::policy::load_embedded_policy()?;
     let exclusions = effective_group_exclusions(profile);
@@ -894,6 +898,7 @@ fn merge_base_groups(profile: &mut Profile) -> Result<()> {
     Ok(())
 }
 
+/// Merge legacy `security.trust_groups` with preferred `policy.exclude_groups`.
 pub(crate) fn effective_group_exclusions(profile: &Profile) -> Vec<String> {
     dedup_append(
         &profile.security.trust_groups,
@@ -1118,7 +1123,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
 }
 
 /// Append child items after base items, deduplicating while preserving order.
-fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &[T]) -> Vec<T> {
+pub(crate) fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &[T]) -> Vec<T> {
     let mut seen = std::collections::HashSet::with_capacity(base.len() + child.len());
     let mut result = Vec::with_capacity(base.len() + child.len());
     for item in base.iter().chain(child.iter()) {

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 // Re-export InjectMode from nono-proxy for use in profiles
 pub use nono_proxy::config::InjectMode;
@@ -687,9 +688,7 @@ pub struct SecurityConfig {
     /// Policy group names to resolve (from policy.json)
     #[serde(default)]
     pub groups: Vec<String>,
-    /// Base groups to exclude for this profile (overrides base policy).
-    /// Populated during deserialization and consumed during base-group merging.
-    /// Will also be consumed by `--trust-group` CLI flag handling.
+    /// Deprecated legacy exclusions. Prefer `policy.exclude_groups`.
     #[serde(default)]
     #[allow(dead_code)]
     pub trust_groups: Vec<String>,
@@ -847,6 +846,17 @@ pub fn load_profile_from_path(path: &Path) -> Result<Profile> {
 
 /// Resolve inheritance and apply base-group merging for a raw profile.
 pub(crate) fn finalize_profile(mut profile: Profile) -> Result<Profile> {
+    if !profile.security.trust_groups.is_empty() {
+        let profile_name = if profile.meta.name.is_empty() {
+            "<unnamed>"
+        } else {
+            profile.meta.name.as_str()
+        };
+        warn!(
+            "profile '{}' uses deprecated security.trust_groups; use policy.exclude_groups instead",
+            profile_name
+        );
+    }
     merge_base_groups(&mut profile)?;
     Ok(profile)
 }
@@ -861,16 +871,14 @@ pub(crate) fn resolve_and_finalize_profile(profile: Profile) -> Result<Profile> 
 /// User profiles loaded from file only declare their own groups in
 /// `security.groups`. Built-in profiles also resolve through the same raw
 /// profile pipeline before base_groups are merged.
-/// This function applies: `(base_groups - trust_groups) + profile.groups`.
+/// This function applies: `((base_groups + profile.groups) - effective_exclusions)`.
 fn merge_base_groups(profile: &mut Profile) -> Result<()> {
     let policy = crate::policy::load_embedded_policy()?;
-    crate::policy::validate_trust_groups(&policy, &profile.security.trust_groups)?;
+    let exclusions = effective_group_exclusions(profile);
+    crate::policy::validate_group_exclusions(&policy, &exclusions)?;
 
     let base = policy.base_groups;
-    let mut merged: Vec<String> = base
-        .into_iter()
-        .filter(|g| !profile.security.trust_groups.contains(g))
-        .collect();
+    let mut merged: Vec<String> = base;
     // Append profile-specific groups (avoiding duplicates)
     let mut seen: std::collections::HashSet<String> = merged.iter().cloned().collect();
     for g in &profile.security.groups {
@@ -878,8 +886,19 @@ fn merge_base_groups(profile: &mut Profile) -> Result<()> {
             merged.push(g.clone());
         }
     }
+    if !exclusions.is_empty() {
+        let exclude_set: std::collections::HashSet<&String> = exclusions.iter().collect();
+        merged.retain(|g| !exclude_set.contains(g));
+    }
     profile.security.groups = merged;
     Ok(())
+}
+
+pub(crate) fn effective_group_exclusions(profile: &Profile) -> Vec<String> {
+    dedup_append(
+        &profile.security.trust_groups,
+        &profile.policy.exclude_groups,
+    )
 }
 
 /// Parse a profile JSON file without resolving inheritance.
@@ -1527,13 +1546,38 @@ mod tests {
 
         merge_base_groups(&mut profile).expect("merge should succeed");
 
-        // trust_groups should be excluded
+        // Legacy trust_groups exclusions should still be honored.
         assert!(
             !profile
                 .security
                 .groups
                 .contains(&"dangerous_commands".to_string()),
             "trusted group 'dangerous_commands' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_merge_base_groups_respects_policy_exclude_groups() {
+        let mut profile = Profile {
+            security: SecurityConfig {
+                groups: vec!["node_runtime".to_string()],
+                ..Default::default()
+            },
+            policy: PolicyPatchConfig {
+                exclude_groups: vec!["dangerous_commands".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        merge_base_groups(&mut profile).expect("merge should succeed");
+
+        assert!(
+            !profile
+                .security
+                .groups
+                .contains(&"dangerous_commands".to_string()),
+            "excluded group 'dangerous_commands' should be removed"
         );
     }
 
@@ -2365,6 +2409,18 @@ mod tests {
             .security
             .trust_groups
             .contains(&"child_trust".to_string()));
+    }
+
+    #[test]
+    fn test_effective_group_exclusions_combines_legacy_and_policy_fields() {
+        let mut profile = Profile::default();
+        profile.security.trust_groups = vec!["legacy_exclusion".to_string()];
+        profile.policy.exclude_groups = vec!["new_exclusion".to_string()];
+
+        let exclusions = effective_group_exclusions(&profile);
+
+        assert!(exclusions.contains(&"legacy_exclusion".to_string()));
+        assert!(exclusions.contains(&"new_exclusion".to_string()));
     }
 
     #[test]

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -288,11 +288,12 @@ Groups are named, composable collections of security rules. Profiles reference g
 Every profile's effective capability set is built through composition:
 
 ```
-(base_groups - trust_groups) + profile.security.groups + profile.filesystem + CLI flags
+((base_groups + profile.security.groups) - effective_group_exclusions) + profile.filesystem + CLI flags
 ```
 
 1. **base_groups** are always applied (deny rules, system paths, dangerous commands)
-2. **trust_groups** are per-profile exclusions from base (e.g., removing `deny_credentials` for an infrastructure agent that legitimately needs credential access)
+2. **effective_group_exclusions** come from `policy.exclude_groups`
+   Legacy `security.trust_groups` is still honored for backward compatibility, but is deprecated.
 3. **profile.security.groups** add additional groups on top
 4. **profile.filesystem** entries are additive
 5. **CLI overrides** (`--allow`, `--read`, etc.) are applied last

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -298,6 +298,9 @@ Every profile's effective capability set is built through composition:
 4. **profile.filesystem** entries are additive
 5. **CLI overrides** (`--allow`, `--read`, etc.) are applied last
 
+Exclusions are applied after group addition. If the same group appears in both
+`security.groups` and the effective exclusions, the exclusion wins.
+
 ### Group Taxonomy
 
 Groups use a structured allow/deny taxonomy:


### PR DESCRIPTION
    feat(policy): deprecate security.trust_groups in favor of policy.exclude_groups

Consolidate group exclusion mechanisms into a single `policy.exclude_groups`
field. The legacy `security.trust_groups` field is now deprecated but still
honored for backward compatibility during profile finalization.

Changes:
    - Remove `trust_groups` from all embedded profiles in policy.json
    - Add `exclude_groups` field to ProfileDef for built-in profile exclusions
    - Implement `combine_group_exclusions()` to merge three exclusion sources:
      primary (ProfileDef.exclude_groups), legacy (ProfileDef.trust_groups),
      and additional (PolicyPatchConfig.exclude_groups)
    - Add `effective_group_exclusions()` helper to combine legacy and policy fields
    - Update `merge_base_groups()` to apply exclusions after base + profile groups
    - Add deprecation warning when `security.trust_groups` is encountered
    - Update docs to reflect the new composition formula
    - Rename test cases to reflect generic exclusion terminology

 Signed-off-by: Luke Hinds <lukehinds@gmail.com>