### PR TITLE
fix(policy): honor excluded dangerous command groups for direct exec

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -656,13 +656,7 @@ mod tests {
     #[test]
     fn test_from_loaded_profile_extends_default_respects_excluded_blocked_commands() {
         let dir = tempdir().expect("tmpdir");
-        let original_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", dir.path());
-        std::fs::create_dir_all(dir.path().join(".config/nono/profiles")).expect("mkdir profiles");
-
-        let profile_path = dir
-            .path()
-            .join(".config/nono/profiles/no-dangerous-commands.json");
+        let profile_path = dir.path().join("no-dangerous-commands.json");
         std::fs::write(
             &profile_path,
             r#"{
@@ -680,17 +674,11 @@ mod tests {
         )
         .expect("write profile");
 
-        let profile = crate::profile::load_profile("no-dangerous-commands").expect("load profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
         let (caps, _) =
             CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
-
-        if let Some(home) = original_home {
-            std::env::set_var("HOME", home);
-        } else {
-            std::env::remove_var("HOME");
-        }
 
         assert!(
             !caps.blocked_commands().contains(&"rm".to_string()),

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -654,6 +654,55 @@ mod tests {
     }
 
     #[test]
+    fn test_from_loaded_profile_extends_default_respects_excluded_blocked_commands() {
+        let dir = tempdir().expect("tmpdir");
+        let original_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", dir.path());
+        std::fs::create_dir_all(dir.path().join(".config/nono/profiles")).expect("mkdir profiles");
+
+        let profile_path = dir
+            .path()
+            .join(".config/nono/profiles/no-dangerous-commands.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "no-dangerous-commands", "version": "1.0.0" },
+                "extends": "default",
+                "policy": {
+                    "exclude_groups": [
+                        "dangerous_commands",
+                        "dangerous_commands_linux",
+                        "dangerous_commands_macos"
+                    ]
+                },
+                "workdir": { "access": "readwrite" }
+            }"#,
+        )
+        .expect("write profile");
+
+        let profile = crate::profile::load_profile("no-dangerous-commands").expect("load profile");
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        assert!(
+            !caps.blocked_commands().contains(&"rm".to_string()),
+            "excluded dangerous_commands should remove rm from blocked commands"
+        );
+        assert!(
+            !caps.blocked_commands().contains(&"shred".to_string()),
+            "excluded dangerous_commands_linux should remove shred from blocked commands"
+        );
+    }
+
+    #[test]
     fn test_from_profile_policy_add_allow_paths_add_capabilities() {
         let dir = tempdir().expect("tmpdir");
         let read_dir = dir.path().join("read-dir");

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1554,13 +1554,7 @@ mod tests {
     #[test]
     fn test_load_profile_extends_default_respects_excluded_groups() {
         let dir = tempdir().expect("tmpdir");
-        let original_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", dir.path());
-        std::fs::create_dir_all(dir.path().join(".config/nono/profiles")).expect("mkdir profiles");
-
-        let profile_path = dir
-            .path()
-            .join(".config/nono/profiles/no-dangerous-commands.json");
+        let profile_path = dir.path().join("no-dangerous-commands.json");
         std::fs::write(
             &profile_path,
             r#"{
@@ -1578,16 +1572,13 @@ mod tests {
         )
         .expect("write profile");
 
-        let profile = load_profile("no-dangerous-commands").expect("load profile");
-
-        if let Some(home) = original_home {
-            std::env::set_var("HOME", home);
-        } else {
-            std::env::remove_var("HOME");
-        }
+        let profile = load_profile_from_path(&profile_path).expect("load profile");
 
         assert!(
-            !profile.security.groups.contains(&"dangerous_commands".to_string()),
+            !profile
+                .security
+                .groups
+                .contains(&"dangerous_commands".to_string()),
             "excluded dangerous_commands should not be present in finalized groups"
         );
         assert!(

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1552,6 +1552,54 @@ mod tests {
     }
 
     #[test]
+    fn test_load_profile_extends_default_respects_excluded_groups() {
+        let dir = tempdir().expect("tmpdir");
+        let original_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", dir.path());
+        std::fs::create_dir_all(dir.path().join(".config/nono/profiles")).expect("mkdir profiles");
+
+        let profile_path = dir
+            .path()
+            .join(".config/nono/profiles/no-dangerous-commands.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "no-dangerous-commands", "version": "1.0.0" },
+                "extends": "default",
+                "policy": {
+                    "exclude_groups": [
+                        "dangerous_commands",
+                        "dangerous_commands_linux",
+                        "dangerous_commands_macos"
+                    ]
+                },
+                "workdir": { "access": "readwrite" }
+            }"#,
+        )
+        .expect("write profile");
+
+        let profile = load_profile("no-dangerous-commands").expect("load profile");
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        assert!(
+            !profile.security.groups.contains(&"dangerous_commands".to_string()),
+            "excluded dangerous_commands should not be present in finalized groups"
+        );
+        assert!(
+            !profile
+                .security
+                .groups
+                .contains(&"dangerous_commands_macos".to_string()),
+            "excluded dangerous_commands_macos should not be present in finalized groups"
+        );
+    }
+
+    #[test]
     fn test_workdir_config_readwrite() {
         let json_str = r#"{
             "meta": { "name": "test-profile" },


### PR DESCRIPTION
The previous fix  6e86b34f0ec7521aa6b5d57eef8cfb0428502552 did not fully restore the intended runtime behavior for profiles excluding `dangerous_commands*`.

Ensure direct command blocking is driven by the resolved capability set so profiles like `no-dangerous-commands` can actually permit commands such as `rm`.