### PR TITLE
feat(capability): remove exact file caps when deny patch overrides grant

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -375,6 +375,11 @@ fn finalize_caps(
     // Apply deny overrides before validation (punch holes through deny groups)
     policy::apply_deny_overrides(&args.override_deny, &mut resolved.deny_paths, caps)?;
 
+    // Remove exact file grants for the deny paths that remain after overrides.
+    // This lets profile deny patches override inherited file capabilities while
+    // preserving `--override-deny` validation against the original grant set.
+    caps.remove_exact_file_caps_for_paths(&resolved.deny_paths);
+
     // Validate deny/allow overlaps (hard-fail on Linux where Landlock cannot enforce denies)
     policy::validate_deny_overlaps(&resolved.deny_paths, caps)?;
 
@@ -783,6 +788,94 @@ mod tests {
         assert!(
             err.to_string().contains("Landlock deny-overlap"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_add_deny_access_removes_symlinked_file_grant() {
+        let dir = tempdir().expect("tmpdir");
+        let target = dir.path().join("real_gitconfig");
+        std::fs::write(&target, "[user]\n").expect("write target");
+        let target_canonical = target.canonicalize().expect("canonicalize target");
+        let link = dir.path().join(".gitconfig");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let profile_path = dir.path().join("policy-deny-file-symlink.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "policy-deny-file-symlink" }},
+                    "filesystem": {{
+                        "read_file": ["{}"]
+                    }},
+                    "policy": {{
+                        "add_deny_access": ["{}"]
+                    }}
+                }}"#,
+                target.display(),
+                link.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            !caps
+                .fs_capabilities()
+                .iter()
+                .any(|cap| cap.is_file && cap.resolved == target_canonical),
+            "deny patch should remove the inherited file grant for the symlink target"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_add_deny_access_respects_override_deny_for_symlinked_file() {
+        let dir = tempdir().expect("tmpdir");
+        let target = dir.path().join("real_gitconfig");
+        std::fs::write(&target, "[user]\n").expect("write target");
+        let target_canonical = target.canonicalize().expect("canonicalize target");
+        let link = dir.path().join(".gitconfig");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let profile_path = dir.path().join("policy-deny-file-symlink-override.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "policy-deny-file-symlink-override" }},
+                    "filesystem": {{
+                        "read_file": ["{}"]
+                    }},
+                    "policy": {{
+                        "add_deny_access": ["{}"]
+                    }}
+                }}"#,
+                target.display(),
+                link.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let mut args = sandbox_args();
+        args.override_deny = vec![target.clone()];
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            caps.fs_capabilities()
+                .iter()
+                .any(|cap| cap.is_file && cap.resolved == target_canonical),
+            "override should preserve the inherited file grant for the denied symlink target"
         );
     }
 

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -781,6 +781,22 @@ impl CapabilitySet {
         Ok(())
     }
 
+    /// Remove exact file capabilities whose original or resolved path matches
+    /// any of the provided denied paths.
+    ///
+    /// Directory capabilities are preserved so platform-specific deny rules can
+    /// still narrow access within an allowed tree.
+    pub fn remove_exact_file_caps_for_paths(&mut self, denied_paths: &[PathBuf]) -> usize {
+        let before = self.fs.len();
+        self.fs.retain(|cap| {
+            !cap.is_file
+                || !denied_paths
+                    .iter()
+                    .any(|denied| cap.original == *denied || cap.resolved == *denied)
+        });
+        before.saturating_sub(self.fs.len())
+    }
+
     // Accessors
 
     /// Get filesystem capabilities
@@ -1779,5 +1795,24 @@ mod tests {
         caps.add_fs(FsCapability::new_file(&file_path, AccessMode::ReadWrite).unwrap());
 
         assert!(!caps.path_covered_with_access(&file_canonical, AccessMode::Read));
+    }
+
+    #[test]
+    fn test_remove_exact_file_caps_for_paths_matches_original_and_resolved() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        fs::write(&target, "secret").unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability::new_file(&link, AccessMode::Read).unwrap());
+        caps.add_fs(FsCapability::new_dir(dir.path(), AccessMode::Read).unwrap());
+
+        let removed = caps.remove_exact_file_caps_for_paths(&[link.clone(), target.clone()]);
+
+        assert_eq!(removed, 1);
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        assert!(!caps.fs_capabilities()[0].is_file);
     }
 }

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -151,7 +151,11 @@ for entry in "${SUITES[@]}"; do
                 wait "$pid" 2>/dev/null || true
             fi
         done
-        PIDS=("${NEW_PIDS[@]}")
+        if [[ ${#NEW_PIDS[@]} -gt 0 ]]; then
+            PIDS=("${NEW_PIDS[@]}")
+        else
+            PIDS=()
+        fi
         if [[ ${#PIDS[@]} -ge $MAX_JOBS ]]; then
             sleep 0.2
         fi


### PR DESCRIPTION
Add `remove_exact_file_caps_for_paths()` method to CapabilitySet to handle symlinked file grants shadowed by deny patches. When a profile's `add_deny_access` denies a symlink, remove the corresponding file capability (both original and resolved paths checked) while preserving directory capabilities for platform-specific narrowing.

Includes two integration tests: one verifying deny patch removal of symlinked file grants, and another confirming `--override-deny` restores the grant against the original set. Also fixes bash array handling in integration test runner to prevent unbound variable errors.