### PR TITLE
feat(policy): extract git config paths into reusable group

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -455,6 +455,16 @@
         ]
       }
     },
+    "git_config": {
+      "description": "Read access to git configuration files",
+      "allow": {
+        "read": [
+          "$HOME/.gitconfig",
+          "$HOME/.gitignore_global",
+          "$HOME/.config/git/ignore"
+        ]
+      }
+    },
     "unlink_protection": {
       "description": "Block file deletion globally, override for user-writable paths",
       "deny": {
@@ -590,6 +600,7 @@
           "vscode_macos",
           "vscode_linux",
           "nix_runtime",
+          "git_config",
           "unlink_protection"
         ],
         "signal_mode": "isolated",
@@ -597,8 +608,7 @@
       },
       "filesystem": {
         "allow": ["$HOME/.claude"],
-        "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"],
-        "read_file": ["$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
+        "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"]
       },
       "network": { "block": false },
       "workdir": { "access": "readwrite" },
@@ -637,6 +647,7 @@
           "rust_runtime",
           "python_runtime",
           "nix_runtime",
+          "git_config",
           "unlink_protection"
         ],
         "signal_mode": "isolated",
@@ -692,7 +703,7 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "unlink_protection"],
+        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "git_config", "unlink_protection"],
         "signal_mode": "isolated"
       },
       "filesystem": {
@@ -792,6 +803,7 @@
           "node_runtime",
           "user_caches_macos",
           "user_caches_linux",
+          "git_config",
           "unlink_protection"
         ],
         "signal_mode": "isolated",
@@ -801,8 +813,7 @@
         "allow": [
           "$HOME/.config/swival",
           "$HOME/.local/share/swival"
-        ],
-        "read_file": ["$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
+        ]
       },
       "network": { "block": false },
       "workdir": { "access": "readwrite" },

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -50,11 +50,13 @@ If you need different permissions, create a custom profile at `~/.config/nono/pr
     "version": "1.0.0",
     "description": "Claude Code with additional project access"
   },
+  "security": {
+    "groups": ["git_config"]
+  },
   "filesystem": {
     "allow": ["$WORKDIR", "$HOME/.claude"],
     "read": ["$HOME/shared-libs"],
-    "allow_file": ["$HOME/.claude.json"],
-    "read_file": ["$HOME/.gitconfig"]
+    "allow_file": ["$HOME/.claude.json"]
   },
   "network": {
     "block": false
@@ -243,7 +245,7 @@ Claude Code installs a VS Code extension on startup. The built-in profile alread
 
 ### Git Configuration
 
-Claude Code reads git configuration for repository operations. The built-in profile already grants read access to `~/.gitconfig`, `~/.gitignore_global`, and `~/.config/git/ignore`. No additional flags are needed for git operations.
+Claude Code reads git configuration for repository operations. The built-in profile includes the `git_config` group, which grants read access to `~/.gitconfig`, `~/.gitignore_global`, and `~/.config/git/ignore`. No additional flags are needed for git operations.
 
 ## Secretive (SSH Keys in Secure Enclave)
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -54,14 +54,14 @@ Profiles use JSON format:
     "access": "readwrite"
   },
   "security": {
-    "groups": ["node_runtime", "python_runtime"]
+    "groups": ["node_runtime", "python_runtime", "git_config"]
   },
   "filesystem": {
     "allow": ["$HOME/.config/my-agent"],
     "read": [],
     "write": [],
     "allow_file": [],
-    "read_file": ["$HOME/.gitconfig"],
+    "read_file": [],
     "write_file": []
   },
   "policy": {
@@ -547,9 +547,9 @@ The base profile that all other profiles extend. Provides system path access, de
 nono run --profile claude-code -- claude
 ```
 
-**Groups:** `claude_code_macos`, `claude_code_linux`, `user_caches_macos`, `claude_cache_linux`, `node_runtime`, `rust_runtime`, `python_runtime`, `vscode_macos`, `vscode_linux`, `nix_runtime`, `unlink_protection` (plus `default` groups)
+**Groups:** `claude_code_macos`, `claude_code_linux`, `user_caches_macos`, `claude_cache_linux`, `node_runtime`, `rust_runtime`, `python_runtime`, `vscode_macos`, `vscode_linux`, `nix_runtime`, `git_config`, `unlink_protection` (plus `default` groups)
 
-**Filesystem:** `~/.claude` (read+write), `~/.claude.json` and `~/.claude.json.lock` (read+write), `~/.gitconfig`, `~/.gitignore_global`, `~/.config/git/ignore` (read), plus platform-specific Claude Code and VS Code paths from the matching `_macos` or `_linux` groups
+**Filesystem:** `~/.claude` (read+write), `~/.claude.json` and `~/.claude.json.lock` (read+write), plus platform-specific Claude Code and VS Code paths from the matching `_macos` or `_linux` groups, and git config files from `git_config` group
 
 **Network:** Allowed
 
@@ -563,9 +563,9 @@ nono run --profile claude-code -- claude
 nono run --profile codex -- codex
 ```
 
-**Groups:** `codex_macos`, `node_runtime`, `rust_runtime`, `python_runtime`, `nix_runtime`, `unlink_protection` (plus `default` groups)
+**Groups:** `codex_macos`, `node_runtime`, `rust_runtime`, `python_runtime`, `nix_runtime`, `git_config`, `unlink_protection` (plus `default` groups)
 
-**Filesystem:** `~/.codex` (read+write)
+**Filesystem:** `~/.codex` (read+write), plus git config files from `git_config` group
 
 **Network:** Allowed
 
@@ -579,9 +579,9 @@ nono run --profile codex -- codex
 nono run --profile opencode -- opencode
 ```
 
-**Groups:** `user_caches_macos`, `user_caches_linux`, `node_runtime`, `opencode_linux`, `unlink_protection` (plus `default` groups)
+**Groups:** `user_caches_macos`, `user_caches_linux`, `node_runtime`, `opencode_linux`, `git_config`, `unlink_protection` (plus `default` groups)
 
-**Filesystem:** `~/.config/opencode`, `~/.cache/opencode`, `~/.local/share/opencode`, `~/.local/share/opentui` (all read+write)
+**Filesystem:** `~/.config/opencode`, `~/.cache/opencode`, `~/.local/share/opencode`, `~/.local/share/opentui` (all read+write), plus git config files from `git_config` group
 
 **Network:** Allowed
 
@@ -607,9 +607,9 @@ nono run --profile openclaw -- openclaw
 nono run --profile swival -- swival
 ```
 
-**Groups:** `python_runtime`, `node_runtime`, `user_caches_macos`, `user_caches_linux`, `unlink_protection` (plus `default` groups)
+**Groups:** `python_runtime`, `node_runtime`, `user_caches_macos`, `user_caches_linux`, `git_config`, `unlink_protection` (plus `default` groups)
 
-**Filesystem:** `~/.config/swival`, `~/.local/share/swival` (read+write), `~/.gitconfig`, `~/.gitignore_global`, `~/.config/git/ignore` (read)
+**Filesystem:** `~/.config/swival`, `~/.local/share/swival` (read+write), plus git config files from `git_config` group
 
 **Network:** Allowed
 


### PR DESCRIPTION
Move git configuration file access (`~/.gitconfig`, `~/.gitignore_global`, `~/.config/git/ignore`) from individual profile filesystem declarations into a new `git_config` group. Add `git_config` to all profiles that need git access (claude-code, codex, opencode, swival) and remove redundant `read_file` entries.