### PR TITLE
feat(cli): add `nono profile` scaffolding and authoring tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "2"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 toml = "1.0"
 
 # Logging

--- a/crates/nono-cli/build.rs
+++ b/crates/nono-cli/build.rs
@@ -48,4 +48,21 @@ fn main() {
         fs::write(out_path.join("nono-hook.sh"), &content)
             .expect("Failed to write hook script to OUT_DIR");
     }
+
+    // === Embed profile JSON Schema ===
+    let schema_path = Path::new("data/nono-profile.schema.json");
+    if schema_path.exists() {
+        let content = fs::read_to_string(schema_path).expect("Failed to read profile schema");
+        fs::write(out_path.join("nono-profile.schema.json"), &content)
+            .expect("Failed to write profile schema to OUT_DIR");
+    }
+
+    // === Embed profile authoring guide ===
+    let guide_path = Path::new("data/profile-authoring-guide.md");
+    if guide_path.exists() {
+        let content =
+            fs::read_to_string(guide_path).expect("Failed to read profile authoring guide");
+        fs::write(out_path.join("profile-authoring-guide.md"), &content)
+            .expect("Failed to write profile authoring guide to OUT_DIR");
+    }
 }

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1,0 +1,446 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nono.dev/schemas/nono-profile.schema.json",
+  "title": "nono Profile",
+  "description": "A nono profile definition that configures sandbox capabilities, filesystem access, network policy, and other security settings for running untrusted processes.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema URI for editor validation and autocompletion."
+    },
+    "extends": {
+      "type": "string",
+      "description": "Name of a base profile to inherit from. All fields from the base profile are used as defaults, with this profile's values taking precedence."
+    },
+    "meta": {
+      "$ref": "#/$defs/ProfileMeta",
+      "description": "Profile metadata including name, version, description, and author."
+    },
+    "security": {
+      "$ref": "#/$defs/SecurityConfig",
+      "description": "Security configuration referencing policy.json groups, allowed commands, and isolation modes."
+    },
+    "filesystem": {
+      "$ref": "#/$defs/FilesystemConfig",
+      "description": "Filesystem access rules specifying which directories and files the sandboxed process can read or write."
+    },
+    "policy": {
+      "$ref": "#/$defs/PolicyPatchConfig",
+      "description": "Policy patch configuration for subtractive and additive composition on top of inherited groups."
+    },
+    "network": {
+      "$ref": "#/$defs/NetworkConfig",
+      "description": "Network access configuration including proxy settings, credential injection, and port allowlists."
+    },
+    "env_credentials": {
+      "$ref": "#/$defs/SecretsConfig",
+      "description": "Maps keystore account names (or op://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore at startup."
+    },
+    "secrets": {
+      "$ref": "#/$defs/SecretsConfig",
+      "description": "Alias for env_credentials. Maps keystore account names to environment variable names."
+    },
+    "workdir": {
+      "$ref": "#/$defs/WorkdirConfig",
+      "description": "Working directory access configuration controlling whether and how the current working directory is shared with the sandboxed process."
+    },
+    "hooks": {
+      "$ref": "#/$defs/HooksConfig",
+      "description": "Hook configurations for target applications. Maps application names to their hook definitions."
+    },
+    "rollback": {
+      "$ref": "#/$defs/RollbackConfig",
+      "description": "Rollback snapshot configuration controlling which files are excluded from undo snapshots."
+    },
+    "undo": {
+      "$ref": "#/$defs/RollbackConfig",
+      "description": "Alias for rollback. Controls which files are excluded from undo snapshots."
+    },
+    "open_urls": {
+      "oneOf": [
+        { "$ref": "#/$defs/OpenUrlConfig" },
+        { "type": "null" }
+      ],
+      "description": "Supervisor-delegated URL opening configuration for OAuth2 login flows and similar operations. When present, replaces the base profile's config entirely. When absent or null, inherits from the base profile. To clear inherited permissions, provide an explicit empty object with allow_origins: [] and allow_localhost: false."
+    },
+    "allow_launch_services": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "null" }
+      ],
+      "description": "Opt-in gate for temporary direct LaunchServices opens on macOS. Must be paired with the CLI flag --allow-launch-services. Set to null to inherit from the base profile."
+    },
+    "interactive": {
+      "type": "boolean",
+      "description": "Deprecated. Parsed for backward compatibility but ignored. Supervised mode preserves TTY by default.",
+      "deprecated": true
+    }
+  },
+  "$defs": {
+    "ProfileMeta": {
+      "type": "object",
+      "description": "Profile metadata.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name of this profile."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version string for this profile definition."
+        },
+        "description": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Optional description of what this profile is for."
+        },
+        "author": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Optional author or maintainer of this profile."
+        }
+      }
+    },
+    "SecurityConfig": {
+      "type": "object",
+      "description": "Security configuration referencing policy.json groups and isolation modes.",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Policy group names to resolve from policy.json. Groups define sets of allow/deny rules for filesystem paths, commands, and platform-specific behaviors."
+        },
+        "allowed_commands": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Commands to allow even when blocked by default policy. Applied before CLI --allow-command overrides."
+        },
+        "signal_mode": {
+          "oneOf": [
+            { "$ref": "#/$defs/ProfileSignalMode" },
+            { "type": "null" }
+          ],
+          "description": "Signal isolation mode controlling whether the sandboxed process can signal other processes. When null, inherits from the base profile (defaults to isolated)."
+        },
+        "process_info_mode": {
+          "oneOf": [
+            { "$ref": "#/$defs/ProfileProcessInfoMode" },
+            { "type": "null" }
+          ],
+          "description": "Process inspection mode controlling whether the sandboxed process can read process info for other processes. When null, defaults to isolated."
+        },
+        "capability_elevation": {
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "null" }
+          ],
+          "description": "Enable runtime capability elevation via seccomp-notify (Linux). When true, the supervisor intercepts file opens and can grant access to paths not in the initial capability set. When false, the sandbox is static."
+        }
+      }
+    },
+    "ProfileSignalMode": {
+      "type": "string",
+      "enum": ["isolated", "allow_same_sandbox", "allow_all"],
+      "description": "Signal isolation mode for the sandboxed process."
+    },
+    "ProfileProcessInfoMode": {
+      "type": "string",
+      "enum": ["isolated", "allow_same_sandbox", "allow_all"],
+      "description": "Process inspection mode for the sandboxed process."
+    },
+    "FilesystemConfig": {
+      "type": "object",
+      "description": "Filesystem access rules for the sandboxed process.",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories with read+write access."
+        },
+        "read": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories with read-only access."
+        },
+        "write": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories with write-only access."
+        },
+        "allow_file": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Single files with read+write access."
+        },
+        "read_file": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Single files with read-only access."
+        },
+        "write_file": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Single files with write-only access."
+        }
+      }
+    },
+    "PolicyPatchConfig": {
+      "type": "object",
+      "description": "Policy patch configuration for subtractive and additive composition on top of inherited groups and existing filesystem configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "exclude_groups": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Group names to remove from the resolved group set."
+        },
+        "add_allow_read": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional read-only directories to allow."
+        },
+        "add_allow_write": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional write-only directories to allow."
+        },
+        "add_allow_readwrite": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional read-write directories to allow."
+        },
+        "add_deny_access": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional deny.access paths to apply."
+        },
+        "override_deny": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths to exempt from deny groups. Each path must also be explicitly granted via filesystem or policy.add_allow_* fields. Does not implicitly grant access; only removes the deny rule."
+        }
+      }
+    },
+    "NetworkConfig": {
+      "type": "object",
+      "description": "Network access configuration including proxy, credential injection, and port allowlists.",
+      "additionalProperties": false,
+      "properties": {
+        "block": {
+          "type": "boolean",
+          "description": "Block network access. Network is allowed by default; set to true to deny all outbound traffic."
+        },
+        "network_profile": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Network proxy profile name from network-policy.json. When set, outbound traffic is filtered through the proxy. Set to null to clear an inherited value."
+        },
+        "proxy_allow": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional hosts to allow through the proxy on top of the network profile hosts."
+        },
+        "allow_proxy": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Alias for proxy_allow. Additional hosts to allow through the proxy."
+        },
+        "proxy_credentials": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Credential service names to enable via the reverse proxy."
+        },
+        "port_allow": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "Localhost TCP ports to allow bidirectional IPC (connect + bind)."
+        },
+        "allow_port": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "Alias for port_allow. Localhost TCP ports to allow bidirectional IPC."
+        },
+        "custom_credentials": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomCredentialDef"
+          },
+          "description": "Custom credential definitions for services not in network-policy.json. Keys are service names used with --proxy-credential."
+        },
+        "external_proxy": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "External proxy address (host:port) for enterprise proxy passthrough."
+        },
+        "external_proxy_bypass": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Hosts to bypass the external proxy and route directly. Supports exact hostnames and wildcard suffixes (e.g., *.example.com)."
+        }
+      }
+    },
+    "CustomCredentialDef": {
+      "type": "object",
+      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service.",
+      "additionalProperties": false,
+      "required": ["upstream", "credential_key"],
+      "properties": {
+        "upstream": {
+          "type": "string",
+          "description": "Upstream URL to proxy requests to (e.g., \"https://api.telegram.org\"). Must use HTTPS, or HTTP only for loopback addresses."
+        },
+        "credential_key": {
+          "type": "string",
+          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, or an apple-password:// URI."
+        },
+        "inject_mode": {
+          "$ref": "#/$defs/InjectMode",
+          "description": "Credential injection mode. Determines how the credential is inserted into outbound requests.",
+          "default": "header"
+        },
+        "inject_header": {
+          "type": "string",
+          "description": "HTTP header name to inject the credential into. Only used when inject_mode is \"header\".",
+          "default": "Authorization"
+        },
+        "credential_format": {
+          "type": "string",
+          "description": "Format string for the credential value, using {} as placeholder. Only used when inject_mode is \"header\".",
+          "default": "Bearer {}"
+        },
+        "path_pattern": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Pattern to match in incoming URL path, using {} as placeholder for the phantom token. Required when inject_mode is \"url_path\"."
+        },
+        "path_replacement": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Pattern for outgoing URL path, using {} as placeholder for the real credential. Defaults to path_pattern if not specified. Only used when inject_mode is \"url_path\"."
+        },
+        "query_param_name": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Name of the query parameter to add or replace with the credential. Required when inject_mode is \"query_param\"."
+        },
+        "env_var": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Explicit environment variable name for the phantom token (e.g., \"OPENAI_API_KEY\"). Required when credential_key is a URI manager reference (op:// or apple-password://)."
+        }
+      }
+    },
+    "InjectMode": {
+      "type": "string",
+      "enum": ["header", "url_path", "query_param", "basic_auth"],
+      "description": "Credential injection mode for the reverse proxy.",
+      "default": "header"
+    },
+    "SecretsConfig": {
+      "type": "object",
+      "description": "Maps keystore account names (or op://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore under the service name \"nono\".",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Environment variable name to inject the secret value into."
+      }
+    },
+    "WorkdirConfig": {
+      "type": "object",
+      "description": "Working directory access configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "access": {
+          "$ref": "#/$defs/WorkdirAccess",
+          "description": "Access level for the current working directory.",
+          "default": "none"
+        }
+      }
+    },
+    "WorkdirAccess": {
+      "type": "string",
+      "enum": ["none", "read", "write", "readwrite"],
+      "description": "Working directory access level controlling whether and how the current working directory is shared with the sandboxed process."
+    },
+    "HooksConfig": {
+      "type": "object",
+      "description": "Hook configurations for target applications. Keys are application names (e.g., \"claude-code\"), values define the hook to install.",
+      "additionalProperties": {
+        "$ref": "#/$defs/HookConfig"
+      }
+    },
+    "HookConfig": {
+      "type": "object",
+      "description": "Hook definition for a target application.",
+      "additionalProperties": false,
+      "required": ["event", "matcher", "script"],
+      "properties": {
+        "event": {
+          "type": "string",
+          "description": "Event that triggers the hook (e.g., \"PostToolUseFailure\")."
+        },
+        "matcher": {
+          "type": "string",
+          "description": "Regex pattern to match tool names (e.g., \"Read|Write|Edit|Bash\")."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script filename from data/hooks/ to install."
+        }
+      }
+    },
+    "RollbackConfig": {
+      "type": "object",
+      "description": "Rollback snapshot configuration controlling which files are excluded from undo snapshots.",
+      "additionalProperties": false,
+      "properties": {
+        "exclude_patterns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Patterns to exclude from rollback snapshots. Matched against path components (exact match) or as substrings of the full path if they contain a slash."
+        },
+        "exclude_globs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns to exclude from rollback snapshots. Matched against the filename using standard glob syntax."
+        }
+      }
+    },
+    "OpenUrlConfig": {
+      "type": "object",
+      "description": "Configuration for supervisor-delegated URL opening, used for OAuth2 login flows and similar operations.",
+      "additionalProperties": false,
+      "properties": {
+        "allow_origins": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowed URL origins (scheme + host, e.g., \"https://console.anthropic.com\"). The supervisor validates each URL open request against this list. An empty list means no URLs are allowed."
+        },
+        "allow_localhost": {
+          "type": "boolean",
+          "description": "Allow opening http://localhost and http://127.0.0.1 URLs, typically for OAuth2 callback handlers."
+        }
+      }
+    }
+  }
+}

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -1,0 +1,366 @@
+# nono Profile Authoring Guide
+
+This guide is designed for LLM agents helping users create custom nono profiles. It covers the full profile schema, common patterns, and validation workflow.
+
+## 1. Profile File Location
+
+User profiles live at `~/.config/nono/profiles/<name>.json`.
+
+Profile names must be alphanumeric with hyphens only. No leading or trailing hyphens.
+
+Valid: `my-agent`, `ci-build`, `dev2`
+Invalid: `-leading`, `trailing-`, `has spaces`, `special_chars!`
+
+User profiles take precedence over built-in profiles of the same name.
+
+## 2. Minimal Profile Example
+
+```json
+{
+  "meta": {
+    "name": "my-agent",
+    "description": "Profile for my agent"
+  },
+  "security": {
+    "groups": []
+  },
+  "workdir": {
+    "access": "readwrite"
+  }
+}
+```
+
+## 3. Section Reference
+
+### meta
+
+| Field         | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `name`        | string | yes      | Profile name             |
+| `version`     | string | no       | Semver version string    |
+| `description` | string | no       | Human-readable summary   |
+| `author`      | string | no       | Author name              |
+
+### extends
+
+Inherit from another profile by name:
+
+```json
+{
+  "extends": "default"
+}
+```
+
+- Inheritance chain max depth: 10.
+- Scalar fields: child overrides base.
+- Array fields (`groups`, `filesystem.*`, `policy.*`, `proxy_allow`, `port_allow`, `rollback.*`, `external_proxy_bypass`): child values are appended to base values and deduplicated. To remove inherited entries, use `policy.exclude_groups` for groups; there is no mechanism to remove inherited filesystem paths.
+- Map fields (`env_credentials`, `hooks`, `custom_credentials`): child entries are merged into base; child keys override matching base keys.
+- `network_profile` supports three-state inheritance via `InheritableValue`: absent = inherit base value, `null` = explicitly clear, string = override. This is the only field that supports null-clearing.
+- `open_urls`: if the child provides the field (even as `{}`), it replaces the base entirely. If absent, the base value is inherited. Setting to `null` in JSON is equivalent to omitting it (both inherit the base).
+- `workdir`: child overrides base unless child is `"none"` (which inherits the base value instead).
+
+### security
+
+| Field                 | Type            | Default      | Description |
+|-----------------------|-----------------|--------------|-------------|
+| `groups`              | array of string | `[]`         | Policy group names from `policy.json`. Use `nono policy groups` to list available groups. |
+| `allowed_commands`    | array of string | `[]`         | Commands to allow even when blocked by deny groups (e.g., `["rm"]`). |
+| `signal_mode`         | string          | `"isolated"` | One of: `"isolated"`, `"allow_same_sandbox"`, `"allow_all"`. |
+| `process_info_mode`   | string          | `"isolated"` | One of: `"isolated"`, `"allow_same_sandbox"`, `"allow_all"`. |
+| `capability_elevation`| boolean         | `false`      | Enable runtime capability elevation via seccomp-notify. Linux only. |
+
+### filesystem
+
+| Field        | Type            | Description |
+|--------------|-----------------|-------------|
+| `allow`      | array of string | Directories with read+write access. |
+| `read`       | array of string | Directories with read-only access. |
+| `write`      | array of string | Directories with write-only access. |
+| `allow_file` | array of string | Single files with read+write access. |
+| `read_file`  | array of string | Single files with read-only access. |
+| `write_file` | array of string | Single files with write-only access. |
+
+All path fields support variable expansion (see Section 6).
+
+### workdir
+
+| Field    | Type   | Default  | Description |
+|----------|--------|----------|-------------|
+| `access` | string | `"none"` | One of: `"none"`, `"read"`, `"write"`, `"readwrite"`. Controls automatic CWD sharing with the sandboxed process. |
+
+### policy (patches)
+
+Provides subtractive and additive composition on top of inherited groups and filesystem configuration.
+
+| Field                | Type            | Description |
+|----------------------|-----------------|-------------|
+| `exclude_groups`     | array of string | Group names to remove from the resolved group set, including inherited defaults. |
+| `add_allow_read`     | array of string | Additional read-only path grants. |
+| `add_allow_write`    | array of string | Additional write-only path grants. |
+| `add_allow_readwrite`| array of string | Additional read+write path grants. |
+| `add_deny_access`    | array of string | Additional deny paths. |
+| `override_deny`      | array of string | Paths to exempt from deny groups. Each path must also be granted via `filesystem` or `add_allow_*`. Does not implicitly grant access; only removes the deny rule. |
+
+### network
+
+| Field                   | Type                              | Default  | Description |
+|-------------------------|-----------------------------------|----------|-------------|
+| `block`                 | boolean                           | `false`  | Block all network access. |
+| `network_profile`       | string or null                    | inherit  | Name from `network-policy.json` for proxy filtering. Set to `null` to clear inherited value. |
+| `proxy_allow`           | array of string                   | `[]`     | Additional hosts to allow through proxy. Alias: `allow_proxy`. |
+| `proxy_credentials`     | array of string                   | `[]`     | Credential services to enable via reverse proxy. |
+| `port_allow`            | array of integer                  | `[]`     | Localhost TCP ports for bidirectional IPC. Alias: `allow_port`. |
+| `custom_credentials`    | map of string to credential def   | `{}`     | Custom credential route definitions (see below). |
+| `external_proxy`        | string                            | `null`   | Enterprise proxy address (`host:port`). |
+| `external_proxy_bypass` | array of string                   | `[]`     | Hosts to bypass external proxy. Supports `*.` wildcard suffixes. |
+
+#### custom_credentials entry
+
+Define a custom reverse proxy credential route for services not in `network-policy.json`:
+
+```json
+{
+  "upstream": "https://api.example.com",
+  "credential_key": "example_api_key",
+  "inject_mode": "header",
+  "inject_header": "Authorization",
+  "credential_format": "Bearer {}"
+}
+```
+
+| Field               | Type   | Required    | Description |
+|---------------------|--------|-------------|-------------|
+| `upstream`          | string | yes         | Upstream URL. Must be HTTPS (HTTP only for loopback). |
+| `credential_key`    | string | yes         | Keystore account name, `op://` URI, or `apple-password://` URI. |
+| `inject_mode`       | string | no          | One of: `"header"` (default), `"url_path"`, `"query_param"`, `"basic_auth"`. |
+| `inject_header`     | string | header mode | HTTP header name. Default: `"Authorization"`. |
+| `credential_format` | string | header mode | Format string with `{}` placeholder. Default: `"Bearer {}"`. |
+| `path_pattern`      | string | url_path    | Pattern to match in URL path. Use `{}` for placeholder. |
+| `path_replacement`  | string | url_path    | Replacement pattern. Defaults to `path_pattern`. |
+| `query_param_name`  | string | query_param | Query parameter name for credential injection. |
+| `env_var`           | string | URI keys    | Environment variable name for SDK API key. Required when `credential_key` is a URI. |
+
+### env_credentials (alias: secrets)
+
+Maps keystore account names to environment variable names. Secrets are loaded from the system keystore (macOS Keychain / Linux Secret Service) under the service name "nono".
+
+```json
+{
+  "env_credentials": {
+    "openai_api_key": "OPENAI_API_KEY",
+    "op://vault/item/field": "ANTHROPIC_API_KEY"
+  }
+}
+```
+
+Supported key formats:
+- Bare keystore account name: `"openai_api_key"`
+- 1Password URI: `"op://vault/item/field"`
+- Apple Passwords URI: `"apple-password://account/name"`
+- Environment reference: `"env://EXISTING_VAR"`
+
+### hooks
+
+Map of application name to hook configuration:
+
+```json
+{
+  "hooks": {
+    "claude-code": {
+      "event": "PostToolUseFailure",
+      "matcher": "Read|Write|Edit|Bash",
+      "script": "nono-hook.sh"
+    }
+  }
+}
+```
+
+| Field     | Type   | Description |
+|-----------|--------|-------------|
+| `event`   | string | Trigger event name. |
+| `matcher` | string | Regex for tool name matching. |
+| `script`  | string | Script filename from embedded hooks. |
+
+### rollback (alias: undo)
+
+| Field              | Type            | Description |
+|--------------------|-----------------|-------------|
+| `exclude_patterns` | array of string | Path component patterns to exclude from snapshots. |
+| `exclude_globs`    | array of string | Glob patterns for filename exclusion. |
+
+### open_urls
+
+Controls supervisor-delegated URL opening (e.g., OAuth2 login flows).
+
+| Field             | Type            | Default | Description |
+|-------------------|-----------------|---------|-------------|
+| `allow_origins`   | array of string | `[]`    | Allowed URL origins (scheme + host, e.g., `"https://console.anthropic.com"`). |
+| `allow_localhost`  | boolean         | `false` | Allow `http://localhost` and `http://127.0.0.1` URLs. |
+
+To replace inherited URL-opening permissions, provide `open_urls` with an explicit empty object: `"open_urls": { "allow_origins": [], "allow_localhost": false }`. Omitting `open_urls` inherits the base profile's configuration.
+
+## 4. Common Patterns
+
+### Developer profile (extending default)
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "developer",
+    "description": "General development"
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "filesystem": {
+    "read": ["$HOME/.config"]
+  }
+}
+```
+
+### CI profile (locked down)
+
+```json
+{
+  "meta": {
+    "name": "ci-build",
+    "description": "CI build environment"
+  },
+  "security": {
+    "groups": ["deny_credentials", "deny_ssh_keys"]
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "network": {
+    "block": true
+  }
+}
+```
+
+### Agent with API access
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "api-agent",
+    "description": "Agent with API access"
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "env_credentials": {
+    "openai_api_key": "OPENAI_API_KEY"
+  },
+  "network": {
+    "network_profile": "standard"
+  }
+}
+```
+
+### Profile with deny overrides
+
+When a deny group blocks a path you need access to, use `override_deny` together with an explicit grant:
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "shell-config-reader",
+    "description": "Needs to read shell configs"
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "filesystem": {
+    "read_file": ["$HOME/.bashrc", "$HOME/.zshrc"]
+  },
+  "policy": {
+    "override_deny": ["$HOME/.bashrc", "$HOME/.zshrc"]
+  }
+}
+```
+
+### Profile with group exclusion
+
+Remove an inherited deny group that is too restrictive for your use case:
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "browser-tool",
+    "description": "Needs browser data access"
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "policy": {
+    "exclude_groups": ["deny_browser_data_macos", "deny_browser_data_linux"]
+  }
+}
+```
+
+### Profile with custom credential routing
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "telegram-bot",
+    "description": "Telegram bot with credential injection"
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "network": {
+    "custom_credentials": {
+      "telegram": {
+        "upstream": "https://api.telegram.org",
+        "credential_key": "telegram_bot_token",
+        "inject_mode": "url_path",
+        "path_pattern": "/bot{}/",
+        "path_replacement": "/bot{}/"
+      }
+    },
+    "proxy_credentials": ["telegram"]
+  }
+}
+```
+
+## 5. Validation
+
+Run these commands to verify a profile:
+
+```
+nono policy validate <path>       # Check a profile file for errors
+nono policy show <name>           # Show the fully resolved profile (after inheritance)
+nono policy groups                # List available security groups
+nono policy diff <a> <b>          # Compare two profiles
+```
+
+## 6. Variable Expansion
+
+The following variables are expanded in all path fields (`filesystem.*`, `policy.add_allow_*`, `policy.add_deny_access`, `policy.override_deny`):
+
+| Variable           | Expands to |
+|--------------------|------------|
+| `$HOME`            | User's home directory |
+| `$WORKDIR`         | Working directory (from `--workdir` flag or cwd) |
+| `$TMPDIR`          | System temporary directory |
+| `$XDG_CONFIG_HOME` | XDG config directory (default: `$HOME/.config`) |
+| `$XDG_DATA_HOME`   | XDG data directory (default: `$HOME/.local/share`) |
+
+Always use these variables instead of hardcoded absolute paths to keep profiles portable across machines and users.
+
+## 7. Key Rules
+
+- A profile with no `security.groups` has no deny rules. Always include appropriate deny groups for untrusted workloads.
+- `override_deny` only removes the deny rule. It does not grant access. You must also add the path via `filesystem` or `policy.add_allow_*`.
+- `exclude_groups` removes groups from the resolved set. This weakens the sandbox. Use it only when you understand which protections you are removing.
+- `extends` chains resolve recursively up to depth 10. Circular inheritance is an error.
+- Platform-specific groups (suffix `_macos` or `_linux`) are filtered at resolution time. Include both variants for cross-platform profiles.
+- `network.block: true` blocks all network access. It cannot be combined with proxy settings.
+- `custom_credentials` upstream URLs must use HTTPS. HTTP is only accepted for loopback addresses (localhost, 127.0.0.1, ::1).

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -239,6 +239,28 @@ PLATFORM NOTES:
 ")]
     Policy(PolicyArgs),
 
+    /// Create and manage nono profiles
+    #[command(after_help = "EXAMPLES:
+    # Create a new profile with default settings
+    nono profile init my-agent
+
+    # Create a profile extending an existing one
+    nono profile init my-agent --extends default --groups deny_credentials
+
+    # Generate a full skeleton with all sections
+    nono profile init my-agent --full
+
+    # Output to a specific file
+    nono profile init my-agent --output ./my-profile.json
+
+    # Print JSON Schema for editor validation
+    nono profile schema
+
+    # Print profile authoring guide
+    nono profile guide
+")]
+    Profile(ProfileCmdArgs),
+
     /// Internal: open a URL via supervisor IPC
     #[command(hide = true)]
     OpenUrlHelper(OpenUrlHelperArgs),
@@ -326,6 +348,56 @@ pub struct PolicyValidateArgs {
     #[arg(long)]
     pub json: bool,
 }
+
+#[derive(Parser, Debug)]
+pub struct ProfileCmdArgs {
+    #[command(subcommand)]
+    pub command: ProfileCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProfileCommands {
+    /// Generate a skeleton profile JSON file
+    Init(ProfileInitArgs),
+    /// Output the JSON Schema for profile files
+    Schema(ProfileSchemaArgs),
+    /// Print the profile authoring guide
+    Guide(ProfileGuideArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileInitArgs {
+    /// Profile name (alphanumeric + hyphens)
+    pub name: String,
+    /// Base profile to extend
+    #[arg(long)]
+    pub extends: Option<String>,
+    /// Security groups to include (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    pub groups: Vec<String>,
+    /// Profile description
+    #[arg(long)]
+    pub description: Option<String>,
+    /// Generate a full skeleton with all sections
+    #[arg(long)]
+    pub full: bool,
+    /// Output file path (default: ~/.config/nono/profiles/<name>.json)
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+    /// Overwrite existing file
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileSchemaArgs {
+    /// Write schema to a file instead of stdout
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileGuideArgs {}
 
 #[derive(Parser, Debug, Clone, Default)]
 pub struct SandboxArgs {
@@ -1664,5 +1736,115 @@ mod tests {
             }
             _ => panic!("Expected Run command"),
         }
+    }
+
+    #[test]
+    fn test_profile_init_basic() {
+        let cli = Cli::parse_from(["nono", "profile", "init", "my-agent"]);
+        match cli.command {
+            Commands::Profile(args) => match args.command {
+                ProfileCommands::Init(init) => {
+                    assert_eq!(init.name, "my-agent");
+                    assert!(init.extends.is_none());
+                    assert!(init.groups.is_empty());
+                    assert!(init.description.is_none());
+                    assert!(!init.full);
+                    assert!(init.output.is_none());
+                    assert!(!init.force);
+                }
+                _ => panic!("Expected Init subcommand"),
+            },
+            _ => panic!("Expected Profile command"),
+        }
+    }
+
+    #[test]
+    fn test_profile_init_all_flags() {
+        let cli = Cli::parse_from([
+            "nono",
+            "profile",
+            "init",
+            "my-agent",
+            "--extends",
+            "default",
+            "--groups",
+            "deny_credentials,node_runtime",
+            "--description",
+            "My agent profile",
+            "--full",
+            "--output",
+            "/tmp/out.json",
+            "--force",
+        ]);
+        match cli.command {
+            Commands::Profile(args) => match args.command {
+                ProfileCommands::Init(init) => {
+                    assert_eq!(init.name, "my-agent");
+                    assert_eq!(init.extends, Some("default".to_string()));
+                    assert_eq!(init.groups, vec!["deny_credentials", "node_runtime"]);
+                    assert_eq!(init.description, Some("My agent profile".to_string()));
+                    assert!(init.full);
+                    assert_eq!(init.output, Some(std::path::PathBuf::from("/tmp/out.json")));
+                    assert!(init.force);
+                }
+                _ => panic!("Expected Init subcommand"),
+            },
+            _ => panic!("Expected Profile command"),
+        }
+    }
+
+    #[test]
+    fn test_profile_schema_default() {
+        let cli = Cli::parse_from(["nono", "profile", "schema"]);
+        match cli.command {
+            Commands::Profile(args) => match args.command {
+                ProfileCommands::Schema(schema) => {
+                    assert!(schema.output.is_none());
+                }
+                _ => panic!("Expected Schema subcommand"),
+            },
+            _ => panic!("Expected Profile command"),
+        }
+    }
+
+    #[test]
+    fn test_profile_schema_with_output() {
+        let cli = Cli::parse_from(["nono", "profile", "schema", "-o", "/tmp/schema.json"]);
+        match cli.command {
+            Commands::Profile(args) => match args.command {
+                ProfileCommands::Schema(schema) => {
+                    assert_eq!(
+                        schema.output,
+                        Some(std::path::PathBuf::from("/tmp/schema.json"))
+                    );
+                }
+                _ => panic!("Expected Schema subcommand"),
+            },
+            _ => panic!("Expected Profile command"),
+        }
+    }
+
+    #[test]
+    fn test_profile_guide() {
+        let cli = Cli::parse_from(["nono", "profile", "guide"]);
+        match cli.command {
+            Commands::Profile(args) => match args.command {
+                ProfileCommands::Guide(_) => {}
+                _ => panic!("Expected Guide subcommand"),
+            },
+            _ => panic!("Expected Profile command"),
+        }
+    }
+
+    #[test]
+    fn test_profile_init_missing_name() {
+        let result = Cli::try_parse_from(["nono", "profile", "init"]);
+        assert!(result.is_err(), "init without name should fail");
+    }
+
+    #[test]
+    fn test_profile_no_subcommand() {
+        let result = Cli::try_parse_from(["nono", "profile"]);
+        assert!(result.is_err(), "profile without subcommand should fail");
     }
 }

--- a/crates/nono-cli/src/config/embedded.rs
+++ b/crates/nono-cli/src/config/embedded.rs
@@ -25,6 +25,24 @@ pub fn embedded_network_policy_json() -> &'static str {
     EMBEDDED_NETWORK_POLICY_JSON
 }
 
+/// Embedded profile JSON Schema (compiled into binary by build.rs)
+const EMBEDDED_PROFILE_SCHEMA: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/nono-profile.schema.json"));
+
+/// Get the embedded profile JSON Schema
+pub fn embedded_profile_schema() -> &'static str {
+    EMBEDDED_PROFILE_SCHEMA
+}
+
+/// Embedded profile authoring guide (compiled into binary by build.rs)
+const EMBEDDED_PROFILE_GUIDE: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/profile-authoring-guide.md"));
+
+/// Get the embedded profile authoring guide
+pub fn embedded_profile_guide() -> &'static str {
+    EMBEDDED_PROFILE_GUIDE
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -15,6 +15,7 @@ mod output;
 mod policy;
 mod policy_cmd;
 mod profile;
+mod profile_cmd;
 mod protected_paths;
 mod query_ext;
 mod rollback_commands;
@@ -122,6 +123,7 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         | Commands::Trust(_)
         | Commands::Audit(_)
         | Commands::Policy(_)
+        | Commands::Profile(_)
         | Commands::OpenUrlHelper(_) => 0,
     }
 }
@@ -174,6 +176,10 @@ fn run(cli: Cli) -> Result<()> {
         Commands::Policy(args) => {
             show_update_notification(&mut update_handle, cli.silent);
             policy_cmd::run_policy(args)
+        }
+        Commands::Profile(args) => {
+            show_update_notification(&mut update_handle, cli.silent);
+            profile_cmd::run_profile(args)
         }
         Commands::OpenUrlHelper(args) => run_open_url_helper(args),
     }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -7,7 +7,7 @@
 pub(crate) mod builtin;
 
 use nono::{NonoError, Result};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 pub use nono_proxy::config::InjectMode;
 
 /// Profile metadata
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[allow(dead_code)]
 pub struct ProfileMeta {
     pub name: String,
@@ -29,7 +29,7 @@ pub struct ProfileMeta {
 }
 
 /// Filesystem configuration in a profile
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FilesystemConfig {
     /// Directories with read+write access
     #[serde(default)]
@@ -55,7 +55,7 @@ pub struct FilesystemConfig {
 ///
 /// These fields provide explicit subtractive/additive composition on top of
 /// inherited groups and existing filesystem configuration.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PolicyPatchConfig {
     /// Group names to remove from the resolved group set.
     #[serde(default)]
@@ -90,7 +90,7 @@ pub struct PolicyPatchConfig {
 /// - `url_path`: Replace pattern in URL path (e.g., Telegram Bot API `/bot{}/`)
 /// - `query_param`: Add/replace query parameter (e.g., `?api_key=...`)
 /// - `basic_auth`: HTTP Basic Authentication (credential as `username:password`)
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomCredentialDef {
     /// Upstream URL to proxy requests to (e.g., "https://api.telegram.org")
     pub upstream: String,
@@ -502,6 +502,33 @@ impl<T> InheritableValue<T> {
             Self::Inherit | Self::Clear => None,
         }
     }
+
+    /// Returns `true` if this value is `Inherit` (absent in the source JSON).
+    ///
+    /// Used with `#[serde(skip_serializing_if)]` to omit inherited fields
+    /// from serialized output, preserving the distinction between absent
+    /// (inherit) and explicit null (clear).
+    pub fn is_inherit(&self) -> bool {
+        matches!(self, Self::Inherit)
+    }
+}
+
+impl<T> Serialize for InheritableValue<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Set(value) => value.serialize(serializer),
+            Self::Clear => serializer.serialize_none(),
+            // Inherit should be skipped via skip_serializing_if.
+            // If serialize is called anyway, emit null as a safe fallback.
+            Self::Inherit => serializer.serialize_none(),
+        }
+    }
 }
 
 impl<'de, T> Deserialize<'de> for InheritableValue<T>
@@ -520,7 +547,7 @@ where
 }
 
 /// Network configuration in a profile
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NetworkConfig {
     /// Block network access (network allowed by default; true = blocked).
     /// Canonical profile key: `block`.
@@ -531,7 +558,7 @@ pub struct NetworkConfig {
     ///
     /// `null` explicitly clears an inherited profile value, while an absent
     /// field inherits the base profile's value.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "InheritableValue::is_inherit")]
     pub network_profile: InheritableValue<String>,
     /// Additional hosts to allow through the proxy (on top of profile hosts).
     /// Canonical profile key: `allow_proxy` (legacy `proxy_allow` also accepted).
@@ -578,7 +605,7 @@ impl NetworkConfig {
 /// Maps keystore account names to environment variable names.
 /// Secrets are loaded from the system keystore (macOS Keychain / Linux Secret Service)
 /// under the service name "nono".
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SecretsConfig {
     /// Map of keystore account name -> environment variable name
     /// Example: { "openai_api_key" = "OPENAI_API_KEY" }
@@ -590,7 +617,7 @@ pub struct SecretsConfig {
 ///
 /// Defines hooks that nono will install for the target application.
 /// For example, Claude Code hooks are installed to ~/.claude/hooks/
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HookConfig {
     /// Event that triggers the hook (e.g., "PostToolUseFailure")
     pub event: String,
@@ -604,7 +631,7 @@ pub struct HookConfig {
 ///
 /// Maps target application names to their hook configurations.
 /// Example: [hooks.claude-code] for Claude Code hooks
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HooksConfig {
     /// Map of target application -> hook configuration
     #[serde(flatten)]
@@ -619,7 +646,7 @@ pub struct HooksConfig {
 /// Signal isolation mode as specified in a profile.
 ///
 /// Maps to `nono::SignalMode` when building the `CapabilitySet`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProfileSignalMode {
     /// Signals restricted to the current process only
@@ -643,7 +670,7 @@ impl From<ProfileSignalMode> for nono::SignalMode {
 /// Process inspection mode as specified in a profile.
 ///
 /// Maps to `nono::ProcessInfoMode` when building the `CapabilitySet`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProfileProcessInfoMode {
     /// Inspection restricted to self only (default)
@@ -664,7 +691,7 @@ impl From<ProfileProcessInfoMode> for nono::ProcessInfoMode {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkdirAccess {
     /// No automatic CWD access
@@ -679,7 +706,7 @@ pub enum WorkdirAccess {
 }
 
 /// Working directory configuration in a profile
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkdirConfig {
     /// Access level for the current working directory
     #[serde(default)]
@@ -687,7 +714,7 @@ pub struct WorkdirConfig {
 }
 
 /// Security configuration referencing policy.json groups
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SecurityConfig {
     /// Policy group names to resolve (from policy.json)
     #[serde(default)]
@@ -720,7 +747,7 @@ pub struct SecurityConfig {
 /// matched against path components (exact match) or, if they contain `/`,
 /// as substrings of the full path. Glob patterns are matched against
 /// the filename (last path component).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RollbackConfig {
     /// Patterns to exclude from rollback snapshots.
     /// Added on top of the CLI's base exclusion list.
@@ -737,7 +764,7 @@ pub struct RollbackConfig {
 /// Controls which URLs the sandboxed child can request the supervisor to
 /// open in the user's browser. Used for OAuth2 login flows and similar
 /// operations where the sandboxed process cannot launch a browser directly.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OpenUrlConfig {
     /// Allowed URL origins (scheme + host, e.g., "https://console.anthropic.com").
     /// The supervisor validates each URL open request against this list.
@@ -750,7 +777,7 @@ pub struct OpenUrlConfig {
 }
 
 /// A complete profile definition
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Profile {
     /// Optional base profile to inherit from (by name)
     #[serde(default)]
@@ -1177,7 +1204,7 @@ pub(crate) fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &
 }
 
 /// Get the path to a user profile
-fn get_user_profile_path(name: &str) -> Result<PathBuf> {
+pub(crate) fn get_user_profile_path(name: &str) -> Result<PathBuf> {
     let config_dir = resolve_user_config_dir()?;
 
     Ok(config_dir
@@ -1237,7 +1264,7 @@ fn home_dir() -> Result<PathBuf> {
 }
 
 /// Validate profile name (alphanumeric + hyphen only, no path traversal)
-fn is_valid_profile_name(name: &str) -> bool {
+pub(crate) fn is_valid_profile_name(name: &str) -> bool {
     !name.is_empty()
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
         && !name.starts_with('-')

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -1,0 +1,566 @@
+//! Profile authoring subcommand implementations
+//!
+//! Handles `nono profile init|schema|guide` for creating and managing
+//! nono profiles with scaffolding, schema, and guidance.
+
+use crate::cli::{
+    ProfileCmdArgs, ProfileCommands, ProfileGuideArgs, ProfileInitArgs, ProfileSchemaArgs,
+};
+use crate::config::embedded;
+use crate::policy;
+use crate::profile;
+use crate::theme;
+use colored::Colorize;
+use nono::{NonoError, Result};
+use std::fs;
+use std::io::Write;
+
+/// Prefix used for all profile command output
+fn prefix() -> colored::ColoredString {
+    let t = theme::current();
+    theme::fg("nono profile", t.brand).bold()
+}
+
+/// Dispatch to the appropriate profile subcommand.
+pub fn run_profile(args: ProfileCmdArgs) -> Result<()> {
+    match args.command {
+        ProfileCommands::Init(args) => cmd_init(args),
+        ProfileCommands::Schema(args) => cmd_schema(args),
+        ProfileCommands::Guide(args) => cmd_guide(args),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// nono profile init
+// ---------------------------------------------------------------------------
+
+fn cmd_init(args: ProfileInitArgs) -> Result<()> {
+    // Validate profile name
+    if !profile::is_valid_profile_name(&args.name) {
+        return Err(NonoError::ProfileParse(format!(
+            "Invalid profile name '{}': must be alphanumeric with hyphens, no leading/trailing hyphens",
+            args.name
+        )));
+    }
+
+    // Determine output path
+    let output_path = match &args.output {
+        Some(path) => path.clone(),
+        None => profile::get_user_profile_path(&args.name)?,
+    };
+
+    // Check for existing file
+    if output_path.exists() && !args.force {
+        return Err(NonoError::ProfileParse(format!(
+            "Profile file already exists: {}\nUse --force to overwrite",
+            output_path.display()
+        )));
+    }
+
+    // Validate --extends target exists
+    if let Some(ref base) = args.extends {
+        if !profile_exists(base) {
+            return Err(NonoError::ProfileParse(format!(
+                "Base profile '{}' not found (built-in or user profile)",
+                base
+            )));
+        }
+    }
+
+    // Validate --groups against embedded policy
+    if !args.groups.is_empty() {
+        let pol = policy::load_embedded_policy()?;
+        for group in &args.groups {
+            if !pol.groups.contains_key(group.as_str()) {
+                return Err(NonoError::ProfileParse(format!(
+                    "Unknown security group '{}'. Use `nono policy groups` to list available groups",
+                    group
+                )));
+            }
+        }
+    }
+
+    // Build skeleton JSON
+    let skeleton = build_skeleton(&args);
+
+    // Ensure parent directory exists
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            NonoError::ProfileParse(format!(
+                "Failed to create directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    // Write file
+    let json = serde_json::to_string_pretty(&skeleton)
+        .map_err(|e| NonoError::ProfileParse(format!("JSON serialization failed: {e}")))?;
+
+    fs::write(&output_path, format!("{json}\n")).map_err(|e| {
+        NonoError::ProfileParse(format!(
+            "Failed to write profile to {}: {}",
+            output_path.display(),
+            e
+        ))
+    })?;
+
+    eprintln!(
+        "{} Created profile at {}",
+        prefix(),
+        output_path.display().to_string().bold()
+    );
+    eprintln!(
+        "{} Validate with: nono policy validate {}",
+        prefix(),
+        output_path.display()
+    );
+    eprintln!(
+        "{} For editor autocomplete: nono profile schema -o nono-profile.schema.json",
+        prefix()
+    );
+
+    Ok(())
+}
+
+/// Build a skeleton profile JSON value with controlled field ordering.
+fn build_skeleton(args: &ProfileInitArgs) -> serde_json::Value {
+    let mut root = serde_json::Map::new();
+
+    if let Some(ref base) = args.extends {
+        root.insert(
+            "extends".to_string(),
+            serde_json::Value::String(base.clone()),
+        );
+    }
+
+    // meta
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "name".to_string(),
+        serde_json::Value::String(args.name.clone()),
+    );
+    if let Some(ref desc) = args.description {
+        meta.insert(
+            "description".to_string(),
+            serde_json::Value::String(desc.clone()),
+        );
+    }
+    root.insert("meta".to_string(), serde_json::Value::Object(meta));
+
+    // security
+    let mut security = serde_json::Map::new();
+    let groups: Vec<serde_json::Value> = args
+        .groups
+        .iter()
+        .map(|g| serde_json::Value::String(g.clone()))
+        .collect();
+    security.insert("groups".to_string(), serde_json::Value::Array(groups));
+    root.insert("security".to_string(), serde_json::Value::Object(security));
+
+    // workdir
+    let mut workdir = serde_json::Map::new();
+    workdir.insert(
+        "access".to_string(),
+        serde_json::Value::String("readwrite".to_string()),
+    );
+    root.insert("workdir".to_string(), serde_json::Value::Object(workdir));
+
+    // filesystem (minimal has allow + read; full adds all fields)
+    let mut filesystem = serde_json::Map::new();
+    filesystem.insert("allow".to_string(), serde_json::Value::Array(vec![]));
+    filesystem.insert("read".to_string(), serde_json::Value::Array(vec![]));
+    if args.full {
+        filesystem.insert("write".to_string(), serde_json::Value::Array(vec![]));
+        filesystem.insert("allow_file".to_string(), serde_json::Value::Array(vec![]));
+        filesystem.insert("read_file".to_string(), serde_json::Value::Array(vec![]));
+        filesystem.insert("write_file".to_string(), serde_json::Value::Array(vec![]));
+    }
+    root.insert(
+        "filesystem".to_string(),
+        serde_json::Value::Object(filesystem),
+    );
+
+    // Full skeleton adds additional sections
+    if args.full {
+        // policy
+        let mut pol = serde_json::Map::new();
+        pol.insert(
+            "exclude_groups".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
+            "add_allow_read".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
+            "add_allow_write".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
+            "add_allow_readwrite".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
+            "add_deny_access".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
+            "override_deny".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        root.insert("policy".to_string(), serde_json::Value::Object(pol));
+
+        // network
+        // NOTE: network_profile is intentionally omitted. Emitting null would
+        // clear an inherited proxy profile (e.g., "developer" from python-dev),
+        // silently broadening network access. Absent = inherit from base.
+        let mut network = serde_json::Map::new();
+        network.insert("block".to_string(), serde_json::Value::Bool(false));
+        network.insert("proxy_allow".to_string(), serde_json::Value::Array(vec![]));
+        network.insert(
+            "proxy_credentials".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        network.insert("port_allow".to_string(), serde_json::Value::Array(vec![]));
+        network.insert(
+            "custom_credentials".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+        root.insert("network".to_string(), serde_json::Value::Object(network));
+
+        // env_credentials
+        root.insert(
+            "env_credentials".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+
+        // hooks
+        root.insert(
+            "hooks".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+
+        // rollback
+        let mut rollback = serde_json::Map::new();
+        rollback.insert(
+            "exclude_patterns".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        rollback.insert(
+            "exclude_globs".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        root.insert("rollback".to_string(), serde_json::Value::Object(rollback));
+
+        // NOTE: open_urls and allow_launch_services are intentionally omitted.
+        // Emitting them would replace inherited values from base profiles like
+        // claude-code (which grants OAuth2 origins and launch services).
+        // Absent = inherit from base. Authors who need to override these
+        // should add them explicitly.
+    }
+
+    serde_json::Value::Object(root)
+}
+
+/// Check if a profile exists (built-in or user).
+fn profile_exists(name: &str) -> bool {
+    // Check built-in profiles
+    if profile::builtin::get_builtin(name).is_some() {
+        return true;
+    }
+    // Check user profiles
+    if let Ok(path) = profile::get_user_profile_path(name) {
+        return path.exists();
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// nono profile schema
+// ---------------------------------------------------------------------------
+
+fn cmd_schema(args: ProfileSchemaArgs) -> Result<()> {
+    let schema = embedded::embedded_profile_schema();
+
+    match args.output {
+        Some(path) => {
+            fs::write(&path, schema).map_err(|e| {
+                NonoError::ProfileParse(format!(
+                    "Failed to write schema to {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            eprintln!(
+                "{} Schema written to {}",
+                prefix(),
+                path.display().to_string().bold()
+            );
+        }
+        None => {
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            handle
+                .write_all(schema.as_bytes())
+                .map_err(|e| NonoError::ProfileParse(format!("Failed to write to stdout: {e}")))?;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// nono profile guide
+// ---------------------------------------------------------------------------
+
+fn cmd_guide(_args: ProfileGuideArgs) -> Result<()> {
+    let guide = embedded::embedded_profile_guide();
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    handle
+        .write_all(guide.as_bytes())
+        .map_err(|e| NonoError::ProfileParse(format!("Failed to write to stdout: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::Profile;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_minimal_skeleton_is_valid_profile() {
+        let args = ProfileInitArgs {
+            name: "test-profile".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        };
+        let skeleton = build_skeleton(&args);
+        let json = serde_json::to_string(&skeleton).expect("serialize");
+        let profile: Profile = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(profile.meta.name, "test-profile");
+    }
+
+    #[test]
+    fn test_full_skeleton_is_valid_profile() {
+        let args = ProfileInitArgs {
+            name: "full-test".to_string(),
+            extends: Some("default".to_string()),
+            groups: vec![],
+            description: Some("A full test profile".to_string()),
+            full: true,
+            output: None,
+            force: false,
+        };
+        let skeleton = build_skeleton(&args);
+        let json = serde_json::to_string(&skeleton).expect("serialize");
+        let profile: Profile = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(profile.meta.name, "full-test");
+        assert_eq!(profile.extends, Some("default".to_string()));
+        assert_eq!(
+            profile.meta.description,
+            Some("A full test profile".to_string())
+        );
+    }
+
+    #[test]
+    fn test_skeleton_with_groups() {
+        let args = ProfileInitArgs {
+            name: "grouped".to_string(),
+            extends: None,
+            groups: vec!["deny_credentials".to_string()],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        };
+        let skeleton = build_skeleton(&args);
+        let groups = skeleton["security"]["groups"].as_array().expect("array");
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], "deny_credentials");
+    }
+
+    #[test]
+    fn test_skeleton_omits_schema_url() {
+        let args = ProfileInitArgs {
+            name: "schema-test".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        };
+        let skeleton = build_skeleton(&args);
+        // $schema is not emitted because the URL is not hosted;
+        // users export the schema locally via `nono profile schema`
+        assert!(skeleton.get("$schema").is_none());
+    }
+
+    #[test]
+    fn test_invalid_profile_name() {
+        let result = cmd_init(ProfileInitArgs {
+            name: "-bad-name-".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(PathBuf::from("/tmp/nono-test-bad.json")),
+            force: false,
+        });
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(err.to_string().contains("Invalid profile name"));
+    }
+
+    #[test]
+    fn test_invalid_group_name() {
+        let result = cmd_init(ProfileInitArgs {
+            name: "test-profile".to_string(),
+            extends: None,
+            groups: vec!["nonexistent_group_xyz".to_string()],
+            description: None,
+            full: false,
+            output: Some(PathBuf::from("/tmp/nono-test-badgroup.json")),
+            force: false,
+        });
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(err.to_string().contains("Unknown security group"));
+    }
+
+    #[test]
+    fn test_invalid_extends_target() {
+        let result = cmd_init(ProfileInitArgs {
+            name: "test-profile".to_string(),
+            extends: Some("nonexistent-base-profile-xyz".to_string()),
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(PathBuf::from("/tmp/nono-test-badextends.json")),
+            force: false,
+        });
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_force_overwrite() {
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join("nono-test-force-overwrite.json");
+        // Create existing file
+        let mut f = fs::File::create(&tmp).expect("create");
+        f.write_all(b"{}").expect("write");
+        drop(f);
+
+        // Without force: should fail
+        let result = cmd_init(ProfileInitArgs {
+            name: "test-profile".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(tmp.clone()),
+            force: false,
+        });
+        assert!(result.is_err());
+
+        // With force: should succeed
+        let result = cmd_init(ProfileInitArgs {
+            name: "test-profile".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(tmp.clone()),
+            force: true,
+        });
+        assert!(result.is_ok());
+
+        // Verify file was written with correct content
+        let content = fs::read_to_string(&tmp).expect("read");
+        let profile: Profile = serde_json::from_str(&content).expect("parse");
+        assert_eq!(profile.meta.name, "test-profile");
+
+        // Cleanup
+        let _ = fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn test_full_vs_minimal_differences() {
+        let minimal_args = ProfileInitArgs {
+            name: "minimal".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        };
+        let full_args = ProfileInitArgs {
+            name: "full".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: true,
+            output: None,
+            force: false,
+        };
+        let minimal = build_skeleton(&minimal_args);
+        let full = build_skeleton(&full_args);
+
+        let minimal_obj = minimal.as_object().expect("object");
+        let full_obj = full.as_object().expect("object");
+
+        // Full has more keys than minimal
+        assert!(full_obj.len() > minimal_obj.len());
+
+        // Full has sections that minimal does not
+        assert!(full_obj.contains_key("policy"));
+        assert!(full_obj.contains_key("network"));
+        assert!(full_obj.contains_key("env_credentials"));
+        assert!(full_obj.contains_key("hooks"));
+        assert!(full_obj.contains_key("rollback"));
+
+        // open_urls and allow_launch_services are intentionally omitted
+        // to avoid silently overriding inherited values from base profiles
+        assert!(!full_obj.contains_key("open_urls"));
+        assert!(!full_obj.contains_key("allow_launch_services"));
+
+        assert!(!minimal_obj.contains_key("policy"));
+        assert!(!minimal_obj.contains_key("network"));
+        assert!(!minimal_obj.contains_key("hooks"));
+
+        // Full filesystem has all fields
+        let full_fs = full_obj["filesystem"].as_object().expect("fs object");
+        assert!(full_fs.contains_key("write"));
+        assert!(full_fs.contains_key("allow_file"));
+        assert!(full_fs.contains_key("read_file"));
+        assert!(full_fs.contains_key("write_file"));
+
+        // Minimal filesystem has only allow + read
+        let min_fs = minimal_obj["filesystem"].as_object().expect("fs object");
+        assert!(!min_fs.contains_key("write"));
+        assert!(!min_fs.contains_key("allow_file"));
+
+        // Full policy has add_deny_access
+        let full_pol = full_obj["policy"].as_object().expect("policy object");
+        assert!(full_pol.contains_key("add_deny_access"));
+
+        // Full network has all fields
+        let full_net = full_obj["network"].as_object().expect("network object");
+        assert!(full_net.contains_key("proxy_allow"));
+        assert!(full_net.contains_key("proxy_credentials"));
+        assert!(full_net.contains_key("port_allow"));
+        assert!(full_net.contains_key("custom_credentials"));
+    }
+}

--- a/crates/nono-cli/tests/profile_cmd.rs
+++ b/crates/nono-cli/tests/profile_cmd.rs
@@ -1,0 +1,324 @@
+//! Integration tests for `nono profile` subcommands.
+//!
+//! These run as separate processes, so they are fully isolated from unit tests.
+
+use std::process::Command;
+
+fn nono_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nono"))
+}
+
+// ---------------------------------------------------------------------------
+// nono profile init
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_creates_valid_profile() {
+    let dir = std::env::temp_dir().join("nono-test-profile-init");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let out = dir.join("test-agent.json");
+
+    let output = nono_bin()
+        .args([
+            "profile",
+            "init",
+            "test-agent",
+            "--extends",
+            "default",
+            "--groups",
+            "deny_credentials",
+            "--description",
+            "Integration test profile",
+            "--output",
+        ])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(out.exists(), "profile file should be created");
+
+    // Validate the generated file with nono policy validate
+    let validate = nono_bin()
+        .args(["policy", "validate"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        validate.status.success(),
+        "generated profile should be valid, stderr: {}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+
+    // Parse and check content
+    let content = std::fs::read_to_string(&out).expect("read profile");
+    let val: serde_json::Value = serde_json::from_str(&content).expect("parse json");
+    assert_eq!(val["meta"]["name"], "test-agent");
+    assert_eq!(val["extends"], "default");
+    assert_eq!(val["meta"]["description"], "Integration test profile");
+    assert_eq!(val["security"]["groups"][0], "deny_credentials");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_init_full_creates_all_additive_sections() {
+    let dir = std::env::temp_dir().join("nono-test-profile-init-full");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let out = dir.join("full-agent.json");
+
+    let output = nono_bin()
+        .args(["profile", "init", "full-agent", "--full", "--output"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(&out).expect("read profile");
+    let val: serde_json::Value = serde_json::from_str(&content).expect("parse json");
+
+    // Full skeleton must include these additive sections
+    assert!(val.get("policy").is_some(), "missing policy section");
+    assert!(val.get("network").is_some(), "missing network section");
+    assert!(
+        val.get("env_credentials").is_some(),
+        "missing env_credentials"
+    );
+    assert!(val.get("hooks").is_some(), "missing hooks section");
+    assert!(val.get("rollback").is_some(), "missing rollback section");
+
+    // Full skeleton must NOT include override-sensitive fields
+    assert!(
+        val.get("open_urls").is_none(),
+        "open_urls should be omitted"
+    );
+    assert!(
+        val.get("allow_launch_services").is_none(),
+        "allow_launch_services should be omitted"
+    );
+    assert!(
+        val["network"].get("network_profile").is_none(),
+        "network_profile should be omitted"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_init_rejects_existing_file_without_force() {
+    let dir = std::env::temp_dir().join("nono-test-profile-init-noforce");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let out = dir.join("existing.json");
+    std::fs::write(&out, "{}").expect("create existing file");
+
+    let output = nono_bin()
+        .args(["profile", "init", "existing", "--output"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(!output.status.success(), "should fail without --force");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already exists") || stderr.contains("--force"),
+        "error should mention existing file, got: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_init_force_overwrites() {
+    let dir = std::env::temp_dir().join("nono-test-profile-init-force");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let out = dir.join("overwrite.json");
+    std::fs::write(&out, "{}").expect("create existing file");
+
+    let output = nono_bin()
+        .args(["profile", "init", "overwrite", "--force", "--output"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "should succeed with --force, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(&out).expect("read profile");
+    let val: serde_json::Value = serde_json::from_str(&content).expect("parse json");
+    assert_eq!(val["meta"]["name"], "overwrite");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_init_invalid_name_exits_error() {
+    let out = std::env::temp_dir().join("nono-test-badname-nonexistent.json");
+    let _ = std::fs::remove_file(&out);
+
+    let output = nono_bin()
+        .args(["profile", "init", "-bad-name-", "--output"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(!output.status.success(), "should fail for invalid name");
+    assert!(!out.exists(), "file should not be created");
+}
+
+#[test]
+fn test_init_invalid_group_exits_error() {
+    let out = std::env::temp_dir().join("nono-test-badgroup-nonexistent.json");
+    let _ = std::fs::remove_file(&out);
+
+    let output = nono_bin()
+        .args([
+            "profile",
+            "init",
+            "test-agent",
+            "--groups",
+            "nonexistent_group_xyz",
+            "--output",
+        ])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(!output.status.success(), "should fail for unknown group");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nonexistent_group_xyz"),
+        "error should name the bad group, got: {stderr}"
+    );
+    assert!(!out.exists(), "file should not be created");
+}
+
+#[test]
+fn test_init_invalid_extends_exits_error() {
+    let out = std::env::temp_dir().join("nono-test-badextends-nonexistent.json");
+    let _ = std::fs::remove_file(&out);
+
+    let output = nono_bin()
+        .args([
+            "profile",
+            "init",
+            "test-agent",
+            "--extends",
+            "nonexistent-base-xyz",
+            "--output",
+        ])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(!output.status.success(), "should fail for unknown base");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nonexistent-base-xyz"),
+        "error should name the bad base, got: {stderr}"
+    );
+    assert!(!out.exists(), "file should not be created");
+}
+
+// ---------------------------------------------------------------------------
+// nono profile schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_schema_outputs_valid_json() {
+    let output = nono_bin()
+        .args(["profile", "schema"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value =
+        serde_json::from_str(&stdout).expect("schema output should be valid JSON");
+    assert_eq!(
+        val["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(val["title"], "nono Profile");
+    assert!(
+        val.get("properties").is_some(),
+        "schema should have properties"
+    );
+}
+
+#[test]
+fn test_schema_output_to_file() {
+    let dir = std::env::temp_dir().join("nono-test-profile-schema");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let out = dir.join("schema.json");
+
+    let output = nono_bin()
+        .args(["profile", "schema", "--output"])
+        .arg(&out)
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(out.exists(), "schema file should be created");
+
+    let content = std::fs::read_to_string(&out).expect("read schema");
+    let val: serde_json::Value =
+        serde_json::from_str(&content).expect("schema file should be valid JSON");
+    assert_eq!(val["title"], "nono Profile");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// nono profile guide
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_guide_outputs_markdown() {
+    let output = nono_bin()
+        .args(["profile", "guide"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("# nono Profile Authoring Guide"),
+        "guide should start with the expected heading"
+    );
+    assert!(
+        stdout.contains("Variable Expansion"),
+        "guide should cover variable expansion"
+    );
+}

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -1,0 +1,318 @@
+---
+title: Profile Authoring
+description: Scaffolding, schema validation, and tooling for creating custom profiles
+---
+
+The `nono profile` command provides scaffolding and tooling for creating custom profiles. Instead of reverse-engineering the JSON structure from built-in profiles, you can generate skeleton files, get editor autocomplete via JSON Schema, and access an LLM-oriented authoring guide.
+
+<Tip>
+  For an overview of what profiles are and how they compose with groups, see [Profiles & Groups](/cli/features/profiles-groups).
+</Tip>
+
+## Generating a Profile
+
+Use `nono profile init` to scaffold a new profile:
+
+```bash
+# Minimal skeleton
+nono profile init my-agent
+
+# With inheritance and groups
+nono profile init my-agent --extends default --groups deny_credentials
+
+# With a description
+nono profile init my-agent --extends default --description "Profile for my agent"
+
+# Full skeleton with all sections
+nono profile init my-agent --full
+
+# Output to a specific path instead of ~/.config/nono/profiles/
+nono profile init my-agent --output ./my-agent.json
+```
+
+By default, the profile is written to `~/.config/nono/profiles/<name>.json`. Use `--force` to overwrite an existing file.
+
+### Minimal Skeleton
+
+A minimal skeleton includes the core sections most profiles need:
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "my-agent",
+    "description": "Profile for my agent"
+  },
+  "security": {
+    "groups": [
+      "deny_credentials"
+    ]
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "filesystem": {
+    "allow": [],
+    "read": []
+  }
+}
+```
+
+### Full Skeleton
+
+With `--full`, additional sections are included as empty stubs for all additive fields:
+
+```json
+{
+  "meta": {
+    "name": "my-agent"
+  },
+  "security": {
+    "groups": []
+  },
+  "workdir": {
+    "access": "readwrite"
+  },
+  "filesystem": {
+    "allow": [],
+    "read": [],
+    "write": [],
+    "allow_file": [],
+    "read_file": [],
+    "write_file": []
+  },
+  "policy": {
+    "exclude_groups": [],
+    "add_allow_read": [],
+    "add_allow_write": [],
+    "add_allow_readwrite": [],
+    "add_deny_access": [],
+    "override_deny": []
+  },
+  "network": {
+    "block": false,
+    "proxy_allow": [],
+    "proxy_credentials": [],
+    "port_allow": [],
+    "custom_credentials": {}
+  },
+  "env_credentials": {},
+  "hooks": {},
+  "rollback": {
+    "exclude_patterns": [],
+    "exclude_globs": []
+  }
+}
+```
+
+<Note>
+  Fields that would override inherited behavior are intentionally omitted from the skeleton: `network_profile` (emitting `null` would clear an inherited proxy profile), `open_urls` (would replace inherited OAuth2 origins), and `allow_launch_services` (would override inherited browser-opening permissions). Add these explicitly only when you intend to change the inherited behavior.
+</Note>
+
+### Validation
+
+The `init` command validates inputs before writing:
+
+- **Profile name** must be alphanumeric with hyphens (no leading/trailing hyphens)
+- **`--extends`** target must exist as a built-in or user profile
+- **`--groups`** are checked against the embedded policy groups
+
+After creating a profile, validate it:
+
+```bash
+nono policy validate ~/.config/nono/profiles/my-agent.json
+```
+
+## JSON Schema
+
+nono ships with a JSON Schema for profile files. Use it for editor autocomplete and validation.
+
+### Exporting the Schema
+
+```bash
+# Print to stdout
+nono profile schema
+
+# Write to a file
+nono profile schema --output nono-profile.schema.json
+```
+
+### Editor Integration
+
+Export the schema locally, then add a `$schema` field to your profile for automatic validation in editors that support JSON Schema (VS Code, IntelliJ, Neovim with LSP, etc.):
+
+```json
+{
+  "$schema": "./nono-profile.schema.json",
+  "meta": {
+    "name": "my-agent"
+  }
+}
+```
+
+In VS Code, you can also configure schema association in `.vscode/settings.json`:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["**/profiles/*.json"],
+      "url": "./nono-profile.schema.json"
+    }
+  ]
+}
+```
+
+## Authoring Guide
+
+nono includes an embedded authoring guide designed for LLM agents assisting with profile creation:
+
+```bash
+nono profile guide
+```
+
+This outputs a comprehensive reference covering every profile section, field descriptions, common patterns, variable expansion, and validation workflow. It is useful when asking an LLM to help you write a profile -- pipe or paste the guide into your conversation for context.
+
+## Workflow
+
+A typical profile authoring workflow:
+
+1. **Scaffold** the profile:
+   ```bash
+   nono profile init my-agent --extends default --groups deny_credentials --full
+   ```
+
+2. **Edit** the generated file in your editor (with schema autocomplete):
+   ```bash
+   $EDITOR ~/.config/nono/profiles/my-agent.json
+   ```
+
+3. **Validate** the profile:
+   ```bash
+   nono policy validate ~/.config/nono/profiles/my-agent.json
+   ```
+
+4. **Inspect** the resolved profile (after inheritance and group expansion):
+   ```bash
+   nono policy show my-agent
+   ```
+
+5. **Compare** against a baseline:
+   ```bash
+   nono policy diff default my-agent
+   ```
+
+6. **Test** the profile:
+   ```bash
+   nono run --profile my-agent --dry-run -- my-command
+   ```
+
+7. **Use** the profile:
+   ```bash
+   nono run --profile my-agent -- my-command
+   ```
+
+## Available Groups
+
+Use `nono policy groups` to list all available security groups. To see details for a specific group:
+
+```bash
+nono policy groups deny_credentials
+```
+
+Groups are referenced by name in the `security.groups` field. See [Profiles & Groups](/cli/features/profiles-groups#groups) for the full group taxonomy and built-in group list.
+
+## Common Patterns
+
+### Agent with API Credentials
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "api-agent",
+    "description": "Agent with API access via credential injection"
+  },
+  "workdir": { "access": "readwrite" },
+  "env_credentials": {
+    "openai_api_key": "OPENAI_API_KEY"
+  },
+  "network": {
+    "network_profile": "standard"
+  }
+}
+```
+
+### CI Build Environment
+
+```json
+{
+  "meta": {
+    "name": "ci-build",
+    "description": "Locked-down CI environment"
+  },
+  "security": {
+    "groups": ["deny_credentials"]
+  },
+  "workdir": { "access": "readwrite" },
+  "network": { "block": true }
+}
+```
+
+### Override a Deny Rule
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "docker-agent",
+    "description": "Agent that needs Docker access"
+  },
+  "workdir": { "access": "readwrite" },
+  "filesystem": {
+    "allow": ["$HOME/.docker"]
+  },
+  "policy": {
+    "override_deny": ["$HOME/.docker"]
+  }
+}
+```
+
+<Note>
+  `override_deny` only removes the deny rule. You must also grant access via `filesystem` or `policy.add_allow_*` for the path to be accessible.
+</Note>
+
+### Exclude Inherited Groups
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "permissive-agent",
+    "description": "Agent without dangerous command blocking"
+  },
+  "workdir": { "access": "readwrite" },
+  "policy": {
+    "exclude_groups": [
+      "dangerous_commands",
+      "dangerous_commands_macos",
+      "dangerous_commands_linux"
+    ]
+  }
+}
+```
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `nono profile init <name>` | Generate a skeleton profile |
+| `nono profile init <name> --extends <base>` | Inherit from a base profile |
+| `nono profile init <name> --groups <g1>,<g2>` | Pre-populate security groups |
+| `nono profile init <name> --full` | Include all optional sections |
+| `nono profile init <name> --output <path>` | Write to a specific file |
+| `nono profile init <name> --force` | Overwrite existing file |
+| `nono profile init <name> --description <text>` | Set the profile description |
+| `nono profile schema` | Output JSON Schema to stdout |
+| `nono profile schema --output <path>` | Write JSON Schema to a file |
+| `nono profile guide` | Print the authoring guide |

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -334,6 +334,10 @@ Profiles support these environment variables in path values:
 
 ### Creating User Profiles
 
+<Tip>
+  Use `nono profile init` to scaffold profiles with validation, JSON Schema, and editor autocomplete. See [Profile Authoring](/cli/features/profile-authoring) for the full workflow.
+</Tip>
+
 1. Create the profiles directory:
    ```bash
    mkdir -p ~/.config/nono/profiles

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,6 +38,7 @@
         "group": "Features",
         "pages": [
           "cli/features/profiles-groups",
+          "cli/features/profile-authoring",
           "cli/features/atomic-rollbacks",
           "cli/features/audit",
           "cli/features/supervisor",


### PR DESCRIPTION
Add comprehensive profile authoring support with three new subcommands:

- `nono profile init`: Generate skeleton profile JSON with validation of profile names, group references, and base profile targets. Supports `--extends`, `--groups`, `--description`, `--full` (all sections), `--output`, and `--force`. Minimal skeleton includes meta, security, workdir, and filesystem sections. Full skeleton adds policy, network, env_credentials, hooks, and rollback. Intentionally omits override-sensitive fields (network_profile, open_urls, allow_launch_services) to prevent silently weakening inherited base profiles.

- `nono profile schema`: Export JSON Schema (draft 2020-12) for editor autocomplete and validation. Supports `--output` to write to file; default outputs to stdout.

- `nono profile guide`: Output embedded Markdown authoring guide covering all profile sections, common patterns, variable expansion, and validation workflow. Designed for LLM agents assisting with profile creation.

Build system enhancements:
- Embed profile schema and guide in binary via build.rs
- Add serde_json preserve_order feature for consistent field ordering in output
- Expose helper functions: is_valid_profile_name(), get_user_profile_path()

Documentation:
- Add docs/cli/features/profile-authoring.mdx with workflow examples and patterns
- Update profiles-groups.mdx to reference profile authoring tooling

Testing:
- Unit tests for skeleton generation, full vs minimal differences, validation errors
- Integration tests for init (with/without force), schema output, guide invocation
- Verify generated profiles pass `nono policy validate`