### PR TITLE
fix(exec): prevent implicit cwd access under restrictive profiles

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -172,6 +172,8 @@ pub struct ExecConfig<'a> {
     pub env_vars: Vec<(&'a str, &'a str)>,
     /// Path to the capability state file.
     pub cap_file: &'a std::path::Path,
+    /// Directory the child process should start in.
+    pub current_dir: &'a std::path::Path,
     /// Whether to suppress diagnostic output.
     pub no_diagnostics: bool,
     /// Threading context for fork safety validation.
@@ -221,6 +223,7 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
 
     let mut cmd = Command::new(config.resolved_program);
     cmd.env_clear();
+    cmd.current_dir(config.current_dir);
 
     for (key, value) in std::env::vars() {
         if !should_skip_env_var(&key, &config.env_vars, &["NONO_CAP_FILE"]) {
@@ -638,6 +641,15 @@ pub fn execute_supervised(
 
             // Close inherited FDs (but keep stdin/stdout/stderr and supervisor socket)
             close_inherited_fds(max_fd, &child_keep_fds);
+
+            if let Err(e) = nix::unistd::chdir(config.current_dir) {
+                eprintln!(
+                    "nono: failed to enter child working directory {}: {}",
+                    config.current_dir.display(),
+                    e
+                );
+                std::process::exit(126);
+            }
 
             // Execute using pre-prepared CStrings (no allocation)
             unsafe {

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -28,6 +28,7 @@ use std::collections::HashSet;
 use std::ffi::{CString, OsStr};
 use std::os::fd::FromRawFd;
 use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
@@ -291,6 +292,8 @@ pub fn execute_supervised(
     // Convert program path to CString for execve
     let program_c = CString::new(program_path.to_string_lossy().as_bytes())
         .map_err(|_| NonoError::SandboxInit("Program path contains null byte".to_string()))?;
+    let current_dir_c = CString::new(config.current_dir.as_os_str().as_bytes())
+        .map_err(|_| NonoError::SandboxInit("Working directory contains null byte".to_string()))?;
 
     // Build argv: [program, args..., NULL]
     let mut argv_c: Vec<CString> = Vec::with_capacity(1 + cmd_args.len());
@@ -642,13 +645,21 @@ pub fn execute_supervised(
             // Close inherited FDs (but keep stdin/stdout/stderr and supervisor socket)
             close_inherited_fds(max_fd, &child_keep_fds);
 
-            if let Err(e) = nix::unistd::chdir(config.current_dir) {
-                eprintln!(
-                    "nono: failed to enter child working directory {}: {}",
-                    config.current_dir.display(),
-                    e
-                );
-                std::process::exit(126);
+            // SAFETY: `current_dir_c` was prepared before fork and remains valid
+            // for the lifetime of the child. `chdir` is async-signal-safe.
+            let chdir_result = unsafe { libc::chdir(current_dir_c.as_ptr()) };
+            if chdir_result != 0 {
+                const MSG: &[u8] = b"nono: failed to enter child working directory\n";
+                // SAFETY: `write` and `_exit` are async-signal-safe and we're in
+                // the post-fork child path where higher-level Rust APIs are unsafe.
+                unsafe {
+                    libc::write(
+                        libc::STDERR_FILENO,
+                        MSG.as_ptr().cast::<libc::c_void>(),
+                        MSG.len(),
+                    );
+                    libc::_exit(126);
+                }
             }
 
             // Execute using pre-prepared CStrings (no allocation)

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -753,6 +753,11 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
         prepared.secrets,
         ExecutionFlags {
             strategy,
+            workdir: args
+                .workdir
+                .clone()
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics,
             rollback,
             no_rollback: run_args.no_rollback,
@@ -841,6 +846,12 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         prepared.caps,
         prepared.secrets,
         ExecutionFlags {
+            workdir: args
+                .sandbox
+                .workdir
+                .clone()
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics: true,
             capability_elevation: prepared.capability_elevation,
             ..ExecutionFlags::defaults(silent)?
@@ -919,6 +930,11 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
         prepared.secrets,
         ExecutionFlags {
             strategy: exec_strategy::ExecStrategy::Direct,
+            workdir: args
+                .workdir
+                .clone()
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics,
             ..ExecutionFlags::defaults(silent)?
         },
@@ -928,6 +944,7 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
 /// Flags controlling sandboxed execution behavior.
 struct ExecutionFlags {
     strategy: exec_strategy::ExecStrategy,
+    workdir: std::path::PathBuf,
     no_diagnostics: bool,
     rollback: bool,
     no_rollback: bool,
@@ -985,6 +1002,8 @@ impl ExecutionFlags {
     fn defaults(silent: bool) -> Result<Self> {
         Ok(Self {
             strategy: exec_strategy::ExecStrategy::Supervised,
+            workdir: std::env::current_dir()
+                .map_err(|e| NonoError::SandboxInit(format!("Failed to get cwd: {e}")))?,
             no_diagnostics: false,
             rollback: false,
             no_rollback: false,
@@ -1169,6 +1188,25 @@ fn cleanup_capability_state_file(cap_file_path: &std::path::Path) {
     }
 }
 
+fn execution_start_dir(
+    workdir: &std::path::Path,
+    caps: &CapabilitySet,
+) -> Result<std::path::PathBuf> {
+    let workdir_canonical =
+        workdir
+            .canonicalize()
+            .map_err(|e| NonoError::PathCanonicalization {
+                path: workdir.to_path_buf(),
+                source: e,
+            })?;
+
+    if caps.path_covered(&workdir_canonical) {
+        Ok(workdir_canonical)
+    } else {
+        Ok(std::path::PathBuf::from("/"))
+    }
+}
+
 fn execute_sandboxed(
     program: OsString,
     cmd_args: Vec<OsString>,
@@ -1323,6 +1361,8 @@ fn execute_sandboxed(
         strategy, threading
     );
 
+    let current_dir = execution_start_dir(&flags.workdir, &caps)?;
+
     // Create execution config
     let config = exec_strategy::ExecConfig {
         command: &command,
@@ -1330,6 +1370,7 @@ fn execute_sandboxed(
         caps: &caps,
         env_vars,
         cap_file: &cap_file_path,
+        current_dir: &current_dir,
         no_diagnostics: flags.no_diagnostics || flags.silent,
         threading,
         protected_paths: &flags.protected_paths,
@@ -2502,6 +2543,29 @@ mod tests {
             exec_strategy::ExecStrategy::Supervised
         );
     }
+
+    #[test]
+    fn test_execution_start_dir_keeps_workdir_when_covered() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability::new_dir(dir.path(), AccessMode::Read).expect("grant"));
+
+        let start_dir = execution_start_dir(dir.path(), &caps).expect("start dir");
+
+        assert_eq!(start_dir, canonical);
+    }
+
+    #[test]
+    fn test_execution_start_dir_falls_back_to_root_when_not_covered() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let caps = CapabilitySet::new();
+
+        let start_dir = execution_start_dir(dir.path(), &caps).expect("start dir");
+
+        assert_eq!(start_dir, std::path::PathBuf::from("/"));
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn test_maybe_enable_macos_launch_services_adds_rule_when_enabled() {


### PR DESCRIPTION
Set the sandboxed child working directory explicitly. When the requested
working directory is not covered by the resolved capabilities, run the
child from `/` rather than leaving it in the caller's original working directory.

This prevents commands run under profiles such as `default` (`workdir.access = "none"`) 
from retaining unintended access to the workspace through an inherited cwd.