### PR TITLE
fix(deny): canonicalize parent directories in deny access rules

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -283,6 +283,45 @@ When a deny group blocks a path you need access to, use `override_deny` together
 }
 ```
 
+### Denying specific project files
+
+Block access to a file in the working directory while keeping the rest accessible. Use `$WORKDIR` to reference the current working directory — relative paths like `./` are not expanded:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "no-dotenv",
+    "description": "Claude Code without .env access"
+  },
+  "policy": {
+    "add_deny_access": ["$WORKDIR/.env"]
+  }
+}
+```
+
+**macOS**: This works directly. Seatbelt can deny a specific file within an allowed directory.
+
+**Linux**: Landlock is strictly allow-list and cannot deny a child of an allowed parent. Use supervised mode instead, which intercepts file opens via seccomp-notify and checks them against the deny list before granting access:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "no-dotenv",
+    "description": "Claude Code without .env access"
+  },
+  "security": {
+    "capability_elevation": true
+  },
+  "policy": {
+    "add_deny_access": ["$WORKDIR/.env"]
+  }
+}
+```
+
+With `capability_elevation` enabled, nono runs in supervised mode where every file access outside the initial grant set is trapped and evaluated. The deny list is checked before the supervisor prompts for approval, so denied paths are blocked regardless of platform.
+
 ### Profile with group exclusion
 
 Remove an inherited deny group that is too restrictive for your use case:

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -951,6 +951,63 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn test_from_profile_workdir_deny_env_extends_claude_code() {
+        let workdir = tempdir().expect("workdir");
+        std::fs::write(workdir.path().join(".env"), "SECRET=test").expect("write .env");
+
+        let profile_path = workdir.path().join("deny-env.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "extends": "claude-code",
+                "meta": { "name": "claude-code-deny-env" },
+                "policy": {
+                    "add_deny_access": ["$WORKDIR/.env"]
+                }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let args = sandbox_args();
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        let rules = caps.platform_rules().join("\n");
+        // On macOS, tempdir is under /var/folders which is a symlink to /private/var/folders.
+        // The deny rule must use the canonical path so it matches the kernel-resolved path
+        // that Seatbelt sees at runtime.
+        let env_path = workdir.path().join(".env");
+        let env_canonical = env_path.canonicalize().expect("canonicalize .env");
+
+        // Check: does the deny rule use the canonical path?
+        let has_canonical_deny = rules.contains(&format!(
+            "deny file-read-data (literal \"{}\")",
+            env_canonical.display()
+        ));
+        // Check: does the deny rule use the original (possibly non-canonical) path?
+        let has_original_deny = rules.contains(&format!(
+            "deny file-read-data (literal \"{}\")",
+            env_path.display()
+        ));
+
+        // The deny must cover the canonical path, otherwise Seatbelt won't enforce it
+        assert!(
+            has_canonical_deny,
+            "deny rule must use canonical path {}.\n\
+             Has original path deny: {}\n\
+             Original path: {}\n\
+             Canonical path: {}\n\
+             All platform rules:\n{}",
+            env_canonical.display(),
+            has_original_deny,
+            env_path.display(),
+            env_canonical.display(),
+            rules
+        );
+    }
+
+    #[test]
     fn test_from_profile_policy_add_deny_access_emits_seatbelt_rules() {
         let dir = tempdir().expect("tmpdir");
         let denied = dir.path().join("denied");

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -1007,6 +1007,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_from_profile_policy_add_deny_access_emits_seatbelt_rules() {
         let dir = tempdir().expect("tmpdir");

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -449,65 +449,45 @@ pub(crate) fn add_deny_access_rules(
     let path = expand_path(path_str)?;
     deny_paths.push(path.clone());
 
-    // If the deny path is a symlink, also deny the resolved target.
-    // Without this, `--read-file ~/.zshrc` where ~/.zshrc is a symlink
-    // canonicalizes to the target, which wouldn't match the deny path.
-    let resolved = if path.is_symlink() {
-        path.canonicalize().ok()
-    } else {
-        None
-    };
-    if let Some(ref resolved) = resolved {
-        if *resolved != path {
-            deny_paths.push(resolved.clone());
+    // Canonicalize to resolve symlinks anywhere in the path (the deny target
+    // itself, or any parent directory such as /var -> /private/var on macOS).
+    // Seatbelt operates on kernel-resolved paths, so deny rules must use
+    // the canonical form. We also keep the original to cover both forms.
+    let canonical = path.canonicalize().ok();
+    if let Some(ref canonical) = canonical {
+        if *canonical != path {
+            deny_paths.push(canonical.clone());
         }
     }
 
     // Seatbelt deny rules only apply on macOS
     if cfg!(target_os = "macos") {
-        let escaped = escape_seatbelt_path(path_to_utf8(&path)?)?;
-
-        // Determine filter type: literal for files, subpath for directories
-        let filter = if path.exists() && path.is_file() {
-            format!("literal \"{}\"", escaped)
-        } else {
-            // Default to subpath for dirs and non-existent paths (defensive)
-            format!("subpath \"{}\"", escaped)
+        // Helper: emit metadata-allow + read-deny + write-deny for a single path
+        let emit_deny_rules = |p: &Path, caps: &mut CapabilitySet| -> Result<()> {
+            let escaped = escape_seatbelt_path(path_to_utf8(p)?)?;
+            let filter = if p.exists() && p.is_file() {
+                format!("literal \"{}\"", escaped)
+            } else {
+                format!("subpath \"{}\"", escaped)
+            };
+            caps.add_platform_rule(format!("(allow file-read-metadata ({}))", filter))?;
+            caps.add_platform_rule(format!("(deny file-read-data ({}))", filter))?;
+            caps.add_platform_rule(format!("(deny file-write* ({}))", filter))?;
+            Ok(())
         };
 
-        caps.add_platform_rule(format!("(allow file-read-metadata ({}))", filter))?;
-        caps.add_platform_rule(format!("(deny file-read-data ({}))", filter))?;
-        caps.add_platform_rule(format!("(deny file-write* ({}))", filter))?;
+        // Emit deny rules for the original path
+        emit_deny_rules(&path, caps)?;
 
-        // Emit deny rules for the symlink target too
-        if let Some(ref resolved) = resolved {
-            if *resolved != path {
-                if let Ok(resolved_utf8) = path_to_utf8(resolved) {
-                    if let Ok(resolved_escaped) = escape_seatbelt_path(resolved_utf8) {
-                        let resolved_filter = if resolved.is_file() {
-                            format!("literal \"{}\"", resolved_escaped)
-                        } else {
-                            format!("subpath \"{}\"", resolved_escaped)
-                        };
-
-                        if let Err(e) = caps.add_platform_rule(format!(
-                            "(allow file-read-metadata ({}))",
-                            resolved_filter
-                        )) {
-                            warn!("Skipping symlink target deny metadata rule: {}", e);
-                        }
-                        if let Err(e) = caps.add_platform_rule(format!(
-                            "(deny file-read-data ({}))",
-                            resolved_filter
-                        )) {
-                            warn!("Skipping symlink target deny read rule: {}", e);
-                        }
-                        if let Err(e) = caps
-                            .add_platform_rule(format!("(deny file-write* ({}))", resolved_filter))
-                        {
-                            warn!("Skipping symlink target deny write rule: {}", e);
-                        }
-                    }
+        // Emit deny rules for the canonical path too (covers parent symlinks)
+        if let Some(ref canonical) = canonical {
+            if *canonical != path {
+                if let Err(e) = emit_deny_rules(canonical, caps) {
+                    warn!(
+                        "Skipping canonical deny rules for {}: {}",
+                        canonical.display(),
+                        e
+                    );
                 }
             }
         }
@@ -1387,10 +1367,17 @@ mod tests {
 
     #[test]
     fn test_deny_access_non_symlink_no_duplicate() {
-        // A regular (non-symlink) file should only produce one deny_paths entry
+        // A regular (non-symlink) file whose parents also resolve to the same
+        // canonical path should produce one deny_paths entry. On macOS tempdir
+        // lives under /var/folders (symlink to /private/var/folders), so the
+        // canonical and original paths differ — that's two entries, which is
+        // correct because Seatbelt needs both forms.
         let dir = tempfile::tempdir().expect("create tempdir");
         let file = dir.path().join("regular_file");
         std::fs::write(&file, "content").expect("write file");
+
+        let canonical = file.canonicalize().expect("canonicalize");
+        let parent_is_symlinked = canonical != file;
 
         let mut caps = CapabilitySet::new();
         let mut deny_paths = Vec::new();
@@ -1398,10 +1385,14 @@ mod tests {
         add_deny_access_rules(file_str, &mut caps, &mut deny_paths)
             .expect("add deny rules for regular file");
 
+        let expected = if parent_is_symlinked { 2 } else { 1 };
         assert_eq!(
             deny_paths.len(),
-            1,
-            "regular file should have one deny_paths entry"
+            expected,
+            "deny_paths entries: expected {} (parent symlinked: {}), got {:?}",
+            expected,
+            parent_is_symlinked,
+            deny_paths
         );
     }
 


### PR DESCRIPTION
Seatbelt operates on kernel-resolved paths, but add_deny_access_rules only canonicalized the deny target when it was itself a symlink. Parent directory symlinks (e.g. /var -> /private/var on macOS) caused the deny rule path to diverge from what Seatbelt sees at runtime, silently failing to block access.

Now always canonicalize and emit deny rules for both the original and canonical paths, matching how allow rules already handle symlinked parents via path_filters_for_cap.

Also adds a profile authoring guide entry for denying specific project files with $WORKDIR, covering both macOS (Seatbelt) and Linux (supervised mode via seccomp-notify).