### PR TITLE
feat(profile): add profile-level override_deny for deny group exceptions

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -8,7 +8,7 @@ use crate::policy;
 use crate::profile::{expand_vars, Profile};
 use crate::protected_paths::{self, ProtectedRoots};
 use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
 /// Try to create a directory capability, warning and skipping on PathNotFound.
@@ -186,7 +186,7 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_blocked_command(cmd.clone());
         }
 
-        finalize_caps(&mut caps, &mut resolved, &loaded_policy, args)?;
+        finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
 
         Ok((caps, resolved.needs_unlink_overrides))
     }
@@ -355,7 +355,20 @@ impl CapabilitySetExt for CapabilitySet {
         // Apply CLI overrides (CLI args take precedence)
         add_cli_overrides(&mut caps, args)?;
 
-        finalize_caps(&mut caps, &mut resolved, &loaded_policy, args)?;
+        // Expand profile-level override_deny paths for finalize_caps
+        let mut profile_overrides = Vec::with_capacity(profile.policy.override_deny.len());
+        for path_template in &profile.policy.override_deny {
+            let path = expand_vars(path_template, workdir)?;
+            profile_overrides.push(path);
+        }
+
+        finalize_caps(
+            &mut caps,
+            &mut resolved,
+            &loaded_policy,
+            args,
+            &profile_overrides,
+        )?;
 
         Ok((caps, resolved.needs_unlink_overrides))
     }
@@ -371,8 +384,12 @@ fn finalize_caps(
     resolved: &mut policy::ResolvedGroups,
     _loaded_policy: &policy::Policy,
     args: &SandboxArgs,
+    profile_override_deny: &[PathBuf],
 ) -> Result<()> {
-    // Apply deny overrides before validation (punch holes through deny groups)
+    // Apply profile-level deny overrides first, then CLI overrides.
+    // Profile overrides come from `policy.override_deny` in the profile JSON.
+    // CLI `--override-deny` flags are applied on top.
+    policy::apply_deny_overrides(profile_override_deny, &mut resolved.deny_paths, caps)?;
     policy::apply_deny_overrides(&args.override_deny, &mut resolved.deny_paths, caps)?;
 
     // Remove exact file grants for the deny paths that remain after overrides.
@@ -488,36 +505,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn sandbox_args() -> SandboxArgs {
-        SandboxArgs {
-            allow: vec![],
-            read: vec![],
-            write: vec![],
-            allow_file: vec![],
-            read_file: vec![],
-            write_file: vec![],
-            block_net: false,
-            allow_net: false,
-            network_profile: None,
-            allow_proxy: vec![],
-            proxy_credential: vec![],
-            external_proxy: None,
-            external_proxy_bypass: vec![],
-            override_deny: vec![],
-            allow_command: vec![],
-            block_command: vec![],
-            env_credential: None,
-            env_credential_map: vec![],
-            profile: None,
-            allow_cwd: false,
-            allow_launch_services: false,
-            workdir: None,
-            config: None,
-            verbose: 0,
-            dry_run: false,
-            allow_bind: vec![],
-            allow_port: vec![],
-            proxy_port: None,
-        }
+        SandboxArgs::default()
     }
 
     #[test]
@@ -916,6 +904,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_from_profile_policy_override_deny_via_symlink_path() {
+        let dir = tempdir().expect("tmpdir");
+        let target = dir.path().join("real_gitconfig");
+        std::fs::write(&target, "[user]\n").expect("write target");
+        let target_canonical = target.canonicalize().expect("canonicalize target");
+        let link = dir.path().join(".gitconfig");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        // Override via the symlink path (not the canonical target)
+        let profile_path = dir.path().join("override-deny-symlink.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "override-deny-symlink" }},
+                    "filesystem": {{
+                        "read_file": ["{target}"]
+                    }},
+                    "policy": {{
+                        "add_deny_access": ["{link}"],
+                        "override_deny": ["{link}"]
+                    }}
+                }}"#,
+                target = target.display(),
+                link = link.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            caps.fs_capabilities()
+                .iter()
+                .any(|cap| cap.is_file && cap.resolved == target_canonical),
+            "override via symlink path should preserve the file grant for the canonical target"
+        );
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn test_from_profile_policy_add_deny_access_emits_seatbelt_rules() {
@@ -955,6 +988,83 @@ mod tests {
             rules.contains("deny file-write*"),
             "expected macOS deny write rule, got:\n{}",
             rules
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_override_deny_punches_through_deny_group() {
+        let dir = tempdir().expect("tmpdir");
+        let denied = dir.path().join("denied_dir");
+        std::fs::create_dir_all(&denied).expect("mkdir denied");
+
+        let profile_path = dir.path().join("override-deny-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "override-deny-test" }},
+                    "policy": {{
+                        "add_allow_readwrite": ["{path}"],
+                        "add_deny_access": ["{path}"],
+                        "override_deny": ["{path}"]
+                    }}
+                }}"#,
+                path = denied.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        // The allow should survive because override_deny punches through the deny
+        let canonical = denied.canonicalize().expect("canonicalize");
+        assert!(
+            caps.fs_capabilities()
+                .iter()
+                .any(|cap| !cap.is_file && cap.resolved == canonical),
+            "override_deny should preserve the directory grant despite deny group"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_override_deny_requires_matching_grant() {
+        // Override path is under temp dir which is covered by system groups,
+        // but the grant check requires user-intent sources (User/Profile),
+        // so group coverage is not sufficient.
+        let dir = tempdir().expect("tmpdir");
+        let denied = dir.path().join("denied_no_grant");
+        std::fs::create_dir_all(&denied).expect("mkdir denied");
+
+        let profile_path = dir.path().join("override-deny-no-grant.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "override-deny-no-grant" }},
+                    "policy": {{
+                        "add_deny_access": ["{path}"],
+                        "override_deny": ["{path}"]
+                    }}
+                }}"#,
+                path = denied.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+            .expect_err("override_deny without user-intent grant should fail");
+        assert!(
+            err.to_string().contains("no matching grant"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -234,7 +234,7 @@ pub struct OpenUrlHelperArgs {
     pub url: String,
 }
 
-#[derive(Parser, Debug, Clone)]
+#[derive(Parser, Debug, Clone, Default)]
 pub struct SandboxArgs {
     // === Directory permissions (recursive) ===
     /// Directories to allow read+write access (recursive).

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -392,11 +392,16 @@ fn run_why(args: WhyArgs) -> Result<()> {
     use query_ext::{print_result, query_network, query_path, QueryResult};
     use sandbox_state::load_sandbox_state;
 
-    // Build capability set from args or load from sandbox state
-    let caps = if args.self_query {
+    // Build capability set from args or load from sandbox state.
+    // Also collect overridden paths so the query can skip sensitive-path checks
+    // for paths that have been exempted via override_deny.
+    let (caps, overridden_paths): (CapabilitySet, Vec<std::path::PathBuf>) = if args.self_query {
         // Inside sandbox - load from state file
         match load_sandbox_state() {
-            Some(state) => state.to_caps()?,
+            Some(state) => {
+                let paths = state.override_deny_as_paths();
+                (state.to_caps()?, paths)
+            }
             None => {
                 let result = QueryResult::NotSandboxed {
                     message: "Not running inside a nono sandbox".to_string(),
@@ -421,7 +426,6 @@ fn run_why(args: WhyArgs) -> Result<()> {
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-        // Create a minimal SandboxArgs to pass to from_profile
         let sandbox_args = SandboxArgs {
             allow: args.allow.clone(),
             read: args.read.clone(),
@@ -430,36 +434,29 @@ fn run_why(args: WhyArgs) -> Result<()> {
             read_file: args.read_file.clone(),
             write_file: args.write_file.clone(),
             block_net: args.block_net,
-            allow_net: false,
-            network_profile: None,
-            allow_proxy: vec![],
-            proxy_credential: vec![],
-            external_proxy: None,
-            external_proxy_bypass: vec![],
-            override_deny: vec![],
-            allow_command: vec![],
-            block_command: vec![],
-            env_credential: None,
-            env_credential_map: vec![],
-            profile: None,
-            allow_cwd: false,
-            allow_launch_services: false,
             workdir: args.workdir.clone(),
-            config: None,
-            verbose: 0,
-            dry_run: false,
-            allow_bind: vec![],
-            allow_port: vec![],
-            proxy_port: None,
+            ..SandboxArgs::default()
         };
+
+        // Collect overridden paths from profile for the query
+        let mut override_paths = Vec::new();
+        for tmpl in &prof.policy.override_deny {
+            let expanded = profile::expand_vars(tmpl, &workdir)?;
+            if expanded.exists() {
+                if let Ok(c) = expanded.canonicalize() {
+                    override_paths.push(c);
+                }
+            } else {
+                override_paths.push(expanded);
+            }
+        }
 
         let (mut caps, needs_unlink) = CapabilitySet::from_profile(&prof, &workdir, &sandbox_args)?;
         if needs_unlink {
             crate::policy::apply_unlink_overrides(&mut caps);
         }
-        caps
+        (caps, override_paths)
     } else {
-        // Build from CLI args
         let sandbox_args = SandboxArgs {
             allow: args.allow.clone(),
             read: args.read.clone(),
@@ -468,34 +465,15 @@ fn run_why(args: WhyArgs) -> Result<()> {
             read_file: args.read_file.clone(),
             write_file: args.write_file.clone(),
             block_net: args.block_net,
-            allow_net: false,
-            network_profile: None,
-            allow_proxy: vec![],
-            proxy_credential: vec![],
-            external_proxy: None,
-            external_proxy_bypass: vec![],
-            override_deny: vec![],
-            allow_command: vec![],
-            block_command: vec![],
-            env_credential: None,
-            env_credential_map: vec![],
-            profile: None,
-            allow_cwd: false,
-            allow_launch_services: false,
             workdir: args.workdir.clone(),
-            config: None,
-            verbose: 0,
-            dry_run: false,
-            allow_bind: vec![],
-            allow_port: vec![],
-            proxy_port: None,
+            ..SandboxArgs::default()
         };
 
         let (mut caps, needs_unlink) = CapabilitySet::from_args(&sandbox_args)?;
         if needs_unlink {
             crate::policy::apply_unlink_overrides(&mut caps);
         }
-        caps
+        (caps, vec![])
     };
 
     // Execute the query
@@ -506,7 +484,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
             None => AccessMode::Read, // Default to read
         };
-        query_path(path, op, &caps)?
+        query_path(path, op, &caps, &overridden_paths)?
     } else if let Some(ref host) = args.host {
         query_network(host, args.port, &caps)
     } else {
@@ -785,6 +763,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             open_url_origins: prepared.open_url_origins,
             open_url_allow_localhost: prepared.open_url_allow_localhost,
             allow_launch_services_active: prepared.allow_launch_services_active,
+            override_deny_paths: prepared.override_deny_paths,
         },
     )
 }
@@ -855,6 +834,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
                 .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics: true,
             capability_elevation: prepared.capability_elevation,
+            override_deny_paths: prepared.override_deny_paths,
             ..ExecutionFlags::defaults(silent)?
         },
     )
@@ -937,6 +917,7 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
                 .or_else(|| std::env::current_dir().ok())
                 .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics,
+            override_deny_paths: prepared.override_deny_paths,
             ..ExecutionFlags::defaults(silent)?
         },
     )
@@ -996,6 +977,8 @@ struct ExecutionFlags {
     open_url_allow_localhost: bool,
     /// Whether direct LaunchServices opening is enabled for this session.
     allow_launch_services_active: bool,
+    /// Canonicalized paths exempted from deny groups via override_deny
+    override_deny_paths: Vec<std::path::PathBuf>,
 }
 
 impl ExecutionFlags {
@@ -1035,6 +1018,7 @@ impl ExecutionFlags {
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             allow_launch_services_active: false,
+            override_deny_paths: Vec::new(),
         })
     }
 }
@@ -1243,7 +1227,7 @@ fn execute_sandboxed(
     let resolved_program = exec_strategy::resolve_program(&command[0])?;
 
     // Write capability state file BEFORE applying sandbox
-    let cap_file = write_capability_state_file(&caps, flags.silent);
+    let cap_file = write_capability_state_file(&caps, &flags.override_deny_paths, flags.silent);
     let cap_file_path = cap_file.unwrap_or_else(|| std::path::PathBuf::from("/dev/null"));
 
     // Validate that secret env var names are not dangerous (e.g. LD_PRELOAD).
@@ -1757,6 +1741,8 @@ struct PreparedSandbox {
     open_url_origins: Vec<String>,
     /// Whether to allow http://localhost URL opens
     open_url_allow_localhost: bool,
+    /// Canonicalized paths exempted from deny groups via override_deny
+    override_deny_paths: Vec<std::path::PathBuf>,
 }
 
 fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, String)>> {
@@ -1911,6 +1897,46 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .clone()
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+    // Collect override_deny paths from profile (canonicalized for query use)
+    let override_deny_paths: Vec<std::path::PathBuf> = loaded_profile
+        .as_ref()
+        .map(|prof| {
+            prof.policy
+                .override_deny
+                .iter()
+                .filter_map(|tmpl| {
+                    profile::expand_vars(tmpl, &workdir).ok().map(|expanded| {
+                        if expanded.exists() {
+                            expanded.canonicalize().unwrap_or(expanded)
+                        } else {
+                            expanded
+                        }
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Also include CLI --override-deny paths.
+    // Apply the same ~ / $HOME expansion that apply_deny_overrides uses
+    // so the stored paths match the canonicalized form used by query_path.
+    let override_deny_paths: Vec<std::path::PathBuf> = {
+        let mut paths = override_deny_paths;
+        for p in &args.override_deny {
+            let path_str = p.to_string_lossy();
+            let expanded = profile::expand_vars(&path_str, &workdir).unwrap_or_else(|_| p.clone());
+            let canonical = if expanded.exists() {
+                expanded.canonicalize().unwrap_or(expanded)
+            } else {
+                expanded
+            };
+            if !paths.contains(&canonical) {
+                paths.push(canonical);
+            }
+        }
+        paths
+    };
 
     // Extract config before profile is consumed for secrets
     let capability_elevation = loaded_profile
@@ -2190,6 +2216,7 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         allow_launch_services_active,
         open_url_origins,
         open_url_allow_localhost,
+        override_deny_paths,
     })
 }
 
@@ -2284,10 +2311,14 @@ fn enforce_rollback_limits(silent: bool) {
     }
 }
 
-fn write_capability_state_file(caps: &CapabilitySet, silent: bool) -> Option<std::path::PathBuf> {
+fn write_capability_state_file(
+    caps: &CapabilitySet,
+    override_deny_paths: &[std::path::PathBuf],
+    silent: bool,
+) -> Option<std::path::PathBuf> {
     // Write sandbox state for `nono why --self`.
     let cap_file = std::env::temp_dir().join(format!(".nono-{}.json", std::process::id()));
-    let state = sandbox_state::SandboxState::from_caps(caps);
+    let state = sandbox_state::SandboxState::from_caps(caps, override_deny_paths);
     if let Err(e) = state.write_to_file(&cap_file) {
         error!(
             "Failed to write capability state file: {}. \
@@ -2311,36 +2342,7 @@ mod tests {
     use super::*;
 
     fn sandbox_args() -> SandboxArgs {
-        SandboxArgs {
-            allow: vec![],
-            read: vec![],
-            write: vec![],
-            allow_file: vec![],
-            read_file: vec![],
-            write_file: vec![],
-            block_net: false,
-            allow_net: false,
-            network_profile: None,
-            allow_proxy: vec![],
-            proxy_credential: vec![],
-            external_proxy: None,
-            external_proxy_bypass: vec![],
-            override_deny: vec![],
-            allow_command: vec![],
-            block_command: vec![],
-            env_credential: None,
-            env_credential_map: vec![],
-            profile: None,
-            allow_cwd: false,
-            allow_launch_services: false,
-            workdir: None,
-            config: None,
-            verbose: 0,
-            dry_run: false,
-            allow_bind: vec![],
-            allow_port: vec![],
-            proxy_port: None,
-        }
+        SandboxArgs::default()
     }
 
     #[test]
@@ -2440,6 +2442,7 @@ mod tests {
             allow_launch_services_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
+            override_deny_paths: Vec::new(),
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -2477,6 +2480,7 @@ mod tests {
             allow_launch_services_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
+            override_deny_paths: Vec::new(),
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -301,6 +301,12 @@ pub fn print_sandbox_active(silent: bool) {
     eprintln!();
 }
 
+/// Print a styled warning message to stderr
+pub fn print_warning(message: &str) {
+    let t = theme::current();
+    eprintln!("  {} {}", fg("warning:", t.red).bold(), fg(message, t.text),);
+}
+
 /// Print dry run message
 pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
     if silent {

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -625,51 +625,90 @@ pub fn apply_deny_overrides(
             expanded.clone()
         };
 
-        // Verify the override path is actually granted via --allow/--read/--write.
-        // Without a grant, the deny removal is a no-op on Linux (Landlock is allow-list),
-        // but on macOS the Seatbelt allow rules below would implicitly grant access,
-        // creating a platform behavior divergence.
-        let is_granted = caps.fs_capabilities().iter().any(|cap| {
-            if cap.is_file {
+        // Verify the override path is actually granted via explicit user intent
+        // (CLI flags or profile filesystem/policy config), not just covered by a
+        // system or group grant. Without this, a deny override under /tmp would
+        // silently pass because system_write_macos grants /var/folders, creating
+        // an unintended permission grant.
+        //
+        // Compute the union of access modes across ALL matching user-intent grants.
+        // This runs before deduplicate() which merges complementary Read + Write
+        // grants into ReadWrite, so we must aggregate here to avoid emitting
+        // Seatbelt allow rules for only the first grant's access mode.
+        let mut grant_has_read = false;
+        let mut grant_has_write = false;
+        for cap in caps.fs_capabilities() {
+            if !cap.source.is_user_intent() {
+                continue;
+            }
+            let covers = if cap.is_file {
                 cap.resolved == canonical
             } else {
                 canonical.starts_with(&cap.resolved)
+            };
+            if covers {
+                match cap.access {
+                    AccessMode::Read => grant_has_read = true,
+                    AccessMode::Write => grant_has_write = true,
+                    AccessMode::ReadWrite => {
+                        grant_has_read = true;
+                        grant_has_write = true;
+                    }
+                }
             }
-        });
-        if !is_granted {
+        }
+        if !grant_has_read && !grant_has_write {
             return Err(NonoError::SandboxInit(format!(
-                "--override-deny '{}' has no matching grant. \
-                 Add --allow, --read, or --write for this path.",
+                "override_deny '{}' has no matching grant. \
+                 Add a filesystem allow (--allow, --read, --write, or profile filesystem/policy) \
+                 for this path.",
                 override_path.display(),
             )));
         }
 
         // Warn about the security relaxation
-        eprintln!(
-            "nono: warning: --override-deny relaxing deny rule for '{}'",
+        crate::output::print_warning(&format!(
+            "override_deny relaxing deny rule for '{}'",
             canonical.display()
-        );
+        ));
 
-        // On macOS: emit Seatbelt allow rules to punch through deny
+        // On macOS: emit Seatbelt allow rules to punch through deny.
+        // Only emit rules matching the effective access mode from the union
+        // of all covering grants to preserve least-privilege.
         if cfg!(target_os = "macos") {
-            let path_utf8 = path_to_utf8(&canonical)?;
-            let escaped = escape_seatbelt_path(path_utf8)?;
+            // Emit allow rules for both the canonical path and the original
+            // expanded path (if it differs, e.g. symlink). This mirrors
+            // add_deny_access_rules which denies both the symlink and target.
+            let mut override_paths = vec![canonical.clone()];
+            if expanded != canonical {
+                override_paths.push(expanded.clone());
+            }
 
-            let filter = if canonical.exists() && canonical.is_file() {
-                format!("literal \"{}\"", escaped)
-            } else {
-                format!("subpath \"{}\"", escaped)
-            };
+            for op in &override_paths {
+                let path_utf8 = path_to_utf8(op)?;
+                let escaped = escape_seatbelt_path(path_utf8)?;
 
-            // Allow read and write, overriding the deny rules
-            caps.add_platform_rule(format!("(allow file-read-data ({}))", filter))?;
-            caps.add_platform_rule(format!("(allow file-write* ({}))", filter))?;
+                let filter = if op.exists() && op.is_file() {
+                    format!("literal \"{}\"", escaped)
+                } else {
+                    format!("subpath \"{}\"", escaped)
+                };
+
+                if grant_has_read {
+                    caps.add_platform_rule(format!("(allow file-read-data ({}))", filter))?;
+                }
+                if grant_has_write {
+                    caps.add_platform_rule(format!("(allow file-write* ({}))", filter))?;
+                }
+            }
         }
 
         // Remove deny entries that the override covers (equal or child of the override path).
-        // Do NOT remove broader deny entries when the override is a child — e.g., overriding
-        // ~/.aws must not remove a deny on the entire home directory.
-        deny_paths.retain(|dp| !dp.starts_with(&canonical));
+        // Check both the canonical and expanded (symlink) forms so that deny entries
+        // recorded for either the symlink or its target are removed.
+        // Do NOT remove broader deny entries when the override is a child — e.g.,
+        // overriding ~/.aws must not remove a deny on the entire home directory.
+        deny_paths.retain(|dp| !dp.starts_with(&canonical) && !dp.starts_with(&expanded));
     }
 
     Ok(())
@@ -1852,6 +1891,94 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_deny_overrides_respects_read_only_grant() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let denied = dir.path().join("readonly");
+        std::fs::create_dir_all(&denied).expect("mkdir");
+
+        let denied_canonical = denied.canonicalize().expect("canonicalize");
+        let mut deny_paths = vec![denied_canonical];
+        let mut caps = CapabilitySet::new();
+        // Grant read-only access
+        caps.add_fs(FsCapability::new_dir(&denied, AccessMode::Read).expect("grant"));
+        let overrides = vec![denied];
+
+        apply_deny_overrides(&overrides, &mut deny_paths, &mut caps).expect("should succeed");
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            rules.contains("allow file-read-data"),
+            "should emit read rule for read-only grant, got: {}",
+            rules
+        );
+        assert!(
+            !rules.contains("allow file-write*"),
+            "must NOT emit write rule for read-only grant, got: {}",
+            rules
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_deny_overrides_respects_write_only_grant() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let denied = dir.path().join("writeonly");
+        std::fs::create_dir_all(&denied).expect("mkdir");
+
+        let denied_canonical = denied.canonicalize().expect("canonicalize");
+        let mut deny_paths = vec![denied_canonical];
+        let mut caps = CapabilitySet::new();
+        // Grant write-only access
+        caps.add_fs(FsCapability::new_dir(&denied, AccessMode::Write).expect("grant"));
+        let overrides = vec![denied];
+
+        apply_deny_overrides(&overrides, &mut deny_paths, &mut caps).expect("should succeed");
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            !rules.contains("allow file-read-data"),
+            "must NOT emit read rule for write-only grant, got: {}",
+            rules
+        );
+        assert!(
+            rules.contains("allow file-write*"),
+            "should emit write rule for write-only grant, got: {}",
+            rules
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_deny_overrides_merges_complementary_read_write_grants() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let denied = dir.path().join("merged_rw");
+        std::fs::create_dir_all(&denied).expect("mkdir");
+
+        let denied_canonical = denied.canonicalize().expect("canonicalize");
+        let mut deny_paths = vec![denied_canonical];
+        let mut caps = CapabilitySet::new();
+        // Two separate grants: Read and Write (not yet deduplicated)
+        caps.add_fs(FsCapability::new_dir(&denied, AccessMode::Read).expect("read grant"));
+        caps.add_fs(FsCapability::new_dir(&denied, AccessMode::Write).expect("write grant"));
+        let overrides = vec![denied];
+
+        apply_deny_overrides(&overrides, &mut deny_paths, &mut caps).expect("should succeed");
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            rules.contains("allow file-read-data"),
+            "should emit read rule from merged Read+Write grants, got: {}",
+            rules
+        );
+        assert!(
+            rules.contains("allow file-write*"),
+            "should emit write rule from merged Read+Write grants, got: {}",
+            rules
+        );
+    }
+
     #[test]
     fn test_apply_deny_overrides_does_not_remove_broader_deny() {
         // Overriding a child path must NOT remove a broader parent deny.
@@ -1893,6 +2020,59 @@ mod tests {
             err.to_string().contains("no matching grant"),
             "error should mention missing grant, got: {}",
             err
+        );
+    }
+
+    #[test]
+    fn test_apply_deny_overrides_rejects_group_sourced_grant() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let denied = dir.path().join("group_granted");
+        std::fs::create_dir_all(&denied).expect("mkdir");
+
+        let denied_canonical = denied.canonicalize().expect("canonicalize");
+        let mut deny_paths = vec![denied_canonical];
+        let mut caps = CapabilitySet::new();
+        // Add a group-sourced grant (not user intent)
+        let mut cap = FsCapability::new_dir(dir.path(), AccessMode::ReadWrite).expect("grant");
+        cap.source = CapabilitySource::Group("system_write".to_string());
+        caps.add_fs(cap);
+        let overrides = vec![denied];
+
+        let result = apply_deny_overrides(&overrides, &mut deny_paths, &mut caps);
+        assert!(result.is_err());
+        let err = result.expect_err("expected error");
+        assert!(
+            err.to_string().contains("no matching grant"),
+            "group grant should not satisfy override_deny, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_apply_deny_overrides_removes_symlink_and_target_deny_paths() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let target = dir.path().join("real_dir");
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        let link = dir.path().join("link_dir");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        let target_canonical = target.canonicalize().expect("canonicalize target");
+        let link_expanded = link.clone();
+
+        // add_deny_access_rules records both the symlink path and the resolved target
+        let mut deny_paths = vec![link_expanded.clone(), target_canonical.clone()];
+        let mut caps = CapabilitySet::new();
+        // Grant via the target (which is what profile filesystem grants canonicalize to)
+        caps.add_fs(FsCapability::new_dir(&target, AccessMode::ReadWrite).expect("grant"));
+        // Override via the symlink path (what the user writes in their profile)
+        let overrides = vec![link];
+
+        apply_deny_overrides(&overrides, &mut deny_paths, &mut caps).expect("should succeed");
+
+        assert!(
+            deny_paths.is_empty(),
+            "both symlink and target deny paths should be removed, remaining: {:?}",
+            deny_paths
         );
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -72,6 +72,11 @@ pub struct PolicyPatchConfig {
     /// Additional deny.access paths to apply.
     #[serde(default)]
     pub add_deny_access: Vec<String>,
+    /// Paths to exempt from deny groups.
+    /// Each path must also be explicitly granted via `filesystem` or `policy.add_allow_*`.
+    /// Does not implicitly grant access; only removes the deny rule.
+    #[serde(default)]
+    pub override_deny: Vec<String>,
 }
 
 /// Custom credential route definition for reverse proxy.
@@ -1044,6 +1049,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.policy.add_deny_access,
                 &child.policy.add_deny_access,
             ),
+            override_deny: dedup_append(&base.policy.override_deny, &child.policy.override_deny),
         },
         network: NetworkConfig {
             block: base.network.block || child.network.block,
@@ -2120,6 +2126,7 @@ mod tests {
                 add_allow_write: vec![],
                 add_allow_readwrite: vec![],
                 add_deny_access: vec!["/base/policy-deny".to_string()],
+                override_deny: vec!["/base/override-deny".to_string()],
             },
             network: NetworkConfig {
                 block: false,
@@ -2184,6 +2191,7 @@ mod tests {
                 add_allow_write: vec!["/child/policy-write".to_string()],
                 add_allow_readwrite: vec!["/child/policy-rw".to_string()],
                 add_deny_access: vec!["/child/policy-deny".to_string()],
+                override_deny: vec!["/child/override-deny".to_string()],
             },
             network: NetworkConfig {
                 block: false,
@@ -2849,6 +2857,14 @@ mod tests {
             .policy
             .add_deny_access
             .contains(&"/child/policy-deny".to_string()));
+        assert!(merged
+            .policy
+            .override_deny
+            .contains(&"/base/override-deny".to_string()));
+        assert!(merged
+            .policy
+            .override_deny
+            .contains(&"/child/override-deny".to_string()));
     }
 
     #[test]
@@ -2903,7 +2919,8 @@ mod tests {
                     "add_allow_read": ["/tmp/read"],
                     "add_allow_write": ["/tmp/write"],
                     "add_allow_readwrite": ["/tmp/rw"],
-                    "add_deny_access": ["/tmp/deny"]
+                    "add_deny_access": ["/tmp/deny"],
+                    "override_deny": ["~/.docker"]
                 }
             }"#,
         )
@@ -2914,6 +2931,7 @@ mod tests {
         assert_eq!(profile.policy.add_allow_write, vec!["/tmp/write"]);
         assert_eq!(profile.policy.add_allow_readwrite, vec!["/tmp/rw"]);
         assert_eq!(profile.policy.add_deny_access, vec!["/tmp/deny"]);
+        assert_eq!(profile.policy.override_deny, vec!["~/.docker"]);
     }
 
     #[test]

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -35,7 +35,16 @@ pub enum QueryResult {
 }
 
 /// Query whether a path operation is permitted
-pub fn query_path(path: &Path, requested: AccessMode, caps: &CapabilitySet) -> Result<QueryResult> {
+///
+/// `overridden_paths` contains canonicalized paths that have been exempted from
+/// deny groups via `override_deny`. The sensitive-path check is skipped for any
+/// query path that is equal to or a child of an overridden path.
+pub fn query_path(
+    path: &Path,
+    requested: AccessMode,
+    caps: &CapabilitySet,
+    overridden_paths: &[std::path::PathBuf],
+) -> Result<QueryResult> {
     // Canonicalize the path for proper comparison
     let canonical = if path.exists() {
         path.canonicalize()
@@ -63,15 +72,23 @@ pub fn query_path(path: &Path, requested: AccessMode, caps: &CapabilitySet) -> R
         }
     };
 
-    // First, check if this is a sensitive path (CLI security policy)
-    if let Some(matched) = config::check_sensitive_path(&canonical.to_string_lossy())? {
-        return Ok(QueryResult::Denied {
-            reason: "sensitive_path".to_string(),
-            details: Some(format!(
-                "Path matches sensitive pattern '{}'. Access blocked by security policy.",
-                matched
-            )),
-        });
+    // Check if this path is covered by an override_deny exemption
+    let is_overridden = overridden_paths
+        .iter()
+        .any(|op| canonical == *op || canonical.starts_with(op));
+
+    // Check if this is a sensitive path (CLI security policy), but skip
+    // the check for paths that have been explicitly overridden.
+    if !is_overridden {
+        if let Some(matched) = config::check_sensitive_path(&canonical.to_string_lossy())? {
+            return Ok(QueryResult::Denied {
+                reason: "sensitive_path".to_string(),
+                details: Some(format!(
+                    "Path matches sensitive pattern '{}'. Access blocked by security policy.",
+                    matched
+                )),
+            });
+        }
     }
 
     // Check capabilities. Prefer the most specific matching grant so broad system
@@ -207,7 +224,7 @@ mod tests {
         let test_file = dir.path().join("test.txt");
         std::fs::write(&test_file, "test").expect("Failed to write test file");
 
-        let result = query_path(&test_file, AccessMode::Read, &caps).expect("Query failed");
+        let result = query_path(&test_file, AccessMode::Read, &caps, &[]).expect("Query failed");
         assert!(matches!(result, QueryResult::Allowed { .. }));
     }
 
@@ -216,7 +233,7 @@ mod tests {
         let caps = CapabilitySet::new();
         let path = PathBuf::from("/some/random/path");
 
-        let result = query_path(&path, AccessMode::Read, &caps).expect("Query failed");
+        let result = query_path(&path, AccessMode::Read, &caps, &[]).expect("Query failed");
         assert!(matches!(result, QueryResult::Denied { .. }));
     }
 
@@ -252,7 +269,7 @@ mod tests {
         let test_file = dir_canon.join("test.txt");
         std::fs::write(&test_file, "test").expect("Failed to write test file");
 
-        let result = query_path(&test_file, AccessMode::Write, &caps).expect("Query failed");
+        let result = query_path(&test_file, AccessMode::Write, &caps, &[]).expect("Query failed");
         assert!(matches!(result, QueryResult::Allowed { .. }));
     }
 

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -25,6 +25,9 @@ pub struct SandboxState {
     pub allowed_commands: Vec<String>,
     /// Commands explicitly blocked
     pub blocked_commands: Vec<String>,
+    /// Paths exempted from deny groups via override_deny (canonicalized)
+    #[serde(default)]
+    pub override_deny_paths: Vec<String>,
 }
 
 /// Serializable filesystem capability state
@@ -41,8 +44,8 @@ pub struct FsCapState {
 }
 
 impl SandboxState {
-    /// Create sandbox state from a CapabilitySet
-    pub fn from_caps(caps: &CapabilitySet) -> Self {
+    /// Create sandbox state from a CapabilitySet and override_deny paths
+    pub fn from_caps(caps: &CapabilitySet, override_deny_paths: &[PathBuf]) -> Self {
         Self {
             fs: caps
                 .fs_capabilities()
@@ -61,7 +64,16 @@ impl SandboxState {
             net_blocked: caps.is_network_blocked(),
             allowed_commands: caps.allowed_commands().to_vec(),
             blocked_commands: caps.blocked_commands().to_vec(),
+            override_deny_paths: override_deny_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
         }
+    }
+
+    /// Get override_deny paths as PathBufs for query use
+    pub fn override_deny_as_paths(&self) -> Vec<PathBuf> {
+        self.override_deny_paths.iter().map(PathBuf::from).collect()
     }
 
     /// Convert back to a CapabilitySet
@@ -346,7 +358,7 @@ mod tests {
         let mut caps = CapabilitySet::new().block_network();
         caps.add_allowed_command("pip".to_string());
 
-        let state = SandboxState::from_caps(&caps);
+        let state = SandboxState::from_caps(&caps, &[]);
         assert!(state.net_blocked);
         assert_eq!(state.allowed_commands, vec!["pip"]);
 
@@ -364,7 +376,7 @@ mod tests {
 
         let caps = CapabilitySet::new().block_network();
 
-        let state = SandboxState::from_caps(&caps);
+        let state = SandboxState::from_caps(&caps, &[]);
         state
             .write_to_file(&file_path)
             .expect("Failed to write state");

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -65,7 +65,8 @@ Profiles use JSON format:
     "add_allow_read": [],
     "add_allow_write": [],
     "add_allow_readwrite": [],
-    "add_deny_access": []
+    "add_deny_access": [],
+    "override_deny": []
   },
   "network": {
     "block": false
@@ -122,6 +123,7 @@ The `policy` section provides fine-grained, additive and subtractive composition
 | `add_allow_write` | Additional write-only directories to allow |
 | `add_allow_readwrite` | Additional read+write directories to allow |
 | `add_deny_access` | Additional deny rules to apply (block read and write content) |
+| `override_deny` | Paths to exempt from deny groups (must also have a matching grant) |
 
 #### Adding a Deny Rule to an Inherited Profile
 
@@ -183,6 +185,34 @@ Remove the dangerous command blocking group to allow `rm`, `chmod`, etc.:
     ]
   }
 }
+```
+
+#### Overriding a Deny Rule for a Specific Path
+
+Some deny groups (like `deny_credentials`) are marked as required and cannot be excluded. Use `override_deny` to punch a targeted hole through a deny group for a specific path. The path must also be explicitly granted via `filesystem` or `policy.add_allow_*`.
+
+```json
+{
+  "meta": {
+    "name": "docker-agent",
+    "version": "1.0.0"
+  },
+  "extends": "opencode",
+  "filesystem": {
+    "allow": ["$HOME/.docker"]
+  },
+  "policy": {
+    "override_deny": ["$HOME/.docker"]
+  }
+}
+```
+
+This allows access to `~/.docker` even though `deny_credentials` blocks it by default. The deny override does not implicitly grant access -- the matching `filesystem.allow` entry is required.
+
+This is equivalent to the CLI flag `--override-deny`:
+
+```bash
+nono run --profile opencode --allow ~/.docker --override-deny ~/.docker -- opencode
 ```
 
 <Note>
@@ -374,7 +404,7 @@ Groups are named, composable collections of security rules. Profiles reference g
 Every profile's effective capability set is built through composition:
 
 ```
-((default_profile_groups + profile.security.groups) - profile.policy.exclude_groups) + profile.policy.add_* + profile.filesystem + CLI flags
+((default_profile_groups + profile.security.groups) - profile.policy.exclude_groups) + profile.policy.add_* + profile.filesystem - deny_groups + profile.policy.override_deny + CLI flags
 ```
 
 1. **default_profile_groups** come from the built-in `default` profile
@@ -382,7 +412,8 @@ Every profile's effective capability set is built through composition:
 3. **profile.policy.exclude_groups** removes groups from the composed set (exclusion wins)
 4. **profile.policy.add_allow_*** and **profile.policy.add_deny_access** apply additive overrides
 5. **profile.filesystem** entries are additive
-6. **CLI overrides** (`--allow`, `--read`, etc.) are applied last
+6. **profile.policy.override_deny** punches targeted holes through deny groups (requires matching grant)
+7. **CLI overrides** (`--allow`, `--read`, `--override-deny`, etc.) are applied last
 
 Exclusions are applied after group addition. If the same group appears in both
 `security.groups` and `policy.exclude_groups`, the exclusion wins.

--- a/tests/integration/test_override_deny.sh
+++ b/tests/integration/test_override_deny.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# Override Deny Tests
+# Verifies that override_deny in profiles and --override-deny CLI flag
+# correctly punch through deny groups while requiring explicit grants.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+echo ""
+echo -e "${BLUE}=== Override Deny Tests ===${NC}"
+
+verify_nono_binary
+if ! require_working_sandbox "override deny suite"; then
+    print_summary
+    exit 0
+fi
+
+# Create test fixtures
+TMPDIR=$(setup_test_dir)
+trap 'cleanup_test_dir "$TMPDIR"' EXIT
+
+PROFILES_DIR="$TMPDIR/profiles"
+mkdir -p "$PROFILES_DIR"
+
+# Create a directory that mimics a sensitive path for testing.
+# We use ~/.docker which is in deny_credentials.
+DOCKER_DIR="$HOME/.docker"
+
+echo ""
+echo "Test directory: $TMPDIR"
+echo ""
+
+# =============================================================================
+# CLI --override-deny
+# =============================================================================
+
+echo "--- CLI --override-deny ---"
+
+if [[ -d "$DOCKER_DIR" ]]; then
+    # override-deny with matching grant should succeed
+    expect_success "CLI --override-deny with --allow succeeds (dry-run)" \
+        "$NONO_BIN" run --allow "$DOCKER_DIR" --override-deny "$DOCKER_DIR" --dry-run -- echo ok
+
+    # override-deny without grant should fail
+    expect_failure "CLI --override-deny without grant fails" \
+        "$NONO_BIN" run --override-deny "$DOCKER_DIR" --dry-run -- echo ok
+
+    # override-deny with read-only grant should succeed
+    expect_success "CLI --override-deny with --read succeeds (dry-run)" \
+        "$NONO_BIN" run --read "$DOCKER_DIR" --override-deny "$DOCKER_DIR" --dry-run -- echo ok
+else
+    skip_test "CLI --override-deny with --allow" "~/.docker not found"
+    skip_test "CLI --override-deny without grant" "~/.docker not found"
+    skip_test "CLI --override-deny with --read" "~/.docker not found"
+fi
+
+# =============================================================================
+# Profile override_deny
+# =============================================================================
+
+echo ""
+echo "--- Profile override_deny ---"
+
+if [[ -d "$DOCKER_DIR" ]]; then
+    # Profile with override_deny and matching filesystem grant
+    cat > "$PROFILES_DIR/docker-override.json" <<EOF
+{
+    "meta": { "name": "docker-override", "version": "1.0.0" },
+    "extends": "default",
+    "filesystem": {
+        "allow": ["\$HOME/.docker"]
+    },
+    "policy": {
+        "override_deny": ["\$HOME/.docker"]
+    }
+}
+EOF
+
+    expect_success "profile override_deny with filesystem grant succeeds (dry-run)" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-override.json" --dry-run -- echo ok
+
+    expect_output_contains "profile override_deny shows .docker in capabilities" ".docker" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-override.json" --dry-run -- echo ok
+
+    # Profile with override_deny but NO filesystem grant
+    cat > "$PROFILES_DIR/docker-no-grant.json" <<EOF
+{
+    "meta": { "name": "docker-no-grant", "version": "1.0.0" },
+    "extends": "default",
+    "policy": {
+        "override_deny": ["\$HOME/.docker"]
+    }
+}
+EOF
+
+    expect_failure "profile override_deny without grant fails" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-no-grant.json" --dry-run -- echo ok
+
+    expect_output_contains "profile override_deny without grant mentions missing grant" \
+        "no matching grant" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-no-grant.json" --dry-run -- echo ok
+
+    # Profile with read-only grant (least privilege)
+    cat > "$PROFILES_DIR/docker-readonly.json" <<EOF
+{
+    "meta": { "name": "docker-readonly", "version": "1.0.0" },
+    "extends": "default",
+    "filesystem": {
+        "read": ["\$HOME/.docker"]
+    },
+    "policy": {
+        "override_deny": ["\$HOME/.docker"]
+    }
+}
+EOF
+
+    expect_success "profile override_deny with read-only grant succeeds (dry-run)" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-readonly.json" --dry-run -- echo ok
+else
+    skip_test "profile override_deny with filesystem grant" "~/.docker not found"
+    skip_test "profile override_deny shows .docker in capabilities" "~/.docker not found"
+    skip_test "profile override_deny without grant fails" "~/.docker not found"
+    skip_test "profile override_deny without grant mentions missing grant" "~/.docker not found"
+    skip_test "profile override_deny with read-only grant" "~/.docker not found"
+fi
+
+# =============================================================================
+# nono why with override_deny
+# =============================================================================
+
+echo ""
+echo "--- nono why with override_deny ---"
+
+if [[ -d "$DOCKER_DIR" ]]; then
+    # Without override, ~/.docker should be denied
+    expect_output_contains "nono why reports .docker denied without override" \
+        "sensitive_path" \
+        "$NONO_BIN" --silent why --json --path "$DOCKER_DIR" --op read
+
+    # With profile override_deny, ~/.docker should be allowed
+    expect_output_contains "nono why reports .docker allowed with profile override" \
+        "\"status\": \"allowed\"" \
+        "$NONO_BIN" --silent why --json --profile "$PROFILES_DIR/docker-override.json" \
+            --path "$DOCKER_DIR" --op read
+
+    # With read-only profile, write should be denied
+    expect_output_contains "nono why reports .docker write denied with read-only profile" \
+        "insufficient_access" \
+        "$NONO_BIN" --silent why --json --profile "$PROFILES_DIR/docker-readonly.json" \
+            --path "$DOCKER_DIR" --op write
+else
+    skip_test "nono why reports .docker denied without override" "~/.docker not found"
+    skip_test "nono why reports .docker allowed with profile override" "~/.docker not found"
+    skip_test "nono why reports .docker write denied with read-only profile" "~/.docker not found"
+fi
+
+# =============================================================================
+# Override deny with profile inheritance
+# =============================================================================
+
+echo ""
+echo "--- Profile Inheritance ---"
+
+if [[ -d "$DOCKER_DIR" ]]; then
+    # Child profile inherits override_deny from parent via user profiles directory.
+    # The extends field resolves by name from ~/.config/nono/profiles/.
+    USER_PROFILES_DIR="$HOME/.config/nono/profiles"
+    CREATED_USER_PROFILES=0
+    if [[ ! -d "$USER_PROFILES_DIR" ]]; then
+        mkdir -p "$USER_PROFILES_DIR"
+        CREATED_USER_PROFILES=1
+    fi
+
+    cat > "$USER_PROFILES_DIR/nono-test-docker-base.json" <<EOF
+{
+    "meta": { "name": "nono-test-docker-base", "version": "1.0.0" },
+    "extends": "default",
+    "filesystem": {
+        "allow": ["\$HOME/.docker"]
+    },
+    "policy": {
+        "override_deny": ["\$HOME/.docker"]
+    }
+}
+EOF
+
+    cat > "$USER_PROFILES_DIR/nono-test-docker-child.json" <<EOF
+{
+    "meta": { "name": "nono-test-docker-child", "version": "1.0.0" },
+    "extends": "nono-test-docker-base",
+    "filesystem": {
+        "read": ["\$HOME/.config"]
+    }
+}
+EOF
+
+    expect_success "child profile inherits override_deny from parent (dry-run)" \
+        "$NONO_BIN" run --profile nono-test-docker-child --dry-run -- echo ok
+
+    expect_output_contains "child profile shows .docker from inherited override" ".docker" \
+        "$NONO_BIN" run --profile nono-test-docker-child --dry-run -- echo ok
+
+    # Cleanup
+    rm -f "$USER_PROFILES_DIR/nono-test-docker-base.json" \
+          "$USER_PROFILES_DIR/nono-test-docker-child.json"
+    if [[ "$CREATED_USER_PROFILES" -eq 1 ]]; then
+        rmdir "$USER_PROFILES_DIR" 2>/dev/null || true
+    fi
+else
+    skip_test "child profile inherits override_deny from parent" "~/.docker not found"
+    skip_test "child profile shows .docker from inherited override" "~/.docker not found"
+fi
+
+# =============================================================================
+# Override deny does NOT bypass other deny groups
+# =============================================================================
+
+echo ""
+echo "--- Override scope is targeted ---"
+
+if [[ -d "$DOCKER_DIR" ]] && [[ -d "$HOME/.ssh" ]]; then
+    # Overriding .docker must NOT also unlock .ssh
+    expect_output_contains "override_deny for .docker does not bypass .ssh deny" \
+        "sensitive_path" \
+        "$NONO_BIN" --silent why --json --profile "$PROFILES_DIR/docker-override.json" \
+            --path "$HOME/.ssh" --op read
+else
+    skip_test "override_deny for .docker does not bypass .ssh deny" "~/.docker or ~/.ssh not found"
+fi
+
+# =============================================================================
+# Warning output
+# =============================================================================
+
+echo ""
+echo "--- Warning output ---"
+
+if [[ -d "$DOCKER_DIR" ]]; then
+    expect_output_contains "override_deny shows styled warning" \
+        "warning:" \
+        "$NONO_BIN" run --profile "$PROFILES_DIR/docker-override.json" --dry-run -- echo ok
+else
+    skip_test "override_deny shows styled warning" "~/.docker not found"
+fi
+
+# =============================================================================
+# Required groups cannot be excluded
+# =============================================================================
+
+echo ""
+echo "--- Required group protection ---"
+
+cat > "$PROFILES_DIR/exclude-required.json" <<EOF
+{
+    "meta": { "name": "exclude-required", "version": "1.0.0" },
+    "extends": "default",
+    "policy": {
+        "exclude_groups": ["deny_credentials"]
+    }
+}
+EOF
+
+expect_failure "excluding required deny_credentials group fails" \
+    "$NONO_BIN" run --profile "$PROFILES_DIR/exclude-required.json" --dry-run -- echo ok
+
+expect_output_contains "excluding required group mentions 'required'" \
+    "required" \
+    "$NONO_BIN" run --profile "$PROFILES_DIR/exclude-required.json" --dry-run -- echo ok
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+print_summary

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -81,6 +81,7 @@ SUITES=(
     "test_rollback.sh:Rollback"
     "test_setup.sh:Setup"
     "test_learn.sh:Learn Mode"
+    "test_override_deny.sh:Override Deny"
 )
 
 TOTAL_SUITES=${#SUITES[@]}


### PR DESCRIPTION
Allow profiles to specify `policy.override_deny` paths that punch targeted holes through deny groups. Each override must have a matching grant via `filesystem` or `policy.add_allow_*`. Add tests validating that overrides require grants and preserve directory access through deny rules. Update docs with usage examples and composition diagram.