### PR TITLE
feat(macos): gate open shim installation behind launch services flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 (glibc)
+          # Linux x86_64 (glibc) - use 22.04 for broader GLIBC compatibility
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: nono
 
           # macOS x86_64 (Intel)

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -207,6 +207,13 @@ pub struct SupervisorConfig<'a> {
     pub open_url_origins: &'a [String],
     /// Whether to allow http://localhost and http://127.0.0.1 URLs.
     pub open_url_allow_localhost: bool,
+    /// Whether direct LaunchServices opening is enabled for this session.
+    pub allow_launch_services_active: bool,
+}
+
+#[cfg(target_os = "macos")]
+fn should_install_macos_open_shim(supervisor: Option<&SupervisorConfig<'_>>) -> bool {
+    supervisor.is_some_and(|cfg| !cfg.allow_launch_services_active)
 }
 
 /// Execute a command using the Direct strategy (exec, nono disappears).
@@ -384,25 +391,27 @@ pub fn execute_supervised(
 
             #[cfg(target_os = "macos")]
             {
-                // Create a shim `open` script that delegates to nono open-url-helper.
-                // The npm `open` package spawns `open <url>` on macOS; by placing our
-                // shim earlier in PATH, we intercept the call.
-                if let Some(shim) = create_open_shim(&nono_exe) {
-                    // Prepend shim dir to PATH and also set BROWSER for any tool
-                    // that does respect it.
-                    let current_path = std::env::var("PATH").unwrap_or_default();
-                    let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
-                    if let Ok(cstr) = CString::new(new_path) {
-                        // Remove existing PATH from env_c, then add our modified one
-                        env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
-                        env_c.push(cstr);
+                if should_install_macos_open_shim(supervisor) {
+                    // Create a shim `open` script that delegates to nono open-url-helper.
+                    // The npm `open` package spawns `open <url>` on macOS; by placing our
+                    // shim earlier in PATH, we intercept the call.
+                    if let Some(shim) = create_open_shim(&nono_exe) {
+                        // Prepend shim dir to PATH and also set BROWSER for any tool
+                        // that does respect it.
+                        let current_path = std::env::var("PATH").unwrap_or_default();
+                        let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
+                        if let Ok(cstr) = CString::new(new_path) {
+                            // Remove existing PATH from env_c, then add our modified one
+                            env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
+                            env_c.push(cstr);
+                        }
+                        let quoted_helper = shell_quote(&shim.helper_exe.display().to_string());
+                        let browser_cmd = format!("BROWSER={quoted_helper} open-url-helper");
+                        if let Ok(cstr) = CString::new(browser_cmd) {
+                            env_c.push(cstr);
+                        }
+                        open_shim = Some(shim);
                     }
-                    let quoted_helper = shell_quote(&shim.helper_exe.display().to_string());
-                    let browser_cmd = format!("BROWSER={quoted_helper} open-url-helper");
-                    if let Ok(cstr) = CString::new(browser_cmd) {
-                        env_c.push(cstr);
-                    }
-                    open_shim = Some(shim);
                 }
             }
         }
@@ -2506,6 +2515,8 @@ mod tests {
             session_id: "test-session",
             open_url_origins: &[],
             open_url_allow_localhost: false,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
 
         // Fork a child that closes its socket end and exits immediately.
@@ -2579,6 +2590,8 @@ mod tests {
             session_id: "test",
             open_url_origins: &origins,
             open_url_allow_localhost: false,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
 
         // Allowed origin: validation passes
@@ -2604,6 +2617,8 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
 
         let result = validate_url("file:///etc/passwd", &config);
@@ -2627,6 +2642,8 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: true,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
         let config_deny = SupervisorConfig {
             protected_roots: &[],
@@ -2634,6 +2651,8 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
 
         // Localhost denied when not allowed
@@ -2662,6 +2681,8 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
+            #[cfg(target_os = "macos")]
+            allow_launch_services_active: false,
         };
 
         let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
@@ -2739,6 +2760,44 @@ mod tests {
         assert!(
             script.contains(&format!("exec {helper} open-url-helper \"$url_arg\"")),
             "shim should exec the copied helper"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_should_install_macos_open_shim_respects_launch_services_flag() {
+        struct TestBackend;
+        impl ApprovalBackend for TestBackend {
+            fn request_capability(
+                &self,
+                _req: &nono::supervisor::CapabilityRequest,
+            ) -> nono::Result<ApprovalDecision> {
+                Ok(ApprovalDecision::Denied {
+                    reason: "test".to_string(),
+                })
+            }
+            fn backend_name(&self) -> &str {
+                "test"
+            }
+        }
+
+        let backend = TestBackend;
+        let config = SupervisorConfig {
+            protected_roots: &[],
+            approval_backend: &backend,
+            session_id: "test",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+            allow_launch_services_active: true,
+        };
+
+        assert!(
+            !should_install_macos_open_shim(Some(&config)),
+            "launch services sessions should skip the macOS open shim"
+        );
+        assert!(
+            !should_install_macos_open_shim(None),
+            "without supervisor config, the helper should not install the macOS open shim"
         );
     }
 

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -208,6 +208,7 @@ pub struct SupervisorConfig<'a> {
     /// Whether to allow http://localhost and http://127.0.0.1 URLs.
     pub open_url_allow_localhost: bool,
     /// Whether direct LaunchServices opening is enabled for this session.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub allow_launch_services_active: bool,
 }
 
@@ -2515,7 +2516,6 @@ mod tests {
             session_id: "test-session",
             open_url_origins: &[],
             open_url_allow_localhost: false,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
 
@@ -2590,7 +2590,6 @@ mod tests {
             session_id: "test",
             open_url_origins: &origins,
             open_url_allow_localhost: false,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
 
@@ -2617,7 +2616,6 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
 
@@ -2642,7 +2640,6 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: true,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
         let config_deny = SupervisorConfig {
@@ -2651,7 +2648,6 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
 
@@ -2681,7 +2677,6 @@ mod tests {
             session_id: "test",
             open_url_origins: &[],
             open_url_allow_localhost: false,
-            #[cfg(target_os = "macos")]
             allow_launch_services_active: false,
         };
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -784,6 +784,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             proxy_port: args.proxy_port,
             open_url_origins: prepared.open_url_origins,
             open_url_allow_localhost: prepared.open_url_allow_localhost,
+            allow_launch_services_active: prepared.allow_launch_services_active,
         },
     )
 }
@@ -993,6 +994,8 @@ struct ExecutionFlags {
     open_url_origins: Vec<String>,
     /// Whether to allow http://localhost URL opens
     open_url_allow_localhost: bool,
+    /// Whether direct LaunchServices opening is enabled for this session.
+    allow_launch_services_active: bool,
 }
 
 impl ExecutionFlags {
@@ -1031,6 +1034,7 @@ impl ExecutionFlags {
             proxy_port: None,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
+            allow_launch_services_active: false,
         })
     }
 }
@@ -1579,6 +1583,7 @@ fn execute_sandboxed(
                 session_id: &supervisor_session_id,
                 open_url_origins: &flags.open_url_origins,
                 open_url_allow_localhost: flags.open_url_allow_localhost,
+                allow_launch_services_active: flags.allow_launch_services_active,
             };
 
             let trust_interceptor = if flags.trust_interception_active {

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -3,27 +3,27 @@ title: Claude Code
 description: Sandboxing Anthropic Claude Code with nono
 ---
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's CLI coding agent. It reads and writes files, runs commands, and interacts with git on your behalf. Running it under nono ensures it can only access what you explicitly allow.
-
 ## Why Sandbox Claude Code?
 
-Claude Code operates includes its own sandbox mechanism, but the Agent is able to override the sandbox by calling `dangerouslyOverrideSandbox: true` and access any file and perform any operation on the system.
+Claude Code includes its own sandbox mechanism, but the agent is able to override the sandbox by calling `dangerouslyOverrideSandbox: true` and access any file and perform any operation on the system.
 
 ![Claude Code using dangerouslyOverrideSandbox](/assets/claude-code-overrides-the-sandbox-without-permission.webp)
-
-This creates several risks:
-
-- It could read sensitive files outside your project (SSH keys, cloud credentials)
-- A prompt injection in a dependency could trigger unintended file access
-- Mistakes in file operations could affect directories outside your workspace
-
-nono's kernel-enforced sandbox makes these scenarios structurally impossible.
 
 ## Quick Start
 
 ```bash
 nono run --profile claude-code -- claude
 ```
+
+<Warning>
+**macOS users:** Claude Code needs to open a browser on **first use** (e.g., for `claude /login`), you must add the `--allow-launch-services` flag:
+
+```bash
+nono run --profile claude-code --allow-launch-services -- claude
+```
+After this initial login, you can exit and rerun without `--allow-launch-services` for better security.
+See [OAuth2 Login](#oauth2-login) for details.
+</Warning>
 
 The built-in profile provides:
 - **Read+write access** to the current working directory

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -247,12 +247,28 @@ Claude Code reads git configuration for repository operations. The built-in prof
 
 ## Secretive (SSH Keys in Secure Enclave)
 
-If you use [Secretive](https://github.com/maxgoedjen/secretive) to store SSH keys in the macOS Secure Enclave, git commit signing (`git commit -S`) needs access to the Secretive agent socket. A community profile is provided at `data/profiles/claude-code-secretive.toml`.
+If you use [Secretive](https://github.com/maxgoedjen/secretive) to store SSH keys in the macOS Secure Enclave, git commit signing (`git commit -S`) needs access to the Secretive agent socket. Create a custom profile that extends the built-in Claude Code profile:
 
-**Install the profile:**
-```bash
-mkdir -p ~/.config/nono/profiles
-cp data/profiles/claude-code-secretive.toml ~/.config/nono/profiles/
+```json
+// ~/.config/nono/profiles/claude-code-secretive.json
+{
+  "meta": {
+    "name": "claude-code-secretive",
+    "version": "1.0.0",
+    "description": "Claude Code with Secretive SSH agent support"
+  },
+  "extends": "claude-code",
+  "filesystem": {
+    "read": [
+      "$HOME/.ssh/config",
+      "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+    ],
+    "allow_file": ["$HOME/.ssh/known_hosts"]
+  },
+  "policy": {
+    "add_allow_readwrite": ["$HOME/.ssh/known_hosts"]
+  }
+}
 ```
 
 **Usage:**
@@ -261,12 +277,12 @@ nono run --profile claude-code-secretive --allow-cwd -- claude
 ```
 
 The profile extends the standard Claude Code profile with:
-- **Read access** to `~/.gitconfig` and `~/.ssh/config` (git signing configuration)
+- **Read access** to `~/.ssh/config` (git signing configuration)
 - **Read access** to the Secretive agent socket (`~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh`)
 - **Read+write access** to `~/.ssh/known_hosts` (SSH may append new host keys)
 
 <Note>
-The Secretive socket is a Unix domain socket, not a regular file. nono v0.4+ supports granting capabilities on sockets directly, so only the socket itself is exposed — not the entire container directory.
+The Secretive socket is a Unix domain socket, not a regular file. nono supports granting capabilities on sockets directly, so only the socket itself is exposed — not the entire container directory.
 </Note>
 ## Overriding Profile Settings
 


### PR DESCRIPTION
Add `allow_launch_services_active` field to `SupervisorConfig` to conditionally
install the macOS open shim. When launch services are enabled, skip shim
installation to allow direct LaunchServices opening. Update tests and
documentation to explain the macOS browser launch workflow more clearly

 Signed-off-by: Luke Hinds <lukehinds@gmail.com>