### PR TITLE
ci: add change classification to skip unnecessary jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,75 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  changes:
+    name: Classify Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_code_jobs: ${{ steps.classify.outputs.run_code_jobs }}
+      run_docs_checks: ${{ steps.classify.outputs.run_docs_checks }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          run_code_jobs=true
+          run_docs_checks=true
+
+          case "${EVENT_NAME}" in
+            pull_request)
+              base_sha="${PR_BASE_SHA}"
+              head_sha="${PR_HEAD_SHA}"
+              ;;
+            push)
+              base_sha="${PUSH_BEFORE_SHA}"
+              head_sha="${PUSH_HEAD_SHA}"
+              ;;
+            *)
+              base_sha=""
+              head_sha=""
+              ;;
+          esac
+
+          if [[ -n "${base_sha}" && -n "${head_sha}" && "${base_sha}" != "0000000000000000000000000000000000000000" ]]; then
+            mapfile -t changed_files < <(git diff --name-only "${base_sha}" "${head_sha}")
+
+            if [[ ${#changed_files[@]} -gt 0 ]]; then
+              run_code_jobs=false
+              run_docs_checks=false
+
+              for file in "${changed_files[@]}"; do
+                [[ -z "${file}" ]] && continue
+                echo "changed: ${file}"
+
+                if [[ ! "${file}" =~ (^docs/)|(\.md$)|(\.mdx$)|(^LICENSE$)|(^\.github/ISSUE_TEMPLATE/) ]]; then
+                  run_code_jobs=true
+                fi
+
+                if [[ "${file}" =~ (^docs/)|(^\.github/scripts/check-cli-doc-flags\.sh$)|(^crates/nono-cli/src/cli\.rs$) ]]; then
+                  run_docs_checks=true
+                fi
+              done
+            fi
+          fi
+
+          echo "run_code_jobs=${run_code_jobs}" >> "${GITHUB_OUTPUT}"
+          echo "run_docs_checks=${run_docs_checks}" >> "${GITHUB_OUTPUT}"
+
   test:
     name: Test
-    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
+    needs: changes
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') && needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,6 +117,8 @@ jobs:
 
   fmt:
     name: Rustfmt
+    needs: changes
+    if: ${{ needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -65,7 +133,8 @@ jobs:
 
   ffi-header:
     name: Verify FFI Header
-    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
+    needs: changes
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') && needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -89,7 +158,8 @@ jobs:
 
   clippy:
     name: Clippy
-    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
+    needs: changes
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') && needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -112,7 +182,8 @@ jobs:
 
   integration:
     name: Integration Tests
-    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') }}
+    needs: changes
+    if: ${{ !startsWith(github.head_ref, 'dependabot/github_actions/') && needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -144,6 +215,8 @@ jobs:
 
   audit:
     name: Cargo Audit
+    needs: changes
+    if: ${{ needs.changes.outputs.run_code_jobs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -159,6 +232,8 @@ jobs:
 
   docs-checks:
     name: Docs Checks
+    needs: changes
+    if: ${{ needs.changes.outputs.run_docs_checks == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,26 @@ jobs:
             pull_request)
               base_sha="${PR_BASE_SHA}"
               head_sha="${PR_HEAD_SHA}"
+              diff_mode="merge-base"
               ;;
             push)
               base_sha="${PUSH_BEFORE_SHA}"
               head_sha="${PUSH_HEAD_SHA}"
+              diff_mode="direct"
               ;;
             *)
               base_sha=""
               head_sha=""
+              diff_mode=""
               ;;
           esac
 
           if [[ -n "${base_sha}" && -n "${head_sha}" && "${base_sha}" != "0000000000000000000000000000000000000000" ]]; then
-            mapfile -t changed_files < <(git diff --name-only "${base_sha}" "${head_sha}")
+            if [[ "${diff_mode}" == "merge-base" ]]; then
+              mapfile -t changed_files < <(git diff --name-only "${base_sha}...${head_sha}")
+            else
+              mapfile -t changed_files < <(git diff --name-only "${base_sha}" "${head_sha}")
+            fi
 
             if [[ ${#changed_files[@]} -gt 0 ]]; then
               run_code_jobs=false


### PR DESCRIPTION
Add a new `changes` job that classifies which CI jobs to run based on
modified files. Code jobs (test, fmt, clippy, etc.) only run if
non-documentation files change. Docs checks only run if documentation,
CLI definition, or docs check scripts change. This reduces CI overhead
for documentation-only and code-only changes.

Signed-off-by: Luke Hinds <lukehinds@gmail.com>