### PR TITLE
feat(policy): add standard I/O and fd paths to base_posix group

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -278,6 +278,11 @@
           "/dev/zero",
           "/dev/full",
           "/dev/tty",
+          "/dev/stdout",
+          "/dev/stderr",
+          "/dev/fd",
+          "/dev/pts",
+          "/proc/self/fd",
           "$TMPDIR"
         ]
       }


### PR DESCRIPTION
On Arch Linux (and most Linux distros), /dev/stdout is a symlink to /proc/self/fd/1, which points to a PTY like /dev/pts/14.

When Landlock is applied with only read access to /dev/stdout, /dev/fd, /dev/pts, and /proc/self, the child process can't write to stdout/stderr — causing the immediate "Permission denied" on any output.

fixes: #428