### PR TITLE
feat(trust): scaffold policies, enforce missing includes at startup, and simplify write protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,7 @@ dependencies = [
  "colored",
  "dirs",
  "dns-lookup",
+ "ignore",
  "jsonschema",
  "keyring",
  "landlock",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -42,6 +42,7 @@ toml = "1.0"
 xdg-home = "1.3.0"
 dirs = "6"
 walkdir = "2"
+ignore.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 
 # Signing key PKCS#8 serialization (already transitive via sigstore-verify)

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -30,6 +30,11 @@ conf-files = ["/etc/nono/profiles/"]
 name = "nono"
 path = "src/main.rs"
 
+[features]
+default = []
+# Enables test-only trust root overrides used by the integration harness.
+test-trust-overrides = []
+
 [dependencies]
 nono = { version = "0.20.0", path = "../nono" }
 nono-proxy = { version = "0.20.0", path = "../nono-proxy" }

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -38,7 +38,7 @@ const STYLES: Styles = Styles::plain().header(Style::new().bold());
 \x1b[1mSESSION MANAGEMENT\x1b[0m
   rollback   Manage rollback sessions (browse, restore, cleanup)
   audit      View audit trail of sandboxed commands
-  trust      Manage instruction file trust and attestation
+  trust      Manage file trust and attestation
 
 \x1b[1mPOLICY & PROFILES\x1b[0m
   policy     Inspect policy groups, profiles, and security rules
@@ -227,7 +227,7 @@ pub enum Commands {
 ")]
     Audit(AuditArgs),
 
-    /// Manage instruction file trust and attestation
+    /// Manage file trust and attestation
     #[command(subcommand_help_heading = "COMMANDS", disable_help_subcommand = true)]
     #[command(help_template = "\
 {about}
@@ -240,8 +240,8 @@ pub enum Commands {
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono trust sign SKILLS.md                    # Sign with default keystore key
   nono trust sign SKILLS.md --key my-key       # Sign with a specific key ID
-  nono trust verify SKILLS.md                  # Verify an instruction file
-  nono trust verify --all                      # Verify all instruction files
+  nono trust verify SKILLS.md                  # Verify a file
+  nono trust verify --all                      # Verify all files matching policy
   nono trust list                              # List files and verification status
   nono trust keygen                            # Generate a new signing key pair
 ")]
@@ -866,7 +866,7 @@ pub struct RunArgs {
     #[arg(long, conflicts_with = "rollback", help_heading = "OPTIONS")]
     pub no_audit: bool,
 
-    /// Disable trust verification for instruction files (not recommended for production)
+    /// Disable trust verification (not recommended for production)
     #[arg(long, help_heading = "OPTIONS")]
     pub trust_override: bool,
 
@@ -1084,6 +1084,7 @@ pub enum RollbackCommands {
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct RollbackListArgs {
     /// Show only the N most recent sessions
     #[arg(long, value_name = "N")]
@@ -1100,9 +1101,14 @@ pub struct RollbackListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct RollbackShowArgs {
     /// Session ID (e.g., 20260214-143022-12345)
     pub session_id: String,
@@ -1122,9 +1128,14 @@ pub struct RollbackShowArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct RollbackRestoreArgs {
     /// Session ID (e.g., 20260214-143022-12345)
     pub session_id: String,
@@ -1136,15 +1147,25 @@ pub struct RollbackRestoreArgs {
     /// Show what would change without modifying files
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct RollbackVerifyArgs {
     /// Session ID (e.g., 20260214-143022-12345)
     pub session_id: String,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct RollbackCleanupArgs {
     /// Retain N newest sessions (default: from config, usually 10)
     #[arg(long, value_name = "N")]
@@ -1161,6 +1182,10 @@ pub struct RollbackCleanupArgs {
     /// Remove all sessions (requires confirmation)
     #[arg(long)]
     pub all: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1187,6 +1212,7 @@ pub enum AuditCommands {
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct AuditListArgs {
     /// Show only sessions from today
     #[arg(long)]
@@ -1215,9 +1241,14 @@ pub struct AuditListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct AuditShowArgs {
     /// Session ID (e.g., 20260214-143022-12345)
     pub session_id: String,
@@ -1225,6 +1256,10 @@ pub struct AuditShowArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1246,13 +1281,13 @@ pub struct TrustArgs {
 pub enum TrustCommands {
     /// Create a trust-policy.json in the current directory
     Init(TrustInitArgs),
-    /// Sign an instruction file, producing a .bundle alongside it
+    /// Sign a file, producing a .bundle alongside it
     Sign(TrustSignArgs),
     /// Sign a trust policy file, producing a .bundle alongside it
     SignPolicy(TrustSignPolicyArgs),
-    /// Verify an instruction file's bundle against the trust policy
+    /// Verify a file's bundle against the trust policy
     Verify(TrustVerifyArgs),
-    /// List instruction files and their verification status
+    /// List files and their verification status
     List(TrustListArgs),
     /// Generate a new ECDSA P-256 signing key pair
     Keygen(TrustKeygenArgs),
@@ -1261,12 +1296,13 @@ pub enum TrustCommands {
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustSignArgs {
     /// Instruction file(s) to sign
     #[arg(required_unless_present = "all")]
     pub files: Vec<PathBuf>,
 
-    /// Sign all instruction files matching trust policy patterns in CWD
+    /// Sign all files matching trust policy patterns in CWD
     #[arg(long)]
     pub all: bool,
 
@@ -1278,12 +1314,21 @@ pub struct TrustSignArgs {
     #[arg(long)]
     pub keyless: bool,
 
+    /// Produce a single .nono-trust.bundle containing all subjects instead of per-file bundles
+    #[arg(long)]
+    pub multi_subject: bool,
+
     /// Trust policy file (default: auto-discover)
     #[arg(long, value_name = "FILE")]
     pub policy: Option<PathBuf>,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustSignPolicyArgs {
     /// Trust policy file to sign (default: trust-policy.json in CWD)
     pub file: Option<PathBuf>,
@@ -1291,43 +1336,58 @@ pub struct TrustSignPolicyArgs {
     /// Key ID to use from the system keystore (default: "default")
     #[arg(long, value_name = "KEY_ID")]
     pub key: Option<String>,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustVerifyArgs {
     /// Instruction file(s) to verify
     #[arg(required_unless_present = "all")]
     pub files: Vec<PathBuf>,
 
-    /// Verify all instruction files matching trust policy patterns in CWD
+    /// Verify all files matching trust policy patterns in CWD
     #[arg(long)]
     pub all: bool,
 
     /// Trust policy file (default: auto-discover)
     #[arg(long, value_name = "FILE")]
     pub policy: Option<PathBuf>,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustInitArgs {
-    /// Scan subdirectories recursively for files to include as patterns
-    #[arg(long, short = 'r')]
-    pub recursive: bool,
-
-    /// Additional directories to exclude from scanning (on top of .gitignore and built-in list)
-    #[arg(long, value_name = "DIR", num_args = 1..)]
-    pub exclude_dirs: Vec<String>,
+    /// Glob patterns for files to include in the trust policy (e.g., "*.md", "*.py", "SKILLS.md")
+    #[arg(long, value_name = "PATTERN", num_args = 1..)]
+    pub include: Vec<String>,
 
     /// Key ID to include as a publisher (default: "default")
     #[arg(long, value_name = "KEY_ID")]
     pub key: Option<String>,
 
+    /// Create a user-level policy at ~/.config/nono/ instead of the current directory
+    #[arg(long)]
+    pub user: bool,
+
     /// Overwrite existing trust-policy.json
     #[arg(long)]
     pub force: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustListArgs {
     /// Trust policy file (default: auto-discover)
     #[arg(long, value_name = "FILE")]
@@ -1336,9 +1396,14 @@ pub struct TrustListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustKeygenArgs {
     /// Key identifier (stored in system keystore under this name)
     #[arg(long, value_name = "NAME", default_value = "default")]
@@ -1347,9 +1412,14 @@ pub struct TrustKeygenArgs {
     /// Overwrite existing key with the same ID
     #[arg(long)]
     pub force: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct TrustExportKeyArgs {
     /// Key identifier to export (default: "default")
     #[arg(long, value_name = "NAME", default_value = "default")]
@@ -1358,6 +1428,10 @@ pub struct TrustExportKeyArgs {
     /// Output as PEM instead of base64 DER
     #[arg(long)]
     pub pem: bool,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[cfg(test)]
@@ -1680,10 +1754,9 @@ mod tests {
         match cli.command {
             Commands::Trust(args) => match args.command {
                 TrustCommands::Init(init_args) => {
-                    assert!(!init_args.recursive);
                     assert!(!init_args.force);
                     assert!(init_args.key.is_none());
-                    assert!(init_args.exclude_dirs.is_empty());
+                    assert!(init_args.include.is_empty());
                 }
                 _ => panic!("Expected Init subcommand"),
             },
@@ -1692,23 +1765,21 @@ mod tests {
     }
 
     #[test]
-    fn test_trust_init_recursive_with_excludes() {
+    fn test_trust_init_with_includes() {
         let cli = Cli::parse_from([
             "nono",
             "trust",
             "init",
-            "-r",
-            "--exclude-dirs",
-            "tmp",
-            "logs",
+            "--include",
+            "*.md",
+            "*.py",
             "--force",
         ]);
         match cli.command {
             Commands::Trust(args) => match args.command {
                 TrustCommands::Init(init_args) => {
-                    assert!(init_args.recursive);
                     assert!(init_args.force);
-                    assert_eq!(init_args.exclude_dirs, vec!["tmp", "logs"]);
+                    assert_eq!(init_args.include, vec!["*.md", "*.py"]);
                 }
                 _ => panic!("Expected Init subcommand"),
             },
@@ -1754,6 +1825,22 @@ mod tests {
                 TrustCommands::Sign(sign_args) => {
                     assert!(sign_args.all);
                     assert!(sign_args.files.is_empty());
+                    assert!(!sign_args.multi_subject);
+                }
+                _ => panic!("Expected Sign subcommand"),
+            },
+            _ => panic!("Expected Trust command"),
+        }
+    }
+
+    #[test]
+    fn test_trust_sign_multi_subject() {
+        let cli = Cli::parse_from(["nono", "trust", "sign", "--all", "--multi-subject"]);
+        match cli.command {
+            Commands::Trust(args) => match args.command {
+                TrustCommands::Sign(sign_args) => {
+                    assert!(sign_args.all);
+                    assert!(sign_args.multi_subject);
                 }
                 _ => panic!("Expected Sign subcommand"),
             },

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1244,6 +1244,8 @@ pub struct TrustArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum TrustCommands {
+    /// Create a trust-policy.json in the current directory
+    Init(TrustInitArgs),
     /// Sign an instruction file, producing a .bundle alongside it
     Sign(TrustSignArgs),
     /// Sign a trust policy file, producing a .bundle alongside it
@@ -1304,6 +1306,25 @@ pub struct TrustVerifyArgs {
     /// Trust policy file (default: auto-discover)
     #[arg(long, value_name = "FILE")]
     pub policy: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct TrustInitArgs {
+    /// Scan subdirectories recursively for files to include as patterns
+    #[arg(long, short = 'r')]
+    pub recursive: bool,
+
+    /// Additional directories to exclude from scanning (on top of .gitignore and built-in list)
+    #[arg(long, value_name = "DIR", num_args = 1..)]
+    pub exclude_dirs: Vec<String>,
+
+    /// Key ID to include as a publisher (default: "default")
+    #[arg(long, value_name = "KEY_ID")]
+    pub key: Option<String>,
+
+    /// Overwrite existing trust-policy.json
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -1650,6 +1671,48 @@ mod tests {
                 _ => panic!("Expected Cleanup subcommand"),
             },
             _ => panic!("Expected Rollback command"),
+        }
+    }
+
+    #[test]
+    fn test_trust_init_defaults() {
+        let cli = Cli::parse_from(["nono", "trust", "init"]);
+        match cli.command {
+            Commands::Trust(args) => match args.command {
+                TrustCommands::Init(init_args) => {
+                    assert!(!init_args.recursive);
+                    assert!(!init_args.force);
+                    assert!(init_args.key.is_none());
+                    assert!(init_args.exclude_dirs.is_empty());
+                }
+                _ => panic!("Expected Init subcommand"),
+            },
+            _ => panic!("Expected Trust command"),
+        }
+    }
+
+    #[test]
+    fn test_trust_init_recursive_with_excludes() {
+        let cli = Cli::parse_from([
+            "nono",
+            "trust",
+            "init",
+            "-r",
+            "--exclude-dirs",
+            "tmp",
+            "logs",
+            "--force",
+        ]);
+        match cli.command {
+            Commands::Trust(args) => match args.command {
+                TrustCommands::Init(init_args) => {
+                    assert!(init_args.recursive);
+                    assert!(init_args.force);
+                    assert_eq!(init_args.exclude_dirs, vec!["tmp", "logs"]);
+                }
+                _ => panic!("Expected Init subcommand"),
+            },
+            _ => panic!("Expected Trust command"),
         }
     }
 

--- a/crates/nono-cli/src/instruction_deny.rs
+++ b/crates/nono-cli/src/instruction_deny.rs
@@ -1,14 +1,14 @@
-//! Write-protection rules for verified instruction files (macOS Seatbelt)
+//! Write-protection rules for verified files (macOS Seatbelt)
 //!
-//! After the pre-exec trust scan verifies instruction files, this module
-//! injects literal `(deny file-write-data ...)` rules into the Seatbelt
-//! profile for each verified file. This makes verified instruction files
-//! structurally immutable at the kernel level — the agent cannot tamper
-//! with them even though the parent directory has write access granted.
+//! After the pre-exec trust scan verifies files, this module injects
+//! literal `(deny file-write-data ...)` rules into the Seatbelt profile
+//! for each verified file. This makes verified files structurally immutable
+//! at the kernel level — the agent cannot tamper with them even though the
+//! parent directory has write access granted.
 //!
 //! # Design
 //!
-//! The trust policy's `instruction_patterns` define which files are scanned
+//! The trust policy's `includes` patterns define which files are scanned
 //! and verified. The pre-exec scan resolves every matching file to an
 //! absolute path with a concrete verification outcome. Only files that
 //! pass verification reach this module, and they receive literal write-deny
@@ -24,7 +24,7 @@ use nono::Result;
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
-/// Write-protect verified instruction files in the Seatbelt profile.
+/// Write-protect verified files in the Seatbelt profile.
 ///
 /// For each verified file path, adds a
 /// `(deny file-write-data (literal ...))` rule to prevent modification.
@@ -59,9 +59,9 @@ pub fn write_protect_verified_files(
     Ok(())
 }
 
-/// Add a `(deny file-write-data (literal ...))` rule for a verified instruction file.
+/// Add a `(deny file-write-data (literal ...))` rule for a verified file.
 ///
-/// This prevents modification of signed instruction files even when the parent
+/// This prevents modification of signed files even when the parent
 /// directory has write access granted. The deny rule takes precedence over
 /// directory-level `(allow file-write* (subpath ...))` rules.
 ///

--- a/crates/nono-cli/src/instruction_deny.rs
+++ b/crates/nono-cli/src/instruction_deny.rs
@@ -1,153 +1,33 @@
-//! Instruction file deny rules for macOS Seatbelt profiles
+//! Write-protection rules for verified instruction files (macOS Seatbelt)
 //!
-//! Converts glob patterns from the trust policy's `instruction_patterns` into
-//! Seatbelt regex deny rules, and adds literal allow overrides for verified files.
+//! After the pre-exec trust scan verifies instruction files, this module
+//! injects literal `(deny file-write-data ...)` rules into the Seatbelt
+//! profile for each verified file. This makes verified instruction files
+//! structurally immutable at the kernel level — the agent cannot tamper
+//! with them even though the parent directory has write access granted.
 //!
-//! # Approach
+//! # Design
 //!
-//! On macOS, Seatbelt `(deny file-read-data (regex ...))` blocks reads even
-//! within `(allow file-read* (subpath ...))` directories. More specific
-//! `(allow file-read-data (literal ...))` rules override deny-regex rules.
+//! The trust policy's `instruction_patterns` define which files are scanned
+//! and verified. The pre-exec scan resolves every matching file to an
+//! absolute path with a concrete verification outcome. Only files that
+//! pass verification reach this module, and they receive literal write-deny
+//! rules keyed to their exact paths.
 //!
-//! This provides kernel-level instruction file protection:
-//! - Deny regex rules prevent reading ANY file matching instruction patterns
-//! - Literal allows re-enable reading for files that passed trust verification
-//! - Files created at runtime (e.g., by curl) are blocked by deny regex
+//! No regex deny-read rules are used. The pre-exec scan gates execution
+//! (aborting if any file fails verification), and the supervisor's
+//! `TrustInterceptor` handles runtime verification of files opened
+//! mid-session.
 
-use nono::trust::TrustPolicy;
 use nono::CapabilitySet;
 use nono::Result;
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
-/// Convert a glob pattern to a Seatbelt regex string.
+/// Write-protect verified instruction files in the Seatbelt profile.
 ///
-/// Handles common glob constructs:
-/// - `*` matches any characters within a single path segment (not `/`)
-/// - `**` matches any number of path segments (including zero)
-/// - Literal characters are regex-escaped
-///
-/// The resulting regex is anchored to match at the end of path components,
-/// prefixed with `/` to ensure it matches complete filename components.
-///
-/// # Examples
-///
-/// - `SKILLS*` -> `#"/SKILLS[^/]*$"`
-/// - `CLAUDE*` -> `#"/CLAUDE[^/]*$"`
-/// - `.claude/**/*.md` -> `#"/\\.claude/.*/[^/]*\\.md$"`
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-pub fn glob_to_seatbelt_regex(pattern: &str) -> Result<String> {
-    if pattern.is_empty() {
-        return Err(nono::NonoError::ConfigParse(
-            "empty instruction pattern".to_string(),
-        ));
-    }
-
-    let mut regex = String::with_capacity(pattern.len().saturating_mul(2));
-    if !pattern.starts_with('/') {
-        regex.push('/');
-    }
-
-    let chars: Vec<char> = pattern.chars().collect();
-    let mut i = 0;
-
-    while i < chars.len() {
-        match chars[i] {
-            '*' => {
-                if i + 1 < chars.len() && chars[i + 1] == '*' {
-                    // `**` — match any path segments
-                    regex.push_str(".*");
-                    i += 2;
-                    // Skip trailing `/` after `**/`
-                    if i < chars.len() && chars[i] == '/' {
-                        regex.push('/');
-                        i += 1;
-                    }
-                } else {
-                    // Single `*` — match within one segment
-                    regex.push_str("[^/]*");
-                    i += 1;
-                }
-            }
-            '.' => {
-                regex.push_str("\\.");
-                i += 1;
-            }
-            '[' => {
-                regex.push_str("\\[");
-                i += 1;
-            }
-            ']' => {
-                regex.push_str("\\]");
-                i += 1;
-            }
-            '(' => {
-                regex.push_str("\\(");
-                i += 1;
-            }
-            ')' => {
-                regex.push_str("\\)");
-                i += 1;
-            }
-            '{' => {
-                regex.push_str("\\{");
-                i += 1;
-            }
-            '}' => {
-                regex.push_str("\\}");
-                i += 1;
-            }
-            '+' => {
-                regex.push_str("\\+");
-                i += 1;
-            }
-            '?' => {
-                regex.push_str("\\?");
-                i += 1;
-            }
-            '^' => {
-                regex.push_str("\\^");
-                i += 1;
-            }
-            '$' => {
-                regex.push_str("\\$");
-                i += 1;
-            }
-            '|' => {
-                regex.push_str("\\|");
-                i += 1;
-            }
-            '\\' => {
-                regex.push_str("\\\\");
-                i += 1;
-            }
-            '"' => {
-                regex.push_str("\\\"");
-                i += 1;
-            }
-            '/' => {
-                regex.push('/');
-                i += 1;
-            }
-            c => {
-                regex.push(c);
-                i += 1;
-            }
-        }
-    }
-
-    regex.push('$');
-
-    Ok(format!("(deny file-read-data (regex #\"{regex}\"))"))
-}
-
-/// Inject instruction file deny rules into a `CapabilitySet`.
-///
-/// For each pattern in the trust policy's `instruction_patterns`, adds a
-/// Seatbelt `(deny file-read-data (regex ...))` rule. For each verified
-/// file path, adds:
-/// - `(allow file-read-data (literal ...))` to permit reading
-/// - `(deny file-write-data (literal ...))` to prevent modification
+/// For each verified file path, adds a
+/// `(deny file-write-data (literal ...))` rule to prevent modification.
 ///
 /// On macOS, handles symlinks by emitting rules for both the original
 /// path and the canonical path when they differ (e.g., `/tmp/` vs
@@ -157,23 +37,13 @@ pub fn glob_to_seatbelt_regex(pattern: &str) -> Result<String> {
 ///
 /// # Errors
 ///
-/// Returns an error if pattern conversion fails or if `add_platform_rule`
-/// rejects a generated rule.
+/// Returns an error if `add_platform_rule` rejects a generated rule.
 #[cfg(target_os = "macos")]
-pub fn inject_instruction_deny_rules(
+pub fn write_protect_verified_files(
     caps: &mut CapabilitySet,
-    policy: &TrustPolicy,
     verified_paths: &[std::path::PathBuf],
 ) -> Result<()> {
-    // Add deny rules for each instruction pattern
-    for pattern in &policy.instruction_patterns {
-        let deny_rule = glob_to_seatbelt_regex(pattern)?;
-        caps.add_platform_rule(deny_rule)?;
-    }
-
-    // Add literal allows (read) and denies (write) for verified files
     for path in verified_paths {
-        add_literal_allow(caps, path)?;
         add_literal_write_deny(caps, path)?;
     }
 
@@ -182,40 +52,10 @@ pub fn inject_instruction_deny_rules(
 
 /// No-op on non-macOS platforms.
 #[cfg(not(target_os = "macos"))]
-pub fn inject_instruction_deny_rules(
+pub fn write_protect_verified_files(
     _caps: &mut CapabilitySet,
-    _policy: &TrustPolicy,
     _verified_paths: &[std::path::PathBuf],
 ) -> Result<()> {
-    Ok(())
-}
-
-/// Add a `(allow file-read-data (literal ...))` rule for a verified file.
-///
-/// On macOS, if the path contains symlinks (e.g., `/tmp` -> `/private/tmp`),
-/// emits rules for both the original and resolved paths.
-///
-/// Rejects paths containing characters that would break Seatbelt literal syntax
-/// (`"` and `\`), since these are not legitimate instruction file path characters
-/// and could allow sandbox rule injection.
-#[cfg(target_os = "macos")]
-fn add_literal_allow(caps: &mut CapabilitySet, path: &Path) -> Result<()> {
-    let path_str = path.display().to_string();
-    validate_seatbelt_path(&path_str)?;
-
-    let allow_rule = format!("(allow file-read-data (literal \"{path_str}\"))");
-    caps.add_platform_rule(allow_rule)?;
-
-    // Handle macOS symlinks: emit rule for canonical path too
-    if let Ok(canonical) = std::fs::canonicalize(path) {
-        if canonical != path {
-            let canonical_str = canonical.display().to_string();
-            validate_seatbelt_path(&canonical_str)?;
-            let canonical_rule = format!("(allow file-read-data (literal \"{canonical_str}\"))");
-            caps.add_platform_rule(canonical_rule)?;
-        }
-    }
-
     Ok(())
 }
 
@@ -268,140 +108,52 @@ fn validate_seatbelt_path(path_str: &str) -> Result<()> {
 mod tests {
     use super::*;
 
-    // -----------------------------------------------------------------------
-    // glob_to_seatbelt_regex
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn glob_skills_star_md() {
-        let rule = glob_to_seatbelt_regex("SKILLS*.md").unwrap();
-        assert_eq!(
-            rule,
-            "(deny file-read-data (regex #\"/SKILLS[^/]*\\.md$\"))"
-        );
-    }
-
-    #[test]
-    fn glob_claude_star_md() {
-        let rule = glob_to_seatbelt_regex("CLAUDE*.md").unwrap();
-        assert_eq!(
-            rule,
-            "(deny file-read-data (regex #\"/CLAUDE[^/]*\\.md$\"))"
-        );
-    }
-
-    #[test]
-    fn glob_agent_star_md() {
-        let rule = glob_to_seatbelt_regex("AGENT*.md").unwrap();
-        assert_eq!(rule, "(deny file-read-data (regex #\"/AGENT[^/]*\\.md$\"))");
-    }
-
-    #[test]
-    fn glob_dot_claude_recursive() {
-        let rule = glob_to_seatbelt_regex(".claude/**/*.md").unwrap();
-        assert_eq!(
-            rule,
-            "(deny file-read-data (regex #\"/\\.claude/.*/[^/]*\\.md$\"))"
-        );
-    }
-
-    #[test]
-    fn glob_copilot_instructions() {
-        let rule = glob_to_seatbelt_regex(".github/copilot-instructions.md").unwrap();
-        assert_eq!(
-            rule,
-            "(deny file-read-data (regex #\"/\\.github/copilot-instructions\\.md$\"))"
-        );
-    }
-
-    #[test]
-    fn glob_empty_returns_error() {
-        assert!(glob_to_seatbelt_regex("").is_err());
-    }
-
-    #[test]
-    fn glob_pattern_with_leading_slash_no_double_slash() {
-        // A pattern that already starts with '/' must not produce a double slash
-        let rule = glob_to_seatbelt_regex("/SKILLS*").unwrap();
-        assert_eq!(rule, "(deny file-read-data (regex #\"/SKILLS[^/]*$\"))");
-        assert!(!rule.contains("//"));
-    }
-
-    #[test]
-    fn glob_special_chars_escaped() {
-        let rule = glob_to_seatbelt_regex("test[1].md").unwrap();
-        assert_eq!(
-            rule,
-            "(deny file-read-data (regex #\"/test\\[1\\]\\.md$\"))"
-        );
-    }
-
-    #[test]
-    fn glob_double_star_at_start() {
-        let rule = glob_to_seatbelt_regex("**/*.md").unwrap();
-        assert_eq!(rule, "(deny file-read-data (regex #\"/.*/[^/]*\\.md$\"))");
-    }
-
-    #[test]
-    fn glob_quote_escaped_in_regex() {
-        let rule = glob_to_seatbelt_regex("test\"file.md").unwrap();
-        assert!(rule.contains("\\\""));
-        assert!(!rule.contains("\"test"));
+    fn write_protect_with_no_paths_is_noop() {
+        let mut caps = CapabilitySet::new();
+        write_protect_verified_files(&mut caps, &[]).unwrap();
+        assert!(caps.platform_rules().is_empty());
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn literal_allow_rejects_path_with_quote() {
+    fn write_protect_adds_deny_write_rule() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("SKILLS.md");
+        std::fs::write(&file, "content").unwrap();
+
         let mut caps = CapabilitySet::new();
-        let bad_path = Path::new("/tmp/SKILLS\") (allow file-write* (subpath \"/\")) ;.md");
-        let result = add_literal_allow(&mut caps, bad_path);
+        write_protect_verified_files(&mut caps, std::slice::from_ref(&file)).unwrap();
+
+        let rules = caps.platform_rules();
+        assert!(!rules.is_empty());
+        // Should have a write-deny rule for the file
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("deny file-write-data")
+                    && r.contains(&file.display().to_string()))
+        );
+        // Should NOT have any read-deny rules
+        assert!(!rules.iter().any(|r| r.contains("deny file-read-data")));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn write_protect_rejects_path_with_quote() {
+        let mut caps = CapabilitySet::new();
+        let bad_path =
+            std::path::PathBuf::from("/tmp/SKILLS\") (allow file-write* (subpath \"/\")) ;.md");
+        let result = write_protect_verified_files(&mut caps, &[bad_path]);
         assert!(result.is_err());
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn literal_allow_rejects_path_with_backslash() {
+    fn write_protect_rejects_path_with_backslash() {
         let mut caps = CapabilitySet::new();
-        let bad_path = Path::new("/tmp/SKILLS\\.md");
-        let result = add_literal_allow(&mut caps, bad_path);
+        let bad_path = std::path::PathBuf::from("/tmp/SKILLS\\.md");
+        let result = write_protect_verified_files(&mut caps, &[bad_path]);
         assert!(result.is_err());
-    }
-
-    // -----------------------------------------------------------------------
-    // inject_instruction_deny_rules
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn inject_with_no_patterns_is_noop() {
-        let mut caps = CapabilitySet::new();
-        let policy = TrustPolicy {
-            instruction_patterns: Vec::new(),
-            ..TrustPolicy::default()
-        };
-
-        inject_instruction_deny_rules(&mut caps, &policy, &[]).unwrap();
-        assert!(caps.platform_rules().is_empty());
-    }
-
-    #[test]
-    fn inject_adds_deny_and_allow_rules() {
-        let mut caps = CapabilitySet::new();
-        let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS*".to_string()],
-            ..TrustPolicy::default()
-        };
-
-        // On macOS, we'd have actual deny rules. On other platforms, it's a no-op.
-        // Test the glob conversion at least.
-        let deny = glob_to_seatbelt_regex("SKILLS*").unwrap();
-        assert!(deny.starts_with("(deny"));
-
-        inject_instruction_deny_rules(&mut caps, &policy, &[]).unwrap();
-
-        #[cfg(target_os = "macos")]
-        assert_eq!(caps.platform_rules().len(), 1);
-
-        #[cfg(not(target_os = "macos"))]
-        assert!(caps.platform_rules().is_empty());
     }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -28,6 +28,7 @@ mod terminal_approval;
 mod theme;
 mod trust_cmd;
 mod trust_intercept;
+mod trust_keystore;
 mod trust_scan;
 mod update_check;
 
@@ -1084,7 +1085,7 @@ impl ExecutionFlags {
 }
 
 fn trust_interception_active(policy: Option<&nono::trust::TrustPolicy>) -> bool {
-    policy.is_some_and(|policy| !policy.instruction_patterns.is_empty())
+    policy.is_some_and(|policy| !policy.includes.is_empty())
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -2580,9 +2581,9 @@ mod tests {
     }
 
     #[test]
-    fn test_trust_interception_active_when_instruction_patterns_exist() {
+    fn test_trust_interception_active_when_includes_exist() {
         let policy = nono::trust::TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             ..nono::trust::TrustPolicy::default()
         };
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -665,15 +665,11 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             });
         }
 
-        // Inject instruction file deny rules into the Seatbelt profile (macOS only).
-        // Deny-regex rules block reading any file matching instruction patterns.
-        // Literal allows re-enable reading for files that passed verification.
+        // Write-protect verified instruction files in the Seatbelt profile (macOS).
+        // Literal deny-write rules make verified files structurally immutable at the
+        // kernel level, preventing the agent from tampering with them mid-session.
         let verified = result.verified_paths();
-        instruction_deny::inject_instruction_deny_rules(
-            &mut prepared.caps,
-            &trust_policy,
-            &verified,
-        )?;
+        instruction_deny::write_protect_verified_files(&mut prepared.caps, &verified)?;
 
         // Add verified multi-subject files as read-only capabilities.
         // This makes the files structurally immutable post-sandbox on both

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -6,6 +6,7 @@ use crate::cli::{
     TrustArgs, TrustCommands, TrustExportKeyArgs, TrustInitArgs, TrustKeygenArgs, TrustListArgs,
     TrustSignArgs, TrustSignPolicyArgs, TrustVerifyArgs,
 };
+use crate::trust_keystore;
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
 use colored::Colorize;
@@ -19,6 +20,9 @@ const TRUST_SERVICE: &str = "nono-trust";
 
 /// Keystore service name for public keys (verification-only, no private key material)
 const TRUST_PUB_SERVICE: &str = "nono-trust-pub";
+
+/// Test-only override for the user trust policy path.
+pub(crate) const TEST_USER_POLICY_PATH_ENV: &str = "NONO_TRUST_TEST_USER_POLICY_PATH";
 
 /// Run a trust subcommand.
 pub fn run_trust(args: TrustArgs) -> Result<()> {
@@ -37,59 +41,40 @@ pub fn run_trust(args: TrustArgs) -> Result<()> {
 // init
 // ---------------------------------------------------------------------------
 
-/// Directories to always skip when scanning for file patterns, even if not
-/// covered by `.gitignore`. These are common build artifacts, caches, and
-/// tool directories that are never interesting as trust policy targets.
-const SKIP_DIRS: &[&str] = &[
-    ".git",
-    ".hg",
-    ".svn",
-    "node_modules",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".env",
-    ".tox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    "target",
-    "dist",
-    "build",
-    ".next",
-    ".nuxt",
-    ".output",
-    ".cache",
-    ".turbo",
-    "vendor",
-    ".terraform",
-    ".bundle",
-    "coverage",
-    ".idea",
-    ".vscode",
-];
-
 fn run_init(args: TrustInitArgs) -> Result<()> {
-    let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
-    let policy_path = cwd.join("trust-policy.json");
+    let is_user = args.user;
+    let policy_path = if is_user {
+        let path = user_trust_policy_path().ok_or_else(|| {
+            nono::NonoError::TrustPolicy("could not determine user config directory".to_string())
+        })?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(nono::NonoError::Io)?;
+        }
+        path
+    } else {
+        let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
+        cwd.join("trust-policy.json")
+    };
 
     if policy_path.exists() && !args.force {
-        return Err(nono::NonoError::TrustPolicy(
-            "trust-policy.json already exists (use --force to overwrite)".to_string(),
-        ));
+        return Err(nono::NonoError::TrustPolicy(format!(
+            "{} already exists (use --force to overwrite)",
+            policy_path.display()
+        )));
     }
 
-    let patterns = collect_file_patterns(&cwd, args.recursive, &args.exclude_dirs)?;
+    let patterns = if is_user && args.include.is_empty() {
+        // User-level policies focus on publishers and enforcement, not file patterns
+        Vec::new()
+    } else {
+        args.include
+    };
 
-    if patterns.is_empty() {
-        eprintln!(
-            "  {} no files found in {}",
-            "Warning:".yellow(),
-            cwd.display()
-        );
+    if !is_user && patterns.is_empty() {
+        eprintln!("  {} no --include patterns specified", "Warning:".yellow(),);
         eprintln!(
             "  {}",
-            "Add patterns manually to trust-policy.json after creation.".yellow()
+            "Add patterns manually to trust-policy.json or re-run with --include.".yellow()
         );
     }
 
@@ -125,7 +110,7 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
 
     let policy = serde_json::json!({
         "version": 1,
-        "instruction_patterns": patterns,
+        "includes": patterns,
         "publishers": publishers,
         "blocklist": {
             "digests": [],
@@ -143,7 +128,7 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
     eprintln!("  {} {}", "Created".green(), policy_path.display());
 
     if !patterns.is_empty() {
-        eprintln!("  Patterns ({}):", patterns.len());
+        eprintln!("  Includes ({}):", patterns.len());
         for p in &patterns {
             eprintln!("    {p}");
         }
@@ -153,83 +138,17 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
         eprintln!("\n  {}", "Next steps:".bold());
         eprintln!("  1. nono trust keygen");
         eprintln!("  2. nono trust init --force");
-        eprintln!("  3. nono trust sign --all");
-        eprintln!("  4. nono trust sign-policy");
+        eprintln!("  3. nono trust sign-policy {}", policy_path.display());
+        eprintln!("  4. nono trust sign --all");
     } else {
         eprintln!("\n  {}", "Next steps:".bold());
-        eprintln!("  1. Review the patterns in trust-policy.json");
-        eprintln!("  2. nono trust sign --all");
-        eprintln!("  3. nono trust sign-policy");
+        eprintln!("  1. nono trust sign-policy {}", policy_path.display());
+        if !is_user {
+            eprintln!("  2. nono trust sign --all");
+        }
     }
 
     Ok(())
-}
-
-/// Walk the directory using the `ignore` crate (respects `.gitignore`),
-/// skip built-in noise directories and user-specified `--exclude-dirs`,
-/// and collect relative file paths as patterns.
-fn collect_file_patterns(
-    root: &Path,
-    recursive: bool,
-    extra_exclude: &[String],
-) -> Result<Vec<String>> {
-    use ignore::WalkBuilder;
-
-    let mut builder = WalkBuilder::new(root);
-    builder
-        .hidden(false) // don't skip hidden — .claude/, .github/ contain important files
-        .git_ignore(true) // respect .gitignore
-        .git_global(true) // respect global gitignore
-        .git_exclude(true); // respect .git/info/exclude
-
-    if !recursive {
-        builder.max_depth(Some(1));
-    }
-
-    // Combine built-in skip dirs with user-specified ones (owned for 'static closure)
-    let all_skip: std::collections::HashSet<String> = SKIP_DIRS
-        .iter()
-        .map(|s| (*s).to_string())
-        .chain(extra_exclude.iter().cloned())
-        .collect();
-
-    builder.filter_entry(move |entry| {
-        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            let name = entry.file_name().to_string_lossy();
-            return !all_skip.contains(name.as_ref() as &str);
-        }
-        true
-    });
-
-    let mut patterns = std::collections::BTreeSet::new();
-
-    for result in builder.build() {
-        let entry = result
-            .map_err(|e| nono::NonoError::TrustPolicy(format!("failed to walk directory: {e}")))?;
-
-        // Skip directories and the root itself
-        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            continue;
-        }
-
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy();
-
-        // Skip bundle files, lockfiles, and the policy file itself
-        if name.ends_with(".bundle")
-            || name.ends_with(".lock")
-            || name.ends_with(".sum")
-            || name == "trust-policy.json"
-        {
-            continue;
-        }
-
-        if let Ok(rel) = path.strip_prefix(root) {
-            patterns.insert(rel.to_string_lossy().to_string());
-        }
-    }
-
-    Ok(patterns.into_iter().collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -240,15 +159,10 @@ fn run_keygen(args: TrustKeygenArgs) -> Result<()> {
     let key_id = &args.id;
 
     // Check if key already exists
-    if !args.force {
-        let entry = keyring::Entry::new(TRUST_SERVICE, key_id).map_err(|e| {
-            nono::NonoError::KeystoreAccess(format!("failed to access keystore: {e}"))
-        })?;
-        if entry.get_password().is_ok() {
-            return Err(nono::NonoError::KeystoreAccess(format!(
-                "key '{key_id}' already exists in keystore (use --force to overwrite)"
-            )));
-        }
+    if !args.force && trust_keystore::contains_secret(TRUST_SERVICE, key_id)? {
+        return Err(nono::NonoError::KeystoreAccess(format!(
+            "key '{key_id}' already exists in keystore (use --force to overwrite)"
+        )));
     }
 
     // Generate ECDSA P-256 key pair and get PKCS#8 bytes
@@ -266,27 +180,22 @@ fn run_keygen(args: TrustKeygenArgs) -> Result<()> {
     let hex_id = trust::key_id_hex(&key_pair)?;
     let pub_key = trust::export_public_key(&key_pair)?;
 
-    // Store PKCS#8 as base64 in system keystore (zeroized after store)
+    // Store PKCS#8 as base64 in the configured trust keystore.
     let pkcs8_b64 = Zeroizing::new(base64_encode(pkcs8_doc.as_ref()));
-    let entry = keyring::Entry::new(TRUST_SERVICE, key_id)
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to access keystore: {e}")))?;
-    entry
-        .set_password(pkcs8_b64.as_str())
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to store key: {e}")))?;
+    trust_keystore::store_secret(TRUST_SERVICE, key_id, pkcs8_b64.as_str())?;
 
     // Store public key separately so verification never needs the private key
     let pub_key_b64 = base64_encode(pub_key.as_bytes());
-    let pub_entry = keyring::Entry::new(TRUST_PUB_SERVICE, key_id)
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to access keystore: {e}")))?;
-    pub_entry
-        .set_password(&pub_key_b64)
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to store public key: {e}")))?;
+    trust_keystore::store_secret(TRUST_PUB_SERVICE, key_id, &pub_key_b64)?;
 
     eprintln!("{}", "Signing key generated successfully.".green());
     eprintln!("  Key ID:      {key_id}");
     eprintln!("  Fingerprint: {hex_id}");
     eprintln!("  Algorithm:   ECDSA P-256 (SHA-256)");
-    eprintln!("  Stored in:   system keystore (service: {TRUST_SERVICE})");
+    eprintln!(
+        "  Stored in:   {}",
+        trust_keystore::backend_description(TRUST_SERVICE)
+    );
     eprintln!();
     eprintln!("Public key (base64 DER, for trust-policy.json):");
     eprintln!("  {pub_key_b64}");
@@ -333,12 +242,11 @@ fn run_sign(args: TrustSignArgs) -> Result<()> {
     let files = resolve_files(&args.files, args.all, args.policy.as_deref())?;
 
     if files.is_empty() {
-        eprintln!("No instruction files found to sign.");
+        eprintln!("No files found to sign.");
         return Ok(());
     }
 
-    // Multi-file: produce a single .nono-trust.bundle with all subjects
-    if files.len() > 1 {
+    if args.multi_subject {
         return run_sign_multi_keyed(&files, &key_pair, key_id);
     }
 
@@ -436,10 +344,11 @@ fn run_sign_multi_keyed(files: &[PathBuf], key_pair: &trust::KeyPair, key_id: &s
 // ---------------------------------------------------------------------------
 
 fn run_sign_keyless(args: TrustSignArgs) -> Result<()> {
+    let multi_subject = args.multi_subject;
     let files = resolve_files(&args.files, args.all, args.policy.as_deref())?;
 
     if files.is_empty() {
-        eprintln!("No instruction files found to sign.");
+        eprintln!("No files found to sign.");
         return Ok(());
     }
 
@@ -458,8 +367,7 @@ fn run_sign_keyless(args: TrustSignArgs) -> Result<()> {
     let context = sigstore_sign::SigningContext::production();
     let signer = context.signer(token);
 
-    // Multi-file: produce a single .nono-trust.bundle with all subjects
-    if files.len() > 1 {
+    if multi_subject {
         return rt.block_on(run_sign_multi_keyless(&files, &signer));
     }
 
@@ -741,7 +649,7 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
     }
 
     if files.is_empty() && multi_bundles.is_empty() {
-        eprintln!("No instruction files or multi-subject bundles found to verify.");
+        eprintln!("No files or multi-subject bundles found to verify.");
         return Ok(());
     }
 
@@ -1013,13 +921,13 @@ fn run_list(args: TrustListArgs) -> Result<()> {
     let policy = load_trust_policy(args.policy.as_deref())?;
 
     let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
-    let files = trust::find_instruction_files(&policy, &cwd)?;
+    let files = trust::find_included_files(&policy, &cwd)?;
 
     // Surface missing-literal warnings so `trust list` matches `nono run`.
     crate::trust_scan::check_missing_literals(&policy, &cwd, &files, false)?;
 
     if files.is_empty() {
-        eprintln!("No instruction files found in current directory.");
+        eprintln!("No files found matching policy includes in current directory.");
         return Ok(());
     }
 
@@ -1096,16 +1004,11 @@ fn run_list(args: TrustListArgs) -> Result<()> {
 /// Uses the `nono-trust-pub` service to avoid loading private key material
 /// into memory for verification-only operations.
 pub(crate) fn load_public_key_bytes(key_id: &str) -> Result<Vec<u8>> {
-    let entry = keyring::Entry::new(TRUST_PUB_SERVICE, key_id)
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to access keystore: {e}")))?;
-
-    let b64 = entry.get_password().map_err(|e| match e {
-        keyring::Error::NoEntry => nono::NonoError::SecretNotFound(format!(
+    let b64 = trust_keystore::load_secret(TRUST_PUB_SERVICE, key_id).map_err(|e| match e {
+        nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
             "public key '{key_id}' not found in keystore (run 'nono trust keygen' to regenerate)"
         )),
-        other => nono::NonoError::KeystoreAccess(format!(
-            "failed to load public key '{key_id}': {other}"
-        )),
+        other => other,
     })?;
 
     base64_decode(&b64)
@@ -1113,15 +1016,14 @@ pub(crate) fn load_public_key_bytes(key_id: &str) -> Result<Vec<u8>> {
 }
 
 pub(crate) fn load_signing_key(key_id: &str) -> Result<trust::KeyPair> {
-    let entry = keyring::Entry::new(TRUST_SERVICE, key_id)
-        .map_err(|e| nono::NonoError::KeystoreAccess(format!("failed to access keystore: {e}")))?;
-
-    let pkcs8_b64 = Zeroizing::new(entry.get_password().map_err(|e| match e {
-        keyring::Error::NoEntry => nono::NonoError::SecretNotFound(format!(
-            "signing key '{key_id}' not found in keystore (run 'nono trust keygen' first)"
-        )),
-        other => nono::NonoError::KeystoreAccess(format!("failed to load key '{key_id}': {other}")),
-    })?);
+    let pkcs8_b64 = Zeroizing::new(trust_keystore::load_secret(TRUST_SERVICE, key_id).map_err(
+        |e| match e {
+            nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
+                "signing key '{key_id}' not found in keystore (run 'nono trust keygen' first)"
+            )),
+            other => other,
+        },
+    )?);
 
     let pkcs8_bytes = Zeroizing::new(base64_decode(pkcs8_b64.as_str()).map_err(|e| {
         nono::NonoError::KeystoreAccess(format!("corrupt key data in keystore: {e}"))
@@ -1167,6 +1069,9 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
                 return trust::merge_policies(&[user_policy, project_policy]);
             }
         }
+        let user_path = user_trust_policy_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
         eprintln!(
             "  {}",
             "Warning: project-level trust-policy.json found but no user-level policy exists."
@@ -1174,15 +1079,15 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
         );
         eprintln!(
             "  {}",
-            "Project policies are not authoritative without a user-level policy to anchor trust."
+            "A user-level policy defines who you trust across all projects (publishers, enforcement, blocklist)."
                 .yellow()
         );
-        let policy_path = user_trust_policy_path()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
         eprintln!(
             "  {}",
-            format!("Create a signed policy at {policy_path} to enforce verification.").yellow()
+            format!(
+                "Run 'nono trust init --user' to create one, then 'nono trust sign-policy {user_path}' to sign it."
+            )
+            .yellow()
         );
         return Ok(project_policy);
     }
@@ -1221,7 +1126,22 @@ fn verify_policy_if_exists(policy_path: &Path) -> Result<()> {
     crate::trust_scan::verify_policy_signature(policy_path)
 }
 
-fn user_trust_policy_path() -> Option<PathBuf> {
+pub(crate) fn user_trust_policy_path() -> Option<PathBuf> {
+    if let Some(raw_path) = std::env::var_os(TEST_USER_POLICY_PATH_ENV) {
+        if !raw_path.is_empty() {
+            let path = PathBuf::from(&raw_path);
+            if path.is_absolute() {
+                return Some(path);
+            }
+
+            tracing::warn!(
+                "Ignoring invalid {}='{}' (must be absolute), falling back to user config dir",
+                TEST_USER_POLICY_PATH_ENV,
+                path.display()
+            );
+        }
+    }
+
     crate::profile::resolve_user_config_dir()
         .ok()
         .map(|d| d.join("nono").join("trust-policy.json"))
@@ -1238,8 +1158,15 @@ fn resolve_files(
 ) -> Result<Vec<PathBuf>> {
     if all {
         let policy = load_trust_policy(policy_path)?;
+        if policy.includes.is_empty() {
+            eprintln!(
+                "No files found to sign: trust policy has no 'includes' patterns.\n\
+                 Create a trust policy with: nono trust init --include \"<pattern>\""
+            );
+            return Ok(Vec::new());
+        }
         let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
-        trust::find_instruction_files(&policy, &cwd)
+        trust::find_included_files(&policy, &cwd)
     } else {
         canonicalize_paths(explicit)
     }
@@ -1253,7 +1180,7 @@ fn resolve_files_with_policy(
 ) -> Result<Vec<PathBuf>> {
     if all {
         let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
-        trust::find_instruction_files(policy, &cwd)
+        trust::find_included_files(policy, &cwd)
     } else {
         canonicalize_paths(explicit)
     }
@@ -1349,6 +1276,23 @@ mod tests {
         // Just verify it returns Some on a normal system
         let path = user_trust_policy_path();
         assert!(path.is_some());
+    }
+
+    #[test]
+    fn user_trust_policy_path_prefers_test_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("trust-policy.json");
+        let original = std::env::var(TEST_USER_POLICY_PATH_ENV).ok();
+
+        std::env::set_var(TEST_USER_POLICY_PATH_ENV, &override_path);
+        let resolved = user_trust_policy_path();
+
+        match original {
+            Some(value) => std::env::set_var(TEST_USER_POLICY_PATH_ENV, value),
+            None => std::env::remove_var(TEST_USER_POLICY_PATH_ENV),
+        }
+
+        assert_eq!(resolved, Some(override_path));
     }
 
     #[test]

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -3,8 +3,8 @@
 //! Implements `nono trust sign|verify|list|keygen` subcommands.
 
 use crate::cli::{
-    TrustArgs, TrustCommands, TrustExportKeyArgs, TrustKeygenArgs, TrustListArgs, TrustSignArgs,
-    TrustSignPolicyArgs, TrustVerifyArgs,
+    TrustArgs, TrustCommands, TrustExportKeyArgs, TrustInitArgs, TrustKeygenArgs, TrustListArgs,
+    TrustSignArgs, TrustSignPolicyArgs, TrustVerifyArgs,
 };
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
@@ -23,6 +23,7 @@ const TRUST_PUB_SERVICE: &str = "nono-trust-pub";
 /// Run a trust subcommand.
 pub fn run_trust(args: TrustArgs) -> Result<()> {
     match args.command {
+        TrustCommands::Init(init_args) => run_init(init_args),
         TrustCommands::Sign(sign_args) => run_sign(sign_args),
         TrustCommands::SignPolicy(sign_policy_args) => run_sign_policy(sign_policy_args),
         TrustCommands::Verify(verify_args) => run_verify(verify_args),
@@ -30,6 +31,205 @@ pub fn run_trust(args: TrustArgs) -> Result<()> {
         TrustCommands::Keygen(keygen_args) => run_keygen(keygen_args),
         TrustCommands::ExportKey(export_args) => run_export_key(export_args),
     }
+}
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+/// Directories to always skip when scanning for file patterns, even if not
+/// covered by `.gitignore`. These are common build artifacts, caches, and
+/// tool directories that are never interesting as trust policy targets.
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".env",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".cache",
+    ".turbo",
+    "vendor",
+    ".terraform",
+    ".bundle",
+    "coverage",
+    ".idea",
+    ".vscode",
+];
+
+fn run_init(args: TrustInitArgs) -> Result<()> {
+    let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
+    let policy_path = cwd.join("trust-policy.json");
+
+    if policy_path.exists() && !args.force {
+        return Err(nono::NonoError::TrustPolicy(
+            "trust-policy.json already exists (use --force to overwrite)".to_string(),
+        ));
+    }
+
+    let patterns = collect_file_patterns(&cwd, args.recursive, &args.exclude_dirs)?;
+
+    if patterns.is_empty() {
+        eprintln!(
+            "  {} no files found in {}",
+            "Warning:".yellow(),
+            cwd.display()
+        );
+        eprintln!(
+            "  {}",
+            "Add patterns manually to trust-policy.json after creation.".yellow()
+        );
+    }
+
+    // Try to include the public key if a signing key exists
+    let key_id = args.key.as_deref().unwrap_or("default");
+    let publisher = match load_public_key_bytes(key_id) {
+        Ok(pub_bytes) => {
+            let b64 = base64_encode(&pub_bytes);
+            Some(serde_json::json!({
+                "name": key_id,
+                "key_id": key_id,
+                "public_key": b64
+            }))
+        }
+        Err(_) => {
+            eprintln!(
+                "  {} signing key '{}' not found in keystore, skipping publisher entry.",
+                "Note:".cyan(),
+                key_id
+            );
+            eprintln!(
+                "  {}",
+                "Run 'nono trust keygen' to generate a key, then re-run 'nono trust init'.".cyan()
+            );
+            None
+        }
+    };
+
+    let publishers = match publisher {
+        Some(p) => vec![p],
+        None => Vec::new(),
+    };
+
+    let policy = serde_json::json!({
+        "version": 1,
+        "instruction_patterns": patterns,
+        "publishers": publishers,
+        "blocklist": {
+            "digests": [],
+            "publishers": []
+        },
+        "enforcement": "deny"
+    });
+
+    let json = serde_json::to_string_pretty(&policy).map_err(|e| {
+        nono::NonoError::TrustPolicy(format!("failed to serialize trust policy: {e}"))
+    })?;
+
+    std::fs::write(&policy_path, format!("{json}\n")).map_err(nono::NonoError::Io)?;
+
+    eprintln!("  {} {}", "Created".green(), policy_path.display());
+
+    if !patterns.is_empty() {
+        eprintln!("  Patterns ({}):", patterns.len());
+        for p in &patterns {
+            eprintln!("    {p}");
+        }
+    }
+
+    if publishers.is_empty() {
+        eprintln!("\n  {}", "Next steps:".bold());
+        eprintln!("  1. nono trust keygen");
+        eprintln!("  2. nono trust init --force");
+        eprintln!("  3. nono trust sign --all");
+        eprintln!("  4. nono trust sign-policy");
+    } else {
+        eprintln!("\n  {}", "Next steps:".bold());
+        eprintln!("  1. Review the patterns in trust-policy.json");
+        eprintln!("  2. nono trust sign --all");
+        eprintln!("  3. nono trust sign-policy");
+    }
+
+    Ok(())
+}
+
+/// Walk the directory using the `ignore` crate (respects `.gitignore`),
+/// skip built-in noise directories and user-specified `--exclude-dirs`,
+/// and collect relative file paths as patterns.
+fn collect_file_patterns(
+    root: &Path,
+    recursive: bool,
+    extra_exclude: &[String],
+) -> Result<Vec<String>> {
+    use ignore::WalkBuilder;
+
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .hidden(true) // skip hidden files/dirs
+        .git_ignore(true) // respect .gitignore
+        .git_global(true) // respect global gitignore
+        .git_exclude(true); // respect .git/info/exclude
+
+    if !recursive {
+        builder.max_depth(Some(1));
+    }
+
+    // Combine built-in skip dirs with user-specified ones (owned for 'static closure)
+    let all_skip: std::collections::HashSet<String> = SKIP_DIRS
+        .iter()
+        .map(|s| (*s).to_string())
+        .chain(extra_exclude.iter().cloned())
+        .collect();
+
+    builder.filter_entry(move |entry| {
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            let name = entry.file_name().to_string_lossy();
+            return !all_skip.contains(name.as_ref() as &str);
+        }
+        true
+    });
+
+    let mut patterns = std::collections::BTreeSet::new();
+
+    for result in builder.build() {
+        let entry = result
+            .map_err(|e| nono::NonoError::TrustPolicy(format!("failed to walk directory: {e}")))?;
+
+        // Skip directories and the root itself
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            continue;
+        }
+
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy();
+
+        // Skip bundle files, lockfiles, and the policy file itself
+        if name.ends_with(".bundle")
+            || name.ends_with(".lock")
+            || name.ends_with(".sum")
+            || name == "trust-policy.json"
+        {
+            continue;
+        }
+
+        if let Ok(rel) = path.strip_prefix(root) {
+            patterns.insert(rel.to_string_lossy().to_string());
+        }
+    }
+
+    Ok(patterns.into_iter().collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -482,6 +682,9 @@ fn run_sign_policy(args: TrustSignPolicyArgs) -> Result<()> {
             default_path
         }
     };
+
+    // Validate the policy file is well-formed before signing.
+    trust::load_policy_from_file(&policy_path)?;
 
     let bundle_json = trust::sign_policy_file(&policy_path, &key_pair, key_id)?;
     trust::write_bundle(&policy_path, &bundle_json)?;
@@ -1009,7 +1212,9 @@ fn verify_policy_if_exists(policy_path: &Path) -> Result<()> {
 }
 
 fn user_trust_policy_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("nono").join("trust-policy.json"))
+    crate::profile::resolve_user_config_dir()
+        .ok()
+        .map(|d| d.join("nono").join("trust-policy.json"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1139,8 +1344,13 @@ mod tests {
     #[test]
     fn load_trust_policy_returns_default_when_no_file() {
         // CWD mutation with catch_unwind to guarantee cleanup even on panic.
+        // Isolate from real user config dir to avoid picking up invalid files.
         let dir = tempfile::tempdir().unwrap();
         let original = std::env::current_dir().unwrap();
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let xdg_dir = dir.path().join("xdg");
+        std::fs::create_dir_all(&xdg_dir).unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_dir);
 
         let result = std::panic::catch_unwind(|| {
             std::env::set_current_dir(dir.path()).unwrap();
@@ -1149,6 +1359,10 @@ mod tests {
         });
 
         std::env::set_current_dir(original).unwrap();
+        match orig_xdg {
+            Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
         result.unwrap();
     }
 }

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -733,6 +733,13 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
         }
     }
 
+    // Run the same missing-literal check that nono run uses, so
+    // `trust verify --all` surfaces the same errors as startup.
+    if args.all {
+        let cwd_for_check = std::env::current_dir().map_err(nono::NonoError::Io)?;
+        crate::trust_scan::check_missing_literals(&policy, &cwd_for_check, &files, false)?;
+    }
+
     if files.is_empty() && multi_bundles.is_empty() {
         eprintln!("No instruction files or multi-subject bundles found to verify.");
         return Ok(());
@@ -1007,6 +1014,9 @@ fn run_list(args: TrustListArgs) -> Result<()> {
 
     let cwd = std::env::current_dir().map_err(nono::NonoError::Io)?;
     let files = trust::find_instruction_files(&policy, &cwd)?;
+
+    // Surface missing-literal warnings so `trust list` matches `nono run`.
+    crate::trust_scan::check_missing_literals(&policy, &cwd, &files, false)?;
 
     if files.is_empty() {
         eprintln!("No instruction files found in current directory.");

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -22,6 +22,7 @@ const TRUST_SERVICE: &str = "nono-trust";
 const TRUST_PUB_SERVICE: &str = "nono-trust-pub";
 
 /// Test-only override for the user trust policy path.
+#[cfg(feature = "test-trust-overrides")]
 pub(crate) const TEST_USER_POLICY_PATH_ENV: &str = "NONO_TRUST_TEST_USER_POLICY_PATH";
 
 /// Run a trust subcommand.
@@ -1127,18 +1128,21 @@ fn verify_policy_if_exists(policy_path: &Path) -> Result<()> {
 }
 
 pub(crate) fn user_trust_policy_path() -> Option<PathBuf> {
-    if let Some(raw_path) = std::env::var_os(TEST_USER_POLICY_PATH_ENV) {
-        if !raw_path.is_empty() {
-            let path = PathBuf::from(&raw_path);
-            if path.is_absolute() {
-                return Some(path);
-            }
+    #[cfg(feature = "test-trust-overrides")]
+    {
+        if let Some(raw_path) = std::env::var_os(TEST_USER_POLICY_PATH_ENV) {
+            if !raw_path.is_empty() {
+                let path = PathBuf::from(&raw_path);
+                if path.is_absolute() {
+                    return Some(path);
+                }
 
-            tracing::warn!(
-                "Ignoring invalid {}='{}' (must be absolute), falling back to user config dir",
-                TEST_USER_POLICY_PATH_ENV,
-                path.display()
-            );
+                tracing::warn!(
+                    "Ignoring invalid {}='{}' (must be absolute), falling back to user config dir",
+                    TEST_USER_POLICY_PATH_ENV,
+                    path.display()
+                );
+            }
         }
     }
 
@@ -1278,6 +1282,7 @@ mod tests {
         assert!(path.is_some());
     }
 
+    #[cfg(feature = "test-trust-overrides")]
     #[test]
     fn user_trust_policy_path_prefers_test_override() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -177,7 +177,7 @@ fn collect_file_patterns(
 
     let mut builder = WalkBuilder::new(root);
     builder
-        .hidden(true) // skip hidden files/dirs
+        .hidden(false) // don't skip hidden — .claude/, .github/ contain important files
         .git_ignore(true) // respect .gitignore
         .git_global(true) // respect global gitignore
         .git_exclude(true); // respect .git/info/exclude

--- a/crates/nono-cli/src/trust_intercept.rs
+++ b/crates/nono-cli/src/trust_intercept.rs
@@ -52,8 +52,8 @@ pub struct TrustVerified {
 pub struct TrustInterceptor {
     /// Trust policy for evaluation
     policy: TrustPolicy,
-    /// Compiled instruction file pattern matcher
-    matcher: trust::InstructionPatterns,
+    /// Compiled include pattern matcher
+    matcher: trust::IncludePatterns,
     /// Verification result cache keyed by canonical path
     cache: HashMap<PathBuf, CacheEntry>,
     /// Project root for computing relative paths in pattern matching
@@ -64,13 +64,13 @@ impl TrustInterceptor {
     /// Create a new trust interceptor from a trust policy and project root.
     ///
     /// The `project_root` is used to compute relative paths from absolute paths
-    /// for instruction file pattern matching (e.g., `.claude/**/*.md`).
+    /// for include pattern matching (e.g., `.claude/**/*.md`).
     ///
     /// # Errors
     ///
-    /// Returns an error if the instruction patterns cannot be compiled.
+    /// Returns an error if the include patterns cannot be compiled.
     pub fn new(policy: TrustPolicy, project_root: PathBuf) -> nono::Result<Self> {
-        let matcher = policy.instruction_matcher()?;
+        let matcher = policy.include_matcher()?;
         Ok(Self {
             policy,
             matcher,
@@ -434,7 +434,7 @@ mod tests {
         std::fs::write(&skills, "# Skills").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             ..TrustPolicy::default()
         };
         let mut interceptor = TrustInterceptor::new(policy, dir.path().to_path_buf()).unwrap();
@@ -451,7 +451,7 @@ mod tests {
         std::fs::write(&skills, "# Skills").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -472,7 +472,7 @@ mod tests {
         std::fs::write(&skills, "# Skills v1").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -500,7 +500,7 @@ mod tests {
         let digest = trust::bytes_digest(content);
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: trust::Enforcement::Audit,
             blocklist: trust::Blocklist {
                 digests: vec![trust::BlocklistEntry {

--- a/crates/nono-cli/src/trust_keystore.rs
+++ b/crates/nono-cli/src/trust_keystore.rs
@@ -1,0 +1,222 @@
+//! Trust signing key storage backends.
+//!
+//! Trust commands use the OS keyring by default. Integration tests can opt
+//! into a file-backed store by setting `NONO_TRUST_TEST_KEYSTORE_DIR`, which
+//! avoids interactive keychain prompts on local machines and in CI.
+
+use nono::{NonoError, Result};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// Test-only override for trust key storage.
+pub(crate) const TEST_KEYSTORE_DIR_ENV: &str = "NONO_TRUST_TEST_KEYSTORE_DIR";
+
+enum TrustKeyStore {
+    System,
+    File(PathBuf),
+}
+
+impl TrustKeyStore {
+    fn selected() -> Self {
+        match std::env::var_os(TEST_KEYSTORE_DIR_ENV) {
+            Some(dir) if !dir.is_empty() => Self::File(PathBuf::from(dir)),
+            _ => Self::System,
+        }
+    }
+
+    fn description(&self, service: &str) -> String {
+        match self {
+            Self::System => format!("system keystore (service: {service})"),
+            Self::File(root) => format!("test keystore directory ({})", root.display()),
+        }
+    }
+
+    fn contains(&self, service: &str, account: &str) -> Result<bool> {
+        match self {
+            Self::System => {
+                let entry = keyring::Entry::new(service, account).map_err(|e| {
+                    NonoError::KeystoreAccess(format!("failed to access keystore: {e}"))
+                })?;
+                match entry.get_password() {
+                    Ok(_) => Ok(true),
+                    Err(keyring::Error::NoEntry) => Ok(false),
+                    Err(other) => Err(NonoError::KeystoreAccess(format!(
+                        "failed to access key '{account}': {other}"
+                    ))),
+                }
+            }
+            Self::File(root) => Ok(file_path(root, service, account).exists()),
+        }
+    }
+
+    fn load(&self, service: &str, account: &str) -> Result<String> {
+        match self {
+            Self::System => {
+                let entry = keyring::Entry::new(service, account).map_err(|e| {
+                    NonoError::KeystoreAccess(format!("failed to access keystore: {e}"))
+                })?;
+                entry.get_password().map_err(|e| match e {
+                    keyring::Error::NoEntry => {
+                        NonoError::SecretNotFound(format!("key '{account}' not found in keystore"))
+                    }
+                    other => NonoError::KeystoreAccess(format!(
+                        "failed to load key '{account}': {other}"
+                    )),
+                })
+            }
+            Self::File(root) => {
+                let path = file_path(root, service, account);
+                std::fs::read_to_string(&path).map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        NonoError::SecretNotFound(format!(
+                            "key '{account}' not found in test keystore"
+                        ))
+                    } else {
+                        NonoError::KeystoreAccess(format!(
+                            "failed to load key '{account}' from {}: {e}",
+                            path.display()
+                        ))
+                    }
+                })
+            }
+        }
+    }
+
+    fn store(&self, service: &str, account: &str, secret: &str) -> Result<()> {
+        match self {
+            Self::System => {
+                let entry = keyring::Entry::new(service, account).map_err(|e| {
+                    NonoError::KeystoreAccess(format!("failed to access keystore: {e}"))
+                })?;
+                entry
+                    .set_password(secret)
+                    .map_err(|e| NonoError::KeystoreAccess(format!("failed to store key: {e}")))
+            }
+            Self::File(root) => {
+                let path = file_path(root, service, account);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        NonoError::KeystoreAccess(format!(
+                            "failed to create test keystore directory {}: {e}",
+                            parent.display()
+                        ))
+                    })?;
+                }
+
+                std::fs::write(&path, secret).map_err(|e| {
+                    NonoError::KeystoreAccess(format!(
+                        "failed to store key '{account}' at {}: {e}",
+                        path.display()
+                    ))
+                })?;
+
+                #[cfg(unix)]
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(
+                    |e| {
+                        NonoError::KeystoreAccess(format!(
+                            "failed to secure test keystore file {}: {e}",
+                            path.display()
+                        ))
+                    },
+                )?;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+fn file_path(root: &Path, service: &str, account: &str) -> PathBuf {
+    root.join(hex_component(service))
+        .join(hex_component(account))
+}
+
+fn hex_component(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len().saturating_mul(2));
+    for byte in value.as_bytes() {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    encoded
+}
+
+pub(crate) fn backend_description(service: &str) -> String {
+    TrustKeyStore::selected().description(service)
+}
+
+pub(crate) fn contains_secret(service: &str, account: &str) -> Result<bool> {
+    TrustKeyStore::selected().contains(service, account)
+}
+
+pub(crate) fn load_secret(service: &str, account: &str) -> Result<String> {
+    TrustKeyStore::selected().load(service, account)
+}
+
+pub(crate) fn store_secret(service: &str, account: &str, secret: &str) -> Result<()> {
+    TrustKeyStore::selected().store(service, account, secret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_backend_roundtrips_secret() {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => panic!("failed to create tempdir: {e}"),
+        };
+        let store = TrustKeyStore::File(dir.path().to_path_buf());
+
+        assert!(!store.contains("service", "account").unwrap_or(true));
+        assert!(store.store("service", "account", "secret-value").is_ok());
+        assert!(store.contains("service", "account").unwrap_or(false));
+
+        let loaded = match store.load("service", "account") {
+            Ok(loaded) => loaded,
+            Err(e) => panic!("failed to load test secret: {e}"),
+        };
+        assert_eq!(loaded, "secret-value");
+    }
+
+    #[test]
+    fn file_backend_missing_secret_is_not_found() {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => panic!("failed to create tempdir: {e}"),
+        };
+        let store = TrustKeyStore::File(dir.path().to_path_buf());
+
+        match store.load("service", "missing") {
+            Err(NonoError::SecretNotFound(msg)) => {
+                assert!(msg.contains("missing"));
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+            Ok(_) => panic!("expected missing secret to fail"),
+        }
+    }
+
+    #[test]
+    fn file_backend_separates_service_namespaces() {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => panic!("failed to create tempdir: {e}"),
+        };
+        let store = TrustKeyStore::File(dir.path().to_path_buf());
+
+        assert!(store.store("service-a", "account", "secret-a").is_ok());
+        assert!(store.store("service-b", "account", "secret-b").is_ok());
+
+        let a = match store.load("service-a", "account") {
+            Ok(value) => value,
+            Err(e) => panic!("failed to load service-a secret: {e}"),
+        };
+        let b = match store.load("service-b", "account") {
+            Ok(value) => value,
+            Err(e) => panic!("failed to load service-b secret: {e}"),
+        };
+
+        assert_eq!(a, "secret-a");
+        assert_eq!(b, "secret-b");
+    }
+}

--- a/crates/nono-cli/src/trust_keystore.rs
+++ b/crates/nono-cli/src/trust_keystore.rs
@@ -7,27 +7,37 @@
 use nono::{NonoError, Result};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(feature = "test-trust-overrides")]
 use std::path::{Path, PathBuf};
 
 /// Test-only override for trust key storage.
+#[cfg(feature = "test-trust-overrides")]
 pub(crate) const TEST_KEYSTORE_DIR_ENV: &str = "NONO_TRUST_TEST_KEYSTORE_DIR";
 
 enum TrustKeyStore {
     System,
+    #[cfg(feature = "test-trust-overrides")]
     File(PathBuf),
 }
 
 impl TrustKeyStore {
     fn selected() -> Self {
+        #[cfg(feature = "test-trust-overrides")]
         match std::env::var_os(TEST_KEYSTORE_DIR_ENV) {
             Some(dir) if !dir.is_empty() => Self::File(PathBuf::from(dir)),
             _ => Self::System,
+        }
+
+        #[cfg(not(feature = "test-trust-overrides"))]
+        {
+            Self::System
         }
     }
 
     fn description(&self, service: &str) -> String {
         match self {
             Self::System => format!("system keystore (service: {service})"),
+            #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => format!("test keystore directory ({})", root.display()),
         }
     }
@@ -46,6 +56,7 @@ impl TrustKeyStore {
                     ))),
                 }
             }
+            #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => Ok(file_path(root, service, account).exists()),
         }
     }
@@ -65,6 +76,7 @@ impl TrustKeyStore {
                     )),
                 })
             }
+            #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => {
                 let path = file_path(root, service, account);
                 std::fs::read_to_string(&path).map_err(|e| {
@@ -93,6 +105,7 @@ impl TrustKeyStore {
                     .set_password(secret)
                     .map_err(|e| NonoError::KeystoreAccess(format!("failed to store key: {e}")))
             }
+            #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => {
                 let path = file_path(root, service, account);
                 if let Some(parent) = path.parent() {
@@ -127,11 +140,13 @@ impl TrustKeyStore {
     }
 }
 
+#[cfg(feature = "test-trust-overrides")]
 fn file_path(root: &Path, service: &str, account: &str) -> PathBuf {
     root.join(hex_component(service))
         .join(hex_component(account))
 }
 
+#[cfg(feature = "test-trust-overrides")]
 fn hex_component(value: &str) -> String {
     let mut encoded = String::with_capacity(value.len().saturating_mul(2));
     for byte in value.as_bytes() {
@@ -156,7 +171,7 @@ pub(crate) fn store_secret(service: &str, account: &str, secret: &str) -> Result
     TrustKeyStore::selected().store(service, account, secret)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-trust-overrides"))]
 mod tests {
     use super::*;
 

--- a/crates/nono-cli/src/trust_keystore.rs
+++ b/crates/nono-cli/src/trust_keystore.rs
@@ -5,7 +5,7 @@
 //! avoids interactive keychain prompts on local machines and in CI.
 
 use nono::{NonoError, Result};
-#[cfg(unix)]
+#[cfg(all(unix, feature = "test-trust-overrides"))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(feature = "test-trust-overrides")]
 use std::path::{Path, PathBuf};

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -39,9 +39,7 @@ pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy
         None
     };
 
-    let user_path = crate::profile::resolve_user_config_dir()
-        .ok()
-        .map(|d| d.join("nono").join("trust-policy.json"));
+    let user_path = crate::trust_cmd::user_trust_policy_path();
 
     let user = if let Some(ref path) = user_path {
         if path.exists() {
@@ -270,7 +268,7 @@ pub fn run_pre_exec_scan(
     policy: &TrustPolicy,
     silent: bool,
 ) -> Result<ScanResult> {
-    let files = trust::find_instruction_files(policy, scan_root)?;
+    let files = trust::find_included_files(policy, scan_root)?;
     let multi_bundle = trust::multi_subject_bundle_path(scan_root);
     let has_multi_bundle = multi_bundle.exists();
 
@@ -398,7 +396,7 @@ fn check_missing_literal_patterns(
 
     let mut missing = Vec::new();
 
-    for pattern in &policy.instruction_patterns {
+    for pattern in &policy.includes {
         if is_glob_pattern(pattern) {
             continue;
         }
@@ -423,7 +421,7 @@ fn check_missing_literal_patterns(
                 "literal pattern(s) in trust policy have no matching file. \
                  On macOS, missing files could be created mid-session with untrusted content \
                  (no runtime interception). \
-                 Remove the pattern from instruction_patterns or create and sign the file(s): {}",
+                 Remove the pattern from includes or create and sign the file(s): {}",
                 missing.join(", ")
             ),
         }),
@@ -919,7 +917,7 @@ mod tests {
         std::fs::write(dir.path().join("SKILLS.md"), "# Skills").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -936,7 +934,7 @@ mod tests {
         std::fs::write(dir.path().join("CLAUDE.md"), "# Claude").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["CLAUDE.md".to_string()],
+            includes: vec!["CLAUDE.md".to_string()],
             enforcement: Enforcement::Deny,
             ..TrustPolicy::default()
         };
@@ -955,7 +953,7 @@ mod tests {
         let digest = trust::bytes_digest(content);
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: Enforcement::Audit, // Even audit blocks blocklisted files
             blocklist: trust::Blocklist {
                 digests: vec![trust::BlocklistEntry {
@@ -980,7 +978,7 @@ mod tests {
         std::fs::write(dir.path().join("CLAUDE.md"), "# Claude").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string(), "CLAUDE.md".to_string()],
+            includes: vec!["SKILLS.md".to_string(), "CLAUDE.md".to_string()],
             enforcement: Enforcement::Audit,
             ..TrustPolicy::default()
         };
@@ -1055,7 +1053,7 @@ mod tests {
         // Create a policy file with no .bundle — should still load with trust_override=true
         std::fs::write(
             dir.path().join("trust-policy.json"),
-            r#"{"version":1,"instruction_patterns":["SKILLS*","CLAUDE*"],"publishers":[],"blocklist":{"digests":[],"publishers":[]},"enforcement":"warn"}"#,
+            r#"{"version":1,"includes":["SKILLS*","CLAUDE*"],"publishers":[],"blocklist":{"digests":[],"publishers":[]},"enforcement":"warn"}"#,
         )
         .unwrap();
 
@@ -1108,7 +1106,7 @@ mod tests {
         std::fs::write(&bundle_path, &bundle_json).unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: Vec::new(), // no instruction patterns — multi-subject only
+            includes: Vec::new(), // no instruction patterns — multi-subject only
             enforcement: Enforcement::Deny,
             publishers: vec![trust::Publisher {
                 name: "test".to_string(),
@@ -1156,7 +1154,7 @@ mod tests {
         std::fs::write(dir.path().join("b.py"), b"TAMPERED").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: Vec::new(),
+            includes: Vec::new(),
             enforcement: Enforcement::Deny,
             publishers: vec![trust::Publisher {
                 name: "test".to_string(),
@@ -1200,7 +1198,7 @@ mod tests {
         std::fs::write(trust::multi_subject_bundle_path(dir.path()), &bundle_json).unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: Vec::new(),
+            includes: Vec::new(),
             enforcement: Enforcement::Deny,
             publishers: vec![trust::Publisher {
                 name: "test".to_string(),
@@ -1237,7 +1235,7 @@ mod tests {
         std::fs::write(trust::multi_subject_bundle_path(dir.path()), &bundle_json).unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: Vec::new(),
+            includes: Vec::new(),
             enforcement: Enforcement::Deny,
             publishers: vec![trust::Publisher {
                 name: "test".to_string(),
@@ -1279,7 +1277,7 @@ mod tests {
         let other_pub_b64 = nono::trust::base64::base64_encode(other_pub_bytes.as_bytes());
 
         let policy = TrustPolicy {
-            instruction_patterns: Vec::new(),
+            includes: Vec::new(),
             enforcement: Enforcement::Deny,
             publishers: vec![trust::Publisher {
                 name: "other".to_string(),
@@ -1316,7 +1314,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // SKILLS.md is listed in the policy but does not exist on disk
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: Enforcement::Deny,
             ..TrustPolicy::default()
         };
@@ -1332,7 +1330,7 @@ mod tests {
     fn missing_literal_pattern_warns_with_warn_enforcement() {
         let dir = tempfile::tempdir().unwrap();
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: Enforcement::Warn,
             ..TrustPolicy::default()
         };
@@ -1346,7 +1344,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // Glob pattern — absence just means "no current matches"
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS*".to_string()],
+            includes: vec!["SKILLS*".to_string()],
             enforcement: Enforcement::Deny,
             ..TrustPolicy::default()
         };
@@ -1361,7 +1359,7 @@ mod tests {
         std::fs::write(dir.path().join("SKILLS.md"), "# Skills").unwrap();
 
         let policy = TrustPolicy {
-            instruction_patterns: vec!["SKILLS.md".to_string()],
+            includes: vec!["SKILLS.md".to_string()],
             enforcement: Enforcement::Deny,
             ..TrustPolicy::default()
         };

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -233,8 +233,9 @@ impl ScanResult {
 
     /// Collect the absolute paths of all verified instruction files.
     ///
-    /// These paths are used on macOS to inject literal `(allow file-read-data ...)`
-    /// rules that override the deny-regex for instruction file patterns.
+    /// These paths are used to write-protect verified files (literal
+    /// `(deny file-write-data ...)` rules on macOS) and to add read-only
+    /// capabilities so both platforms treat them as immutable.
     #[must_use]
     pub fn verified_paths(&self) -> Vec<PathBuf> {
         self.results

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -39,7 +39,9 @@ pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy
         None
     };
 
-    let user_path = dirs::config_dir().map(|d| d.join("nono").join("trust-policy.json"));
+    let user_path = crate::profile::resolve_user_config_dir()
+        .ok()
+        .map(|d| d.join("nono").join("trust-policy.json"));
 
     let user = if let Some(ref path) = user_path {
         if path.exists() {
@@ -952,6 +954,13 @@ mod tests {
     #[test]
     fn load_scan_policy_with_trust_override_skips_verification() {
         let dir = tempfile::tempdir().unwrap();
+        // Isolate from the real user config dir so a stale trust-policy.json
+        // on the developer's machine doesn't interfere with the test.
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let xdg_dir = dir.path().join("xdg");
+        std::fs::create_dir_all(&xdg_dir).unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_dir);
+
         // Create a policy file with no .bundle — should still load with trust_override=true
         std::fs::write(
             dir.path().join("trust-policy.json"),
@@ -961,6 +970,11 @@ mod tests {
 
         let policy = load_scan_policy(dir.path(), true).unwrap();
         assert_eq!(policy.enforcement, Enforcement::Warn);
+
+        match orig_xdg {
+            Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -1340,10 +1340,20 @@ mod tests {
         };
 
         let result = run_pre_exec_scan(dir.path(), &policy, true);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("SKILLS.md"));
-        assert!(err.contains("no matching file"));
+
+        if cfg!(target_os = "linux") {
+            assert!(result.is_ok());
+            return;
+        }
+
+        match result {
+            Err(err) => {
+                let err = err.to_string();
+                assert!(err.contains("SKILLS.md"));
+                assert!(err.contains("no matching file"));
+            }
+            Ok(_) => panic!("expected missing literal includes to block startup on this platform"),
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -396,8 +396,11 @@ fn check_missing_literal_patterns(
 
     let mut missing = Vec::new();
 
+    let mut has_globs = false;
+
     for pattern in &policy.includes {
         if is_glob_pattern(pattern) {
+            has_globs = true;
             continue;
         }
 
@@ -408,6 +411,23 @@ fn check_missing_literal_patterns(
         if !matched && !expected.exists() {
             missing.push(pattern.clone());
         }
+    }
+
+    if has_globs && policy.enforcement.is_blocking() && !silent {
+        eprintln!(
+            "  {}",
+            "Note: glob patterns in 'includes' only match files present at startup on macOS."
+                .yellow()
+        );
+        eprintln!(
+            "  {}",
+            "Files created mid-session matching these patterns will not be verified.".yellow()
+        );
+        eprintln!(
+            "  {}",
+            "Use literal paths for files that must always be verified, or use Linux for runtime interception."
+                .yellow()
+        );
     }
 
     if missing.is_empty() {

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -215,6 +215,7 @@ pub fn verify_policy_signature(policy_path: &Path) -> Result<()> {
 }
 
 /// Result of a pre-exec trust scan.
+#[derive(Debug)]
 pub struct ScanResult {
     /// Individual file verification results
     pub results: Vec<VerificationResult>,
@@ -272,6 +273,12 @@ pub fn run_pre_exec_scan(
     let files = trust::find_instruction_files(policy, scan_root)?;
     let multi_bundle = trust::multi_subject_bundle_path(scan_root);
     let has_multi_bundle = multi_bundle.exists();
+
+    // Check for literal patterns (no glob characters) that matched zero files.
+    // A missing literal file is a security concern: on macOS, there is no
+    // runtime interception, so the agent could create the file mid-session
+    // with arbitrary content and read it as if it were trusted.
+    check_missing_literal_patterns(policy, scan_root, &files, silent)?;
 
     if files.is_empty() && !has_multi_bundle {
         return Ok(ScanResult {
@@ -360,6 +367,71 @@ pub fn run_pre_exec_scan(
         blocked,
         warned,
     })
+}
+
+/// Returns true if a pattern contains glob metacharacters (`*`, `?`, `[`, `{`).
+fn is_glob_pattern(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
+}
+
+/// Check that every literal (non-glob) pattern in the trust policy has at least
+/// one matching file on disk. A missing literal file is a security issue: on
+/// macOS there is no runtime file-open interception, so the agent could create
+/// the file mid-session with arbitrary content.
+///
+/// With `deny` enforcement, missing literal files abort startup.
+/// With `warn`/`audit` enforcement, a warning is printed.
+fn check_missing_literal_patterns(
+    policy: &TrustPolicy,
+    scan_root: &Path,
+    found_files: &[PathBuf],
+    silent: bool,
+) -> Result<()> {
+    let mut missing = Vec::new();
+
+    for pattern in &policy.instruction_patterns {
+        if is_glob_pattern(pattern) {
+            continue;
+        }
+
+        // Literal pattern — check if the file exists under scan_root
+        let expected = scan_root.join(pattern);
+        let matched = found_files.iter().any(|f| f == &expected);
+
+        if !matched && !expected.exists() {
+            missing.push(pattern.clone());
+        }
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    match policy.enforcement {
+        nono::trust::Enforcement::Deny => {
+            Err(nono::NonoError::TrustVerification {
+                path: missing.join(", "),
+                reason: format!(
+                    "literal pattern(s) in trust policy have no matching file. \
+                     Missing files could be created mid-session with untrusted content. \
+                     Remove the pattern from instruction_patterns or create and sign the file(s): {}",
+                    missing.join(", ")
+                ),
+            })
+        }
+        _ => {
+            if !silent {
+                for m in &missing {
+                    eprintln!(
+                        "  {} pattern '{}' has no matching file",
+                        "Warning:".yellow(),
+                        m
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Verify a single instruction file against the trust policy.
@@ -1218,5 +1290,77 @@ mod tests {
         let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
         assert!(result.should_proceed());
         assert!(result.results.is_empty());
+    }
+
+    #[test]
+    fn missing_literal_pattern_blocks_with_deny_enforcement() {
+        let dir = tempfile::tempdir().unwrap();
+        // SKILLS.md is listed in the policy but does not exist on disk
+        let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
+            enforcement: Enforcement::Deny,
+            ..TrustPolicy::default()
+        };
+
+        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SKILLS.md"));
+        assert!(err.contains("no matching file"));
+    }
+
+    #[test]
+    fn missing_literal_pattern_warns_with_warn_enforcement() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
+            enforcement: Enforcement::Warn,
+            ..TrustPolicy::default()
+        };
+
+        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn glob_pattern_with_no_matches_does_not_block() {
+        let dir = tempfile::tempdir().unwrap();
+        // Glob pattern — absence just means "no current matches"
+        let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS*".to_string()],
+            enforcement: Enforcement::Deny,
+            ..TrustPolicy::default()
+        };
+
+        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn literal_pattern_present_on_disk_does_not_block() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("SKILLS.md"), "# Skills").unwrap();
+
+        let policy = TrustPolicy {
+            instruction_patterns: vec!["SKILLS.md".to_string()],
+            enforcement: Enforcement::Deny,
+            ..TrustPolicy::default()
+        };
+
+        // This will fail at verification (unsigned), not at the missing-file check.
+        // The point is: the literal check itself passes because the file exists.
+        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn is_glob_pattern_classification() {
+        assert!(!is_glob_pattern("SKILLS.md"));
+        assert!(!is_glob_pattern(".claude/commands/deploy.md"));
+        assert!(is_glob_pattern("SKILLS*"));
+        assert!(is_glob_pattern("CLAUDE*.md"));
+        assert!(is_glob_pattern(".claude/**/*.md"));
+        assert!(is_glob_pattern("test[0-9].md"));
+        assert!(is_glob_pattern("{a,b}.md"));
     }
 }

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -375,11 +375,14 @@ fn is_glob_pattern(pattern: &str) -> bool {
 }
 
 /// Check that every literal (non-glob) pattern in the trust policy has at least
-/// one matching file on disk. A missing literal file is a security issue: on
-/// macOS there is no runtime file-open interception, so the agent could create
-/// the file mid-session with arbitrary content.
+/// one matching file on disk.
 ///
-/// With `deny` enforcement, missing literal files abort startup.
+/// This check only applies on macOS, where there is no runtime file-open
+/// interception. On Linux, seccomp-notify traps every `openat()` and verifies
+/// files on first open, so a missing file at startup is safely handled at
+/// runtime.
+///
+/// On macOS with `deny` enforcement, missing literal files abort startup.
 /// With `warn`/`audit` enforcement, a warning is printed.
 fn check_missing_literal_patterns(
     policy: &TrustPolicy,
@@ -387,6 +390,12 @@ fn check_missing_literal_patterns(
     found_files: &[PathBuf],
     silent: bool,
 ) -> Result<()> {
+    // On Linux, seccomp-notify provides runtime interception for files that
+    // appear mid-session, so missing files at startup are not a security issue.
+    if cfg!(target_os = "linux") {
+        return Ok(());
+    }
+
     let mut missing = Vec::new();
 
     for pattern in &policy.instruction_patterns {
@@ -408,17 +417,16 @@ fn check_missing_literal_patterns(
     }
 
     match policy.enforcement {
-        nono::trust::Enforcement::Deny => {
-            Err(nono::NonoError::TrustVerification {
-                path: missing.join(", "),
-                reason: format!(
-                    "literal pattern(s) in trust policy have no matching file. \
-                     Missing files could be created mid-session with untrusted content. \
-                     Remove the pattern from instruction_patterns or create and sign the file(s): {}",
-                    missing.join(", ")
-                ),
-            })
-        }
+        nono::trust::Enforcement::Deny => Err(nono::NonoError::TrustVerification {
+            path: missing.join(", "),
+            reason: format!(
+                "literal pattern(s) in trust policy have no matching file. \
+                 On macOS, missing files could be created mid-session with untrusted content \
+                 (no runtime interception). \
+                 Remove the pattern from instruction_patterns or create and sign the file(s): {}",
+                missing.join(", ")
+            ),
+        }),
         _ => {
             if !silent {
                 for m in &missing {
@@ -432,6 +440,17 @@ fn check_missing_literal_patterns(
             Ok(())
         }
     }
+}
+
+/// Public entry point for missing-literal checks, used by CLI commands
+/// (`trust verify --all`, `trust list`) to match `nono run` enforcement.
+pub fn check_missing_literals(
+    policy: &TrustPolicy,
+    scan_root: &Path,
+    found_files: &[PathBuf],
+    silent: bool,
+) -> Result<()> {
+    check_missing_literal_patterns(policy, scan_root, found_files, silent)
 }
 
 /// Verify a single instruction file against the trust policy.

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -80,6 +80,6 @@ pub use supervisor::{
     ApprovalBackend, ApprovalDecision, CapabilityRequest, SupervisorSocket, UrlOpenRequest,
 };
 pub use trust::{
-    Enforcement, InstructionPatterns, Publisher, SignerIdentity, TrustPolicy, VerificationOutcome,
+    Enforcement, IncludePatterns, Publisher, SignerIdentity, TrustPolicy, VerificationOutcome,
     VerificationResult,
 };

--- a/crates/nono/src/trust/mod.rs
+++ b/crates/nono/src/trust/mod.rs
@@ -1,13 +1,12 @@
-//! Instruction file attestation and integrity verification
+//! File attestation and integrity verification
 //!
 //! This module provides types, digest computation, and trust policy primitives
-//! for verifying the provenance of instruction files (SKILLS.md, CLAUDE.md,
-//! AGENT.MD, etc.) before an AI agent ingests them.
+//! for verifying the provenance and integrity of files before they are consumed.
 //!
 //! # Architecture
 //!
 //! ```text
-//! instruction file --> digest --> blocklist check --> bundle verify --> publisher match --> allow/deny
+//! file --> digest --> blocklist check --> bundle verify --> publisher match --> allow/deny
 //! ```
 //!
 //! The library provides attestation primitives reusable by all language bindings.
@@ -53,8 +52,7 @@ pub use dsse::{
     NONO_POLICY_PREDICATE_TYPE, NONO_PREDICATE_TYPE,
 };
 pub use policy::{
-    evaluate_file, find_instruction_files, load_policy_from_file, load_policy_from_str,
-    merge_policies,
+    evaluate_file, find_included_files, load_policy_from_file, load_policy_from_str, merge_policies,
 };
 pub use signing::{
     export_public_key, generate_signing_key, key_id_hex, sign_bytes, sign_files,
@@ -62,6 +60,6 @@ pub use signing::{
     SigningScheme, MAX_MULTI_SUBJECT_FILES,
 };
 pub use types::{
-    BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, InstructionPatterns, Publisher,
+    BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, IncludePatterns, Publisher,
     SignerIdentity, TrustPolicy, VerificationOutcome, VerificationResult, TRUST_POLICY_VERSION,
 };

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -247,118 +247,50 @@ pub fn find_instruction_files<P: AsRef<Path>>(
     policy: &TrustPolicy,
     root: P,
 ) -> Result<Vec<PathBuf>> {
+    use ignore::WalkBuilder;
+
     let root = root.as_ref();
     let matcher = policy.instruction_matcher()?;
+
+    let walker = WalkBuilder::new(root)
+        .hidden(false) // don't skip hidden — .claude/ contains instruction files
+        .git_ignore(true) // respect .gitignore
+        .git_global(true) // respect global gitignore
+        .git_exclude(true) // respect .git/info/exclude
+        .follow_links(true) // follow symlinks (symlinked SKILLS.md must not be skipped)
+        .max_depth(Some(16)) // guard against very deep trees
+        .build();
+
     let mut results = Vec::new();
-    let mut visited = std::collections::HashSet::new();
 
-    find_files_recursive(root, root, &matcher, &mut results, &mut visited, 0)?;
-
-    results.sort();
-    Ok(results)
-}
-
-/// Well-known directory names that never contain instruction files and are
-/// typically very large. Skipping these prevents multi-second walks through
-/// dependency trees and build artifacts. Sorted for binary search.
-const SKIP_DIRS: &[&str] = &[
-    ".cache",
-    ".gradle",
-    ".mypy_cache",
-    ".next",
-    ".nuxt",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".terraform",
-    ".tox",
-    ".venv",
-    "__pycache__",
-    "build",
-    "dist",
-    "node_modules",
-    "target",
-    "vendor",
-    "venv",
-];
-
-/// Recursively walk a directory, collecting files matching instruction patterns.
-///
-/// Tracks visited directory inodes to prevent symlink cycle DoS, and enforces
-/// a maximum recursion depth of 16 levels. Skips well-known heavy directories
-/// (node_modules, target, etc.) that never contain instruction files.
-fn find_files_recursive(
-    root: &Path,
-    dir: &Path,
-    matcher: &super::types::InstructionPatterns,
-    results: &mut Vec<PathBuf>,
-    visited: &mut std::collections::HashSet<u64>,
-    depth: u32,
-) -> Result<()> {
-    // Guard against deep recursion (legitimate instruction files live near the root)
-    const MAX_DEPTH: u32 = 16;
-    if depth > MAX_DEPTH {
-        return Ok(());
-    }
-
-    let entries = std::fs::read_dir(dir).map_err(NonoError::Io)?;
-
-    for entry in entries {
-        let entry = entry.map_err(NonoError::Io)?;
-        let path = entry.path();
-
-        // Use std::fs::metadata (stat) instead of entry.file_type (lstat)
-        // to follow symlinks. A symlinked SKILLS.md must not be silently skipped.
-        let meta = match std::fs::metadata(&path) {
-            Ok(m) => m,
-            Err(_) => continue, // dangling symlink or permission error
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue, // permission error, dangling symlink, etc.
         };
 
-        if meta.is_dir() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            // Skip hidden directories except .claude
-            if name_str.starts_with('.') && name_str != ".claude" {
-                continue;
-            }
-            // Skip well-known heavy directories that never contain instruction files
-            if SKIP_DIRS.binary_search(&name_str.as_ref()).is_ok() {
-                continue;
-            }
+        // Skip directories and the root itself
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            continue;
+        }
 
-            // Track visited directory inodes to break symlink cycles.
-            // If we have already visited this inode, skip it entirely.
-            #[cfg(unix)]
-            let inode = {
-                use std::os::unix::fs::MetadataExt;
-                meta.ino()
-            };
-            #[cfg(not(unix))]
-            let inode = {
-                // On non-Unix, use depth limit as the sole cycle guard
-                0u64
-            };
+        let path = entry.path();
 
-            if inode != 0 && !visited.insert(inode) {
-                continue;
-            }
+        // Skip Sigstore sidecar bundles
+        if path.to_string_lossy().ends_with(".bundle") {
+            continue;
+        }
 
-            find_files_recursive(root, &path, matcher, results, visited, depth + 1)?;
-        } else if meta.is_file() {
-            // Skip Sigstore sidecar bundles; only source instruction files should be scanned.
-            if path.to_string_lossy().ends_with(".bundle") {
-                continue;
-            }
-
-            // Match against relative path from root
-            if let Ok(relative) = path.strip_prefix(root) {
-                if matcher.is_match(relative) {
-                    results.push(path);
-                }
+        // Match against relative path from root
+        if let Ok(relative) = path.strip_prefix(root) {
+            if matcher.is_match(relative) {
+                results.push(path.to_path_buf());
             }
         }
     }
 
-    Ok(())
+    results.sort();
+    Ok(results)
 }
 
 #[cfg(test)]

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -1,8 +1,8 @@
 //! Trust policy loading, merging, and evaluation
 //!
 //! Provides functions for parsing trust policy JSON, merging multiple policies
-//! from different levels (embedded, user, project), and evaluating instruction
-//! files against the merged policy.
+//! from different levels (embedded, user, project), and evaluating files
+//! against the merged policy.
 //!
 //! # Policy Composition
 //!
@@ -10,7 +10,7 @@
 //! - Publishers: union (all publishers from all levels)
 //! - Blocklist digests: union (all blocked digests from all levels)
 //! - Blocked publishers: union
-//! - Instruction patterns: union (all patterns from all levels)
+//! - Include patterns: union (all patterns from all levels)
 //! - Enforcement: strictest wins (deny > warn > audit)
 //!
 //! Project-level policy cannot weaken user-level or embedded policy.
@@ -52,7 +52,7 @@ pub fn load_policy_from_file<P: AsRef<Path>>(path: P) -> Result<TrustPolicy> {
 ///
 /// Policies are merged in order (first = lowest priority, last = highest).
 /// All merging is additive-only:
-/// - Publishers, blocklist entries, blocked publishers, and instruction
+/// - Publishers, blocklist entries, blocked publishers, and include
 ///   patterns are unioned (deduplicated by identity)
 /// - Enforcement uses the strictest level across all policies
 ///
@@ -85,8 +85,8 @@ pub fn merge_policies(policies: &[TrustPolicy]) -> Result<TrustPolicy> {
     let mut strictest_enforcement = Enforcement::Audit;
 
     for policy in policies {
-        // Merge instruction patterns (deduplicate by pattern string)
-        for pattern in &policy.instruction_patterns {
+        // Merge include patterns (deduplicate by pattern string)
+        for pattern in &policy.includes {
             if seen_patterns.insert(pattern.clone()) {
                 merged_patterns.push(pattern.clone());
             }
@@ -97,8 +97,8 @@ pub fn merge_policies(policies: &[TrustPolicy]) -> Result<TrustPolicy> {
         // so user publishers take priority over project publishers.
         for publisher in &policy.publishers {
             if !seen_publisher_names.insert(publisher.name.clone()) {
-                tracing::warn!(
-                    "trust policy merge: publisher '{}' already defined in a higher-precedence policy, skipping duplicate",
+                tracing::debug!(
+                    "trust policy merge: publisher '{}' appears in multiple policies, using the user-level definition for verification",
                     publisher.name
                 );
             } else {
@@ -126,7 +126,7 @@ pub fn merge_policies(policies: &[TrustPolicy]) -> Result<TrustPolicy> {
 
     Ok(TrustPolicy {
         version: policies.iter().map(|p| p.version).max().unwrap_or(1),
-        instruction_patterns: merged_patterns,
+        includes: merged_patterns,
         publishers: merged_publishers,
         blocklist: Blocklist {
             digests: merged_digest_entries,
@@ -136,7 +136,7 @@ pub fn merge_policies(policies: &[TrustPolicy]) -> Result<TrustPolicy> {
     })
 }
 
-/// Evaluate an instruction file against a trust policy.
+/// Evaluate a file against a trust policy.
 ///
 /// Runs the full verification pipeline:
 /// 1. Blocklist check (fast reject by digest)
@@ -243,14 +243,11 @@ fn is_publisher_blocked(policy: &TrustPolicy, identity: &SignerIdentity) -> bool
 ///
 /// Returns `NonoError::TrustPolicy` if patterns cannot be compiled, or
 /// `NonoError::Io` if directory traversal fails.
-pub fn find_instruction_files<P: AsRef<Path>>(
-    policy: &TrustPolicy,
-    root: P,
-) -> Result<Vec<PathBuf>> {
+pub fn find_included_files<P: AsRef<Path>>(policy: &TrustPolicy, root: P) -> Result<Vec<PathBuf>> {
     use ignore::WalkBuilder;
 
     let root = root.as_ref();
-    let matcher = policy.instruction_matcher()?;
+    let matcher = policy.include_matcher()?;
 
     // Trust file discovery must NOT respect .gitignore. An attacker who adds
     // an instruction file to .gitignore could bypass pre-exec trust enforcement.
@@ -310,7 +307,7 @@ mod tests {
     ) -> TrustPolicy {
         TrustPolicy {
             version: 1,
-            instruction_patterns: vec!["SKILLS*".to_string(), "CLAUDE*".to_string()],
+            includes: vec!["SKILLS*".to_string(), "CLAUDE*".to_string()],
             publishers,
             blocklist: Blocklist {
                 digests: blocklist_digests,
@@ -352,7 +349,7 @@ mod tests {
     fn load_valid_policy() {
         let json = r#"{
             "version": 1,
-            "instruction_patterns": ["SKILLS*"],
+            "includes": ["SKILLS*"],
             "publishers": [],
             "blocklist": { "digests": [] },
             "enforcement": "deny"
@@ -360,14 +357,14 @@ mod tests {
         let policy = load_policy_from_str(json).unwrap();
         assert_eq!(policy.version, 1);
         assert_eq!(policy.enforcement, Enforcement::Deny);
-        assert_eq!(policy.instruction_patterns.len(), 1);
+        assert_eq!(policy.includes.len(), 1);
     }
 
     #[test]
     fn load_policy_with_publishers() {
         let json = r#"{
             "version": 1,
-            "instruction_patterns": ["SKILLS*"],
+            "includes": ["SKILLS*"],
             "publishers": [
                 {
                     "name": "local",
@@ -420,7 +417,7 @@ mod tests {
                 f,
                 r#"{{
                     "version": 1,
-                    "instruction_patterns": ["AGENT.MD"],
+                    "includes": ["AGENT.MD"],
                     "publishers": [],
                     "blocklist": {{ "digests": [] }},
                     "enforcement": "audit"
@@ -526,13 +523,13 @@ mod tests {
     }
 
     #[test]
-    fn merge_unions_instruction_patterns() {
+    fn merge_unions_includes() {
         let mut p1 = make_policy(Enforcement::Audit, vec![], vec![]);
-        p1.instruction_patterns = vec!["SKILLS*".to_string()];
+        p1.includes = vec!["SKILLS*".to_string()];
         let mut p2 = make_policy(Enforcement::Audit, vec![], vec![]);
-        p2.instruction_patterns = vec!["AGENT.MD".to_string()];
+        p2.includes = vec!["AGENT.MD".to_string()];
         let merged = merge_policies(&[p1, p2]).unwrap();
-        assert_eq!(merged.instruction_patterns.len(), 2);
+        assert_eq!(merged.includes.len(), 2);
     }
 
     #[test]
@@ -541,7 +538,7 @@ mod tests {
         let p2 = make_policy(Enforcement::Audit, vec![], vec![]);
         // Both have "SKILLS*" and "CLAUDE*"
         let merged = merge_policies(&[p1, p2]).unwrap();
-        assert_eq!(merged.instruction_patterns.len(), 2);
+        assert_eq!(merged.includes.len(), 2);
     }
 
     #[test]
@@ -782,11 +779,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // find_instruction_files
+    // find_included_files
     // -----------------------------------------------------------------------
 
     #[test]
-    fn find_instruction_files_in_directory() {
+    fn find_included_files_in_directory() {
         let dir = tempfile::tempdir().unwrap();
         // Create matching files
         std::fs::write(dir.path().join("SKILLS.md"), "content").unwrap();
@@ -796,62 +793,60 @@ mod tests {
         std::fs::write(dir.path().join("main.rs"), "content").unwrap();
 
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
         assert_eq!(files.len(), 2);
     }
 
     #[test]
-    fn find_instruction_files_in_claude_subdir() {
+    fn find_included_files_in_claude_subdir() {
         let dir = tempfile::tempdir().unwrap();
         let claude_dir = dir.path().join(".claude").join("commands");
         std::fs::create_dir_all(&claude_dir).unwrap();
         std::fs::write(claude_dir.join("deploy.md"), "content").unwrap();
 
         let mut policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        policy
-            .instruction_patterns
-            .push(".claude/**/*.md".to_string());
+        policy.includes.push(".claude/**/*.md".to_string());
 
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
         assert_eq!(files.len(), 1);
     }
 
     #[test]
-    fn find_instruction_files_skips_hidden_dirs() {
+    fn find_included_files_skips_hidden_dirs() {
         let dir = tempfile::tempdir().unwrap();
         let hidden = dir.path().join(".git");
         std::fs::create_dir_all(&hidden).unwrap();
         std::fs::write(hidden.join("SKILLS.md"), "content").unwrap();
 
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
         assert!(files.is_empty());
     }
 
     #[test]
-    fn find_instruction_files_empty_dir() {
+    fn find_included_files_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
         assert!(files.is_empty());
     }
 
     #[cfg(unix)]
     #[test]
-    fn find_instruction_files_follows_symlinks() {
+    fn find_included_files_follows_symlinks() {
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("real_skills.md");
         std::fs::write(&target, "content").unwrap();
         std::os::unix::fs::symlink(&target, dir.path().join("SKILLS.md")).unwrap();
 
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("SKILLS.md"));
     }
 
     #[test]
-    fn find_instruction_files_skips_bundle_sidecars() {
+    fn find_included_files_skips_bundle_sidecars() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("SKILLS.md"), "content").unwrap();
         std::fs::write(dir.path().join("SKILLS.md.bundle"), "{}").unwrap();
@@ -859,7 +854,7 @@ mod tests {
         std::fs::write(dir.path().join("CLAUDE.md.bundle"), "{}").unwrap();
 
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
-        let files = find_instruction_files(&policy, dir.path()).unwrap();
+        let files = find_included_files(&policy, dir.path()).unwrap();
 
         assert_eq!(files.len(), 2);
         assert!(files

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -252,11 +252,15 @@ pub fn find_instruction_files<P: AsRef<Path>>(
     let root = root.as_ref();
     let matcher = policy.instruction_matcher()?;
 
+    // Trust file discovery must NOT respect .gitignore. An attacker who adds
+    // an instruction file to .gitignore could bypass pre-exec trust enforcement.
+    // We use WalkBuilder only for its built-in directory filtering (.git/, etc.)
+    // and symlink cycle detection, not for gitignore integration.
     let walker = WalkBuilder::new(root)
         .hidden(false) // don't skip hidden — .claude/ contains instruction files
-        .git_ignore(true) // respect .gitignore
-        .git_global(true) // respect global gitignore
-        .git_exclude(true) // respect .git/info/exclude
+        .git_ignore(false) // DO NOT respect .gitignore — security boundary
+        .git_global(false) // DO NOT respect global gitignore
+        .git_exclude(false) // DO NOT respect .git/info/exclude
         .follow_links(true) // follow symlinks (symlinked SKILLS.md must not be skipped)
         .max_depth(Some(16)) // guard against very deep trees
         .build();

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -1,4 +1,4 @@
-//! Core types for instruction file attestation
+//! Core types for file attestation
 //!
 //! Defines the trust policy structure, publisher identities, blocklist entries,
 //! and verification results used throughout the attestation pipeline.
@@ -11,7 +11,7 @@ use std::path::Path;
 /// Current supported trust policy format version.
 pub const TRUST_POLICY_VERSION: u32 = 1;
 
-/// Trust policy for instruction file verification.
+/// Trust policy for file verification.
 ///
 /// Loaded from `trust-policy.json` files at embedded, user, and project levels.
 /// Multiple policies are merged: publishers and blocklist entries are unioned,
@@ -20,8 +20,9 @@ pub const TRUST_POLICY_VERSION: u32 = 1;
 pub struct TrustPolicy {
     /// Policy format version
     pub version: u32,
-    /// Glob patterns identifying instruction files
-    pub instruction_patterns: Vec<String>,
+    /// Glob patterns identifying files under attestation
+    #[serde(alias = "instruction_patterns")]
+    pub includes: Vec<String>,
     /// Trusted publisher identities
     pub publishers: Vec<Publisher>,
     /// Known-malicious file digests
@@ -34,7 +35,7 @@ impl Default for TrustPolicy {
     fn default() -> Self {
         Self {
             version: 1,
-            instruction_patterns: Vec::new(),
+            includes: Vec::new(),
             publishers: Vec::new(),
             blocklist: Blocklist::default(),
             enforcement: Enforcement::default(),
@@ -45,8 +46,8 @@ impl Default for TrustPolicy {
 impl TrustPolicy {
     /// Maximum number of blocklist entries to prevent resource exhaustion.
     const MAX_BLOCKLIST_ENTRIES: usize = 10_000;
-    /// Maximum number of instruction patterns to prevent regex compilation exhaustion.
-    const MAX_INSTRUCTION_PATTERNS: usize = 100;
+    /// Maximum number of include patterns to prevent regex compilation exhaustion.
+    const MAX_INCLUDES: usize = 100;
     /// Maximum number of publishers.
     const MAX_PUBLISHERS: usize = 1_000;
 
@@ -70,11 +71,11 @@ impl TrustPolicy {
                 Self::MAX_BLOCKLIST_ENTRIES
             )));
         }
-        if self.instruction_patterns.len() > Self::MAX_INSTRUCTION_PATTERNS {
+        if self.includes.len() > Self::MAX_INCLUDES {
             return Err(NonoError::TrustPolicy(format!(
-                "instruction_patterns has {} entries (max {})",
-                self.instruction_patterns.len(),
-                Self::MAX_INSTRUCTION_PATTERNS
+                "includes has {} entries (max {})",
+                self.includes.len(),
+                Self::MAX_INCLUDES
             )));
         }
         if self.publishers.len() > Self::MAX_PUBLISHERS {
@@ -87,13 +88,13 @@ impl TrustPolicy {
         Ok(())
     }
 
-    /// Build an [`InstructionPatterns`] matcher from this policy's patterns.
+    /// Build an [`IncludePatterns`] matcher from this policy's `includes` patterns.
     ///
     /// # Errors
     ///
     /// Returns `NonoError::TrustPolicy` if any glob pattern is invalid.
-    pub fn instruction_matcher(&self) -> Result<InstructionPatterns> {
-        InstructionPatterns::new(&self.instruction_patterns)
+    pub fn include_matcher(&self) -> Result<IncludePatterns> {
+        IncludePatterns::new(&self.includes)
     }
 
     /// Check if a file digest is on the blocklist.
@@ -338,16 +339,16 @@ impl Enforcement {
     }
 }
 
-/// Compiled glob matcher for instruction file patterns.
+/// Compiled glob matcher for trust policy include patterns.
 ///
-/// Wraps a [`GlobSet`] built from the trust policy's `instruction_patterns`.
+/// Wraps a [`GlobSet`] built from the trust policy's `includes` field.
 #[derive(Debug, Clone)]
-pub struct InstructionPatterns {
+pub struct IncludePatterns {
     glob_set: GlobSet,
     patterns: Vec<String>,
 }
 
-impl InstructionPatterns {
+impl IncludePatterns {
     /// Compile a set of glob patterns into a matcher.
     ///
     /// # Errors
@@ -357,12 +358,12 @@ impl InstructionPatterns {
         let mut builder = GlobSetBuilder::new();
         for pattern in patterns {
             let glob = Glob::new(pattern).map_err(|e| {
-                NonoError::TrustPolicy(format!("invalid instruction pattern '{pattern}': {e}"))
+                NonoError::TrustPolicy(format!("invalid include pattern '{pattern}': {e}"))
             })?;
             builder.add(glob);
         }
         let glob_set = builder.build().map_err(|e| {
-            NonoError::TrustPolicy(format!("failed to build instruction pattern matcher: {e}"))
+            NonoError::TrustPolicy(format!("failed to build include pattern matcher: {e}"))
         })?;
         Ok(Self {
             glob_set,
@@ -370,7 +371,7 @@ impl InstructionPatterns {
         })
     }
 
-    /// Check if a path matches any instruction file pattern.
+    /// Check if a path matches any include pattern.
     #[must_use]
     pub fn is_match<P: AsRef<Path>>(&self, path: P) -> bool {
         self.glob_set.is_match(path)
@@ -407,7 +408,7 @@ pub enum SignerIdentity {
     },
 }
 
-/// Outcome of verifying an instruction file.
+/// Outcome of verifying a file against the trust policy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum VerificationOutcome {
     /// File verified successfully against a trusted publisher
@@ -462,7 +463,7 @@ impl VerificationOutcome {
     }
 }
 
-/// Complete verification result for an instruction file.
+/// Complete verification result for a file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerificationResult {
     /// Path to the verified file
@@ -481,7 +482,7 @@ mod tests {
     fn sample_policy() -> TrustPolicy {
         TrustPolicy {
             version: 1,
-            instruction_patterns: vec![
+            includes: vec![
                 "SKILLS*.md".to_string(),
                 "CLAUDE*.md".to_string(),
                 "AGENT*.md".to_string(),
@@ -522,9 +523,9 @@ mod tests {
     }
 
     #[test]
-    fn instruction_patterns_match() {
+    fn includes_match() {
         let policy = sample_policy();
-        let matcher = policy.instruction_matcher().unwrap();
+        let matcher = policy.include_matcher().unwrap();
         assert!(matcher.is_match("SKILLS.md"));
         assert!(matcher.is_match("SKILLS-custom.md"));
         assert!(matcher.is_match("CLAUDE.md"));
@@ -539,16 +540,16 @@ mod tests {
     }
 
     #[test]
-    fn instruction_patterns_returns_originals() {
+    fn includes_returns_originals() {
         let policy = sample_policy();
-        let matcher = policy.instruction_matcher().unwrap();
+        let matcher = policy.include_matcher().unwrap();
         assert_eq!(matcher.patterns().len(), 5);
         assert_eq!(matcher.patterns()[0], "SKILLS*.md");
     }
 
     #[test]
-    fn instruction_patterns_invalid_glob() {
-        let result = InstructionPatterns::new(&["[invalid".to_string()]);
+    fn includes_invalid_glob() {
+        let result = IncludePatterns::new(&["[invalid".to_string()]);
         assert!(result.is_err());
     }
 

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -249,8 +249,9 @@ Claude Code reads git configuration for repository operations. The built-in prof
 
 If you use [Secretive](https://github.com/maxgoedjen/secretive) to store SSH keys in the macOS Secure Enclave, git commit signing (`git commit -S`) needs access to the Secretive agent socket. Create a custom profile that extends the built-in Claude Code profile:
 
+Save as `~/.config/nono/profiles/claude-code-secretive.json`:
+
 ```json
-// ~/.config/nono/profiles/claude-code-secretive.json
 {
   "meta": {
     "name": "claude-code-secretive",

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -1,17 +1,15 @@
 ---
-title: Agent Instruction Attestation
-description: Cryptographic verification of AI agent instruction files
+title: SKILLS Security
+description: Cryptographic verification of files consumed by AI agents
 ---
 
-AI agent instruction files (`SKILLS.md`, `CLAUDE.md`, `AGENTS.md`, `AGENT.MD`) are natural language files, formatted in markdown - that an LLM will use as a context source for orientation on the project, its structure, and how to execute commands. Because they are natural language based, they are vulnerable to prompt injection attacks - an attacker could modify an instruction file to trick the agent into executing harmful commands.
+AI agents consume various files as context - instruction files (`SKILLS.md`, `CLAUDE.md`, `AGENT.MD`), configuration, helper scripts, and other project artifacts. Because agents treat natural language content as executable instructions, any file an agent reads is a potential prompt injection vector. An attacker who can modify a file the agent trusts can inject malicious instructions that execute with the agent's full privileges.
 
-One of the areas where Large Language Models (LLMs) are most vulnerable to prompt injection is in reading their own instruction files. Unlike traditional software, LLM's do not differentiate a control plane vs data plane - instruction and data are loaded into the same channel: the prompt. This means that if an attacker can modify an instruction file, they can inject malicious instructions that the LLM will execute with the same privileges as the original file.
-
-Nono's sandbox neutralizes the *effects* of prompt injection - dangerous actions are blocked at the kernel. Instruction file trust adds a second layer: verifying the *provenance* and *integrity* of instruction files before the agent can read them. Unsigned or tampered files are hard-denied.
+Nono's sandbox neutralizes the *effects* of prompt injection via malicious skills — dangerous actions are blocked at the kernel. File attestation adds a second layer: verifying the *provenance* and *integrity* of files before the agent can read them. Unsigned or tampered files are hard-denied.
 
 ## What Signing Proves (and What It Does Not)
 
-As with any Sigstore-based attestation, signing an instruction file proves two things:
+As with any Sigstore-based attestation, signing a file proves two things:
 
 1. **Provenance** -- The file was signed by a specific identity (a key you control, or a CI/CD pipeline you trust). You can verify *who* produced the file.
 2. **Integrity** -- The file has not been modified since it was signed. Any tampering -- even a single byte -- breaks the cryptographic digest and the signature is rejected.
@@ -62,9 +60,29 @@ When signing multiple files, nono creates a single `.nono-trust.bundle` file con
 
 ### 3. Create a trust policy
 
-Signing files is only half the equation - you must also define a trust policy that declares which keys are trusted to sign instruction files.
+Signing files is only half the equation - you must also define a trust policy that declares which keys are trusted to sign files.
 
-Create `trust-policy.json` in the project root:
+The quickest way to create a policy is with `nono trust init`:
+
+```bash
+nono trust init
+```
+
+This scans the current directory for files, auto-populates `instruction_patterns`, and includes your signing key's public key as a publisher. The resulting `trust-policy.json` is ready to sign.
+
+To include files from subdirectories:
+
+```bash
+nono trust init --recursive
+```
+
+To exclude specific directories on top of `.gitignore` and the built-in skip list:
+
+```bash
+nono trust init --recursive --exclude-dirs tmp logs
+```
+
+Review the generated `trust-policy.json` and remove any patterns you don't want verified. You can also create the policy manually:
 
 ```json
 {
@@ -90,7 +108,7 @@ Create `trust-policy.json` in the project root:
 }
 ```
 
-To get the public key in base64 format for the policy:
+To get the public key in base64 format for a manual policy:
 
 ```bash
 nono trust export-key --id default
@@ -237,8 +255,9 @@ For stronger guarantees, create a user-level policy that defines your trusted pu
 mkdir -p ~/.config/nono
 ```
 
+Create `~/.config/nono/trust-policy.json`:
+
 ```json
-// ~/.config/nono/trust-policy.json
 {
   "version": 1,
   "instruction_patterns": ["SKILLS*", "CLAUDE*", "AGENT*"],
@@ -260,6 +279,20 @@ nono trust sign-policy ~/.config/nono/trust-policy.json
 With a user-level policy in place, project policies merge additively on top. A project can declare additional publishers (e.g., its CI signing identity), but your user-level enforcement of `deny` cannot be downgraded to `warn` by the project, and your blocklist entries cannot be removed.
 
 ## CLI Commands
+
+### nono trust init
+
+Create a `trust-policy.json` in the current directory. Scans for files, auto-populates `instruction_patterns`, and includes the signing key's public key as a publisher if one exists in the keystore.
+
+```bash
+nono trust init                            # scan root directory only
+nono trust init -r                         # scan recursively
+nono trust init -r --exclude-dirs tmp logs # exclude extra directories
+nono trust init --key my-key               # use a specific signing key
+nono trust init --force                    # overwrite existing policy
+```
+
+File discovery respects `.gitignore`, global gitignore, and `.git/info/exclude`. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default. Use `--exclude-dirs` for project-specific directories not covered by `.gitignore` or the built-in list.
 
 ### nono trust sign
 
@@ -340,7 +373,7 @@ Every time you modify `trust-policy.json`, you must re-sign it.
 
 ## Pre-exec Scanning
 
-When `nono run` launches a command, it scans the working directory for instruction files before applying the sandbox:
+When `nono run` launches a command, it scans the working directory for files matching the trust policy's `instruction_patterns` before applying the sandbox. File discovery respects `.gitignore`, so files excluded by your project's `.gitignore` are not scanned:
 
 ```
 nono run --profile claude-code -- claude
@@ -375,13 +408,9 @@ The verification result is cached by (path, inode, mtime, size) to avoid re-veri
 
 ### macOS (Seatbelt)
 
-On macOS, instruction file patterns are enforced at the kernel level using Seatbelt deny/allow rule specificity:
+On macOS, verified files are write-protected at the kernel level. For each file that passes the pre-exec trust scan, a literal `(deny file-write-data ...)` rule is emitted in the Seatbelt profile, making the file structurally immutable for the duration of the session.
 
-1. Deny-regex rules block reads of all files matching instruction patterns
-2. Literal-allow rules re-enable reading for files that passed the pre-exec trust scan
-3. Files created at runtime have no literal-allow rule and are blocked by the deny-regex
-
-This means a new instruction file introduced after sandbox application (e.g., by `curl` or `git pull`) cannot be read by the agent.
+The pre-exec scan gates execution — if any file matching the trust policy's `instruction_patterns` fails verification, the sandbox refuses to start. The supervisor's `TrustInterceptor` handles runtime verification of files opened mid-session.
 
 ## GitHub Actions Integration
 
@@ -495,12 +524,8 @@ Bundles are checked into version control. A missing bundle for a file that match
 
 ## Why File Name Patterns?
 
-Nono identifies instruction files by matching against configurable file name patterns (e.g., `SKILLS*`, `CLAUDE*`, `AGENT*`, `.claude/**/*.md`). This is a deliberate design choice rooted in how agent frameworks work in practice.
+Nono identifies files for verification by matching against configurable glob patterns (e.g., `SKILLS*`, `CLAUDE*`, `AGENT*`, `.claude/**/*.md`). The default patterns cover well-known conventions used by agent frameworks, but organizations can extend `instruction_patterns` to cover any files their agents consume — helper scripts, configuration, prompt templates, or custom conventions.
 
-Agent clients are purpose-built to discover and ingest files with these naming conventions. Claude Code reads `CLAUDE.md` and files under `.claude/`. Other frameworks look for `SKILLS.md`, `AGENT.MD`, `AGENTS.md`, or similar well-known names. The agent's system prompt or client code directs it to seek out these specific files and treat their contents as trusted instructions. An attacker exploiting this vector will name their payload to match the conventions the agent is already looking for -- there is no advantage to using an arbitrary filename, because the agent would not ingest it as instructions.
+Agent frameworks are purpose-built to discover and ingest files with specific naming conventions. Claude Code reads `CLAUDE.md` and files under `.claude/`. Other frameworks look for `SKILLS.md`, `AGENT.MD`, or similar well-known names. An attacker exploiting prompt injection through these files will use the exact names the agent is already looking for — a file named `SK1LLS.md` or `SKILLZ.md` would not be ingested by the agent as instructions, so there is no value in an attacker using those names.
 
-Pattern matching is also what makes the system practical. It avoids requiring every file in the working directory to be signed, and it aligns the verification boundary with the actual attack surface: the files the agent will treat as authoritative.
-
-The default patterns cover the major agent frameworks. They are configurable via the `instruction_patterns` field in the trust policy, so organizations can extend them to match custom instruction file conventions.
-
-This of course means that any file not matching the patterns is outside the scope of trust verification. If an attacker can get the agent to read from a file with an unprotected name, that is a separate attack vector. However, by defaulting to well-known patterns, we cover the most common and high-value targets for prompt injection in agent contexts. Over time, we may explore additional controls for non-pattern files (e.g., monitoring file access patterns, sandboxing all file reads with a more permissive fallback policy, classification, intent analysis, etc.) but pattern-based verification is the most effective and user-friendly approach for the initial release. Perfect should not be the enemy of good.
+Pattern matching keeps the system practical: it avoids requiring every file in the working directory to be signed, and it aligns the verification boundary with the actual attack surface. Files matching the patterns must have a valid signature from a trusted publisher, and verified files are write-protected at the kernel level so they cannot be tampered with mid-session.

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -1,96 +1,168 @@
 ---
-title: SKILLS Security
-description: Cryptographic verification of files consumed by AI agents
+title: Trust & Attestation
+description: Cryptographic verification of files
 ---
 
-AI agents consume various files as context - instruction files (`SKILLS.md`, `CLAUDE.md`, `AGENT.MD`), configuration, helper scripts, and other project artifacts. Because agents treat natural language content as executable instructions, any file an agent reads is a potential prompt injection vector. An attacker who can modify a file the agent trusts can inject malicious instructions that execute with the agent's full privileges.
-
-Nono's sandbox neutralizes the *effects* of prompt injection via malicious skills — dangerous actions are blocked at the kernel. File attestation adds a second layer: verifying the *provenance* and *integrity* of files before the agent can read them. Unsigned or tampered files are hard-denied.
-
-## What Signing Proves (and What It Does Not)
-
-As with any Sigstore-based attestation, signing a file proves two things:
-
-1. **Provenance** -- The file was signed by a specific identity (a key you control, or a CI/CD pipeline you trust). You can verify *who* produced the file.
-2. **Integrity** -- The file has not been modified since it was signed. Any tampering -- even a single byte -- breaks the cryptographic digest and the signature is rejected.
-
-Signing does **not** prove that the content is safe, correct, or free of malicious instructions. A legitimately signed file could still contain harmful directives if the signer intended it, or if the signer's own environment was compromised before signing. The signature attests to *who signed it* and *that it has not changed*, not to the quality or safety of the content itself.
-
-This is the same trust model as code signing, package signing, or any other supply chain attestation: you decide which signers you trust (via the trust policy's `publishers` list), and the cryptography guarantees that only those signers can produce files that pass verification. The blocklist provides an additional layer for revoking trust in specific file contents after the fact, even if the signature is valid.
-
-## How It Works
-
-Instruction files are signed at time of authoring or amendment using a Sigstore-compatible cryptographic attestation. Before the agent launches, nono scans the working directory for instruction files and verifies each one against a trust policy. Files that fail verification are blocked.
-
-There are two signing modes supported:
-
-**Keyed signing** -- A private key(s) is stored in the system keystore (macOS Keychain / Linux Secret Service). Suitable for individual developers and local workflows. Plans are in place to extend the key store to support more backends (e.g., HashiCorp Vault, AWS KMS) in the future.
-
-**Keyless signing** -- Ephemeral key + OIDC identity + Fulcio certificate + Rekor transparency log. Suitable for CI/CD pipelines with ambient OIDC tokens (e.g., GitHub Actions with `permissions: id-token: write`). The signer's identity is cryptographically bound to the signature via the OIDC token. Interactive browser-based keyless signing is not yet supported.
-
-Both modes produce [Sigstore bundle](https://docs.sigstore.dev/about/bundle/) v0.3 files, recognizable by the `.bundle` extension, stored alongside the signed file (e.g., `SKILLS.md.bundle`). Each bundle contains the signature, signing certificate, and metadata needed for verification.
+Nono's trust system verifies the **provenance** and **integrity** of files before they are consumed. Any file you choose to protect — instruction files, configs, scripts, templates — can be signed and verified. At sandbox startup, nono scans for files matching the trust policy and verifies their signatures. Unsigned or tampered files are hard-denied.
 
 ## Quick Start
 
 ### 1. Generate a signing key
 
 ```bash
-nono trust keygen -id [key-identifier]
+nono trust keygen
 ```
 
-This creates an ECDSA P-256 key pair and stores the private key in the system keystore.
+Creates an ECDSA P-256 key pair in the system keystore (macOS Keychain / Linux Secret Service).
 
-### 2. Sign instruction files
+### 2. Create and sign a trust policy
+
+A trust policy declares which files must be verified and who is allowed to sign them. It lives in the project root as `trust-policy.json` — if a project you're working on already has one, skip this step.
 
 ```bash
-# Sign a single file (uses default key)
+nono trust init --include "SKILLS.md" --include "CLAUDE.md" --include "src/config.py"
+nono trust sign-policy
+```
+
+The first command creates a `trust-policy.json` with the specified include patterns and your signing key's public key as a publisher. The second signs it — an unsigned policy could be modified by an attacker.
+
+Patterns use glob syntax and can be specific files or wildcards — `SKILLS*` matches `SKILLS.md`, `SKILLS-ops.md`, etc. Be specific with patterns: any file that matches `includes` must be signed or verification will fail.
+
+### 3. Sign files
+
+```bash
+# Sign a single file
 nono trust sign SKILLS.md
 
-# Sign with a specific key
-nono trust sign SKILLS.md --key my-signing-key
-
-# Sign multiple files into a single multi-subject bundle
-nono trust sign SKILLS.md CLAUDE.md helper.py
-
-# Sign all instruction files matching trust policy patterns
+# Sign all files matching the trust policy's includes
 nono trust sign --all
 ```
 
-When signing multiple files, nono creates a single `.nono-trust.bundle` file containing all subjects. This is more efficient for projects with many instruction files. Single-file signing creates per-file `.bundle` sidecars (e.g., `SKILLS.md.bundle`). Commit these alongside the instruction files.
+Each file gets its own `.bundle` sidecar (e.g., `SKILLS.md.bundle`). Use `--multi-subject` to produce a single `.nono-trust.bundle` instead. Commit bundles alongside the signed files.
 
-### 3. Create a trust policy
+Signing works on any file — no trust policy is required for explicit file arguments. `--all` uses the policy to discover which files to sign.
 
-Signing files is only half the equation - you must also define a trust policy that declares which keys are trusted to sign files.
-
-The quickest way to create a policy is with `nono trust init`:
+### 4. Verify
 
 ```bash
-nono trust init
+nono trust verify --all
 ```
 
-This scans the current directory for files, auto-populates `instruction_patterns`, and includes your signing key's public key as a publisher. The resulting `trust-policy.json` is ready to sign.
+When you run `nono run`, the pre-exec scan automatically verifies all files matching the policy before the agent launches.
 
-To include files from subdirectories:
+## CLI Commands
+
+### nono trust init
+
+Create a `trust-policy.json` in the current directory.
 
 ```bash
-nono trust init --recursive
+nono trust init --include "*.md"                    # single pattern
+nono trust init --include "*.md" --include "*.py"   # multiple patterns
+nono trust init --include "SKILLS*" --key my-key    # with specific signing key
+nono trust init --user                              # user-level policy (~/.config/nono/)
+nono trust init --force                             # overwrite existing policy
 ```
 
-To exclude specific directories on top of `.gitignore` and the built-in skip list:
+Note: the pre-exec trust scan and `sign --all`/`verify --all` do **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification.
+
+### nono trust sign
+
+Sign files. Any file can be signed — no trust policy is required for explicit file arguments.
 
 ```bash
-nono trust init --recursive --exclude-dirs tmp logs
+nono trust sign SKILLS.md                  # keyed (default key), creates SKILLS.md.bundle
+nono trust sign SKILLS.md --key my-key     # keyed (specific key)
+nono trust sign SKILLS.md CLAUDE.md        # per-file .bundle sidecars
+nono trust sign --all                      # all files matching policy (per-file)
+nono trust sign --all --multi-subject      # single .nono-trust.bundle for all files
 ```
 
-Review the generated `trust-policy.json` and remove any patterns you don't want verified. You can also create the policy manually:
+**Keyless signing** (CI environments only):
+
+```bash
+nono trust sign SKILLS.md --keyless        # requires ambient OIDC (e.g., GitHub Actions)
+```
+
+<Note>
+  Keyless signing requires a CI environment with ambient OIDC tokens, such as GitHub Actions with `permissions: id-token: write`. Interactive browser-based keyless signing is not yet supported. Use keyed signing for local development.
+</Note>
+
+### nono trust verify
+
+```bash
+nono trust verify SKILLS.md                # single file
+nono trust verify --all                    # all files matching policy
+nono trust verify SKILLS.md --policy path  # specific trust policy
+```
+
+### nono trust list
+
+List all files matching the policy and their verification status.
+
+```bash
+nono trust list
+```
+
+```
+  File                               Status       Publisher
+  -------------------------------------------------------------------
+  SKILLS.md                          VERIFIED     local-dev (keyed)
+  CLAUDE.md                          VERIFIED     local-dev (keyed)
+  .claude/commands/deploy.md         UNSIGNED     no .bundle file found
+```
+
+### nono trust keygen
+
+Generate an ECDSA P-256 signing key pair.
+
+```bash
+nono trust keygen                          # default key ID ("default")
+nono trust keygen --id my-signing-key      # named key
+```
+
+### nono trust export-key
+
+Export the public key in base64 DER format for use in trust policy `public_key` fields.
+
+```bash
+nono trust export-key                      # export default key
+nono trust export-key --id my-signing-key  # export named key
+nono trust export-key --pem                # output as PEM instead of base64 DER
+```
+
+### nono trust sign-policy
+
+Sign the trust policy file. Required after every modification to `trust-policy.json`.
+
+```bash
+nono trust sign-policy                     # sign trust-policy.json in CWD
+nono trust sign-policy --key my-key        # specific key
+```
+
+## Development Override
+
+For development and testing, disable attestation enforcement:
+
+```bash
+nono run --profile claude-code --trust-override -- claude
+```
+
+Verification still runs and results are logged, but failures produce warnings instead of hard denies. This flag is CLI-only — it cannot be set in a profile or trust policy.
+
+The `NONO_TRUST_OVERRIDE=1` environment variable is also supported.
+
+## Trust Policy Reference
+
+Trust policy is defined in `trust-policy.json`, separate from the sandbox policy (`policy.json`).
 
 ```json
 {
   "version": 1,
-  "instruction_patterns": [
+  "includes": [
     "SKILLS*",
     "CLAUDE*",
-    "AGENT*",
+    "*.py",
     ".claude/**/*.md"
   ],
   "publishers": [
@@ -114,48 +186,24 @@ To get the public key in base64 format for a manual policy:
 nono trust export-key --id default
 ```
 
-This outputs the public key in base64 DER format, which you paste into the `public_key` field.
+### includes
 
-### 4. Sign the trust policy
-
-The trust policy itself must be signed - an unsigned policy could be modified by an attacker to add themselves as a publisher.
-
-```bash
-nono trust sign-policy
-```
-
-### 5. Verification
-
-```bash
-nono trust verify --all
-```
-
-When you run `nono run`, the pre-exec scan automatically verifies all instruction files before the agent launches.
-
-## Trust Policy
-
-Trust policy is defined in `trust-policy.json`, separate from the sandbox policy (`policy.json`). This keeps concerns separated: `policy.json` defines sandbox rules, `trust-policy.json` defines attestation trust.
-
-### instruction_patterns
-
-Glob patterns that identify instruction files. Any file matching these patterns is subject to attestation verification, regardless of directory depth.
+Glob patterns identifying files under attestation. Any file matching these patterns is subject to verification.
 
 ```json
 {
-  "instruction_patterns": [
+  "includes": [
     "SKILLS*",
     "CLAUDE*",
-    "AGENT*",
+    "*.py",
     ".claude/**/*.md"
   ]
 }
 ```
 
-A `SKILLS.md` in a subdirectory or unpacked from a dependency is caught by `SKILLS*`.
-
 ### publishers
 
-Trusted publisher identities. A file's signature must match at least one publisher entry to be trusted.
+Trusted publisher identities. A file's signature must match at least one publisher.
 
 **Keyed publishers** match by key ID and verify with the embedded public key:
 
@@ -167,7 +215,7 @@ Trusted publisher identities. A file's signature must match at least one publish
 }
 ```
 
-The `public_key` field contains the base64-encoded DER SPKI public key. Use `nono trust export-key` to obtain this value.
+The `public_key` field contains the base64-encoded DER SPKI public key.
 
 **Keyless (OIDC) publishers** match by identity claims from the Fulcio certificate:
 
@@ -181,13 +229,15 @@ The `public_key` field contains the base64-encoded DER SPKI public key. Use `non
 }
 ```
 
+These fields are matched against claims in the Fulcio certificate that Sigstore issues during keyless signing. The certificate embeds the OIDC identity of the CI environment that performed the signing.
+
 | Field | Description | Wildcards |
 |-------|-------------|-----------|
-| `name` | Human-readable identifier | No |
-| `issuer` | OIDC issuer URL | No |
-| `repository` | Source repository (e.g., `org/repo`) | Yes (`org/*`) |
-| `workflow` | Workflow file that signed | Yes (`*`) |
-| `ref_pattern` | Git ref pattern | Yes (`refs/tags/v*`) |
+| `name` | Human-readable label for this publisher (not matched against anything) | No |
+| `issuer` | The OIDC provider URL. For GitHub Actions this is always `https://token.actions.githubusercontent.com` | No |
+| `repository` | The `owner/repo` that ran the signing workflow (maps to the GitHub OIDC `repository` claim). Use `org/*` to trust all repos in an org | Yes (`org/*`) |
+| `workflow` | Path to the workflow file that performed the signing, relative to the repo root | Yes (`*`) |
+| `ref_pattern` | The git ref that triggered the workflow (e.g., `refs/heads/main`, `refs/tags/v1.0`). Use wildcards to trust a range of refs | Yes (`refs/tags/v*`) |
 
 ### blocklist
 
@@ -217,210 +267,6 @@ Blocklist entries are always hard-denied, even in `warn` or `audit` enforcement 
 | `warn` | Log warnings but allow the agent to proceed. |
 | `audit` | Allow access, log verification results for post-hoc review. |
 
-### Policy Composition
-
-Trust policies are composable across three levels:
-
-| Level | Location | Purpose |
-|-------|----------|---------|
-| Embedded | Built into nono binary | Baseline instruction patterns |
-| User | `$XDG_CONFIG_HOME/nono/trust-policy.json` | Personal trusted publishers |
-| Project | `<project-root>/trust-policy.json` | Project-specific publishers |
-
-Merging rules:
-- Publishers: union (all levels combined)
-- Blocklist digests: union (all levels combined)
-- Instruction patterns: union (all levels combined)
-- Enforcement: strictest wins (`deny` > `warn` > `audit`)
-
-Project-level policy **cannot** weaken user-level or embedded policy. A project cannot remove a blocklist entry or downgrade enforcement from `deny` to `warn`.
-
-### Policy Hierarchy and Trust Anchoring
-
-The user-level policy (`~/.config/nono/trust-policy.json`) acts as your personal trust anchor. It defines your baseline expectations: which publishers you trust, which file digests are blocked, and the minimum enforcement level. Project-level policies compose on top of this baseline -- they can add publishers and blocklist entries, but cannot remove or weaken anything from the user level.
-
-When only a project-level policy exists with no user-level policy, nono warns:
-
-```
-Warning: project-level trust-policy.json found but no user-level policy exists.
-Project policies are not authoritative without a user-level policy to anchor trust.
-Create a signed policy at ~/.config/nono/trust-policy.json to enforce verification.
-```
-
-This is because without a user-level policy, the project defines its own trust entirely -- there is no independent authority constraining what the project declares. The project policy still works, but the trust model is weaker: you are trusting whatever publishers and enforcement the project author chose.
-
-For stronger guarantees, create a user-level policy that defines your trusted publishers and enforcement floor:
-
-```bash
-mkdir -p ~/.config/nono
-```
-
-Create `~/.config/nono/trust-policy.json`:
-
-```json
-{
-  "version": 1,
-  "instruction_patterns": ["SKILLS*", "CLAUDE*", "AGENT*"],
-  "publishers": [
-    {
-      "name": "my-key",
-      "key_id": "default"
-    }
-  ],
-  "blocklist": { "digests": [] },
-  "enforcement": "deny"
-}
-```
-
-```bash
-nono trust sign-policy ~/.config/nono/trust-policy.json
-```
-
-With a user-level policy in place, project policies merge additively on top. A project can declare additional publishers (e.g., its CI signing identity), but your user-level enforcement of `deny` cannot be downgraded to `warn` by the project, and your blocklist entries cannot be removed.
-
-## CLI Commands
-
-### nono trust init
-
-Create a `trust-policy.json` in the current directory. Scans for files, auto-populates `instruction_patterns`, and includes the signing key's public key as a publisher if one exists in the keystore.
-
-```bash
-nono trust init                            # scan root directory only
-nono trust init -r                         # scan recursively
-nono trust init -r --exclude-dirs tmp logs # exclude extra directories
-nono trust init --key my-key               # use a specific signing key
-nono trust init --force                    # overwrite existing policy
-```
-
-File discovery for `init` respects `.gitignore` to keep the generated policy clean. Hidden directories like `.claude/` and `.github/` are included. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default. Use `--exclude-dirs` for project-specific directories not covered by `.gitignore` or the built-in list.
-
-Note: the pre-exec trust scan and `sign --all`/`verify --all` do **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification.
-
-### nono trust sign
-
-Sign instruction files. Single files produce per-file `.bundle` sidecars; multiple files produce a single `.nono-trust.bundle` multi-subject bundle.
-
-```bash
-nono trust sign SKILLS.md                  # keyed (default key), creates SKILLS.md.bundle
-nono trust sign SKILLS.md --key my-key     # keyed (specific key)
-nono trust sign SKILLS.md CLAUDE.md        # multi-subject bundle (.nono-trust.bundle)
-nono trust sign --all                      # all instruction files in CWD (multi-subject)
-```
-
-**Keyless signing** (CI environments only):
-
-```bash
-nono trust sign SKILLS.md --keyless        # requires ambient OIDC (e.g., GitHub Actions)
-```
-
-<Note>
-  Keyless signing requires a CI environment with ambient OIDC tokens, such as GitHub Actions with `permissions: id-token: write`. Interactive browser-based keyless signing is not yet supported. Use keyed signing for local development.
-</Note>
-
-### nono trust verify
-
-Verify instruction files against the trust policy.
-
-```bash
-nono trust verify SKILLS.md                # single file
-nono trust verify --all                    # all instruction files in CWD
-nono trust verify SKILLS.md --policy path  # specific trust policy
-```
-
-### nono trust list
-
-List all instruction files and their verification status.
-
-```bash
-nono trust list
-```
-
-```
-  File                               Status       Publisher
-  -------------------------------------------------------------------
-  SKILLS.md                          VERIFIED     local-dev (keyed)
-  CLAUDE.md                          VERIFIED     local-dev (keyed)
-  .claude/commands/deploy.md         UNSIGNED     no .bundle file found
-```
-
-### nono trust keygen
-
-Generate an ECDSA P-256 signing key pair and store it in the system keystore (macOS Keychain / Linux Secret Service).
-
-```bash
-nono trust keygen                          # default key ID ("default")
-nono trust keygen --id my-signing-key      # named key
-```
-
-### nono trust export-key
-
-Export the public key for a signing key in base64 DER format. Use this to populate the `public_key` field in trust policy publishers.
-
-```bash
-nono trust export-key                      # export default key
-nono trust export-key --id my-signing-key  # export named key
-nono trust export-key --pem                # output as PEM instead of base64 DER
-```
-
-### nono trust sign-policy
-
-Sign the trust policy file.
-
-```bash
-nono trust sign-policy                     # sign trust-policy.json in CWD
-nono trust sign-policy --key my-key        # specific key
-```
-
-Every time you modify `trust-policy.json`, you must re-sign it.
-
-## Pre-exec Scanning
-
-When `nono run` launches a command, it scans the working directory for files matching the trust policy's `instruction_patterns` before applying the sandbox. File discovery does **not** respect `.gitignore` — a file added to `.gitignore` is still subject to trust verification. This prevents an attacker from hiding a malicious instruction file by adding it to `.gitignore`:
-
-```
-nono run --profile claude-code -- claude
-  -> Scan CWD for instruction file patterns
-  -> For each match:
-     -> Compute SHA-256 digest
-     -> Check blocklist
-     -> Load and verify .bundle
-     -> Check publisher identity against trust policy
-  -> All pass: proceed with sandbox and exec
-  -> Any fail (enforcement=deny): abort with diagnostic
-```
-
-```
-  Scanning 3 instruction file(s) for trust verification...
-    PASS SKILLS.md (publisher: local-dev)
-    PASS CLAUDE.md (publisher: local-dev)
-    PASS .claude/commands/deploy.md (publisher: local-dev)
-
-  Trust scan: 3 file(s) verified.
-```
-
-## Runtime Interception
-
-The pre-exec scan catches files present at startup. Runtime behavior differs by platform.
-
-### Linux (seccomp-notify)
-
-In [Supervised mode](/cli/features/supervisor), the seccomp-notify supervisor traps every `openat()` syscall. When the target path matches an instruction file pattern, the supervisor verifies the file's bundle before allowing the read. Unsigned, tampered, or blocklisted files are denied with `EPERM`.
-
-The verification result is cached by (path, inode, mtime, size) to avoid re-verifying on repeated opens. If any metadata changes, the cache entry is invalidated and verification re-runs.
-
-This means files that appear mid-session (e.g., via `curl` or `git pull`) are verified on first open. Linux provides true runtime interception.
-
-### macOS (Seatbelt)
-
-On macOS, trust verification is **startup-only**. The pre-exec scan verifies all files matching `instruction_patterns` that exist at launch. For each verified file, a literal `(deny file-write-data ...)` rule is emitted in the Seatbelt profile, making the file structurally immutable for the duration of the session.
-
-macOS does not have syscall-level file-open interception equivalent to Linux's seccomp-notify. A file matching `instruction_patterns` that appears after the sandbox is applied (e.g., created by `curl`, `git pull`, or a dependency install) will be readable if its parent directory has read access granted. It will not be verified before the agent reads it.
-
-The macOS enforcement model provides:
-- **Integrity of verified files** — kernel-level write-protection prevents tampering
-- **Startup gating** — if any existing file fails verification, the sandbox refuses to start
-- **No runtime interception** — file existence and verification are evaluated once at startup
-
 ## GitHub Actions Integration
 
 Keyless signing integrates with GitHub Actions OIDC for automated CI/CD signing.
@@ -428,7 +274,7 @@ Keyless signing integrates with GitHub Actions OIDC for automated CI/CD signing.
 ### Signing Workflow
 
 ```yaml
-name: Sign instruction files
+name: Sign files
 on:
   push:
     branches: [main]
@@ -450,7 +296,7 @@ jobs:
       - name: Install nono
         run: cargo install nono-cli
 
-      - name: Sign instruction files
+      - name: Sign files
         run: |
           for f in SKILLS.md CLAUDE.md; do
             [ -f "$f" ] && nono trust sign "$f" --keyless
@@ -461,18 +307,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add '*.bundle'
-          git diff --staged --quiet || git commit -m "Update instruction file signatures"
+          git diff --staged --quiet || git commit -m "Update file signatures"
           git push
 ```
-
-The `id-token: write` permission enables the GitHub Actions OIDC provider. Nono's `--keyless` flag detects the GitHub Actions environment, requests a Fulcio certificate binding the OIDC identity to an ephemeral key, signs the file, and logs the signature to Rekor for transparency.
 
 ### Trust Policy for CI-Signed Files
 
 ```json
 {
   "version": 1,
-  "instruction_patterns": ["SKILLS*", "CLAUDE*", "AGENT*"],
+  "includes": ["SKILLS*", "CLAUDE*", "AGENT*"],
   "publishers": [
     {
       "name": "my-org-ci",
@@ -487,25 +331,30 @@ The `id-token: write` permission enables the GitHub Actions OIDC provider. Nono'
 }
 ```
 
-This policy declares: only trust instruction files signed by a GitHub Actions workflow in `my-org/my-repo`, from the `main` branch. A fork, manual edit, or compromised developer workstation cannot produce a matching signature.
+This policy declares: only trust files signed by a GitHub Actions workflow in `my-org/my-repo`, from the `main` branch.
 
-## Development Override
+## Signing Modes
 
-For development and testing, the `--trust-override` flag disables attestation enforcement:
+There are two signing modes:
 
-```bash
-nono run --profile claude-code --trust-override -- claude
-```
+**Keyed signing** — A private key stored in the system keystore (macOS Keychain / Linux Secret Service). Suitable for individual developers and local workflows.
 
-When active, verification still runs and results are logged, but failures produce warnings instead of hard denies. This flag is a CLI argument only -- it cannot be set in a profile or trust policy (a project cannot disable its own verification).
+**Keyless signing** — Ephemeral key + OIDC identity + Fulcio certificate + Rekor transparency log. Suitable for CI/CD pipelines with ambient OIDC tokens (e.g., GitHub Actions with `permissions: id-token: write`). The signer's identity is cryptographically bound to the signature via the OIDC token.
 
-The `NONO_TRUST_OVERRIDE=1` environment variable is also supported for CI/CD convenience.
+Both modes produce [Sigstore bundle](https://docs.sigstore.dev/about/bundle/) v0.3 files (`.bundle` extension).
+
+## What Signing Proves (and What It Does Not)
+
+Signing a file proves two things:
+
+1. **Provenance** — The file was signed by a specific identity (a key you control, or a CI/CD pipeline you trust).
+2. **Integrity** — The file has not been modified since it was signed. Any tampering breaks the signature.
+
+Signing does **not** prove that the content is safe or correct. This is the same trust model as code signing or package signing: you decide which signers you trust (via `publishers`), and the cryptography guarantees only those signers can produce files that pass verification.
 
 ## Signature Storage
 
-Bundles are stored in two formats depending on how files are signed:
-
-**Per-file bundles** (single file signing): `<filename>.bundle`
+**Per-file bundles** (default): `<filename>.bundle`
 
 ```
 project/
@@ -515,7 +364,7 @@ project/
   trust-policy.json.bundle
 ```
 
-**Multi-subject bundles** (multiple files signed together): `.nono-trust.bundle`
+**Multi-subject bundles** (with `--multi-subject`): `.nono-trust.bundle`
 
 ```
 project/
@@ -527,14 +376,141 @@ project/
   trust-policy.json.bundle
 ```
 
-Multi-subject bundles are more efficient for projects with many instruction files. The bundle contains cryptographic digests for each subject file, and a single signature covers all of them.
+Bundles are checked into version control. A missing bundle triggers verification failure.
 
-Bundles are checked into version control. A missing bundle for a file that matches instruction patterns triggers verification failure.
+## Recommended Project Structure
 
-## Why File Name Patterns?
+For most projects, use a single `.nono-trust.bundle` via `--multi-subject` rather than per-file sidecars. This keeps the tree clean and avoids bundle proliferation as the number of signed files grows.
 
-Nono identifies files for verification by matching against configurable glob patterns (e.g., `SKILLS*`, `CLAUDE*`, `AGENT*`, `.claude/**/*.md`). The default patterns cover well-known conventions used by agent frameworks, but organizations can extend `instruction_patterns` to cover any files their agents consume — helper scripts, configuration, prompt templates, or custom conventions.
+```
+project/
+  SKILLS.md
+  CLAUDE.md
+  src/
+    config.py
+  .nono-trust.bundle             # single bundle covering all signed files
+  trust-policy.json
+  trust-policy.json.bundle
+```
 
-Agent frameworks are purpose-built to discover and ingest files with specific naming conventions. Claude Code reads `CLAUDE.md` and files under `.claude/`. Other frameworks look for `SKILLS.md`, `AGENT.MD`, or similar well-known names. An attacker exploiting prompt injection through these files will use the exact names the agent is already looking for — a file named `SK1LLS.md` or `SKILLZ.md` would not be ingested by the agent as instructions, so there is no value in an attacker using those names.
+- `trust-policy.json` lives at the project root
+- `trust-policy.json.bundle` is its signature sidecar (always per-file)
+- `.nono-trust.bundle` contains attestations for all files signed with `--multi-subject`
+- Bundle files for signed files in subdirectories (e.g., `src/config.py`) are also stored at the depth of the file when using per-file signing (`src/config.py.bundle`)
 
-Pattern matching keeps the system practical: it avoids requiring every file in the working directory to be signed, and it aligns the verification boundary with the actual attack surface. Files matching the patterns must have a valid signature from a trusted publisher, and verified files are write-protected at the kernel level so they cannot be tampered with mid-session.
+To set this up:
+
+```bash
+nono trust init --include "SKILLS.md" --include "CLAUDE.md" --include "src/config.py"
+nono trust sign-policy
+nono trust sign --all --multi-subject
+```
+
+Commit `trust-policy.json`, `trust-policy.json.bundle`, and `.nono-trust.bundle` alongside your source files.
+
+## Policy Composition
+
+Trust policies compose across three levels:
+
+| Level | Location | Purpose |
+|-------|----------|---------|
+| Embedded | Built into nono binary | Baseline include patterns |
+| User | `$XDG_CONFIG_HOME/nono/trust-policy.json` | Personal trusted publishers |
+| Project | `<project-root>/trust-policy.json` | Project-specific publishers |
+
+Merging rules:
+- Publishers: union (all levels combined)
+- Blocklist digests: union (all levels combined)
+- Include patterns: union (all levels combined)
+- Enforcement: strictest wins (`deny` > `warn` > `audit`)
+
+Project-level policy **cannot** weaken user-level or embedded policy.
+
+### User-Level Policy as Trust Anchor
+
+The user-level policy (`~/.config/nono/trust-policy.json`) defines **who** you trust — your publishers, enforcement floor, and blocklist. Project-level policies define **what** gets verified (include patterns). This separation means a malicious project can't weaken your trust decisions.
+
+When only a project-level policy exists with no user-level policy, nono warns:
+
+```
+Warning: project-level trust-policy.json found but no user-level policy exists.
+Project policies are not authoritative without a user-level policy to anchor trust.
+Create a signed policy at ~/.config/nono/trust-policy.json to enforce verification.
+```
+
+Create a user-level policy:
+
+```bash
+nono trust init --user
+```
+
+This creates `~/.config/nono/trust-policy.json` with empty `includes` and your signing key as a publisher. Edit it to add your trusted OIDC publishers:
+
+```json
+{
+  "version": 1,
+  "includes": [],
+  "publishers": [
+    {
+      "name": "my-org-ci",
+      "issuer": "https://token.actions.githubusercontent.com",
+      "repository": "my-org/*",
+      "workflow": "*",
+      "ref_pattern": "refs/heads/main"
+    }
+  ],
+  "blocklist": { "digests": [] },
+  "enforcement": "deny"
+}
+```
+
+The `includes` list is empty — the project-level policy declares which files to verify. The user-level policy establishes **who** you trust: in this example, any GitHub Actions workflow in your organization signing from `main`. Projects can add additional publishers but can't remove yours, and enforcement of `deny` can't be downgraded.
+
+You can also add keyed publishers for local development keys, though in practice your own key is already trusted implicitly — the user-level policy is more useful for declaring trust in CI/CD identities and other team members.
+
+```bash
+nono trust sign-policy ~/.config/nono/trust-policy.json
+```
+
+## Pre-exec Scanning
+
+When `nono run` launches a command, it scans the working directory for files matching `includes` before applying the sandbox. File discovery does **not** respect `.gitignore` — this prevents hiding files from verification.
+
+```
+nono run --profile claude-code -- claude
+  -> Scan CWD for files matching includes patterns
+  -> For each match:
+     -> Compute SHA-256 digest
+     -> Check blocklist
+     -> Load and verify .bundle
+     -> Check publisher identity against trust policy
+  -> All pass: proceed with sandbox and exec
+  -> Any fail (enforcement=deny): abort with diagnostic
+```
+
+## Runtime Interception
+
+The pre-exec scan catches files present at startup. Runtime behavior differs by platform.
+
+### Linux (seccomp-notify)
+
+In [Supervised mode](/cli/features/supervisor), the seccomp-notify supervisor traps every `openat()` syscall. When the target path matches an include pattern, the supervisor verifies the file's bundle before allowing the read. Unsigned, tampered, or blocklisted files are denied with `EPERM`.
+
+The verification result is cached by (path, inode, mtime, size). If any metadata changes, the cache entry is invalidated.
+
+Files that appear mid-session (e.g., via `curl` or `git pull`) are verified on first open. Linux provides true runtime interception.
+
+### macOS (Seatbelt)
+
+On macOS, trust verification is **startup-only**. For each verified file, a literal `(deny file-write-data ...)` rule is emitted in the Seatbelt profile, making the file structurally immutable for the session.
+
+macOS does not have syscall-level file-open interception equivalent to Linux's seccomp-notify. A file matching `includes` that appears after the sandbox is applied will be readable if its parent directory has read access granted.
+
+The macOS enforcement model provides:
+- **Integrity of verified files** — kernel-level write-protection prevents tampering
+- **Startup gating** — if any existing file fails verification, the sandbox refuses to start
+- **No runtime interception** — file existence and verification are evaluated once at startup
+
+## Why Glob Patterns?
+
+Pattern matching keeps the system practical: it avoids requiring every file in the working directory to be signed, and lets you define the verification boundary to match your needs. Common use cases include agent instruction files (`SKILLS*`, `CLAUDE*`), configuration files (`*.cfg`, `*.ini`), scripts (`*.py`, `*.sh`), or any other files your workflow depends on.

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -292,7 +292,9 @@ nono trust init --key my-key               # use a specific signing key
 nono trust init --force                    # overwrite existing policy
 ```
 
-File discovery respects `.gitignore`, global gitignore, and `.git/info/exclude`. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default. Use `--exclude-dirs` for project-specific directories not covered by `.gitignore` or the built-in list.
+File discovery for `init` respects `.gitignore` to keep the generated policy clean. Hidden directories like `.claude/` and `.github/` are included. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default. Use `--exclude-dirs` for project-specific directories not covered by `.gitignore` or the built-in list.
+
+Note: the pre-exec trust scan and `sign --all`/`verify --all` do **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification.
 
 ### nono trust sign
 
@@ -373,7 +375,7 @@ Every time you modify `trust-policy.json`, you must re-sign it.
 
 ## Pre-exec Scanning
 
-When `nono run` launches a command, it scans the working directory for files matching the trust policy's `instruction_patterns` before applying the sandbox. File discovery respects `.gitignore`, so files excluded by your project's `.gitignore` are not scanned:
+When `nono run` launches a command, it scans the working directory for files matching the trust policy's `instruction_patterns` before applying the sandbox. File discovery does **not** respect `.gitignore` — a file added to `.gitignore` is still subject to trust verification. This prevents an attacker from hiding a malicious instruction file by adding it to `.gitignore`:
 
 ```
 nono run --profile claude-code -- claude
@@ -398,7 +400,7 @@ nono run --profile claude-code -- claude
 
 ## Runtime Interception
 
-The pre-exec scan catches instruction files present at startup. For files that appear or change during the session, nono provides runtime interception.
+The pre-exec scan catches files present at startup. Runtime behavior differs by platform.
 
 ### Linux (seccomp-notify)
 
@@ -406,11 +408,18 @@ In [Supervised mode](/cli/features/supervisor), the seccomp-notify supervisor tr
 
 The verification result is cached by (path, inode, mtime, size) to avoid re-verifying on repeated opens. If any metadata changes, the cache entry is invalidated and verification re-runs.
 
+This means files that appear mid-session (e.g., via `curl` or `git pull`) are verified on first open. Linux provides true runtime interception.
+
 ### macOS (Seatbelt)
 
-On macOS, verified files are write-protected at the kernel level. For each file that passes the pre-exec trust scan, a literal `(deny file-write-data ...)` rule is emitted in the Seatbelt profile, making the file structurally immutable for the duration of the session.
+On macOS, trust verification is **startup-only**. The pre-exec scan verifies all files matching `instruction_patterns` that exist at launch. For each verified file, a literal `(deny file-write-data ...)` rule is emitted in the Seatbelt profile, making the file structurally immutable for the duration of the session.
 
-The pre-exec scan gates execution — if any file matching the trust policy's `instruction_patterns` fails verification, the sandbox refuses to start. The supervisor's `TrustInterceptor` handles runtime verification of files opened mid-session.
+macOS does not have syscall-level file-open interception equivalent to Linux's seccomp-notify. A file matching `instruction_patterns` that appears after the sandbox is applied (e.g., created by `curl`, `git pull`, or a dependency install) will be readable if its parent directory has read access granted. It will not be verified before the agent reads it.
+
+The macOS enforcement model provides:
+- **Integrity of verified files** — kernel-level write-protection prevents tampering
+- **Startup gating** — if any existing file fails verification, the sandbox refuses to start
+- **No runtime interception** — file existence and verification are evaluated once at startup
 
 ## GitHub Actions Integration
 

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -122,7 +122,7 @@ For keyed bundles, the public key is loaded from the system keystore and the ECD
 
 ### Pre-exec Scan
 
-Before fork/exec, nono scans the working directory for files matching `instruction_patterns`. This is the baseline -- it catches instruction files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
+Before fork/exec, nono scans the working directory for files matching `instruction_patterns`. File discovery uses the `ignore` crate, which respects `.gitignore`, global gitignore, and `.git/info/exclude` — files excluded by gitignore are not scanned. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
 
 The pre-exec scan also verifies the trust policy's own signature before trusting it.
 
@@ -139,24 +139,17 @@ The interceptor:
 
 A TOCTOU re-verification step ensures the digest of the opened file descriptor matches the digest verified during the trust check. This prevents a race where the file is swapped between verification and the fd injection.
 
-### Seatbelt Deny Rules (macOS Runtime)
+### Seatbelt Write-Protection (macOS)
 
-On macOS, instruction file patterns are enforced at the kernel level using Seatbelt rule specificity. During sandbox profile generation:
+On macOS, verified files are write-protected at the kernel level using literal Seatbelt deny rules. During sandbox profile generation:
 
-1. Each instruction pattern is converted to a Seatbelt regex (e.g., `SKILLS*` becomes `#"/SKILLS[^/]*$"`)
-2. A `(deny file-read-data (regex ...))` rule is emitted for each pattern
-3. For each file that passed the pre-exec trust scan, a `(allow file-read-data (literal "/full/path"))` rule is emitted
+1. The pre-exec trust scan verifies all files matching `instruction_patterns` in the trust policy
+2. For each file that passed verification, a `(deny file-write-data (literal "/full/path"))` rule is emitted
+3. If the path involves a symlink (e.g., `/tmp` → `/private/tmp`), rules are emitted for both the original and canonical paths
 
-Seatbelt literal-allow rules override regex-deny rules (more specific wins). Files that were not present or did not pass the pre-exec scan have no literal-allow rule and remain blocked by the deny-regex.
+This makes verified files structurally immutable — the sandboxed process cannot modify them even though the parent directory may have write access granted. The pre-exec scan gates execution (aborting if any file fails verification), and the supervisor's `TrustInterceptor` handles runtime verification of files opened mid-session.
 
-Glob-to-regex conversion:
-
-| Glob | Seatbelt Regex |
-|------|---------------|
-| `SKILLS*` | `/SKILLS[^/]*$` |
-| `CLAUDE*` | `/CLAUDE[^/]*$` |
-| `AGENT*` | `/AGENT[^/]*$` |
-| `.claude/**/*.md` | `/\.claude/.*/[^/]*\.md$` |
+Note: filename-pattern-based read blocking (e.g., denying reads of `SKILLS*`) is intentionally not used. An attacker can trivially vary filenames to bypass pattern matching. The security boundary is the trust policy's cryptographic verification, not filename conventions.
 
 ## Verification Cache
 
@@ -224,7 +217,7 @@ Attestation primitives reusable by all language bindings.
 | `trust_cmd.rs` | `nono trust` subcommand handlers |
 | `trust_scan.rs` | Pre-exec scan, policy signature verification |
 | `trust_intercept.rs` | Runtime trust interceptor (cache, verification dispatch) |
-| `instruction_deny.rs` | macOS Seatbelt deny rule generation (glob-to-regex) |
+| `instruction_deny.rs` | macOS Seatbelt write-protection for verified files |
 
 ## Security Properties
 

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -3,7 +3,7 @@ title: Attestation Internals
 description: Sigstore-based cryptographic attestation format and verification pipeline
 ---
 
-This page covers the internal design of nono's instruction file attestation system. For usage instructions, see [Instruction File Trust](/cli/features/trust).
+This page covers the internal design of nono's attestation system. For usage instructions, see [Trust & Attestation](/cli/features/trust).
 
 ## Attestation Format
 
@@ -54,7 +54,7 @@ The DSSE payload is an [in-toto v1 attestation statement](https://github.com/in-
 }
 ```
 
-The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono instruction file attestation. Trust policy signatures use a separate predicate type: `https://nono.sh/attestation/trust-policy/v1`.
+The `subject` binds the statement to a specific file by name and SHA-256 digest. The `predicateType` identifies this as a nono file attestation. Trust policy signatures use a separate predicate type: `https://nono.sh/attestation/trust-policy/v1`.
 
 For keyless signing, the predicate carries OIDC provenance:
 
@@ -122,13 +122,13 @@ For keyed bundles, the public key is loaded from the system keystore and the ECD
 
 ### Pre-exec Scan
 
-Before fork/exec, nono scans the working directory for files matching `instruction_patterns`. File discovery intentionally does **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
+Before fork/exec, nono scans the working directory for files matching `includes`. File discovery intentionally does **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
 
 The pre-exec scan also verifies the trust policy's own signature before trusting it.
 
 ### Seccomp-Notify (Linux Runtime)
 
-On Linux in [Supervised mode](/cli/features/supervisor), the seccomp-notify supervisor already traps `openat`/`openat2` syscalls for capability expansion. When the target path matches an instruction file pattern, the trust interceptor runs verification before the normal approval flow.
+On Linux in [Supervised mode](/cli/features/supervisor), the seccomp-notify supervisor already traps `openat`/`openat2` syscalls for capability expansion. When the target path matches an include pattern, the trust interceptor runs verification before the normal approval flow.
 
 The interceptor:
 1. Reads the file content from disk (the supervisor has unrestricted access)
@@ -143,13 +143,13 @@ A TOCTOU re-verification step ensures the digest of the opened file descriptor m
 
 On macOS, verified files are write-protected at the kernel level using literal Seatbelt deny rules. During sandbox profile generation:
 
-1. The pre-exec trust scan verifies all files matching `instruction_patterns` in the trust policy
+1. The pre-exec trust scan verifies all files matching `includes` in the trust policy
 2. For each file that passed verification, a `(deny file-write-data (literal "/full/path"))` rule is emitted
 3. If the path involves a symlink (e.g., `/tmp` → `/private/tmp`), rules are emitted for both the original and canonical paths
 
 This makes verified files structurally immutable — the sandboxed process cannot modify them even though the parent directory may have write access granted. The pre-exec scan gates execution, aborting if any existing file fails verification.
 
-Unlike Linux (where seccomp-notify intercepts every `openat()` at runtime), macOS trust verification is startup-only. Files matching `instruction_patterns` that appear after sandbox application are not verified before the agent reads them. The macOS enforcement boundary is: integrity of files verified at startup, not runtime interception of all file opens.
+Unlike Linux (where seccomp-notify intercepts every `openat()` at runtime), macOS trust verification is startup-only. Files matching `includes` that appear after sandbox application are not verified before the agent reads them. The macOS enforcement boundary is: integrity of files verified at startup, not runtime interception of all file opens.
 
 ## Verification Cache
 
@@ -167,7 +167,7 @@ If any component of the cache key changes (file modified, replaced, moved), the 
 
 The trust policy itself must be signed to establish a root of trust. Without this, an attacker who can write to the project directory can modify `trust-policy.json` to add themselves as a publisher or weaken enforcement.
 
-Policy bundles use the predicate type `https://nono.sh/attestation/trust-policy/v1` to distinguish them from instruction file bundles.
+Policy bundles use the predicate type `https://nono.sh/attestation/trust-policy/v1` to distinguish them from file attestation bundles.
 
 During pre-exec scan, policy signature verification runs first:
 
@@ -188,12 +188,12 @@ Multiple trust policies merge with additive-only semantics:
 
 | Field | Merge Strategy |
 |-------|---------------|
-| `instruction_patterns` | Union |
+| `includes` | Union |
 | `publishers` | Union |
 | `blocklist.digests` | Union |
 | `enforcement` | Strictest wins (`deny` > `warn` > `audit`) |
 
-Project-level policy cannot weaken user-level or embedded policy. A malicious project's `trust-policy.json` can add publishers but cannot remove blocklist entries, remove instruction patterns, or downgrade enforcement.
+Project-level policy cannot weaken user-level or embedded policy. A malicious project's `trust-policy.json` can add publishers but cannot remove blocklist entries, remove include patterns, or downgrade enforcement.
 
 ## Codebase Layout
 
@@ -207,7 +207,7 @@ Attestation primitives reusable by all language bindings.
 | `digest.rs` | SHA-256 digest computation (file and bytes) |
 | `dsse.rs` | DSSE envelope parsing/construction, PAE, in-toto statements |
 | `bundle.rs` | Sigstore bundle verification, Fulcio cert identity extraction |
-| `policy.rs` | Trust policy loading, merging, evaluation, instruction file discovery |
+| `policy.rs` | Trust policy loading, merging, evaluation, file discovery |
 | `signing.rs` | ECDSA P-256 key generation, keyed signing, bundle construction |
 
 ### CLI (`crates/nono-cli/src/`)

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -122,7 +122,7 @@ For keyed bundles, the public key is loaded from the system keystore and the ECD
 
 ### Pre-exec Scan
 
-Before fork/exec, nono scans the working directory for files matching `instruction_patterns`. File discovery uses the `ignore` crate, which respects `.gitignore`, global gitignore, and `.git/info/exclude` — files excluded by gitignore are not scanned. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
+Before fork/exec, nono scans the working directory for files matching `instruction_patterns`. File discovery intentionally does **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
 
 The pre-exec scan also verifies the trust policy's own signature before trusting it.
 
@@ -147,9 +147,9 @@ On macOS, verified files are write-protected at the kernel level using literal S
 2. For each file that passed verification, a `(deny file-write-data (literal "/full/path"))` rule is emitted
 3. If the path involves a symlink (e.g., `/tmp` → `/private/tmp`), rules are emitted for both the original and canonical paths
 
-This makes verified files structurally immutable — the sandboxed process cannot modify them even though the parent directory may have write access granted. The pre-exec scan gates execution (aborting if any file fails verification), and the supervisor's `TrustInterceptor` handles runtime verification of files opened mid-session.
+This makes verified files structurally immutable — the sandboxed process cannot modify them even though the parent directory may have write access granted. The pre-exec scan gates execution, aborting if any existing file fails verification.
 
-Note: filename-pattern-based read blocking (e.g., denying reads of `SKILLS*`) is intentionally not used. An attacker can trivially vary filenames to bypass pattern matching. The security boundary is the trust policy's cryptographic verification, not filename conventions.
+Unlike Linux (where seccomp-notify intercepts every `openat()` at runtime), macOS trust verification is startup-only. Files matching `instruction_patterns` that appear after sandbox application are not verified before the agent reads them. The macOS enforcement boundary is: integrity of files verified at startup, not runtime interception of all file opens.
 
 ## Verification Cache
 

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -221,9 +221,9 @@ Attestation primitives reusable by all language bindings.
 
 ## Security Properties
 
-**Verification before ingestion.** The pre-exec scan and runtime interception both ensure the agent never sees content that failed verification. If the agent reads the file before verification completes, the injection has already succeeded.
+**Verification before ingestion.** On Linux, the pre-exec scan and seccomp-notify runtime interception together ensure the agent never sees content that failed verification — files present at startup and files that appear mid-session are both verified before the agent can read them. On macOS, verification is startup-only: files present at launch are verified, and verified files are write-protected, but files that appear mid-session are not intercepted (see [Seatbelt Write-Protection](#seatbelt-write-protection-macos) above). To mitigate this on macOS, literal patterns in the trust policy that have no matching file at startup cause a hard failure in `deny` mode.
 
-**No trust-on-first-use.** A file must have a valid signature from a trusted publisher on first encounter. TOFU creates a window where the first encounter is untrusted, which is the supply chain attack scenario this defends against.
+**No trust-on-first-use (Linux).** On Linux, a file must have a valid signature from a trusted publisher on first encounter — seccomp-notify intercepts the `openat()` syscall before the read completes. On macOS, this guarantee applies only to files present at startup.
 
 **Blocklist before crypto.** A known-malicious file is denied even if it has a valid signature. This handles the case of a legitimately-signed file that is later discovered to be malicious.
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -126,17 +126,18 @@ See [Policy Introspection](/cli/features/policy-introspection) for full document
 
 ### `nono trust`
 
-Manage instruction file attestation. Sign, verify, and manage trust for AI agent instruction files.
+Manage file attestation. Sign, verify, and manage trust for files consumed by AI agents.
 
 ```bash
 nono trust <SUBCOMMAND>
 ```
 
 Subcommands:
-- `sign` - Sign instruction files
+- `init` - Create a trust-policy.json in the current directory
+- `sign` - Sign files
 - `sign-policy` - Sign a trust policy file
-- `verify` - Verify instruction files against the trust policy
-- `list` - List instruction files and their verification status
+- `verify` - Verify files against the trust policy
+- `list` - List files and their verification status
 - `keygen` - Generate a new signing key pair
 - `export-key` - Export the public key for a signing key
 
@@ -871,9 +872,31 @@ Available context flags:
 
 ## `nono trust` Options
 
+### `nono trust init`
+
+Create a `trust-policy.json` in the current directory. Scans for files and auto-populates patterns and publisher.
+
+```bash
+nono trust init                            # Scan root directory only
+nono trust init -r                         # Scan recursively
+nono trust init -r --exclude-dirs tmp logs # Exclude extra directories
+nono trust init --key my-key --force       # Specific key, overwrite existing
+```
+
+| Option | Description |
+|--------|-------------|
+| `-r`, `--recursive` | Scan subdirectories recursively |
+| `--exclude-dirs <DIR...>` | Additional directories to exclude (on top of `.gitignore` and built-in list) |
+| `--key <KEY_ID>` | Key ID to include as publisher (default: "default") |
+| `--force` | Overwrite existing `trust-policy.json` |
+
+<Note>
+  File discovery respects `.gitignore`, global gitignore, and `.git/info/exclude`. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default.
+</Note>
+
 ### `nono trust sign`
 
-Sign instruction files, producing bundles for verification.
+Sign files, producing bundles for verification.
 
 ```bash
 nono trust sign <FILES...>                 # Sign specific files

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -891,7 +891,7 @@ nono trust init --key my-key --force       # Specific key, overwrite existing
 | `--force` | Overwrite existing `trust-policy.json` |
 
 <Note>
-  File discovery respects `.gitignore`, global gitignore, and `.git/info/exclude`. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default.
+  File discovery for `init` respects `.gitignore` to keep the generated policy clean. Hidden directories like `.claude/` and `.github/` are included. Common build artifact directories (`node_modules`, `target`, `.venv`, etc.) are skipped by default. Note: the pre-exec trust scan and `sign --all`/`verify --all` do **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification.
 </Note>
 
 ### `nono trust sign`

--- a/tests/integration/test_trust_cli.sh
+++ b/tests/integration/test_trust_cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Trust CLI Tests
-# Tests the trust command lifecycle: key generation, signing, verification, listing
+# Tests trust policy scaffolding, signing, verification, listing, and startup checks
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
@@ -9,20 +9,172 @@ echo ""
 echo -e "${BLUE}=== Trust CLI Tests ===${NC}"
 
 verify_nono_binary
+NONO_BIN="$(cd "$(dirname "$NONO_BIN")" && pwd)/$(basename "$NONO_BIN")"
 
-# Trust CLI does not require a working sandbox (it's a CLI-only feature)
+# Trust CLI is mostly CLI-only, but a small startup section below exercises
+# sandboxed execution when the host supports it.
 
-# Create test fixtures
 TMPDIR=$(setup_test_dir)
 trap 'cleanup_test_dir "$TMPDIR"' EXIT
 
 # Generate a unique key ID for this test run to avoid collisions
 KEY_ID="nono-inttest-$$"
+TEST_XDG="$TMPDIR/xdg"
+TRUST_KEYSTORE_DIR="$TMPDIR/trust-keystore"
+
+INIT_DIR="$TMPDIR/init"
+INIT_NO_KEY_DIR="$TMPDIR/init-no-key"
+SINGLE_DIR="$TMPDIR/single"
+MULTI_DIR="$TMPDIR/multi"
+MISSING_DIR="$TMPDIR/missing"
+STARTUP_DIR="$TMPDIR/startup"
+
+mkdir -p \
+    "$TEST_XDG" \
+    "$TRUST_KEYSTORE_DIR" \
+    "$INIT_DIR" \
+    "$INIT_NO_KEY_DIR" \
+    "$SINGLE_DIR" \
+    "$MULTI_DIR" \
+    "$MISSING_DIR" \
+    "$STARTUP_DIR"
 
 echo ""
 echo "Test directory: $TMPDIR"
 echo "Key ID: $KEY_ID"
 echo ""
+
+CAPTURED_OUTPUT=""
+CAPTURED_EXIT=0
+
+strip_ansi() {
+    sed 's/\x1b\[[0-9;]*m//g'
+}
+
+with_test_env() {
+    env \
+        XDG_CONFIG_HOME="$TEST_XDG" \
+        NONO_TRUST_TEST_USER_POLICY_PATH="$TEST_XDG/nono/trust-policy.json" \
+        NONO_TRUST_TEST_KEYSTORE_DIR="$TRUST_KEYSTORE_DIR" \
+        NONO_NO_UPDATE_CHECK=1 \
+        "$@"
+}
+
+capture_in_dir() {
+    local dir="$1"
+    shift
+
+    local raw_output=""
+
+    set +e
+    raw_output=$(cd "$dir" && "$@" </dev/null 2>&1)
+    CAPTURED_EXIT=$?
+    set -e
+
+    CAPTURED_OUTPUT=$(printf '%s' "$raw_output" | strip_ansi)
+}
+
+expect_in_dir_success() {
+    local name="$1"
+    local dir="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    capture_in_dir "$dir" "$@"
+
+    if [[ "$CAPTURED_EXIT" -eq 0 ]]; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected exit code: 0, got: $CAPTURED_EXIT"
+    echo "       Output: ${CAPTURED_OUTPUT:0:2000}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+expect_in_dir_failure() {
+    local name="$1"
+    local dir="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    capture_in_dir "$dir" "$@"
+
+    if [[ "$CAPTURED_EXIT" -ne 0 ]]; then
+        echo -e "  ${GREEN}PASS${NC}: $name (exit $CAPTURED_EXIT)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected failure, but got success (exit 0)"
+    echo "       Output: ${CAPTURED_OUTPUT:0:2000}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+expect_in_dir_success_contains() {
+    local name="$1"
+    local dir="$2"
+    local expected_str="$3"
+    shift 3
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    capture_in_dir "$dir" "$@"
+
+    if [[ "$CAPTURED_EXIT" -eq 0 ]] && printf '%s' "$CAPTURED_OUTPUT" | grep -Fq "$expected_str"; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected exit code: 0 and output containing: $expected_str"
+    echo "       Exit code: $CAPTURED_EXIT"
+    echo "       Output: ${CAPTURED_OUTPUT:0:2000}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+expect_in_dir_failure_contains() {
+    local name="$1"
+    local dir="$2"
+    local expected_str="$3"
+    shift 3
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    capture_in_dir "$dir" "$@"
+
+    if [[ "$CAPTURED_EXIT" -ne 0 ]] && printf '%s' "$CAPTURED_OUTPUT" | grep -Fq "$expected_str"; then
+        echo -e "  ${GREEN}PASS${NC}: $name (exit $CAPTURED_EXIT)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected failure and output containing: $expected_str"
+    echo "       Exit code: $CAPTURED_EXIT"
+    echo "       Output: ${CAPTURED_OUTPUT:0:2000}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+expect_file_contains() {
+    local name="$1"
+    local file="$2"
+    local expected_str="$3"
+    run_test "$name" 0 grep -Fq "$expected_str" "$file" || true
+}
+
+expect_file_not_contains() {
+    local name="$1"
+    local file="$2"
+    local unexpected_str="$3"
+    run_test "$name" 1 grep -Fq "$unexpected_str" "$file" || true
+}
 
 # =============================================================================
 # Key Generation
@@ -31,107 +183,219 @@ echo ""
 echo "--- Key Generation ---"
 
 expect_success "trust keygen creates key" \
-    "$NONO_BIN" trust keygen --id "$KEY_ID"
+    with_test_env "$NONO_BIN" trust keygen --id "$KEY_ID"
 
 expect_output_contains "trust keygen shows key ID" "$KEY_ID" \
-    "$NONO_BIN" trust keygen --id "${KEY_ID}-show"
+    with_test_env "$NONO_BIN" trust keygen --id "${KEY_ID}-show"
 
 # Duplicate key ID should fail
 expect_failure "trust keygen duplicate ID fails" \
-    "$NONO_BIN" trust keygen --id "$KEY_ID"
+    with_test_env "$NONO_BIN" trust keygen --id "$KEY_ID"
 
 # =============================================================================
-# Signing
+# trust init
 # =============================================================================
 
 echo ""
-echo "--- Signing ---"
+echo "--- trust init ---"
 
-# Create instruction files
-echo "# Test SKILLS file" > "$TMPDIR/SKILLS.md"
-echo "# Test CLAUDE file" > "$TMPDIR/CLAUDE.md"
+mkdir -p "$INIT_DIR/nested" "$INIT_DIR/vendor"
+printf '# Test SKILLS file\n' > "$INIT_DIR/SKILLS.md"
+printf '# Nested AGENT file\n' > "$INIT_DIR/nested/AGENT.md"
+printf '# Ignored vendor file\n' > "$INIT_DIR/vendor/CLAUDE.md"
+
+expect_in_dir_success "trust init creates trust-policy.json" "$INIT_DIR" \
+    with_test_env "$NONO_BIN" trust init --include SKILLS.md --key "$KEY_ID"
+
+run_test "trust init writes policy file" 0 test -f "$INIT_DIR/trust-policy.json"
+expect_file_contains "trust init writes includes field" "$INIT_DIR/trust-policy.json" '"includes"'
+expect_file_contains "trust init includes requested project file" "$INIT_DIR/trust-policy.json" '"SKILLS.md"'
+expect_file_not_contains "trust init omits files not explicitly included" "$INIT_DIR/trust-policy.json" '"nested/AGENT.md"'
+expect_file_not_contains "trust init omits unrelated files" "$INIT_DIR/trust-policy.json" '"vendor/CLAUDE.md"'
+expect_file_contains "trust init embeds publisher name when key exists" "$INIT_DIR/trust-policy.json" "\"name\": \"$KEY_ID\""
+expect_file_contains "trust init embeds publisher public key" "$INIT_DIR/trust-policy.json" '"public_key"'
+
+expect_in_dir_failure "trust init refuses to overwrite existing policy without --force" "$INIT_DIR" \
+    with_test_env "$NONO_BIN" trust init --include SKILLS.md --key "$KEY_ID"
+
+expect_in_dir_success "trust init --force updates explicit include patterns" "$INIT_DIR" \
+    with_test_env "$NONO_BIN" trust init --force --include SKILLS.md nested/AGENT.md --key "$KEY_ID"
+
+expect_file_contains "trust init force update includes nested paths when requested" "$INIT_DIR/trust-policy.json" '"nested/AGENT.md"'
+expect_file_not_contains "trust init force update still omits unrelated files" "$INIT_DIR/trust-policy.json" '"vendor/CLAUDE.md"'
+
+expect_in_dir_success "trust init --user creates a user policy in XDG config" "$INIT_DIR" \
+    with_test_env "$NONO_BIN" trust init --user --force --key "$KEY_ID"
+
+run_test "trust init --user writes user policy file" 0 test -f "$TEST_XDG/nono/trust-policy.json"
+expect_file_contains "trust init --user creates empty includes by default" "$TEST_XDG/nono/trust-policy.json" '"includes": []'
+
+expect_success "trust sign-policy signs user policy" \
+    with_test_env "$NONO_BIN" trust sign-policy "$TEST_XDG/nono/trust-policy.json" --key "$KEY_ID"
+
+run_test "trust init --user writes signed user policy bundle" 0 test -f "$TEST_XDG/nono/trust-policy.json.bundle"
+
+printf '# Test AGENT file\n' > "$INIT_NO_KEY_DIR/AGENT.md"
+
+expect_in_dir_success_contains "trust init notes missing signing key" "$INIT_NO_KEY_DIR" "skipping publisher entry" \
+    with_test_env "$NONO_BIN" trust init --include AGENT.md --key "${KEY_ID}-missing"
+
+expect_file_contains "trust init without key creates empty publisher list" "$INIT_NO_KEY_DIR/trust-policy.json" '"publishers": []'
+
+# =============================================================================
+# Single-file signing, verification, and listing
+# =============================================================================
+
+echo ""
+echo "--- Single-file Signing ---"
+
+printf '# Test SKILLS file\n' > "$SINGLE_DIR/SKILLS.md"
+printf '# Test CLAUDE file\n' > "$SINGLE_DIR/CLAUDE.md"
+printf '# Unsigned AGENT file\n' > "$SINGLE_DIR/AGENT.md"
+
+expect_in_dir_success "single-file project trust init succeeds" "$SINGLE_DIR" \
+    with_test_env "$NONO_BIN" trust init --include SKILLS.md CLAUDE.md AGENT.md --key "$KEY_ID"
 
 expect_success "trust sign creates bundle" \
-    "$NONO_BIN" trust sign "$TMPDIR/SKILLS.md" --key "$KEY_ID"
+    with_test_env "$NONO_BIN" trust sign "$SINGLE_DIR/SKILLS.md" --key "$KEY_ID"
 
-# Verify bundle file was created
-run_test "bundle file exists" 0 test -f "$TMPDIR/SKILLS.md.bundle"
+run_test "bundle file exists" 0 test -f "$SINGLE_DIR/SKILLS.md.bundle"
 
-# Sign another file
 expect_success "trust sign second file" \
-    "$NONO_BIN" trust sign "$TMPDIR/CLAUDE.md" --key "$KEY_ID"
+    with_test_env "$NONO_BIN" trust sign "$SINGLE_DIR/CLAUDE.md" --key "$KEY_ID"
 
-run_test "second bundle file exists" 0 test -f "$TMPDIR/CLAUDE.md.bundle"
+run_test "second bundle file exists" 0 test -f "$SINGLE_DIR/CLAUDE.md.bundle"
 
-# Sign nonexistent file
 expect_failure "trust sign nonexistent file fails" \
-    "$NONO_BIN" trust sign "$TMPDIR/NONEXISTENT.md" --key "$KEY_ID"
+    with_test_env "$NONO_BIN" trust sign "$SINGLE_DIR/NONEXISTENT.md" --key "$KEY_ID"
+
+expect_in_dir_success "trust sign-policy succeeds" "$SINGLE_DIR" \
+    with_test_env "$NONO_BIN" trust sign-policy --key "$KEY_ID"
+
+run_test "trust policy bundle exists" 0 test -f "$SINGLE_DIR/trust-policy.json.bundle"
+
+expect_in_dir_success_contains "trust verify signed file succeeds with trust policy" "$SINGLE_DIR" "VERIFIED" \
+    with_test_env "$NONO_BIN" trust verify SKILLS.md
+
+expect_in_dir_failure_contains "trust verify unsigned file fails (no bundle)" "$SINGLE_DIR" "no .bundle file found" \
+    with_test_env "$NONO_BIN" trust verify AGENT.md
+
+printf '\n# TAMPERED CONTENT\n' >> "$SINGLE_DIR/CLAUDE.md"
+
+expect_in_dir_failure_contains "trust verify tampered file fails" "$SINGLE_DIR" "bundle digest does not match file content" \
+    with_test_env "$NONO_BIN" trust verify CLAUDE.md
+
+expect_in_dir_success_contains "trust list --json reports verified files" "$SINGLE_DIR" '"status": "verified"' \
+    with_test_env "$NONO_BIN" trust list --json
+
+expect_in_dir_success_contains "trust list --json reports unsigned files" "$SINGLE_DIR" '"status": "unsigned"' \
+    with_test_env "$NONO_BIN" trust list --json
+
+expect_in_dir_success_contains "trust list --json reports failed files" "$SINGLE_DIR" '"status": "failed"' \
+    with_test_env "$NONO_BIN" trust list --json
 
 # =============================================================================
-# Verification (without trust policy — expects failure since no trusted publishers)
+# Multi-subject signing
 # =============================================================================
 
 echo ""
-echo "--- Verification ---"
+echo "--- Multi-subject Signing ---"
 
-# Without a trust policy, verify should fail because the signer is not trusted
-expect_failure "trust verify without trust policy fails" \
-    "$NONO_BIN" trust verify "$TMPDIR/SKILLS.md"
+printf '# Multi SKILLS file\n' > "$MULTI_DIR/SKILLS.md"
+printf '# Multi CLAUDE file\n' > "$MULTI_DIR/CLAUDE.md"
 
-# Verify unsigned file fails
-echo "# Unsigned file" > "$TMPDIR/AGENT.md"
-expect_failure "trust verify unsigned file fails (no bundle)" \
-    "$NONO_BIN" trust verify "$TMPDIR/AGENT.md"
+expect_in_dir_success "multi-subject project trust init succeeds" "$MULTI_DIR" \
+    with_test_env "$NONO_BIN" trust init --include SKILLS.md CLAUDE.md --key "$KEY_ID"
 
-# Tamper with signed file and verify
-echo "# TAMPERED CONTENT" >> "$TMPDIR/CLAUDE.md"
-expect_failure "trust verify tampered file fails" \
-    "$NONO_BIN" trust verify "$TMPDIR/CLAUDE.md"
+expect_in_dir_success "trust sign --all creates a multi-subject bundle" "$MULTI_DIR" \
+    with_test_env "$NONO_BIN" trust sign --all --multi-subject --key "$KEY_ID"
+
+run_test "multi-subject bundle exists" 0 test -f "$MULTI_DIR/.nono-trust.bundle"
+run_test "sign --all does not create per-file sidecars" 1 test -f "$MULTI_DIR/SKILLS.md.bundle"
+
+expect_in_dir_success "multi-subject trust sign-policy succeeds" "$MULTI_DIR" \
+    with_test_env "$NONO_BIN" trust sign-policy --key "$KEY_ID"
+
+expect_in_dir_success_contains "trust verify --all accepts multi-subject bundle" "$MULTI_DIR" "Verified 2 file(s) successfully." \
+    with_test_env "$NONO_BIN" trust verify --all
+
+expect_in_dir_success_contains "trust verify .nono-trust.bundle reports first subject" "$MULTI_DIR" "SKILLS.md" \
+    with_test_env "$NONO_BIN" trust verify .nono-trust.bundle
+
+expect_in_dir_success_contains "trust verify .nono-trust.bundle reports second subject" "$MULTI_DIR" "CLAUDE.md" \
+    with_test_env "$NONO_BIN" trust verify .nono-trust.bundle
+
+printf '\n# TAMPERED CONTENT\n' >> "$MULTI_DIR/CLAUDE.md"
+
+expect_in_dir_failure_contains "trust verify --all rejects tampered multi-subject bundle" "$MULTI_DIR" "digest mismatch" \
+    with_test_env "$NONO_BIN" trust verify --all
 
 # =============================================================================
-# Listing
+# Missing literal patterns
 # =============================================================================
 
 echo ""
-echo "--- Listing ---"
+echo "--- Missing Literal Patterns ---"
 
-# List from a directory with instruction files (run from TMPDIR)
-TESTS_RUN=$((TESTS_RUN + 1))
-set +e
-list_output=$(cd "$TMPDIR" && "$NONO_BIN" trust list </dev/null 2>&1)
-list_exit=$?
-set -e
+cat > "$MISSING_DIR/trust-policy.json" <<'EOF'
+{
+  "version": 1,
+  "includes": ["SKILLS.md"],
+  "publishers": [],
+  "blocklist": {
+    "digests": [],
+    "publishers": []
+  },
+  "enforcement": "deny"
+}
+EOF
 
-# List should exit 0 (it lists files regardless of verification status)
-if [[ "$list_exit" -eq 0 ]]; then
-    echo -e "  ${GREEN}PASS${NC}: trust list exits 0"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
+if is_macos; then
+    expect_in_dir_failure_contains "trust verify --all blocks missing literal patterns on macOS" "$MISSING_DIR" "no matching file" \
+        with_test_env "$NONO_BIN" trust verify --all
+
+    expect_in_dir_failure_contains "trust list blocks missing literal patterns on macOS" "$MISSING_DIR" "no matching file" \
+        with_test_env "$NONO_BIN" trust list
 else
-    # list might exit non-zero if it reports failures — that's also valid
-    echo -e "  ${GREEN}PASS${NC}: trust list exits $list_exit (reports verification status)"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
+    expect_in_dir_success_contains "trust verify --all allows missing literal patterns on Linux" "$MISSING_DIR" "No files or multi-subject bundles found to verify." \
+        with_test_env "$NONO_BIN" trust verify --all
+
+    expect_in_dir_success_contains "trust list allows missing literal patterns on Linux" "$MISSING_DIR" "No files found matching policy includes in current directory." \
+        with_test_env "$NONO_BIN" trust list
 fi
 
-# List with --json flag
-TESTS_RUN=$((TESTS_RUN + 1))
-set +e
-json_output=$(cd "$TMPDIR" && "$NONO_BIN" trust list --json </dev/null 2>&1)
-json_exit=$?
-set -e
+# =============================================================================
+# Startup enforcement
+# =============================================================================
 
-# Check if output contains JSON structure
-if echo "$json_output" | grep -q "{"; then
-    echo -e "  ${GREEN}PASS${NC}: trust list --json produces JSON-like output"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-    # If no instruction files found, that's also valid output
-    if echo "$json_output" | grep -qi "no instruction files"; then
-        echo -e "  ${GREEN}PASS${NC}: trust list --json reports no files (expected for non-standard dir)"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+echo ""
+echo "--- Startup Enforcement ---"
+
+cat > "$STARTUP_DIR/trust-policy.json" <<'EOF'
+{
+  "version": 1,
+  "includes": ["SKILLS.md"],
+  "publishers": [],
+  "blocklist": {
+    "digests": [],
+    "publishers": []
+  },
+  "enforcement": "deny"
+}
+EOF
+
+expect_in_dir_success "trust sign-policy signs startup policy" "$STARTUP_DIR" \
+    with_test_env "$NONO_BIN" trust sign-policy --key "$KEY_ID"
+
+run_test "startup trust policy bundle exists" 0 test -f "$STARTUP_DIR/trust-policy.json.bundle"
+
+if require_working_sandbox "trust startup enforcement"; then
+    if is_macos; then
+        expect_in_dir_failure_contains "nono run blocks missing literal instruction files on macOS startup" "$STARTUP_DIR" "no matching file" \
+            with_test_env "$NONO_BIN" run --allow-cwd -- sh -c "printf STARTED"
     else
-        echo -e "  ${RED}FAIL${NC}: trust list --json produces JSON-like output"
-        echo "       Output: ${json_output:0:500}"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        expect_in_dir_success_contains "nono run allows missing literal instruction files on Linux startup" "$STARTUP_DIR" "STARTED" \
+            with_test_env "$NONO_BIN" run --allow-cwd -- sh -c "printf STARTED"
     fi
 fi
 
@@ -143,10 +407,10 @@ echo ""
 echo "--- Export Key ---"
 
 expect_success "trust export-key succeeds" \
-    "$NONO_BIN" trust export-key --id "$KEY_ID"
+    with_test_env "$NONO_BIN" trust export-key --id "$KEY_ID"
 
 expect_output_contains "export-key shows base64 public key" "MF" \
-    "$NONO_BIN" trust export-key --id "$KEY_ID"
+    with_test_env "$NONO_BIN" trust export-key --id "$KEY_ID"
 
 # =============================================================================
 # Summary

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -58,7 +58,13 @@ chmod +x "$SCRIPT_DIR"/lib/*.sh
 
 # Temp directory for suite output files
 RESULTS_DIR=$(mktemp -d)
-trap 'rm -rf "$RESULTS_DIR"' EXIT
+TEST_ENV_DIR=$(mktemp -d)
+trap 'rm -rf "$RESULTS_DIR" "$TEST_ENV_DIR"' EXIT
+
+mkdir -p "$TEST_ENV_DIR/trust-config" "$TEST_ENV_DIR/trust-keystore"
+export NONO_TRUST_TEST_USER_POLICY_PATH="$TEST_ENV_DIR/trust-config/trust-policy.json"
+export NONO_TRUST_TEST_KEYSTORE_DIR="$TEST_ENV_DIR/trust-keystore"
+export NONO_NO_UPDATE_CHECK=1
 
 # All suites to run (script:name pairs)
 SUITES=(

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -25,10 +25,10 @@ echo ""
 # Build
 # =============================================================================
 
-echo -e "${BLUE}Building nono...${NC}"
+echo -e "${BLUE}Building nono with test trust overrides enabled...${NC}"
 cd "$PROJECT_ROOT"
 
-if ! cargo build --release 2>&1; then
+if ! cargo build --release -p nono-cli --features test-trust-overrides 2>&1; then
     echo -e "${RED}Build failed!${NC}"
     exit 1
 fi


### PR DESCRIPTION
Numerous changes to the trust framework

- rename trust policy instruction_patterns to includes and refactor the trust CLI around the new model
- add nono trust init to scaffold project and user trust policies
- block missing literal include targets at startup and clarify the macOS/Linux behavior differences in trust checks
- simplify instruction_deny so it only applies write-protection rules

Closes: #432 #422