### PR TITLE
feat(cli): add `nono policy` introspection subcommand

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -217,6 +217,28 @@ PLATFORM NOTES:
 ")]
     Audit(AuditArgs),
 
+    /// Inspect policy groups, profiles, and security rules
+    #[command(after_help = "EXAMPLES:
+    # List all policy groups
+    nono policy groups
+
+    # Show details for a specific group
+    nono policy groups deny_credentials
+
+    # List all profiles (built-in and user)
+    nono policy profiles
+
+    # Show a fully resolved profile
+    nono policy show claude-code
+
+    # Compare two profiles
+    nono policy diff default claude-code
+
+    # Validate a user profile file
+    nono policy validate ~/my-profile.json
+")]
+    Policy(PolicyArgs),
+
     /// Internal: open a URL via supervisor IPC
     #[command(hide = true)]
     OpenUrlHelper(OpenUrlHelperArgs),
@@ -232,6 +254,77 @@ PLATFORM NOTES:
 pub struct OpenUrlHelperArgs {
     /// The URL to open
     pub url: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyArgs {
+    #[command(subcommand)]
+    pub command: PolicyCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PolicyCommands {
+    /// List policy groups or show details for a specific group
+    Groups(PolicyGroupsArgs),
+    /// List all available profiles (built-in and user)
+    Profiles(PolicyProfilesArgs),
+    /// Show a fully resolved profile
+    Show(PolicyShowArgs),
+    /// Diff two profiles
+    Diff(PolicyDiffArgs),
+    /// Validate a profile JSON file
+    Validate(PolicyValidateArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyGroupsArgs {
+    /// Group name to show details for (omit to list all)
+    pub name: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+    /// Show all platforms (not just current)
+    #[arg(long)]
+    pub all_platforms: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyProfilesArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyShowArgs {
+    /// Profile name or path
+    pub profile: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+    /// Show raw paths before expansion (e.g., $HOME instead of /Users/luke)
+    #[arg(long)]
+    pub raw: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyDiffArgs {
+    /// First profile name or path
+    pub profile1: String,
+    /// Second profile name or path
+    pub profile2: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct PolicyValidateArgs {
+    /// Profile JSON file to validate
+    pub file: PathBuf,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Parser, Debug, Clone, Default)]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -13,6 +13,7 @@ mod learn;
 mod network_policy;
 mod output;
 mod policy;
+mod policy_cmd;
 mod profile;
 mod protected_paths;
 mod query_ext;
@@ -120,6 +121,7 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         | Commands::Rollback(_)
         | Commands::Trust(_)
         | Commands::Audit(_)
+        | Commands::Policy(_)
         | Commands::OpenUrlHelper(_) => 0,
     }
 }
@@ -168,6 +170,10 @@ fn run(cli: Cli) -> Result<()> {
         Commands::Audit(args) => {
             show_update_notification(&mut update_handle, cli.silent);
             audit_commands::run_audit(args)
+        }
+        Commands::Policy(args) => {
+            show_update_notification(&mut update_handle, cli.silent);
+            policy_cmd::run_policy(args)
         }
         Commands::OpenUrlHelper(args) => run_open_url_helper(args),
     }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -160,7 +160,7 @@ impl ProfileDef {
 // ============================================================================
 
 /// Current platform identifier
-fn current_platform() -> &'static str {
+pub(crate) fn current_platform() -> &'static str {
     if cfg!(target_os = "macos") {
         "macos"
     } else if cfg!(target_os = "linux") {
@@ -171,7 +171,7 @@ fn current_platform() -> &'static str {
 }
 
 /// Check if a group applies to the current platform
-fn group_matches_platform(group: &Group) -> bool {
+pub(crate) fn group_matches_platform(group: &Group) -> bool {
     match &group.platform {
         Some(platform) => platform == current_platform(),
         None => true, // No platform restriction = applies everywhere
@@ -185,7 +185,7 @@ fn group_matches_platform(group: &Group) -> bool {
 /// Expand `~` to $HOME and `$TMPDIR` to the environment variable value.
 ///
 /// Returns an error if HOME or TMPDIR are set to non-absolute paths.
-fn expand_path(path_str: &str) -> Result<PathBuf> {
+pub(crate) fn expand_path(path_str: &str) -> Result<PathBuf> {
     use crate::config;
 
     let expanded = if let Some(rest) = path_str.strip_prefix("~/") {

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -14,6 +14,12 @@ use colored::Colorize;
 use nono::{NonoError, Result};
 use std::collections::BTreeSet;
 
+/// Serialize a value to pretty-printed JSON, propagating serialization errors.
+fn to_json(val: &serde_json::Value) -> Result<String> {
+    serde_json::to_string_pretty(val)
+        .map_err(|e| NonoError::ProfileParse(format!("JSON serialization failed: {e}")))
+}
+
 /// Prefix used for all policy command output
 fn prefix() -> colored::ColoredString {
     let t = theme::current();
@@ -66,7 +72,7 @@ fn cmd_groups_list(pol: &policy::Policy, json: bool, all_platforms: bool) -> Res
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+        println!("{}", to_json(&serde_json::Value::Array(arr))?);
         return Ok(());
     }
 
@@ -108,7 +114,7 @@ fn cmd_groups_detail(pol: &policy::Policy, name: &str, json: bool) -> Result<()>
 
     if json {
         let val = group_to_json(name, group);
-        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        println!("{}", to_json(&val)?);
         return Ok(());
     }
 
@@ -360,7 +366,7 @@ fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
             .map(|(n, p)| format_entry(n, p))
             .chain(user_profiles.iter().map(|(n, p)| format_entry(n, p)))
             .collect();
-        println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+        println!("{}", to_json(&serde_json::Value::Array(arr))?);
         return Ok(());
     }
 
@@ -424,7 +430,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
 
     if args.json {
         let val = profile_to_json(&args.profile, &profile, &raw_extends);
-        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        println!("{}", to_json(&val)?);
         return Ok(());
     }
 
@@ -774,7 +780,7 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
 
     if args.json {
         let val = diff_to_json(&args.profile1, &args.profile2, &p1, &p2);
-        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        println!("{}", to_json(&val)?);
         return Ok(());
     }
 
@@ -1685,7 +1691,7 @@ fn cmd_validate(args: PolicyValidateArgs) -> Result<()> {
             "errors": errors,
             "warnings": warnings,
         });
-        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        println!("{}", to_json(&val)?);
         if !errors.is_empty() {
             return Err(NonoError::ProfileParse("validation failed".into()));
         }

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -298,16 +298,38 @@ fn expand_paths_json(paths: &[String]) -> serde_json::Value {
 // nono policy profiles
 // ---------------------------------------------------------------------------
 
+/// Determine the actual source of a loaded profile.
+///
+/// Load precedence is user-first (profile/mod.rs), so a user file with a
+/// built-in name shadows the built-in. We must check the filesystem to
+/// report the real source accurately.
+fn profile_source(name: &str) -> &'static str {
+    let builtin_names = profile::builtin::list_builtin();
+    if profile::is_user_override(name) {
+        if builtin_names.contains(&name.to_string()) {
+            "user (overrides built-in)"
+        } else {
+            "user"
+        }
+    } else if builtin_names.contains(&name.to_string()) {
+        "built-in"
+    } else {
+        "user"
+    }
+}
+
 fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
     let builtin_names = profile::builtin::list_builtin();
     let all_names = profile::list_profiles();
 
-    let mut builtin_profiles: Vec<(String, Option<Profile>)> = Vec::new();
-    let mut user_profiles: Vec<(String, Option<Profile>)> = Vec::new();
+    let mut builtin_profiles: Vec<(String, Result<Profile>)> = Vec::new();
+    let mut user_profiles: Vec<(String, Result<Profile>)> = Vec::new();
 
     for name in &all_names {
-        let p = profile::load_profile(name).ok();
-        if builtin_names.contains(name) {
+        let p = profile::load_profile(name);
+        // Categorize by actual source: user overrides of built-in names
+        // go under user section to make shadowing visible.
+        if builtin_names.contains(name) && !profile::is_user_override(name) {
             builtin_profiles.push((name.clone(), p));
         } else {
             user_profiles.push((name.clone(), p));
@@ -315,30 +337,28 @@ fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
     }
 
     if args.json {
-        let format_entry = |name: &str, profile: &Option<Profile>, source: &str| {
-            let (desc, extends) = match profile {
-                Some(p) => (
-                    p.meta.description.as_deref().unwrap_or(""),
-                    p.extends.as_deref().unwrap_or(""),
-                ),
-                None => ("", ""),
-            };
-            serde_json::json!({
-                "name": name,
-                "source": source,
-                "description": desc,
-                "extends": extends,
-            })
+        let format_entry = |name: &str, result: &Result<Profile>| {
+            let source = profile_source(name);
+            let extends = profile::load_profile_extends(name).unwrap_or_default();
+            match result {
+                Ok(p) => serde_json::json!({
+                    "name": name,
+                    "source": source,
+                    "description": p.meta.description.as_deref().unwrap_or(""),
+                    "extends": extends,
+                }),
+                Err(e) => serde_json::json!({
+                    "name": name,
+                    "source": source,
+                    "error": format!("{}", e),
+                }),
+            }
         };
 
         let arr: Vec<serde_json::Value> = builtin_profiles
             .iter()
-            .map(|(n, p)| format_entry(n, p, "built-in"))
-            .chain(
-                user_profiles
-                    .iter()
-                    .map(|(n, p)| format_entry(n, p, "user")),
-            )
+            .map(|(n, p)| format_entry(n, p))
+            .chain(user_profiles.iter().map(|(n, p)| format_entry(n, p)))
             .collect();
         println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
         return Ok(());
@@ -351,8 +371,8 @@ fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
     if !builtin_profiles.is_empty() {
         println!();
         println!("  {}", theme::fg("Built-in:", t.subtext).bold());
-        for (name, profile) in &builtin_profiles {
-            print_profile_line(name, profile, t);
+        for (name, result) in &builtin_profiles {
+            print_profile_line(name, result, t);
         }
     }
 
@@ -362,31 +382,36 @@ fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
             "  {}",
             theme::fg("User (~/.config/nono/profiles/):", t.subtext).bold()
         );
-        for (name, profile) in &user_profiles {
-            print_profile_line(name, profile, t);
+        for (name, result) in &user_profiles {
+            print_profile_line(name, result, t);
         }
     }
 
     Ok(())
 }
 
-fn print_profile_line(name: &str, profile: &Option<Profile>, t: &theme::Theme) {
-    let (desc, extends) = match profile {
-        Some(p) => (
-            p.meta.description.as_deref().unwrap_or("").to_string(),
-            p.extends
-                .as_ref()
+fn print_profile_line(name: &str, result: &Result<Profile>, t: &theme::Theme) {
+    match result {
+        Ok(p) => {
+            let desc = p.meta.description.as_deref().unwrap_or("").to_string();
+            let extends = profile::load_profile_extends(name)
                 .map(|e| format!("extends {}", e))
-                .unwrap_or_default(),
-        ),
-        None => (String::new(), String::new()),
-    };
-    println!(
-        "    {:<16} {:<42} {}",
-        theme::fg(name, t.text).bold(),
-        theme::fg(&desc, t.subtext),
-        theme::fg(&extends, t.overlay),
-    );
+                .unwrap_or_default();
+            println!(
+                "    {:<16} {:<42} {}",
+                theme::fg(name, t.text).bold(),
+                theme::fg(&desc, t.subtext),
+                theme::fg(&extends, t.overlay),
+            );
+        }
+        Err(e) => {
+            println!(
+                "    {:<16} {}",
+                theme::fg(name, t.text).bold(),
+                theme::fg(&format!("[error: {}]", e), t.red),
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -394,10 +419,11 @@ fn print_profile_line(name: &str, profile: &Option<Profile>, t: &theme::Theme) {
 // ---------------------------------------------------------------------------
 
 fn cmd_show(args: PolicyShowArgs) -> Result<()> {
+    let raw_extends = profile::load_profile_extends(&args.profile);
     let profile = profile::load_profile(&args.profile)?;
 
     if args.json {
-        let val = profile_to_json(&args.profile, &profile);
+        let val = profile_to_json(&args.profile, &profile, &raw_extends);
         println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
         return Ok(());
     }
@@ -418,7 +444,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
             theme::fg(desc, t.text)
         );
     }
-    if let Some(ref extends) = profile.extends {
+    if let Some(ref extends) = raw_extends {
         println!(
             "  {}      {}",
             theme::fg("Extends:", t.subtext),
@@ -636,11 +662,15 @@ fn print_fs_paths(label: &str, paths: &[String], t: &theme::Theme, raw: bool) {
     }
 }
 
-fn profile_to_json(name: &str, profile: &Profile) -> serde_json::Value {
+fn profile_to_json(
+    name: &str,
+    profile: &Profile,
+    raw_extends: &Option<String>,
+) -> serde_json::Value {
     let mut val = serde_json::json!({
         "name": name,
         "description": profile.meta.description.as_deref().unwrap_or(""),
-        "extends": profile.extends.as_deref().unwrap_or(""),
+        "extends": raw_extends.as_deref().unwrap_or(""),
     });
 
     // Security
@@ -693,12 +723,42 @@ fn profile_to_json(name: &str, profile: &Profile) -> serde_json::Value {
         "exclude_globs": profile.rollback.exclude_globs,
     });
 
+    // Env credentials
+    if !profile.env_credentials.mappings.is_empty() {
+        val["env_credentials"] = serde_json::json!(profile.env_credentials.mappings);
+    }
+
+    // Hooks
+    if !profile.hooks.hooks.is_empty() {
+        let hooks: serde_json::Map<String, serde_json::Value> = profile
+            .hooks
+            .hooks
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    serde_json::json!({
+                        "event": v.event,
+                        "matcher": v.matcher,
+                        "script": v.script,
+                    }),
+                )
+            })
+            .collect();
+        val["hooks"] = serde_json::Value::Object(hooks);
+    }
+
     // Open URLs
     if let Some(ref urls) = profile.open_urls {
         val["open_urls"] = serde_json::json!({
             "allow_origins": urls.allow_origins,
             "allow_localhost": urls.allow_localhost,
         });
+    }
+
+    // Allow launch services
+    if let Some(als) = profile.allow_launch_services {
+        val["allow_launch_services"] = serde_json::json!(als);
     }
 
     val
@@ -832,6 +892,26 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         }
     }
 
+    // Security scalar fields
+    any_diff |= diff_scalar_option(
+        "capability_elevation",
+        &p1.security.capability_elevation.map(|v| format!("{v}")),
+        &p2.security.capability_elevation.map(|v| format!("{v}")),
+        t,
+    );
+    any_diff |= diff_scalar_option(
+        "signal_mode",
+        &p1.security.signal_mode.map(|v| format!("{v:?}")),
+        &p2.security.signal_mode.map(|v| format!("{v:?}")),
+        t,
+    );
+    any_diff |= diff_scalar_option(
+        "process_info_mode",
+        &p1.security.process_info_mode.map(|v| format!("{v:?}")),
+        &p2.security.process_info_mode.map(|v| format!("{v:?}")),
+        t,
+    );
+
     // Network
     let mut net_diffs: Vec<(String, String)> = Vec::new();
     if p1.network.block != p2.network.block {
@@ -851,7 +931,29 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         }
     }
 
-    if !net_diffs.is_empty() {
+    let net_vec_diffs = diff_string_vecs(&[
+        (
+            "proxy_allow",
+            &p1.network.proxy_allow,
+            &p2.network.proxy_allow,
+        ),
+        (
+            "proxy_credentials",
+            &p1.network.proxy_credentials,
+            &p2.network.proxy_credentials,
+        ),
+        (
+            "external_proxy_bypass",
+            &p1.network.external_proxy_bypass,
+            &p2.network.external_proxy_bypass,
+        ),
+    ]);
+
+    let port1: Vec<String> = p1.network.port_allow.iter().map(|p| p.to_string()).collect();
+    let port2: Vec<String> = p2.network.port_allow.iter().map(|p| p.to_string()).collect();
+    let port_diffs = diff_string_vecs(&[("port_allow", &port1, &port2)]);
+
+    if !net_diffs.is_empty() || !net_vec_diffs.is_empty() || !port_diffs.is_empty() {
         any_diff = true;
         println!();
         println!("  {}:", theme::fg("Network", t.subtext).bold());
@@ -863,7 +965,23 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
                 println!("    {}", theme::fg(add, t.green));
             }
         }
+        for (label, sign, val) in net_vec_diffs.iter().chain(port_diffs.iter()) {
+            let color = if *sign == "+" { t.green } else { t.red };
+            println!(
+                "    {} {} {}",
+                theme::fg(sign, color),
+                theme::fg(label, t.subtext),
+                theme::fg(val, color)
+            );
+        }
     }
+
+    any_diff |= diff_scalar_option(
+        "external_proxy",
+        &p1.network.external_proxy,
+        &p2.network.external_proxy,
+        t,
+    );
 
     // Workdir
     if p1.workdir.access != p2.workdir.access {
@@ -908,12 +1026,324 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         }
     }
 
+    // Rollback
+    let rb_diffs = diff_string_vecs(&[
+        (
+            "exclude_patterns",
+            &p1.rollback.exclude_patterns,
+            &p2.rollback.exclude_patterns,
+        ),
+        (
+            "exclude_globs",
+            &p1.rollback.exclude_globs,
+            &p2.rollback.exclude_globs,
+        ),
+    ]);
+    if !rb_diffs.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Rollback", t.subtext).bold());
+        for (label, sign, val) in &rb_diffs {
+            let color = if *sign == "+" { t.green } else { t.red };
+            println!(
+                "    {} {} {}",
+                theme::fg(sign, color),
+                theme::fg(label, t.subtext),
+                theme::fg(val, color)
+            );
+        }
+    }
+
+    // Open URLs
+    let ou1_origins: Vec<String> = p1
+        .open_urls
+        .as_ref()
+        .map(|u| u.allow_origins.clone())
+        .unwrap_or_default();
+    let ou2_origins: Vec<String> = p2
+        .open_urls
+        .as_ref()
+        .map(|u| u.allow_origins.clone())
+        .unwrap_or_default();
+    let ou_diffs = diff_string_vecs(&[("allow_origins", &ou1_origins, &ou2_origins)]);
+    let ou1_localhost = p1.open_urls.as_ref().is_some_and(|u| u.allow_localhost);
+    let ou2_localhost = p2.open_urls.as_ref().is_some_and(|u| u.allow_localhost);
+
+    if !ou_diffs.is_empty() || ou1_localhost != ou2_localhost {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Open URLs", t.subtext).bold());
+        for (label, sign, val) in &ou_diffs {
+            let color = if *sign == "+" { t.green } else { t.red };
+            println!(
+                "    {} {} {}",
+                theme::fg(sign, color),
+                theme::fg(label, t.subtext),
+                theme::fg(val, color)
+            );
+        }
+        if ou1_localhost != ou2_localhost {
+            println!(
+                "    {}",
+                theme::fg(
+                    &format!("- allow_localhost: {ou1_localhost}"),
+                    t.red
+                )
+            );
+            println!(
+                "    {}",
+                theme::fg(
+                    &format!("+ allow_localhost: {ou2_localhost}"),
+                    t.green
+                )
+            );
+        }
+    }
+
+    // Allow launch services
+    any_diff |= diff_scalar_option(
+        "allow_launch_services",
+        &p1.allow_launch_services.map(|v| format!("{v}")),
+        &p2.allow_launch_services.map(|v| format!("{v}")),
+        t,
+    );
+
+    // Env credentials
+    let ec1: BTreeSet<(&String, &String)> = p1.env_credentials.mappings.iter().collect();
+    let ec2: BTreeSet<(&String, &String)> = p2.env_credentials.mappings.iter().collect();
+    let ec_added: BTreeSet<&(&String, &String)> = ec2.difference(&ec1).collect();
+    let ec_removed: BTreeSet<&(&String, &String)> = ec1.difference(&ec2).collect();
+    if !ec_added.is_empty() || !ec_removed.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Env credentials", t.subtext).bold());
+        for (k, v) in &ec_removed {
+            println!(
+                "    {} {} -> {}",
+                theme::fg("-", t.red),
+                theme::fg(k, t.red),
+                theme::fg(v, t.red)
+            );
+        }
+        for (k, v) in &ec_added {
+            println!(
+                "    {} {} -> {}",
+                theme::fg("+", t.green),
+                theme::fg(k, t.green),
+                theme::fg(v, t.green)
+            );
+        }
+    }
+
+    // Hooks
+    let h1: BTreeSet<&String> = p1.hooks.hooks.keys().collect();
+    let h2: BTreeSet<&String> = p2.hooks.hooks.keys().collect();
+    let hooks_added: BTreeSet<&&String> = h2.difference(&h1).collect();
+    let hooks_removed: BTreeSet<&&String> = h1.difference(&h2).collect();
+    // Check for hooks present in both but with different config
+    let hooks_changed: Vec<&String> = h1
+        .intersection(&h2)
+        .filter(|k| {
+            let a = &p1.hooks.hooks[**k];
+            let b = &p2.hooks.hooks[**k];
+            a.event != b.event || a.matcher != b.matcher || a.script != b.script
+        })
+        .copied()
+        .collect();
+    if !hooks_added.is_empty() || !hooks_removed.is_empty() || !hooks_changed.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Hooks", t.subtext).bold());
+        for h in &hooks_removed {
+            println!("    {} {}", theme::fg("-", t.red), theme::fg(h, t.red));
+        }
+        for h in &hooks_added {
+            println!("    {} {}", theme::fg("+", t.green), theme::fg(h, t.green));
+        }
+        for h in &hooks_changed {
+            println!(
+                "    {} {} (changed)",
+                theme::fg("~", t.yellow),
+                theme::fg(h, t.yellow)
+            );
+        }
+    }
+
+    // Custom credentials
+    let cc1: BTreeSet<&String> = p1.network.custom_credentials.keys().collect();
+    let cc2: BTreeSet<&String> = p2.network.custom_credentials.keys().collect();
+    let cc_added: BTreeSet<&&String> = cc2.difference(&cc1).collect();
+    let cc_removed: BTreeSet<&&String> = cc1.difference(&cc2).collect();
+    let cc_changed: Vec<&String> = cc1
+        .intersection(&cc2)
+        .filter(|k| p1.network.custom_credentials[**k] != p2.network.custom_credentials[**k])
+        .copied()
+        .collect();
+    if !cc_added.is_empty() || !cc_removed.is_empty() || !cc_changed.is_empty() {
+        any_diff = true;
+        println!();
+        println!(
+            "  {}:",
+            theme::fg("Custom credentials", t.subtext).bold()
+        );
+        for c in &cc_removed {
+            println!("    {} {}", theme::fg("-", t.red), theme::fg(c, t.red));
+        }
+        for c in &cc_added {
+            println!("    {} {}", theme::fg("+", t.green), theme::fg(c, t.green));
+        }
+        for c in &cc_changed {
+            let old = &p1.network.custom_credentials[*c];
+            let new = &p2.network.custom_credentials[*c];
+            println!(
+                "    {} {} (changed)",
+                theme::fg("~", t.yellow),
+                theme::fg(c, t.yellow)
+            );
+            if old.upstream != new.upstream {
+                println!(
+                    "      {} upstream: {}",
+                    theme::fg("-", t.red),
+                    theme::fg(&old.upstream, t.red)
+                );
+                println!(
+                    "      {} upstream: {}",
+                    theme::fg("+", t.green),
+                    theme::fg(&new.upstream, t.green)
+                );
+            }
+            if old.credential_key != new.credential_key {
+                println!(
+                    "      {} credential_key: {}",
+                    theme::fg("-", t.red),
+                    theme::fg(&old.credential_key, t.red)
+                );
+                println!(
+                    "      {} credential_key: {}",
+                    theme::fg("+", t.green),
+                    theme::fg(&new.credential_key, t.green)
+                );
+            }
+            if old.inject_mode != new.inject_mode {
+                println!(
+                    "      {} inject_mode: {:?}",
+                    theme::fg("-", t.red),
+                    old.inject_mode
+                );
+                println!(
+                    "      {} inject_mode: {:?}",
+                    theme::fg("+", t.green),
+                    new.inject_mode
+                );
+            }
+            if old.inject_header != new.inject_header {
+                println!(
+                    "      {} inject_header: {}",
+                    theme::fg("-", t.red),
+                    theme::fg(&old.inject_header, t.red)
+                );
+                println!(
+                    "      {} inject_header: {}",
+                    theme::fg("+", t.green),
+                    theme::fg(&new.inject_header, t.green)
+                );
+            }
+            if old.credential_format != new.credential_format {
+                println!(
+                    "      {} credential_format: {}",
+                    theme::fg("-", t.red),
+                    theme::fg(&old.credential_format, t.red)
+                );
+                println!(
+                    "      {} credential_format: {}",
+                    theme::fg("+", t.green),
+                    theme::fg(&new.credential_format, t.green)
+                );
+            }
+            if old.path_pattern != new.path_pattern {
+                println!(
+                    "      {} path_pattern: {:?}",
+                    theme::fg("-", t.red),
+                    old.path_pattern
+                );
+                println!(
+                    "      {} path_pattern: {:?}",
+                    theme::fg("+", t.green),
+                    new.path_pattern
+                );
+            }
+            if old.path_replacement != new.path_replacement {
+                println!(
+                    "      {} path_replacement: {:?}",
+                    theme::fg("-", t.red),
+                    old.path_replacement
+                );
+                println!(
+                    "      {} path_replacement: {:?}",
+                    theme::fg("+", t.green),
+                    new.path_replacement
+                );
+            }
+            if old.query_param_name != new.query_param_name {
+                println!(
+                    "      {} query_param_name: {:?}",
+                    theme::fg("-", t.red),
+                    old.query_param_name
+                );
+                println!(
+                    "      {} query_param_name: {:?}",
+                    theme::fg("+", t.green),
+                    new.query_param_name
+                );
+            }
+            if old.env_var != new.env_var {
+                println!(
+                    "      {} env_var: {:?}",
+                    theme::fg("-", t.red),
+                    old.env_var
+                );
+                println!(
+                    "      {} env_var: {:?}",
+                    theme::fg("+", t.green),
+                    new.env_var
+                );
+            }
+        }
+    }
+
     if !any_diff {
         println!();
         println!("  {}", theme::fg("(no differences)", t.subtext));
     }
 
     Ok(())
+}
+
+/// Print a diff for an optional scalar field. Returns true if there was a difference.
+fn diff_scalar_option(
+    label: &str,
+    v1: &Option<String>,
+    v2: &Option<String>,
+    t: &theme::Theme,
+) -> bool {
+    if v1 == v2 {
+        return false;
+    }
+    println!();
+    println!("  {}:", theme::fg(label, t.subtext).bold());
+    if let Some(ref old) = v1 {
+        println!(
+            "    {}",
+            theme::fg(&format!("- {old}"), t.red)
+        );
+    }
+    if let Some(ref new) = v2 {
+        println!(
+            "    {}",
+            theme::fg(&format!("+ {new}"), t.green)
+        );
+    }
+    true
 }
 
 fn diff_string_vecs<'a>(
@@ -940,12 +1370,32 @@ fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_j
     let groups_added: Vec<&str> = g2.difference(&g1).copied().collect();
     let groups_removed: Vec<&str> = g1.difference(&g2).copied().collect();
 
+    let diff_vec = |v1: &[String], v2: &[String]| -> serde_json::Value {
+        let s1: BTreeSet<&str> = v1.iter().map(|s| s.as_str()).collect();
+        let s2: BTreeSet<&str> = v2.iter().map(|s| s.as_str()).collect();
+        let added: Vec<&str> = s2.difference(&s1).copied().collect();
+        let removed: Vec<&str> = s1.difference(&s2).copied().collect();
+        serde_json::json!({ "added": added, "removed": removed })
+    };
+
+    let ou1 = p1.open_urls.as_ref();
+    let ou2 = p2.open_urls.as_ref();
+
     serde_json::json!({
         "profile1": name1,
         "profile2": name2,
         "groups": {
             "added": groups_added,
             "removed": groups_removed,
+        },
+        "allowed_commands": diff_vec(
+            &p1.security.allowed_commands,
+            &p2.security.allowed_commands,
+        ),
+        "capability_elevation": {
+            "profile1": p1.security.capability_elevation,
+            "profile2": p2.security.capability_elevation,
+            "changed": p1.security.capability_elevation != p2.security.capability_elevation,
         },
         "filesystem": diff_fs_json(&p1.filesystem, &p2.filesystem),
         "workdir": {
@@ -964,6 +1414,52 @@ fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_j
                 "profile2": p2.network.resolved_network_profile(),
                 "changed": p1.network.resolved_network_profile() != p2.network.resolved_network_profile(),
             },
+            "proxy_allow": diff_vec(&p1.network.proxy_allow, &p2.network.proxy_allow),
+            "proxy_credentials": diff_vec(&p1.network.proxy_credentials, &p2.network.proxy_credentials),
+            "port_allow": {
+                "profile1": p1.network.port_allow,
+                "profile2": p2.network.port_allow,
+                "changed": p1.network.port_allow != p2.network.port_allow,
+            },
+            "external_proxy": {
+                "profile1": p1.network.external_proxy,
+                "profile2": p2.network.external_proxy,
+                "changed": p1.network.external_proxy != p2.network.external_proxy,
+            },
+            "external_proxy_bypass": diff_vec(
+                &p1.network.external_proxy_bypass,
+                &p2.network.external_proxy_bypass,
+            ),
+            "custom_credentials": diff_custom_credentials_json(
+                &p1.network.custom_credentials,
+                &p2.network.custom_credentials,
+            ),
+        },
+        "env_credentials": {
+            "profile1": p1.env_credentials.mappings,
+            "profile2": p2.env_credentials.mappings,
+            "changed": p1.env_credentials.mappings != p2.env_credentials.mappings,
+        },
+        "hooks": diff_hooks_json(&p1.hooks.hooks, &p2.hooks.hooks),
+        "rollback": {
+            "exclude_patterns": diff_vec(&p1.rollback.exclude_patterns, &p2.rollback.exclude_patterns),
+            "exclude_globs": diff_vec(&p1.rollback.exclude_globs, &p2.rollback.exclude_globs),
+        },
+        "open_urls": {
+            "allow_origins": diff_vec(
+                &ou1.map(|u| u.allow_origins.clone()).unwrap_or_default(),
+                &ou2.map(|u| u.allow_origins.clone()).unwrap_or_default(),
+            ),
+            "allow_localhost": {
+                "profile1": ou1.is_some_and(|u| u.allow_localhost),
+                "profile2": ou2.is_some_and(|u| u.allow_localhost),
+                "changed": ou1.is_some_and(|u| u.allow_localhost) != ou2.is_some_and(|u| u.allow_localhost),
+            },
+        },
+        "allow_launch_services": {
+            "profile1": p1.allow_launch_services,
+            "profile2": p2.allow_launch_services,
+            "changed": p1.allow_launch_services != p2.allow_launch_services,
         },
     })
 }
@@ -990,20 +1486,169 @@ fn diff_fs_json(
     })
 }
 
+fn diff_hooks_json(
+    h1: &std::collections::HashMap<String, profile::HookConfig>,
+    h2: &std::collections::HashMap<String, profile::HookConfig>,
+) -> serde_json::Value {
+    let added: Vec<&String> = h2.keys().filter(|k| !h1.contains_key(*k)).collect();
+    let removed: Vec<&String> = h1.keys().filter(|k| !h2.contains_key(*k)).collect();
+    let changed: Vec<&String> = h1
+        .keys()
+        .filter(|k| {
+            h2.get(*k).is_some_and(|v2| {
+                let v1 = &h1[*k];
+                v1.event != v2.event || v1.matcher != v2.matcher || v1.script != v2.script
+            })
+        })
+        .collect();
+
+    let mut changed_details = serde_json::Map::new();
+    for k in &changed {
+        let old = &h1[*k];
+        let new = &h2[*k];
+        let mut detail = serde_json::Map::new();
+        if old.event != new.event {
+            detail.insert(
+                "event".into(),
+                serde_json::json!({"profile1": old.event, "profile2": new.event}),
+            );
+        }
+        if old.matcher != new.matcher {
+            detail.insert(
+                "matcher".into(),
+                serde_json::json!({"profile1": old.matcher, "profile2": new.matcher}),
+            );
+        }
+        if old.script != new.script {
+            detail.insert(
+                "script".into(),
+                serde_json::json!({"profile1": old.script, "profile2": new.script}),
+            );
+        }
+        changed_details.insert((*k).clone(), serde_json::Value::Object(detail));
+    }
+
+    serde_json::json!({
+        "added": added,
+        "removed": removed,
+        "changed": changed_details,
+    })
+}
+
+fn diff_custom_credentials_json(
+    cc1: &std::collections::HashMap<String, profile::CustomCredentialDef>,
+    cc2: &std::collections::HashMap<String, profile::CustomCredentialDef>,
+) -> serde_json::Value {
+    let added: Vec<&String> = cc2
+        .keys()
+        .filter(|k| !cc1.contains_key(*k))
+        .collect();
+    let removed: Vec<&String> = cc1
+        .keys()
+        .filter(|k| !cc2.contains_key(*k))
+        .collect();
+    let changed: Vec<&String> = cc1
+        .keys()
+        .filter(|k| cc2.get(*k).is_some_and(|v2| cc1[*k] != *v2))
+        .collect();
+
+    let mut changed_details = serde_json::Map::new();
+    for k in &changed {
+        let old = &cc1[*k];
+        let new = &cc2[*k];
+        let mut detail = serde_json::Map::new();
+        if old.upstream != new.upstream {
+            detail.insert(
+                "upstream".into(),
+                serde_json::json!({"profile1": old.upstream, "profile2": new.upstream}),
+            );
+        }
+        if old.credential_key != new.credential_key {
+            detail.insert(
+                "credential_key".into(),
+                serde_json::json!({"profile1": old.credential_key, "profile2": new.credential_key}),
+            );
+        }
+        if old.inject_mode != new.inject_mode {
+            detail.insert(
+                "inject_mode".into(),
+                serde_json::json!({"profile1": format!("{:?}", old.inject_mode), "profile2": format!("{:?}", new.inject_mode)}),
+            );
+        }
+        if old.inject_header != new.inject_header {
+            detail.insert(
+                "inject_header".into(),
+                serde_json::json!({"profile1": old.inject_header, "profile2": new.inject_header}),
+            );
+        }
+        if old.credential_format != new.credential_format {
+            detail.insert(
+                "credential_format".into(),
+                serde_json::json!({"profile1": old.credential_format, "profile2": new.credential_format}),
+            );
+        }
+        if old.path_pattern != new.path_pattern {
+            detail.insert(
+                "path_pattern".into(),
+                serde_json::json!({"profile1": old.path_pattern, "profile2": new.path_pattern}),
+            );
+        }
+        if old.path_replacement != new.path_replacement {
+            detail.insert(
+                "path_replacement".into(),
+                serde_json::json!({"profile1": old.path_replacement, "profile2": new.path_replacement}),
+            );
+        }
+        if old.query_param_name != new.query_param_name {
+            detail.insert(
+                "query_param_name".into(),
+                serde_json::json!({"profile1": old.query_param_name, "profile2": new.query_param_name}),
+            );
+        }
+        if old.env_var != new.env_var {
+            detail.insert(
+                "env_var".into(),
+                serde_json::json!({"profile1": old.env_var, "profile2": new.env_var}),
+            );
+        }
+        changed_details.insert((*k).clone(), serde_json::Value::Object(detail));
+    }
+
+    serde_json::json!({
+        "added": added,
+        "removed": removed,
+        "changed": changed_details,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // nono policy validate
 // ---------------------------------------------------------------------------
+
+fn classify_profile_error(e: &NonoError) -> &'static str {
+    match e {
+        NonoError::ProfileParse(msg) if msg.starts_with("expected") || msg.contains("line ") || msg.contains("column ") || msg.contains("EOF") => {
+            "JSON syntax error"
+        }
+        NonoError::ProfileParse(_) => "Profile error",
+        NonoError::ProfileRead { .. } => "File read error",
+        NonoError::ProfileInheritance(_) => "Inheritance error",
+        NonoError::ProfileNotFound(_) => "Profile not found",
+        _ => "Error",
+    }
+}
 
 fn cmd_validate(args: PolicyValidateArgs) -> Result<()> {
     let pol = policy::load_embedded_policy()?;
     let mut errors: Vec<String> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
 
-    // Step 1: Parse JSON
+    // Step 1: Load profile (parse JSON + resolve inheritance)
     let profile = match profile::load_profile_from_path(&args.file) {
         Ok(p) => Some(p),
         Err(e) => {
-            errors.push(format!("JSON parse error: {}", e));
+            let label = classify_profile_error(&e);
+            errors.push(format!("{}: {}", label, e));
             None
         }
     };
@@ -1016,14 +1661,7 @@ fn cmd_validate(args: PolicyValidateArgs) -> Result<()> {
             }
         }
 
-        // Step 3: Check extends target
-        if let Some(ref extends) = profile.extends {
-            if profile::load_profile(extends).is_err() {
-                errors.push(format!("Extends target '{}' not found", extends));
-            }
-        }
-
-        // Step 4: Check exclude_groups
+        // Step 3: Check exclude_groups
         for excl in &profile.policy.exclude_groups {
             if let Some(group) = pol.groups.get(excl) {
                 if group.required {
@@ -1077,16 +1715,6 @@ fn cmd_validate(args: PolicyValidateArgs) -> Result<()> {
     }
 
     if let Some(ref profile) = profile {
-        if let Some(ref extends) = profile.extends {
-            if profile::load_profile(extends).is_ok() {
-                println!(
-                    "  {}  Extends '{}' found",
-                    theme::fg("[ok]", t.green),
-                    extends
-                );
-            }
-        }
-
         let valid_groups = profile
             .security
             .groups

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -949,8 +949,18 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         ),
     ]);
 
-    let port1: Vec<String> = p1.network.port_allow.iter().map(|p| p.to_string()).collect();
-    let port2: Vec<String> = p2.network.port_allow.iter().map(|p| p.to_string()).collect();
+    let port1: Vec<String> = p1
+        .network
+        .port_allow
+        .iter()
+        .map(|p| p.to_string())
+        .collect();
+    let port2: Vec<String> = p2
+        .network
+        .port_allow
+        .iter()
+        .map(|p| p.to_string())
+        .collect();
     let port_diffs = diff_string_vecs(&[("port_allow", &port1, &port2)]);
 
     if !net_diffs.is_empty() || !net_vec_diffs.is_empty() || !port_diffs.is_empty() {
@@ -1085,17 +1095,11 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         if ou1_localhost != ou2_localhost {
             println!(
                 "    {}",
-                theme::fg(
-                    &format!("- allow_localhost: {ou1_localhost}"),
-                    t.red
-                )
+                theme::fg(&format!("- allow_localhost: {ou1_localhost}"), t.red)
             );
             println!(
                 "    {}",
-                theme::fg(
-                    &format!("+ allow_localhost: {ou2_localhost}"),
-                    t.green
-                )
+                theme::fg(&format!("+ allow_localhost: {ou2_localhost}"), t.green)
             );
         }
     }
@@ -1182,10 +1186,7 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
     if !cc_added.is_empty() || !cc_removed.is_empty() || !cc_changed.is_empty() {
         any_diff = true;
         println!();
-        println!(
-            "  {}:",
-            theme::fg("Custom credentials", t.subtext).bold()
-        );
+        println!("  {}:", theme::fg("Custom credentials", t.subtext).bold());
         for c in &cc_removed {
             println!("    {} {}", theme::fg("-", t.red), theme::fg(c, t.red));
         }
@@ -1297,11 +1298,7 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
                 );
             }
             if old.env_var != new.env_var {
-                println!(
-                    "      {} env_var: {:?}",
-                    theme::fg("-", t.red),
-                    old.env_var
-                );
+                println!("      {} env_var: {:?}", theme::fg("-", t.red), old.env_var);
                 println!(
                     "      {} env_var: {:?}",
                     theme::fg("+", t.green),
@@ -1332,16 +1329,10 @@ fn diff_scalar_option(
     println!();
     println!("  {}:", theme::fg(label, t.subtext).bold());
     if let Some(ref old) = v1 {
-        println!(
-            "    {}",
-            theme::fg(&format!("- {old}"), t.red)
-        );
+        println!("    {}", theme::fg(&format!("- {old}"), t.red));
     }
     if let Some(ref new) = v2 {
-        println!(
-            "    {}",
-            theme::fg(&format!("+ {new}"), t.green)
-        );
+        println!("    {}", theme::fg(&format!("+ {new}"), t.green));
     }
     true
 }
@@ -1539,14 +1530,8 @@ fn diff_custom_credentials_json(
     cc1: &std::collections::HashMap<String, profile::CustomCredentialDef>,
     cc2: &std::collections::HashMap<String, profile::CustomCredentialDef>,
 ) -> serde_json::Value {
-    let added: Vec<&String> = cc2
-        .keys()
-        .filter(|k| !cc1.contains_key(*k))
-        .collect();
-    let removed: Vec<&String> = cc1
-        .keys()
-        .filter(|k| !cc2.contains_key(*k))
-        .collect();
+    let added: Vec<&String> = cc2.keys().filter(|k| !cc1.contains_key(*k)).collect();
+    let removed: Vec<&String> = cc1.keys().filter(|k| !cc2.contains_key(*k)).collect();
     let changed: Vec<&String> = cc1
         .keys()
         .filter(|k| cc2.get(*k).is_some_and(|v2| cc1[*k] != *v2))
@@ -1627,7 +1612,12 @@ fn diff_custom_credentials_json(
 
 fn classify_profile_error(e: &NonoError) -> &'static str {
     match e {
-        NonoError::ProfileParse(msg) if msg.starts_with("expected") || msg.contains("line ") || msg.contains("column ") || msg.contains("EOF") => {
+        NonoError::ProfileParse(msg)
+            if msg.starts_with("expected")
+                || msg.contains("line ")
+                || msg.contains("column ")
+                || msg.contains("EOF") =>
+        {
             "JSON syntax error"
         }
         NonoError::ProfileParse(_) => "Profile error",

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -1,0 +1,1301 @@
+//! Policy introspection subcommand implementations
+//!
+//! Handles `nono policy groups|profiles|show|diff|validate` for inspecting
+//! the group-based policy system, profiles, and security rules.
+
+use crate::cli::{
+    PolicyArgs, PolicyCommands, PolicyDiffArgs, PolicyGroupsArgs, PolicyProfilesArgs,
+    PolicyShowArgs, PolicyValidateArgs,
+};
+use crate::policy::{self, AllowOps, DenyOps, Group};
+use crate::profile::{self, Profile, WorkdirAccess};
+use crate::theme;
+use colored::Colorize;
+use nono::{NonoError, Result};
+use std::collections::BTreeSet;
+
+/// Prefix used for all policy command output
+fn prefix() -> colored::ColoredString {
+    let t = theme::current();
+    theme::fg("nono policy", t.brand).bold()
+}
+
+/// Dispatch to the appropriate policy subcommand.
+pub fn run_policy(args: PolicyArgs) -> Result<()> {
+    match args.command {
+        PolicyCommands::Groups(args) => cmd_groups(args),
+        PolicyCommands::Profiles(args) => cmd_profiles(args),
+        PolicyCommands::Show(args) => cmd_show(args),
+        PolicyCommands::Diff(args) => cmd_diff(args),
+        PolicyCommands::Validate(args) => cmd_validate(args),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// nono policy groups
+// ---------------------------------------------------------------------------
+
+fn cmd_groups(args: PolicyGroupsArgs) -> Result<()> {
+    let pol = policy::load_embedded_policy()?;
+
+    match args.name {
+        Some(name) => cmd_groups_detail(&pol, &name, args.json),
+        None => cmd_groups_list(&pol, args.json, args.all_platforms),
+    }
+}
+
+fn cmd_groups_list(pol: &policy::Policy, json: bool, all_platforms: bool) -> Result<()> {
+    let mut groups: Vec<(&String, &Group)> = pol.groups.iter().collect();
+    groups.sort_by_key(|(name, _)| name.as_str());
+
+    if !all_platforms {
+        groups.retain(|(_, g)| policy::group_matches_platform(g));
+    }
+
+    if json {
+        let arr: Vec<serde_json::Value> = groups
+            .iter()
+            .map(|(name, g)| {
+                serde_json::json!({
+                    "name": name,
+                    "description": g.description,
+                    "platform": g.platform.as_deref().unwrap_or("cross-platform"),
+                    "required": g.required,
+                    "allow": count_allow(&g.allow),
+                    "deny": count_deny(&g.deny),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+        return Ok(());
+    }
+
+    let t = theme::current();
+    println!(
+        "{}: {} groups{}",
+        prefix(),
+        groups.len(),
+        if all_platforms {
+            " (all platforms)"
+        } else {
+            ""
+        }
+    );
+    println!();
+
+    for (name, group) in &groups {
+        let platform = group.platform.as_deref().unwrap_or("cross-platform");
+        let required = if group.required { "  required" } else { "" };
+        println!(
+            "  {:<36} {:<42} {}{}",
+            theme::fg(name, t.text).bold(),
+            theme::fg(&group.description, t.subtext),
+            theme::fg(platform, t.overlay),
+            theme::fg(required, t.yellow),
+        );
+    }
+
+    Ok(())
+}
+
+fn cmd_groups_detail(pol: &policy::Policy, name: &str, json: bool) -> Result<()> {
+    let group = pol.groups.get(name).ok_or_else(|| {
+        NonoError::ProfileParse(format!(
+            "group '{}' not found in policy.json. Use 'nono policy groups' to list available groups",
+            name
+        ))
+    })?;
+
+    if json {
+        let val = group_to_json(name, group);
+        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        return Ok(());
+    }
+
+    let t = theme::current();
+    println!("{}: group '{}'", prefix(), theme::fg(name, t.text).bold());
+    println!();
+    println!(
+        "  {}  {}",
+        theme::fg("Description:", t.subtext),
+        theme::fg(&group.description, t.text)
+    );
+    println!(
+        "  {}     {}",
+        theme::fg("Platform:", t.subtext),
+        theme::fg(
+            group.platform.as_deref().unwrap_or("cross-platform"),
+            t.text
+        )
+    );
+    println!(
+        "  {}     {}",
+        theme::fg("Required:", t.subtext),
+        theme::fg(if group.required { "yes" } else { "no" }, t.text)
+    );
+
+    if let Some(ref allow) = group.allow {
+        print_path_section("allow.read", &allow.read, t);
+        print_path_section("allow.write", &allow.write, t);
+        print_path_section("allow.readwrite", &allow.readwrite, t);
+    }
+
+    if let Some(ref deny) = group.deny {
+        print_path_section("deny.access", &deny.access, t);
+        if deny.unlink {
+            println!();
+            println!("  {}", theme::fg("deny.unlink:", t.red).bold());
+            println!("    {}", theme::fg("enabled", t.red));
+        }
+        if !deny.commands.is_empty() {
+            println!();
+            println!("  {}", theme::fg("deny.commands:", t.red).bold());
+            for cmd in &deny.commands {
+                println!("    {}", theme::fg(cmd, t.text));
+            }
+        }
+    }
+
+    if let Some(ref pairs) = group.symlink_pairs {
+        if !pairs.is_empty() {
+            println!();
+            println!("  {}", theme::fg("symlink_pairs:", t.subtext).bold());
+            let mut sorted: Vec<(&String, &String)> = pairs.iter().collect();
+            sorted.sort_by_key(|(k, _)| k.as_str());
+            for (from, to) in sorted {
+                println!(
+                    "    {} -> {}",
+                    theme::fg(from, t.text),
+                    theme::fg(to, t.subtext)
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_path_section(label: &str, paths: &[String], t: &theme::Theme) {
+    if paths.is_empty() {
+        return;
+    }
+    let color = if label.starts_with("deny") {
+        t.red
+    } else {
+        t.green
+    };
+    println!();
+    println!("  {}", theme::fg(&format!("{label}:"), color).bold());
+    for raw in paths {
+        match policy::expand_path(raw) {
+            Ok(expanded) => {
+                let exp_str = expanded.display().to_string();
+                if exp_str == *raw {
+                    println!("    {}", theme::fg(raw, t.text));
+                } else {
+                    println!(
+                        "    {:<36} -> {}",
+                        theme::fg(raw, t.text),
+                        theme::fg(&exp_str, t.subtext)
+                    );
+                }
+            }
+            Err(_) => {
+                println!(
+                    "    {:<36} -> {}",
+                    theme::fg(raw, t.text),
+                    theme::fg("<expansion failed>", t.red)
+                );
+            }
+        }
+    }
+}
+
+fn count_allow(allow: &Option<AllowOps>) -> serde_json::Value {
+    match allow {
+        Some(a) => serde_json::json!({
+            "read": a.read.len(),
+            "write": a.write.len(),
+            "readwrite": a.readwrite.len(),
+        }),
+        None => serde_json::json!({}),
+    }
+}
+
+fn count_deny(deny: &Option<DenyOps>) -> serde_json::Value {
+    match deny {
+        Some(d) => serde_json::json!({
+            "access": d.access.len(),
+            "commands": d.commands.len(),
+            "unlink": d.unlink,
+        }),
+        None => serde_json::json!({}),
+    }
+}
+
+fn group_to_json(name: &str, group: &Group) -> serde_json::Value {
+    let mut val = serde_json::json!({
+        "name": name,
+        "description": group.description,
+        "platform": group.platform.as_deref().unwrap_or("cross-platform"),
+        "required": group.required,
+    });
+
+    if let Some(ref allow) = group.allow {
+        let mut allow_val = serde_json::Map::new();
+        if !allow.read.is_empty() {
+            allow_val.insert("read".into(), expand_paths_json(&allow.read));
+        }
+        if !allow.write.is_empty() {
+            allow_val.insert("write".into(), expand_paths_json(&allow.write));
+        }
+        if !allow.readwrite.is_empty() {
+            allow_val.insert("readwrite".into(), expand_paths_json(&allow.readwrite));
+        }
+        val["allow"] = serde_json::Value::Object(allow_val);
+    }
+
+    if let Some(ref deny) = group.deny {
+        let mut deny_val = serde_json::Map::new();
+        if !deny.access.is_empty() {
+            deny_val.insert("access".into(), expand_paths_json(&deny.access));
+        }
+        if !deny.commands.is_empty() {
+            deny_val.insert("commands".into(), serde_json::json!(deny.commands));
+        }
+        if deny.unlink {
+            deny_val.insert("unlink".into(), serde_json::json!(true));
+        }
+        val["deny"] = serde_json::Value::Object(deny_val);
+    }
+
+    if let Some(ref pairs) = group.symlink_pairs {
+        if !pairs.is_empty() {
+            val["symlink_pairs"] = serde_json::json!(pairs);
+        }
+    }
+
+    val
+}
+
+fn expand_paths_json(paths: &[String]) -> serde_json::Value {
+    let arr: Vec<serde_json::Value> = paths
+        .iter()
+        .map(|raw| {
+            let expanded = policy::expand_path(raw)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<expansion failed>".to_string());
+            serde_json::json!({
+                "raw": raw,
+                "expanded": expanded,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(arr)
+}
+
+// ---------------------------------------------------------------------------
+// nono policy profiles
+// ---------------------------------------------------------------------------
+
+fn cmd_profiles(args: PolicyProfilesArgs) -> Result<()> {
+    let builtin_names = profile::builtin::list_builtin();
+    let all_names = profile::list_profiles();
+
+    let mut builtin_profiles: Vec<(String, Option<Profile>)> = Vec::new();
+    let mut user_profiles: Vec<(String, Option<Profile>)> = Vec::new();
+
+    for name in &all_names {
+        let p = profile::load_profile(name).ok();
+        if builtin_names.contains(name) {
+            builtin_profiles.push((name.clone(), p));
+        } else {
+            user_profiles.push((name.clone(), p));
+        }
+    }
+
+    if args.json {
+        let format_entry = |name: &str, profile: &Option<Profile>, source: &str| {
+            let (desc, extends) = match profile {
+                Some(p) => (
+                    p.meta.description.as_deref().unwrap_or(""),
+                    p.extends.as_deref().unwrap_or(""),
+                ),
+                None => ("", ""),
+            };
+            serde_json::json!({
+                "name": name,
+                "source": source,
+                "description": desc,
+                "extends": extends,
+            })
+        };
+
+        let arr: Vec<serde_json::Value> = builtin_profiles
+            .iter()
+            .map(|(n, p)| format_entry(n, p, "built-in"))
+            .chain(
+                user_profiles
+                    .iter()
+                    .map(|(n, p)| format_entry(n, p, "user")),
+            )
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+        return Ok(());
+    }
+
+    let t = theme::current();
+    let total = builtin_profiles.len() + user_profiles.len();
+    println!("{}: {} profiles", prefix(), total);
+
+    if !builtin_profiles.is_empty() {
+        println!();
+        println!("  {}", theme::fg("Built-in:", t.subtext).bold());
+        for (name, profile) in &builtin_profiles {
+            print_profile_line(name, profile, t);
+        }
+    }
+
+    if !user_profiles.is_empty() {
+        println!();
+        println!(
+            "  {}",
+            theme::fg("User (~/.config/nono/profiles/):", t.subtext).bold()
+        );
+        for (name, profile) in &user_profiles {
+            print_profile_line(name, profile, t);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_profile_line(name: &str, profile: &Option<Profile>, t: &theme::Theme) {
+    let (desc, extends) = match profile {
+        Some(p) => (
+            p.meta.description.as_deref().unwrap_or("").to_string(),
+            p.extends
+                .as_ref()
+                .map(|e| format!("extends {}", e))
+                .unwrap_or_default(),
+        ),
+        None => (String::new(), String::new()),
+    };
+    println!(
+        "    {:<16} {:<42} {}",
+        theme::fg(name, t.text).bold(),
+        theme::fg(&desc, t.subtext),
+        theme::fg(&extends, t.overlay),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// nono policy show
+// ---------------------------------------------------------------------------
+
+fn cmd_show(args: PolicyShowArgs) -> Result<()> {
+    let profile = profile::load_profile(&args.profile)?;
+
+    if args.json {
+        let val = profile_to_json(&args.profile, &profile);
+        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        return Ok(());
+    }
+
+    let t = theme::current();
+    println!(
+        "{}: profile '{}'",
+        prefix(),
+        theme::fg(&args.profile, t.text).bold()
+    );
+
+    // Meta
+    if let Some(ref desc) = profile.meta.description {
+        println!();
+        println!(
+            "  {}  {}",
+            theme::fg("Description:", t.subtext),
+            theme::fg(desc, t.text)
+        );
+    }
+    if let Some(ref extends) = profile.extends {
+        println!(
+            "  {}      {}",
+            theme::fg("Extends:", t.subtext),
+            theme::fg(extends, t.text)
+        );
+    }
+
+    // Security groups
+    if !profile.security.groups.is_empty() {
+        println!();
+        println!("  {}", theme::fg("Security groups:", t.subtext).bold());
+        for g in &profile.security.groups {
+            println!("    {}", theme::fg(g, t.text));
+        }
+    }
+
+    if !profile.security.allowed_commands.is_empty() {
+        println!();
+        println!("  {}", theme::fg("Allowed commands:", t.subtext).bold());
+        for cmd in &profile.security.allowed_commands {
+            println!("    {}", theme::fg(cmd, t.text));
+        }
+    }
+
+    if let Some(mode) = &profile.security.signal_mode {
+        println!("  {}   {:?}", theme::fg("Signal mode:", t.subtext), mode);
+    }
+
+    if let Some(mode) = &profile.security.process_info_mode {
+        println!("  {} {:?}", theme::fg("Process info:", t.subtext), mode);
+    }
+
+    if let Some(elev) = profile.security.capability_elevation {
+        println!(
+            "  {} {}",
+            theme::fg("Capability elevation:", t.subtext),
+            theme::fg(if elev { "enabled" } else { "disabled" }, t.text)
+        );
+    }
+
+    // Filesystem
+    let fs = &profile.filesystem;
+    let has_fs = !fs.allow.is_empty()
+        || !fs.read.is_empty()
+        || !fs.write.is_empty()
+        || !fs.allow_file.is_empty()
+        || !fs.read_file.is_empty()
+        || !fs.write_file.is_empty();
+
+    if has_fs {
+        println!();
+        println!("  {}", theme::fg("Filesystem:", t.subtext).bold());
+        print_fs_paths("allow (r+w)", &fs.allow, t, args.raw);
+        print_fs_paths("read", &fs.read, t, args.raw);
+        print_fs_paths("write", &fs.write, t, args.raw);
+        print_fs_paths("allow_file (r+w)", &fs.allow_file, t, args.raw);
+        print_fs_paths("read_file", &fs.read_file, t, args.raw);
+        print_fs_paths("write_file", &fs.write_file, t, args.raw);
+    }
+
+    // Policy patches
+    let pp = &profile.policy;
+    let has_policy = !pp.exclude_groups.is_empty()
+        || !pp.add_allow_read.is_empty()
+        || !pp.add_allow_write.is_empty()
+        || !pp.add_allow_readwrite.is_empty()
+        || !pp.add_deny_access.is_empty()
+        || !pp.override_deny.is_empty();
+
+    if has_policy {
+        println!();
+        println!("  {}", theme::fg("Policy patches:", t.subtext).bold());
+        if !pp.exclude_groups.is_empty() {
+            println!(
+                "    {}: {}",
+                theme::fg("exclude_groups", t.yellow),
+                pp.exclude_groups.join(", ")
+            );
+        }
+        print_fs_paths("add_allow_read", &pp.add_allow_read, t, args.raw);
+        print_fs_paths("add_allow_write", &pp.add_allow_write, t, args.raw);
+        print_fs_paths("add_allow_readwrite", &pp.add_allow_readwrite, t, args.raw);
+        print_fs_paths("add_deny_access", &pp.add_deny_access, t, args.raw);
+        if !pp.override_deny.is_empty() {
+            println!(
+                "    {}: {}",
+                theme::fg("override_deny", t.yellow),
+                pp.override_deny.join(", ")
+            );
+        }
+    }
+
+    // Network
+    let net = &profile.network;
+    let has_net = net.block
+        || net.resolved_network_profile().is_some()
+        || !net.proxy_allow.is_empty()
+        || !net.proxy_credentials.is_empty()
+        || !net.port_allow.is_empty()
+        || net.external_proxy.is_some();
+
+    if has_net {
+        println!();
+        println!("  {}", theme::fg("Network:", t.subtext).bold());
+        if net.block {
+            println!("    {}", theme::fg("network blocked", t.red));
+        }
+        if let Some(np) = net.resolved_network_profile() {
+            println!(
+                "    {}: {}",
+                theme::fg("network_profile", t.subtext),
+                theme::fg(np, t.text)
+            );
+        }
+        if !net.proxy_allow.is_empty() {
+            println!(
+                "    {}: {}",
+                theme::fg("proxy_allow", t.subtext),
+                net.proxy_allow.join(", ")
+            );
+        }
+        if !net.proxy_credentials.is_empty() {
+            println!(
+                "    {}: {}",
+                theme::fg("proxy_credentials", t.subtext),
+                net.proxy_credentials.join(", ")
+            );
+        }
+        if !net.port_allow.is_empty() {
+            let ports: Vec<String> = net.port_allow.iter().map(|p| p.to_string()).collect();
+            println!(
+                "    {}: {}",
+                theme::fg("port_allow", t.subtext),
+                ports.join(", ")
+            );
+        }
+        if let Some(ref ep) = net.external_proxy {
+            println!(
+                "    {}: {}",
+                theme::fg("external_proxy", t.subtext),
+                theme::fg(ep, t.text)
+            );
+        }
+    }
+
+    // Workdir
+    if profile.workdir.access != WorkdirAccess::None {
+        println!();
+        println!(
+            "  {}  {:?}",
+            theme::fg("Workdir access:", t.subtext).bold(),
+            profile.workdir.access
+        );
+    }
+
+    // Rollback
+    let rb = &profile.rollback;
+    if !rb.exclude_patterns.is_empty() || !rb.exclude_globs.is_empty() {
+        println!();
+        println!("  {}", theme::fg("Rollback exclusions:", t.subtext).bold());
+        for p in &rb.exclude_patterns {
+            println!("    {}", theme::fg(p, t.text));
+        }
+        for g in &rb.exclude_globs {
+            println!(
+                "    {} {}",
+                theme::fg("glob:", t.overlay),
+                theme::fg(g, t.text)
+            );
+        }
+    }
+
+    // Open URLs
+    if let Some(ref urls) = profile.open_urls {
+        println!();
+        println!("  {}", theme::fg("Open URLs:", t.subtext).bold());
+        if urls.allow_localhost {
+            println!("    {}", theme::fg("localhost allowed", t.text));
+        }
+        for origin in &urls.allow_origins {
+            println!("    {}", theme::fg(origin, t.text));
+        }
+    }
+
+    Ok(())
+}
+
+fn print_fs_paths(label: &str, paths: &[String], t: &theme::Theme, raw: bool) {
+    if paths.is_empty() {
+        return;
+    }
+    println!("    {}:", theme::fg(label, t.subtext));
+    for p in paths {
+        if raw {
+            println!("      {}", theme::fg(p, t.text));
+        } else {
+            match policy::expand_path(p) {
+                Ok(expanded) => {
+                    let exp_str = expanded.display().to_string();
+                    if exp_str == *p {
+                        println!("      {}", theme::fg(p, t.text));
+                    } else {
+                        println!(
+                            "      {:<36} -> {}",
+                            theme::fg(p, t.text),
+                            theme::fg(&exp_str, t.subtext)
+                        );
+                    }
+                }
+                Err(_) => {
+                    println!("      {}", theme::fg(p, t.text));
+                }
+            }
+        }
+    }
+}
+
+fn profile_to_json(name: &str, profile: &Profile) -> serde_json::Value {
+    let mut val = serde_json::json!({
+        "name": name,
+        "description": profile.meta.description.as_deref().unwrap_or(""),
+        "extends": profile.extends.as_deref().unwrap_or(""),
+    });
+
+    // Security
+    val["security"] = serde_json::json!({
+        "groups": profile.security.groups,
+        "allowed_commands": profile.security.allowed_commands,
+        "signal_mode": format!("{:?}", profile.security.signal_mode),
+        "process_info_mode": format!("{:?}", profile.security.process_info_mode),
+        "capability_elevation": profile.security.capability_elevation,
+    });
+
+    // Filesystem
+    val["filesystem"] = serde_json::json!({
+        "allow": profile.filesystem.allow,
+        "read": profile.filesystem.read,
+        "write": profile.filesystem.write,
+        "allow_file": profile.filesystem.allow_file,
+        "read_file": profile.filesystem.read_file,
+        "write_file": profile.filesystem.write_file,
+    });
+
+    // Policy patches
+    val["policy"] = serde_json::json!({
+        "exclude_groups": profile.policy.exclude_groups,
+        "add_allow_read": profile.policy.add_allow_read,
+        "add_allow_write": profile.policy.add_allow_write,
+        "add_allow_readwrite": profile.policy.add_allow_readwrite,
+        "add_deny_access": profile.policy.add_deny_access,
+        "override_deny": profile.policy.override_deny,
+    });
+
+    // Network
+    val["network"] = serde_json::json!({
+        "block": profile.network.block,
+        "network_profile": profile.network.resolved_network_profile(),
+        "proxy_allow": profile.network.proxy_allow,
+        "proxy_credentials": profile.network.proxy_credentials,
+        "port_allow": profile.network.port_allow,
+        "external_proxy": profile.network.external_proxy,
+    });
+
+    // Workdir
+    val["workdir"] = serde_json::json!({
+        "access": format!("{:?}", profile.workdir.access),
+    });
+
+    // Rollback
+    val["rollback"] = serde_json::json!({
+        "exclude_patterns": profile.rollback.exclude_patterns,
+        "exclude_globs": profile.rollback.exclude_globs,
+    });
+
+    // Open URLs
+    if let Some(ref urls) = profile.open_urls {
+        val["open_urls"] = serde_json::json!({
+            "allow_origins": urls.allow_origins,
+            "allow_localhost": urls.allow_localhost,
+        });
+    }
+
+    val
+}
+
+// ---------------------------------------------------------------------------
+// nono policy diff
+// ---------------------------------------------------------------------------
+
+fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
+    let p1 = profile::load_profile(&args.profile1)?;
+    let p2 = profile::load_profile(&args.profile2)?;
+
+    if args.json {
+        let val = diff_to_json(&args.profile1, &args.profile2, &p1, &p2);
+        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        return Ok(());
+    }
+
+    let t = theme::current();
+    println!(
+        "{}: diff '{}' vs '{}'",
+        prefix(),
+        theme::fg(&args.profile1, t.text).bold(),
+        theme::fg(&args.profile2, t.text).bold()
+    );
+
+    let mut any_diff = false;
+
+    // Groups
+    let g1: BTreeSet<&str> = p1.security.groups.iter().map(|s| s.as_str()).collect();
+    let g2: BTreeSet<&str> = p2.security.groups.iter().map(|s| s.as_str()).collect();
+    let added_groups: BTreeSet<&&str> = g2.difference(&g1).collect();
+    let removed_groups: BTreeSet<&&str> = g1.difference(&g2).collect();
+
+    if !added_groups.is_empty() || !removed_groups.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Groups", t.subtext).bold());
+        for g in &removed_groups {
+            println!("    {} {}", theme::fg("-", t.red), theme::fg(g, t.red));
+        }
+        for g in &added_groups {
+            println!("    {} {}", theme::fg("+", t.green), theme::fg(g, t.green));
+        }
+    }
+
+    // Filesystem
+    let fs_diffs = diff_string_vecs(&[
+        ("allow", &p1.filesystem.allow, &p2.filesystem.allow),
+        ("read", &p1.filesystem.read, &p2.filesystem.read),
+        ("write", &p1.filesystem.write, &p2.filesystem.write),
+        (
+            "allow_file",
+            &p1.filesystem.allow_file,
+            &p2.filesystem.allow_file,
+        ),
+        (
+            "read_file",
+            &p1.filesystem.read_file,
+            &p2.filesystem.read_file,
+        ),
+        (
+            "write_file",
+            &p1.filesystem.write_file,
+            &p2.filesystem.write_file,
+        ),
+    ]);
+
+    if !fs_diffs.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Filesystem", t.subtext).bold());
+        for (label, sign, path) in &fs_diffs {
+            let color = if *sign == "+" { t.green } else { t.red };
+            println!(
+                "    {} {} {}",
+                theme::fg(sign, color),
+                theme::fg(label, t.subtext),
+                theme::fg(path, color)
+            );
+        }
+    }
+
+    // Policy patches
+    let pp_diffs = diff_string_vecs(&[
+        (
+            "exclude_groups",
+            &p1.policy.exclude_groups,
+            &p2.policy.exclude_groups,
+        ),
+        (
+            "add_allow_read",
+            &p1.policy.add_allow_read,
+            &p2.policy.add_allow_read,
+        ),
+        (
+            "add_allow_write",
+            &p1.policy.add_allow_write,
+            &p2.policy.add_allow_write,
+        ),
+        (
+            "add_allow_readwrite",
+            &p1.policy.add_allow_readwrite,
+            &p2.policy.add_allow_readwrite,
+        ),
+        (
+            "add_deny_access",
+            &p1.policy.add_deny_access,
+            &p2.policy.add_deny_access,
+        ),
+        (
+            "override_deny",
+            &p1.policy.override_deny,
+            &p2.policy.override_deny,
+        ),
+    ]);
+
+    if !pp_diffs.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Policy patches", t.subtext).bold());
+        for (label, sign, val) in &pp_diffs {
+            let color = if *sign == "+" { t.green } else { t.red };
+            println!(
+                "    {} {} {}",
+                theme::fg(sign, color),
+                theme::fg(label, t.subtext),
+                theme::fg(val, color)
+            );
+        }
+    }
+
+    // Network
+    let mut net_diffs: Vec<(String, String)> = Vec::new();
+    if p1.network.block != p2.network.block {
+        net_diffs.push((
+            format!("- block: {}", p1.network.block),
+            format!("+ block: {}", p2.network.block),
+        ));
+    }
+    let np1 = p1.network.resolved_network_profile().unwrap_or("");
+    let np2 = p2.network.resolved_network_profile().unwrap_or("");
+    if np1 != np2 {
+        if !np1.is_empty() {
+            net_diffs.push((format!("- network_profile: {np1}"), String::new()));
+        }
+        if !np2.is_empty() {
+            net_diffs.push((String::new(), format!("+ network_profile: {np2}")));
+        }
+    }
+
+    if !net_diffs.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Network", t.subtext).bold());
+        for (rem, add) in &net_diffs {
+            if !rem.is_empty() {
+                println!("    {}", theme::fg(rem, t.red));
+            }
+            if !add.is_empty() {
+                println!("    {}", theme::fg(add, t.green));
+            }
+        }
+    }
+
+    // Workdir
+    if p1.workdir.access != p2.workdir.access {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Workdir", t.subtext).bold());
+        println!(
+            "    {}",
+            theme::fg(&format!("- access: {:?}", p1.workdir.access), t.red)
+        );
+        println!(
+            "    {}",
+            theme::fg(&format!("+ access: {:?}", p2.workdir.access), t.green)
+        );
+    }
+
+    // Allowed commands
+    let cmd1: BTreeSet<&str> = p1
+        .security
+        .allowed_commands
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    let cmd2: BTreeSet<&str> = p2
+        .security
+        .allowed_commands
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    let added_cmds: BTreeSet<&&str> = cmd2.difference(&cmd1).collect();
+    let removed_cmds: BTreeSet<&&str> = cmd1.difference(&cmd2).collect();
+
+    if !added_cmds.is_empty() || !removed_cmds.is_empty() {
+        any_diff = true;
+        println!();
+        println!("  {}:", theme::fg("Allowed commands", t.subtext).bold());
+        for c in &removed_cmds {
+            println!("    {} {}", theme::fg("-", t.red), theme::fg(c, t.red));
+        }
+        for c in &added_cmds {
+            println!("    {} {}", theme::fg("+", t.green), theme::fg(c, t.green));
+        }
+    }
+
+    if !any_diff {
+        println!();
+        println!("  {}", theme::fg("(no differences)", t.subtext));
+    }
+
+    Ok(())
+}
+
+fn diff_string_vecs<'a>(
+    pairs: &[(&'a str, &[String], &[String])],
+) -> Vec<(&'a str, &'static str, String)> {
+    let mut result = Vec::new();
+    for (label, v1, v2) in pairs {
+        let s1: BTreeSet<&str> = v1.iter().map(|s| s.as_str()).collect();
+        let s2: BTreeSet<&str> = v2.iter().map(|s| s.as_str()).collect();
+        for removed in s1.difference(&s2) {
+            result.push((*label, "-", removed.to_string()));
+        }
+        for added in s2.difference(&s1) {
+            result.push((*label, "+", added.to_string()));
+        }
+    }
+    result
+}
+
+fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_json::Value {
+    let g1: BTreeSet<&str> = p1.security.groups.iter().map(|s| s.as_str()).collect();
+    let g2: BTreeSet<&str> = p2.security.groups.iter().map(|s| s.as_str()).collect();
+
+    let groups_added: Vec<&str> = g2.difference(&g1).copied().collect();
+    let groups_removed: Vec<&str> = g1.difference(&g2).copied().collect();
+
+    serde_json::json!({
+        "profile1": name1,
+        "profile2": name2,
+        "groups": {
+            "added": groups_added,
+            "removed": groups_removed,
+        },
+        "filesystem": diff_fs_json(&p1.filesystem, &p2.filesystem),
+        "workdir": {
+            "profile1": format!("{:?}", p1.workdir.access),
+            "profile2": format!("{:?}", p2.workdir.access),
+            "changed": p1.workdir.access != p2.workdir.access,
+        },
+        "network": {
+            "block": {
+                "profile1": p1.network.block,
+                "profile2": p2.network.block,
+                "changed": p1.network.block != p2.network.block,
+            },
+            "network_profile": {
+                "profile1": p1.network.resolved_network_profile(),
+                "profile2": p2.network.resolved_network_profile(),
+                "changed": p1.network.resolved_network_profile() != p2.network.resolved_network_profile(),
+            },
+        },
+    })
+}
+
+fn diff_fs_json(
+    fs1: &profile::FilesystemConfig,
+    fs2: &profile::FilesystemConfig,
+) -> serde_json::Value {
+    let diff_vec = |v1: &[String], v2: &[String]| -> serde_json::Value {
+        let s1: BTreeSet<&str> = v1.iter().map(|s| s.as_str()).collect();
+        let s2: BTreeSet<&str> = v2.iter().map(|s| s.as_str()).collect();
+        let added: Vec<&str> = s2.difference(&s1).copied().collect();
+        let removed: Vec<&str> = s1.difference(&s2).copied().collect();
+        serde_json::json!({ "added": added, "removed": removed })
+    };
+
+    serde_json::json!({
+        "allow": diff_vec(&fs1.allow, &fs2.allow),
+        "read": diff_vec(&fs1.read, &fs2.read),
+        "write": diff_vec(&fs1.write, &fs2.write),
+        "allow_file": diff_vec(&fs1.allow_file, &fs2.allow_file),
+        "read_file": diff_vec(&fs1.read_file, &fs2.read_file),
+        "write_file": diff_vec(&fs1.write_file, &fs2.write_file),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// nono policy validate
+// ---------------------------------------------------------------------------
+
+fn cmd_validate(args: PolicyValidateArgs) -> Result<()> {
+    let pol = policy::load_embedded_policy()?;
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Step 1: Parse JSON
+    let profile = match profile::load_profile_from_path(&args.file) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            errors.push(format!("JSON parse error: {}", e));
+            None
+        }
+    };
+
+    if let Some(ref profile) = profile {
+        // Step 2: Check group references
+        for group_name in &profile.security.groups {
+            if !pol.groups.contains_key(group_name) {
+                errors.push(format!("Group '{}' not found in policy.json", group_name));
+            }
+        }
+
+        // Step 3: Check extends target
+        if let Some(ref extends) = profile.extends {
+            if profile::load_profile(extends).is_err() {
+                errors.push(format!("Extends target '{}' not found", extends));
+            }
+        }
+
+        // Step 4: Check exclude_groups
+        for excl in &profile.policy.exclude_groups {
+            if let Some(group) = pol.groups.get(excl) {
+                if group.required {
+                    errors.push(format!("Cannot exclude required group '{}'", excl));
+                }
+            } else {
+                warnings.push(format!(
+                    "Excluded group '{}' not found in policy.json",
+                    excl
+                ));
+            }
+        }
+
+        // Step 5: Check for empty paths
+        let check_paths = |paths: &[String], label: &str, w: &mut Vec<String>| {
+            for p in paths {
+                if p.trim().is_empty() {
+                    w.push(format!("Empty path in {}", label));
+                }
+            }
+        };
+        check_paths(&profile.filesystem.allow, "filesystem.allow", &mut warnings);
+        check_paths(&profile.filesystem.read, "filesystem.read", &mut warnings);
+        check_paths(&profile.filesystem.write, "filesystem.write", &mut warnings);
+    }
+
+    if args.json {
+        let val = serde_json::json!({
+            "file": args.file.display().to_string(),
+            "valid": errors.is_empty(),
+            "errors": errors,
+            "warnings": warnings,
+        });
+        println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+        if !errors.is_empty() {
+            return Err(NonoError::ProfileParse("validation failed".into()));
+        }
+        return Ok(());
+    }
+
+    let t = theme::current();
+    println!(
+        "{}: validating {}",
+        prefix(),
+        theme::fg(&args.file.display().to_string(), t.text)
+    );
+    println!();
+
+    if profile.is_some() {
+        println!("  {}  JSON syntax valid", theme::fg("[ok]", t.green));
+    }
+
+    if let Some(ref profile) = profile {
+        if let Some(ref extends) = profile.extends {
+            if profile::load_profile(extends).is_ok() {
+                println!(
+                    "  {}  Extends '{}' found",
+                    theme::fg("[ok]", t.green),
+                    extends
+                );
+            }
+        }
+
+        let valid_groups = profile
+            .security
+            .groups
+            .iter()
+            .filter(|g| pol.groups.contains_key(g.as_str()))
+            .count();
+        let total_groups = profile.security.groups.len();
+        if valid_groups == total_groups && total_groups > 0 {
+            println!(
+                "  {}  All {} group references valid",
+                theme::fg("[ok]", t.green),
+                total_groups
+            );
+        }
+    }
+
+    for w in &warnings {
+        println!(
+            "  {} {}",
+            theme::fg("[warn]", t.yellow),
+            theme::fg(w, t.yellow)
+        );
+    }
+
+    for e in &errors {
+        println!("  {}  {}", theme::fg("[err]", t.red), theme::fg(e, t.red));
+    }
+
+    println!();
+    if errors.is_empty() {
+        let suffix = if warnings.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " ({} warning{})",
+                warnings.len(),
+                if warnings.len() == 1 { "" } else { "s" }
+            )
+        };
+        println!(
+            "  Result: {}{}",
+            theme::fg("valid", t.green).bold(),
+            theme::fg(&suffix, t.yellow)
+        );
+        Ok(())
+    } else {
+        println!(
+            "  Result: {} ({} error{})",
+            theme::fg("invalid", t.red).bold(),
+            errors.len(),
+            if errors.len() == 1 { "" } else { "s" }
+        );
+        Err(NonoError::ProfileParse("validation failed".into()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_groups_lists_all() {
+        let pol = policy::load_embedded_policy().expect("should load policy");
+        assert!(
+            pol.groups.len() > 10,
+            "expected many groups, got {}",
+            pol.groups.len()
+        );
+        assert!(
+            pol.groups.contains_key("deny_credentials"),
+            "expected deny_credentials group"
+        );
+    }
+
+    #[test]
+    fn test_groups_specific_known() {
+        let pol = policy::load_embedded_policy().expect("should load policy");
+        let group = pol
+            .groups
+            .get("deny_credentials")
+            .expect("deny_credentials should exist");
+        assert!(!group.description.is_empty());
+        assert!(group.required);
+        if let Some(ref deny) = group.deny {
+            let all_paths = deny.access.join(" ");
+            assert!(all_paths.contains(".ssh"), "expected .ssh in deny paths");
+            assert!(all_paths.contains(".aws"), "expected .aws in deny paths");
+        } else {
+            panic!("deny_credentials should have deny rules");
+        }
+    }
+
+    #[test]
+    fn test_groups_unknown_errors() {
+        let pol = policy::load_embedded_policy().expect("should load policy");
+        let result = cmd_groups_detail(&pol, "nonexistent_group_xyz", false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_profiles_includes_builtins() {
+        let profiles = profile::list_profiles();
+        assert!(
+            profiles.contains(&"default".to_string()),
+            "expected 'default' in profiles"
+        );
+        assert!(
+            profiles.contains(&"claude-code".to_string()),
+            "expected 'claude-code' in profiles"
+        );
+    }
+
+    #[test]
+    fn test_show_resolves_inheritance() {
+        let profile =
+            profile::load_profile("claude-code").expect("claude-code profile should load");
+        assert!(
+            !profile.security.groups.is_empty(),
+            "claude-code should have security groups"
+        );
+        // claude-code extends default, so it should have default's base groups
+        let has_deny = profile.security.groups.iter().any(|g| g.contains("deny"));
+        assert!(has_deny, "claude-code should inherit deny groups");
+    }
+
+    #[test]
+    fn test_diff_shows_differences() {
+        let p1 = profile::load_profile("default").expect("default should load");
+        let p2 = profile::load_profile("claude-code").expect("claude-code should load");
+
+        let g1: BTreeSet<&str> = p1.security.groups.iter().map(|s| s.as_str()).collect();
+        let g2: BTreeSet<&str> = p2.security.groups.iter().map(|s| s.as_str()).collect();
+
+        let added: BTreeSet<&&str> = g2.difference(&g1).collect();
+        assert!(
+            !added.is_empty(),
+            "claude-code should have additional groups over default"
+        );
+    }
+
+    #[test]
+    fn test_validate_valid_profile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test-profile.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "meta": { "name": "test", "description": "test profile" },
+                "security": { "groups": ["deny_credentials"] },
+                "workdir": { "access": "readwrite" }
+            }"#,
+        )
+        .expect("write");
+
+        let args = PolicyValidateArgs {
+            file: path,
+            json: false,
+        };
+        let result = cmd_validate(args);
+        assert!(result.is_ok(), "valid profile should pass validation");
+    }
+
+    #[test]
+    fn test_validate_invalid_group() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("bad-profile.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "meta": { "name": "test" },
+                "security": { "groups": ["nonexistent_group_xyz"] }
+            }"#,
+        )
+        .expect("write");
+
+        let args = PolicyValidateArgs {
+            file: path,
+            json: false,
+        };
+        let result = cmd_validate(args);
+        assert!(result.is_err(), "invalid group should fail validation");
+    }
+
+    #[test]
+    fn test_validate_exclude_required() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("bad-exclude.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "meta": { "name": "test" },
+                "security": { "groups": [] },
+                "policy": { "exclude_groups": ["deny_credentials"] }
+            }"#,
+        )
+        .expect("write");
+
+        let args = PolicyValidateArgs {
+            file: path,
+            json: false,
+        };
+        let result = cmd_validate(args);
+        assert!(
+            result.is_err(),
+            "excluding required group should fail validation"
+        );
+    }
+}

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -822,7 +822,9 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<String> {
     // User profile
     if let Ok(profile_path) = get_user_profile_path(name_or_path) {
         if profile_path.exists() {
-            return parse_profile_file(&profile_path).ok().and_then(|p| p.extends);
+            return parse_profile_file(&profile_path)
+                .ok()
+                .and_then(|p| p.extends);
         }
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -90,7 +90,7 @@ pub struct PolicyPatchConfig {
 /// - `url_path`: Replace pattern in URL path (e.g., Telegram Bot API `/bot{}/`)
 /// - `query_param`: Add/replace query parameter (e.g., `?api_key=...`)
 /// - `basic_auth`: HTTP Basic Authentication (credential as `username:password`)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct CustomCredentialDef {
     /// Upstream URL to proxy requests to (e.g., "https://api.telegram.org")
     pub upstream: String,
@@ -788,6 +788,52 @@ pub struct Profile {
     /// Supervised mode preserves TTY by default, making this unnecessary.
     #[serde(default)]
     pub interactive: bool,
+}
+
+/// Check whether a profile name is loaded from a user file rather than the built-in set.
+///
+/// Returns `true` when a user profile file exists at `~/.config/nono/profiles/<name>.json`,
+/// which means the user has overridden or shadowed any built-in profile of the same name.
+pub fn is_user_override(name: &str) -> bool {
+    if !is_valid_profile_name(name) {
+        return false;
+    }
+    get_user_profile_path(name)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Load a profile's raw (unresolved) extends target name.
+///
+/// Returns `Some(base_name)` if the profile declares `extends`, `None` otherwise.
+/// This reads the raw profile definition before inheritance resolution clears the field.
+pub fn load_profile_extends(name_or_path: &str) -> Option<String> {
+    // Direct file path
+    if name_or_path.contains('/') || name_or_path.ends_with(".json") {
+        return parse_profile_file(Path::new(name_or_path))
+            .ok()
+            .and_then(|p| p.extends);
+    }
+
+    if !is_valid_profile_name(name_or_path) {
+        return None;
+    }
+
+    // User profile
+    if let Ok(profile_path) = get_user_profile_path(name_or_path) {
+        if profile_path.exists() {
+            return parse_profile_file(&profile_path).ok().and_then(|p| p.extends);
+        }
+    }
+
+    // Built-in profile
+    if let Ok(policy) = crate::policy::load_embedded_policy() {
+        if let Some(def) = policy.profiles.get(name_or_path) {
+            return def.extends.clone();
+        }
+    }
+
+    None
 }
 
 /// Load a profile by name or file path

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -4,7 +4,7 @@
 //! claude-code, openclaw, and opencode. They can be built-in (compiled
 //! into the binary) or user-defined (in ~/.config/nono/profiles/).
 
-mod builtin;
+pub(crate) mod builtin;
 
 use nono::{NonoError, Result};
 use serde::{Deserialize, Deserializer};
@@ -1263,7 +1263,6 @@ pub fn expand_vars(path: &str, workdir: &Path) -> Result<PathBuf> {
 }
 
 /// List available profiles (built-in + user)
-#[allow(dead_code)]
 pub fn list_profiles() -> Vec<String> {
     let mut profiles = builtin::list_builtin();
 

--- a/crates/nono-cli/tests/policy_cmd.rs
+++ b/crates/nono-cli/tests/policy_cmd.rs
@@ -1,0 +1,183 @@
+//! Integration tests for `nono policy` subcommands.
+//!
+//! These run as separate processes, so they are fully isolated from unit tests.
+
+use std::process::Command;
+
+fn nono_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nono"))
+}
+
+#[test]
+fn test_groups_list_output() {
+    let output = nono_bin()
+        .args(["policy", "groups", "--all-platforms"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("deny_credentials"),
+        "expected deny_credentials in output, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_groups_detail_output() {
+    let output = nono_bin()
+        .args(["policy", "groups", "deny_credentials"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(".ssh"),
+        "expected .ssh in deny_credentials detail, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(".aws"),
+        "expected .aws in deny_credentials detail, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_groups_unknown_exits_error() {
+    let output = nono_bin()
+        .args(["policy", "groups", "nonexistent_group_xyz"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+}
+
+#[test]
+fn test_profiles_list_output() {
+    let output = nono_bin()
+        .args(["policy", "profiles"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("claude-code"),
+        "expected claude-code in profiles list, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("default"),
+        "expected default in profiles list, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_show_profile_output() {
+    let output = nono_bin()
+        .args(["policy", "show", "default"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Security groups"),
+        "expected Security groups section, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_show_profile_json() {
+    let output = nono_bin()
+        .args(["policy", "show", "default", "--json"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout).expect("expected valid JSON output");
+    assert!(
+        val.get("security").is_some(),
+        "expected security key in JSON"
+    );
+}
+
+#[test]
+fn test_diff_output() {
+    let output = nono_bin()
+        .args(["policy", "diff", "default", "claude-code"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('+'),
+        "expected + lines in diff output, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_validate_valid_profile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("valid-profile.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "meta": { "name": "test", "description": "test profile" },
+            "security": { "groups": ["deny_credentials"] },
+            "workdir": { "access": "readwrite" }
+        }"#,
+    )
+    .expect("write");
+
+    let output = nono_bin()
+        .args(["policy", "validate", path.to_str().expect("path")])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 for valid profile, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_validate_invalid_group() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("bad-profile.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "meta": { "name": "test" },
+            "security": { "groups": ["fake_group_that_does_not_exist"] }
+        }"#,
+    )
+    .expect("write");
+
+    let output = nono_bin()
+        .args(["policy", "validate", path.to_str().expect("path")])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for invalid group"
+    );
+}
+
+#[test]
+fn test_groups_json() {
+    let output = nono_bin()
+        .args(["policy", "groups", "--json", "--all-platforms"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(output.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout).expect("expected valid JSON output");
+    assert!(val.is_array(), "expected JSON array");
+    let arr = val.as_array().expect("array");
+    assert!(arr.len() > 10, "expected many groups in JSON output");
+}

--- a/docs/cli/features/policy-introspection.mdx
+++ b/docs/cli/features/policy-introspection.mdx
@@ -1,0 +1,361 @@
+---
+title: Policy Introspection
+description: Inspect, compare, and validate security policy from the command line
+---
+
+The `nono policy` command lets you inspect the group-based security policy, explore profiles, compare configurations, and validate user-defined profiles. Every subcommand supports `--json` for programmatic consumption.
+
+## Commands
+
+### `nono policy groups`
+
+List all policy groups or show details for a specific group.
+
+```bash
+# List groups for the current platform
+nono policy groups
+
+# List groups for all platforms
+nono policy groups --all-platforms
+
+# Show details for a specific group
+nono policy groups deny_credentials
+
+# Machine-readable output
+nono policy groups --json
+```
+
+Example output:
+
+```
+nono policy: 21 groups
+
+  claude_code_macos                    Claude Code macOS-specific state and credential paths macos
+  deny_credentials                     Block access to cryptographic keys, tokens, and cloud credentials cross-platform  required
+  deny_shell_history                   Block access to shell command history files cross-platform  required
+  node_runtime                         Node.js runtime and package manager paths  cross-platform
+  system_read_macos                    macOS system paths required for executables to function macos
+  ...
+```
+
+Detailed view shows every path in the group, with variables expanded to their actual values:
+
+```
+nono policy: group 'deny_credentials'
+
+  Description:  Block access to cryptographic keys, tokens, and cloud credentials
+  Platform:     cross-platform
+  Required:     yes
+
+  deny.access:
+    ~/.ssh                               -> /Users/luke/.ssh
+    ~/.aws                               -> /Users/luke/.aws
+    ~/.config/gcloud                     -> /Users/luke/.config/gcloud
+    ~/.docker                            -> /Users/luke/.docker
+    ~/.git-credentials                   -> /Users/luke/.git-credentials
+    ...
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `[NAME]` | Group name to show details for (omit to list all) |
+| `--json` | Output as JSON |
+| `--all-platforms` | Show groups for all platforms, not just the current one |
+
+### `nono policy profiles`
+
+List all available profiles, showing built-in and user-defined profiles separately. User profiles that shadow a built-in name are flagged.
+
+```bash
+nono policy profiles
+nono policy profiles --json
+```
+
+Example output:
+
+```
+nono policy: 15 profiles
+
+  Built-in:
+    claude-code      Anthropic Claude Code CLI agent            extends default
+    codex            OpenAI Codex CLI agent                     extends default
+    default          Default conservative base profile
+    opencode         OpenCode AI coding assistant               extends default
+    python-dev       Python SDK development profile             extends default
+    ...
+
+  User (~/.config/nono/profiles/):
+    my-agent         Custom agent profile                       extends default
+    ...
+```
+
+Malformed user profiles are surfaced with their error instead of being silently hidden:
+
+```
+  User (~/.config/nono/profiles/):
+    broken-profile   [error: Profile error: missing field `meta`]
+```
+
+<Note>
+  Load precedence is user-first. If a user profile file exists at `~/.config/nono/profiles/claude-code.json`, it shadows the built-in `claude-code` profile. The `profiles` command reports the actual source: `"user (overrides built-in)"` in JSON output, and lists the profile under the User section.
+</Note>
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
+
+### `nono policy show`
+
+Display a fully resolved profile, including all inherited groups, filesystem grants, network configuration, hooks, and rollback settings.
+
+```bash
+# Show a built-in profile
+nono policy show default
+
+# Show a user profile
+nono policy show my-agent
+
+# Show a profile by file path
+nono policy show ./profiles/custom.json
+
+# Show raw paths (before variable expansion)
+nono policy show claude-code --raw
+
+# Machine-readable output
+nono policy show claude-code --json
+```
+
+Example output:
+
+```
+nono policy: profile 'claude-code'
+
+  Description:  Anthropic Claude Code CLI agent
+  Extends:      default
+
+  Security groups:
+    deny_credentials
+    deny_keychains_macos
+    node_runtime
+    python_runtime
+    rust_runtime
+    unlink_protection
+    ...
+
+  Filesystem:
+    allow (r+w):
+      $HOME/.claude                        -> /Users/luke/.claude
+    read_file:
+      $HOME/.gitconfig                     -> /Users/luke/.gitconfig
+
+  Workdir access:  ReadWrite
+
+  Rollback exclusions:
+    node_modules
+    target
+    __pycache__
+    glob: *.tmp.[0-9]*.[0-9]*
+
+  Open URLs:
+    localhost allowed
+    https://claude.ai
+```
+
+The `--raw` flag shows path variables as written in the profile (e.g., `$HOME/.claude`) rather than their expanded values. This is useful for understanding what a profile declares versus what it resolves to on a specific machine.
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `<PROFILE>` | Profile name or file path |
+| `--json` | Output as JSON |
+| `--raw` | Show raw paths before variable expansion |
+
+### `nono policy diff`
+
+Compare two profiles side-by-side. Shows additions, removals, and changes across all profile sections: groups, filesystem, policy patches, security settings, network, hooks, rollback, open URLs, env credentials, and custom credentials.
+
+```bash
+# Compare two built-in profiles
+nono policy diff default claude-code
+
+# Compare a user profile against a built-in
+nono policy diff default ./my-profile.json
+
+# Machine-readable output
+nono policy diff default claude-code --json
+```
+
+Example output:
+
+```
+nono policy: diff 'default' vs 'claude-code'
+
+  Groups:
+    + claude_code_macos
+    + node_runtime
+    + python_runtime
+    + rust_runtime
+    + unlink_protection
+    + user_caches_macos
+
+  Filesystem:
+    + allow $HOME/.claude
+    + read_file $HOME/.gitconfig
+    + read_file $HOME/.gitignore_global
+
+  Workdir:
+    - access: None
+    + access: ReadWrite
+
+  Open URLs:
+    + allow_origins https://claude.ai
+    - allow_localhost: false
+    + allow_localhost: true
+
+  Hooks:
+    + claude-code
+```
+
+For custom credentials and hooks, the diff detects value-level changes when two profiles share the same key but differ in configuration (e.g., different `upstream` URL or `inject_mode`):
+
+```
+  Custom credentials:
+    ~ my-api (changed)
+      - upstream: https://old-api.example.com
+      + upstream: https://new-api.example.com
+```
+
+When profiles are identical, the output shows `(no differences)`.
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `<PROFILE1>` | First profile name or path |
+| `<PROFILE2>` | Second profile name or path |
+| `--json` | Output as JSON |
+
+### `nono policy validate`
+
+Validate a user profile JSON file against the embedded policy. Catches common mistakes before they cause runtime failures.
+
+```bash
+nono policy validate ~/my-profile.json
+nono policy validate ./profiles/custom.json --json
+```
+
+Checks performed:
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| JSON syntax | Error | File must be valid JSON and deserialize into a profile |
+| Inheritance | Error | `extends` target must be a loadable profile |
+| Group references | Error | Every group in `security.groups` must exist in policy.json |
+| Required group exclusion | Error | `policy.exclude_groups` cannot exclude required groups |
+| Empty paths | Warning | Empty strings in filesystem path arrays |
+
+Example output for a valid profile:
+
+```
+nono policy: validating /Users/luke/my-profile.json
+
+  [ok]  JSON syntax valid
+  [ok]  All 3 group references valid
+
+  Result: valid
+```
+
+Example output for an invalid profile:
+
+```
+nono policy: validating /Users/luke/bad-profile.json
+
+  [ok]  JSON syntax valid
+  [err]  Group 'nonexistent_group' not found in policy.json
+
+  Result: invalid (1 error)
+```
+
+The command exits with a non-zero status when validation fails, making it suitable for CI pipelines.
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `<FILE>` | Profile JSON file to validate |
+| `--json` | Output as JSON |
+
+## JSON Output
+
+All subcommands support `--json` for integration with scripts, CI pipelines, and tools like `jq`.
+
+```bash
+# List groups and extract names
+nono policy groups --json | jq '.[].name'
+
+# Check if a profile has network blocked
+nono policy show my-profile --json | jq '.network.block'
+
+# Get added groups between two profiles
+nono policy diff default claude-code --json | jq '.groups.added'
+
+# Validate in CI and check result
+nono policy validate ./profile.json --json | jq '.valid'
+```
+
+## Use Cases
+
+### Auditing security posture
+
+Review exactly what a profile grants before deploying it:
+
+```bash
+# What does this profile actually allow?
+nono policy show claude-code
+
+# What groups protect sensitive data?
+nono policy groups deny_credentials
+
+# How does our custom profile differ from the built-in?
+nono policy diff claude-code ./our-custom-profile.json
+```
+
+### Debugging sandbox failures
+
+When a sandboxed process fails because a path is blocked, trace the policy:
+
+```bash
+# What groups apply to the current platform?
+nono policy groups
+
+# Does the profile include the needed runtime group?
+nono policy show my-profile | grep python_runtime
+
+# Compare against a working profile
+nono policy diff my-profile claude-code
+```
+
+### CI/CD validation
+
+Validate custom profiles before they ship:
+
+```bash
+# Validate all profile files in a directory
+for f in profiles/*.json; do
+  nono policy validate "$f" --json || exit 1
+done
+```
+
+### Detecting user overrides
+
+Check whether built-in profiles have been shadowed by user files:
+
+```bash
+# JSON output flags the actual source
+nono policy profiles --json | jq '.[] | select(.source | contains("overrides"))'
+```

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -5,6 +5,10 @@ description: Pre-configured capability sets and composable security groups
 
 Profiles are pre-configured capability sets that define what a sandboxed process can access. Groups are the composable building blocks that profiles are made from. Together they codify security policy so you don't have to specify flags manually every time.
 
+<Tip>
+  Use `nono policy` to inspect, compare, and validate profiles and groups from the command line. See [Policy Introspection](/cli/features/policy-introspection) for details.
+</Tip>
+
 ## Profiles
 
 ### Why Profiles?

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -107,6 +107,23 @@ Set up nono on this system. Verifies installation, tests sandbox support, and op
 nono setup [OPTIONS]
 ```
 
+### `nono policy`
+
+Inspect policy groups, profiles, and security rules.
+
+```bash
+nono policy <SUBCOMMAND>
+```
+
+Subcommands:
+- `groups` - List policy groups or show details for a specific group
+- `profiles` - List all available profiles (built-in and user)
+- `show` - Show a fully resolved profile
+- `diff` - Diff two profiles
+- `validate` - Validate a profile JSON file
+
+See [Policy Introspection](/cli/features/policy-introspection) for full documentation.
+
 ### `nono trust`
 
 Manage instruction file attestation. Sign, verify, and manage trust for AI agent instruction files.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,7 @@
           "cli/features/network-proxy",
           "cli/features/credential-injection",
           "cli/features/execution-modes",
+          "cli/features/policy-introspection",
           "cli/features/learn",
           "cli/features/trust"
         ]


### PR DESCRIPTION
Implement comprehensive policy inspection with five subcommands:
- `nono policy groups` - list all policy groups or show details for a specific group
- `nono policy profiles` - list built-in and user profiles
- `nono policy show` - display fully resolved profile with all inherited settings
- `nono policy diff` - compare two profiles side-by-side
- `nono policy validate` - validate profile JSON and check group references

All subcommands support `--json` output for programmatic use. Groups display
with platform tags, path expansion, and allow/deny counts. Profiles show
inheritance chain, resolved groups, and all security/filesystem/network
settings. Validation catches missing group references, excluded required
groups, and parse errors.

Closes: #381

Signed-off-by: Luke Hinds <lukehinds@gmail.com>