### PR TITLE
fix: change CI release to ubuntu 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 (glibc)
+          # Linux x86_64 (glibc) - use 22.04 for broader GLIBC compatibility
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: nono
 
           # macOS x86_64 (Intel)


### PR DESCRIPTION
In order to support 22 / GLIBC_2.38 pin to the ubuntu 22 image in CI - GBLIC binaries are backwards compat, so 22 will also cover Ubuntu 24

Closes: #372