### PR TITLE
feat(cli): add glob-pattern deny matching for profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,7 @@ dependencies = [
  "colored",
  "dirs",
  "dns-lookup",
+ "globset",
  "ignore",
  "jsonschema",
  "keyring",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -47,6 +47,7 @@ toml = "1.0"
 xdg-home = "1.3.0"
 dirs = "6"
 walkdir = "2"
+globset.workspace = true
 ignore.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -242,6 +242,11 @@
           "items": { "type": "string" },
           "description": "Additional deny.access paths to apply."
         },
+        "add_deny_globs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional deny glob patterns rooted under $WORKDIR. Expanded once at sandbox startup into concrete deny paths."
+        },
         "override_deny": {
           "type": "array",
           "items": { "type": "string" },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -100,6 +100,7 @@ Provides subtractive and additive composition on top of inherited groups and fil
 | `add_allow_write`    | array of string | Additional write-only path grants. |
 | `add_allow_readwrite`| array of string | Additional read+write path grants. |
 | `add_deny_access`    | array of string | Additional deny paths. |
+| `add_deny_globs`     | array of string | Additional deny glob patterns rooted under `$WORKDIR`. Expanded once at sandbox startup into concrete deny paths. |
 | `override_deny`      | array of string | Paths to exempt from deny groups. Each path must also be granted via `filesystem` or `add_allow_*`. Does not implicitly grant access; only removes the deny rule. |
 
 ### network
@@ -323,6 +324,31 @@ Block access to a file in the working directory while keeping the rest accessibl
 ```
 
 With `capability_elevation` enabled, nono runs in supervised mode where every file access outside the initial grant set is trapped and evaluated. The deny list is checked before the supervisor prompts for approval, so denied paths are blocked regardless of platform.
+
+### Denying matching files across a monorepo
+
+Use `add_deny_globs` when you need to deny a class of files under the working tree, such as `appsettings.json` variants spread across multiple projects:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "deny-appsettings",
+    "description": "Block appsettings files across the repo"
+  },
+  "security": {
+    "capability_elevation": true
+  },
+  "policy": {
+    "add_deny_globs": [
+      "$WORKDIR/**/appsettings.json",
+      "$WORKDIR/**/appsettings.*.json"
+    ]
+  }
+}
+```
+
+`add_deny_globs` is intentionally scoped to `$WORKDIR`. Patterns are expanded once when the sandbox starts; if new matching files are created later, restart the sandbox to pick them up. A glob that matches nothing is rejected to avoid a silent no-op security policy.
 
 ### Profile with group exclusion
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -7,9 +7,12 @@ use crate::cli::SandboxArgs;
 use crate::policy;
 use crate::profile::{expand_vars, Profile};
 use crate::protected_paths::{self, ProtectedRoots};
+use globset::Glob;
 use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
+use walkdir::WalkDir;
 
 /// Try to create a directory capability, warning and skipping on PathNotFound.
 /// Propagates all other errors.
@@ -35,6 +38,99 @@ fn try_new_file(path: &Path, access: AccessMode, label: &str) -> Result<Option<F
         }
         Err(e) => Err(e),
     }
+}
+
+fn is_glob_pattern(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
+}
+
+fn normalize_profile_deny_glob(pattern: &str) -> Result<String> {
+    let candidate = if let Some(rest) = pattern.strip_prefix("$WORKDIR/") {
+        rest
+    } else {
+        pattern
+    };
+    let candidate = candidate.strip_prefix("./").unwrap_or(candidate);
+
+    if pattern.starts_with('~')
+        || (pattern.starts_with('$') && !pattern.starts_with("$WORKDIR"))
+        || Path::new(pattern).is_absolute()
+    {
+        return Err(NonoError::ConfigParse(format!(
+            "Profile deny glob '{}' must be relative to $WORKDIR.",
+            pattern
+        )));
+    }
+
+    if !is_glob_pattern(candidate) {
+        return Err(NonoError::ConfigParse(format!(
+            "Profile deny glob '{}' must contain glob metacharacters. Use add_deny_access for exact paths.",
+            pattern
+        )));
+    }
+
+    if candidate.split('/').any(|segment| segment == "..") {
+        return Err(NonoError::ConfigParse(format!(
+            "Profile deny glob '{}' must not traverse outside $WORKDIR.",
+            pattern
+        )));
+    }
+
+    Ok(candidate.to_string())
+}
+
+fn expand_profile_deny_globs(patterns: &[String], workdir: &Path) -> Result<Vec<PathBuf>> {
+    let mut matches = BTreeSet::new();
+
+    for pattern in patterns {
+        let normalized = normalize_profile_deny_glob(pattern)?;
+        let matcher = Glob::new(&normalized)
+            .map_err(|e| {
+                NonoError::ConfigParse(format!("Invalid profile deny glob '{}': {}", pattern, e))
+            })?
+            .compile_matcher();
+
+        let mut matched_this_pattern = false;
+        for entry in WalkDir::new(workdir).follow_links(false) {
+            let entry = entry.map_err(|e| {
+                NonoError::ConfigParse(format!(
+                    "Failed to walk $WORKDIR '{}' while expanding deny glob '{}': {}",
+                    workdir.display(),
+                    pattern,
+                    e
+                ))
+            })?;
+
+            let relative = entry.path().strip_prefix(workdir).map_err(|e| {
+                NonoError::ConfigParse(format!(
+                    "Failed to relativize '{}' against $WORKDIR '{}': {}",
+                    entry.path().display(),
+                    workdir.display(),
+                    e
+                ))
+            })?;
+            let relative = if relative.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                relative
+            };
+
+            if matcher.is_match(relative) {
+                matches.insert(entry.path().to_path_buf());
+                matched_this_pattern = true;
+            }
+        }
+
+        if !matched_this_pattern {
+            return Err(NonoError::ConfigParse(format!(
+                "Profile deny glob '{}' matched no paths under $WORKDIR '{}'. Refusing to continue because a no-op deny glob is a security footgun.",
+                pattern,
+                workdir.display()
+            )));
+        }
+    }
+
+    Ok(matches.into_iter().collect())
 }
 
 fn apply_profile_dir_allows(
@@ -97,6 +193,13 @@ pub(crate) fn default_profile_groups() -> Result<Vec<String>> {
 /// Both methods return `(CapabilitySet, bool)` where the bool indicates whether
 /// `policy::apply_unlink_overrides()` must be called after all writable paths
 /// are finalized (including CWD). The caller is responsible for calling it.
+pub struct BuiltCapabilities {
+    pub caps: CapabilitySet,
+    pub needs_unlink_overrides: bool,
+    pub deny_paths: Vec<PathBuf>,
+}
+
+#[cfg(test)]
 pub trait CapabilitySetExt {
     /// Create a capability set from CLI sandbox arguments.
     /// Returns `(caps, needs_unlink_overrides)`.
@@ -111,84 +214,11 @@ pub trait CapabilitySetExt {
     ) -> Result<(CapabilitySet, bool)>;
 }
 
+#[cfg(test)]
 impl CapabilitySetExt for CapabilitySet {
     fn from_args(args: &SandboxArgs) -> Result<(CapabilitySet, bool)> {
-        let mut caps = CapabilitySet::new();
-        let protected_roots = ProtectedRoots::from_defaults()?;
-
-        // Resolve base policy groups (system paths, deny rules, dangerous commands)
-        let loaded_policy = policy::load_embedded_policy()?;
-        let default_groups = default_profile_groups()?;
-        let mut resolved = policy::resolve_groups(&loaded_policy, &default_groups, &mut caps)?;
-
-        // Directory permissions (canonicalize handles existence check atomically)
-        for path in &args.allow {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
-            if let Some(cap) =
-                try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.read {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
-            if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.write {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
-            if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        // Single file permissions
-        for path in &args.allow_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
-            if let Some(cap) =
-                try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.read_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
-            if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.write_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
-            if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        apply_cli_network_mode(&mut caps, args);
-
-        // Localhost IPC ports
-        for port in &args.allow_port {
-            caps.add_localhost_port(*port);
-        }
-
-        // Command allow/block lists
-        for cmd in &args.allow_command {
-            caps.add_allowed_command(cmd.clone());
-        }
-
-        for cmd in &args.block_command {
-            caps.add_blocked_command(cmd.clone());
-        }
-
-        finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
-
-        Ok((caps, resolved.needs_unlink_overrides))
+        let built = build_caps_from_args(args)?;
+        Ok((built.caps, built.needs_unlink_overrides))
     }
 
     fn from_profile(
@@ -196,192 +226,261 @@ impl CapabilitySetExt for CapabilitySet {
         workdir: &Path,
         args: &SandboxArgs,
     ) -> Result<(CapabilitySet, bool)> {
-        let mut caps = CapabilitySet::new();
-        let protected_roots = ProtectedRoots::from_defaults()?;
-
-        // Resolve policy groups from the already-finalized profile.
-        let loaded_policy = policy::load_embedded_policy()?;
-        let groups = profile.security.groups.clone();
-        let mut resolved = policy::resolve_groups(&loaded_policy, &groups, &mut caps)?;
-        debug!("Resolved {} policy groups", resolved.names.len());
-
-        // Process profile filesystem config (profile-specific paths on top of groups).
-        // These are marked as CapabilitySource::Profile so they are displayed in
-        // the banner but NOT tracked for rollback snapshots (only User-sourced paths
-        // representing the project workspace are tracked).
-        let fs = &profile.filesystem;
-
-        // Directories with read+write access
-        for path_template in &fs.allow {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_dir(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile path '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Directories with read-only access
-        for path_template in &fs.read {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_dir(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile path '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Directories with write-only access
-        for path_template in &fs.write {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_dir(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile path '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_dir(&path, AccessMode::Write, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Single files with read+write access
-        for path_template in &fs.allow_file {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::ReadWrite, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Single files with read-only access
-        for path_template in &fs.read_file {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::Read, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Single files with write-only access
-        for path_template in &fs.write_file {
-            let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
-            let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::Write, &label)? {
-                cap.source = CapabilitySource::Profile;
-                caps.add_fs(cap);
-            }
-        }
-
-        // Policy patch additions
-        apply_profile_dir_allows(
-            &profile.policy.add_allow_readwrite,
-            AccessMode::ReadWrite,
-            workdir,
-            &protected_roots,
-            &mut caps,
-            "Profile policy path",
-        )?;
-        apply_profile_dir_allows(
-            &profile.policy.add_allow_read,
-            AccessMode::Read,
-            workdir,
-            &protected_roots,
-            &mut caps,
-            "Profile policy path",
-        )?;
-        apply_profile_dir_allows(
-            &profile.policy.add_allow_write,
-            AccessMode::Write,
-            workdir,
-            &protected_roots,
-            &mut caps,
-            "Profile policy path",
-        )?;
-
-        for path_template in &profile.policy.add_deny_access {
-            let path = expand_vars(path_template, workdir)?;
-            let path_str = path.to_str().ok_or_else(|| {
-                NonoError::ConfigParse(format!(
-                    "Profile policy deny path contains non-UTF-8 bytes: {}",
-                    path.display()
-                ))
-            })?;
-            policy::add_deny_access_rules(path_str, &mut caps, &mut resolved.deny_paths)?;
-        }
-
-        // Network blocking or proxy mode from profile
-        if profile.network.block {
-            caps.set_network_blocked(true);
-        } else if profile.network.has_proxy_flags() {
-            let bind_ports =
-                crate::merge_dedup_ports(&profile.network.listen_port, &args.allow_bind);
-            // Profile requests proxy mode; port 0 is a placeholder.
-            // bind_ports come from profile listen_port plus CLI --listen-port.
-            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
-                port: 0,
-                bind_ports,
-            });
-        }
-
-        // Localhost IPC ports from profile
-        for port in &profile.network.open_port {
-            caps.add_localhost_port(*port);
-        }
-
-        // Apply allowed commands from profile
-        for cmd in &profile.security.allowed_commands {
-            caps.add_allowed_command(cmd.as_str());
-        }
-
-        // Apply signal mode from profile (None defaults to Isolated)
-        let mode = profile
-            .security
-            .signal_mode
-            .map(nono::SignalMode::from)
-            .unwrap_or_default();
-        caps = caps.set_signal_mode(mode);
-
-        // Apply process inspection mode from profile (None defaults to Isolated)
-        let process_info_mode = profile
-            .security
-            .process_info_mode
-            .map(nono::ProcessInfoMode::from)
-            .unwrap_or_default();
-        caps.set_process_info_mode_mut(process_info_mode);
-
-        // Apply IPC mode from profile (None defaults to SharedMemoryOnly)
-        let ipc_mode = profile
-            .security
-            .ipc_mode
-            .map(nono::IpcMode::from)
-            .unwrap_or_default();
-        caps.set_ipc_mode_mut(ipc_mode);
-
-        // Apply CLI overrides (CLI args take precedence)
-        add_cli_overrides(&mut caps, args)?;
-
-        // Expand profile-level override_deny paths for finalize_caps
-        let mut profile_overrides = Vec::with_capacity(profile.policy.override_deny.len());
-        for path_template in &profile.policy.override_deny {
-            let path = expand_vars(path_template, workdir)?;
-            profile_overrides.push(path);
-        }
-
-        finalize_caps(
-            &mut caps,
-            &mut resolved,
-            &loaded_policy,
-            args,
-            &profile_overrides,
-        )?;
-
-        Ok((caps, resolved.needs_unlink_overrides))
+        let built = build_caps_from_profile(profile, workdir, args)?;
+        Ok((built.caps, built.needs_unlink_overrides))
     }
+}
+
+pub fn build_caps_from_args(args: &SandboxArgs) -> Result<BuiltCapabilities> {
+    let mut caps = CapabilitySet::new();
+    let protected_roots = ProtectedRoots::from_defaults()?;
+
+    let loaded_policy = policy::load_embedded_policy()?;
+    let default_groups = default_profile_groups()?;
+    let mut resolved = policy::resolve_groups(&loaded_policy, &default_groups, &mut caps)?;
+
+    for path in &args.allow {
+        validate_requested_dir(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")? {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.read {
+        validate_requested_dir(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.write {
+        validate_requested_dir(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.allow_file {
+        validate_requested_file(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
+        {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.read_file {
+        validate_requested_file(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.write_file {
+        validate_requested_file(path, "CLI", &protected_roots)?;
+        if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")? {
+            caps.add_fs(cap);
+        }
+    }
+
+    apply_cli_network_mode(&mut caps, args);
+    for port in &args.allow_port {
+        caps.add_localhost_port(*port);
+    }
+    for cmd in &args.allow_command {
+        caps.add_allowed_command(cmd.clone());
+    }
+    for cmd in &args.block_command {
+        caps.add_blocked_command(cmd.clone());
+    }
+
+    finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
+
+    Ok(BuiltCapabilities {
+        caps,
+        needs_unlink_overrides: resolved.needs_unlink_overrides,
+        deny_paths: resolved.deny_paths,
+    })
+}
+
+pub fn build_caps_from_profile(
+    profile: &Profile,
+    workdir: &Path,
+    args: &SandboxArgs,
+) -> Result<BuiltCapabilities> {
+    let mut caps = CapabilitySet::new();
+    let protected_roots = ProtectedRoots::from_defaults()?;
+
+    let loaded_policy = policy::load_embedded_policy()?;
+    let groups = profile.security.groups.clone();
+    let mut resolved = policy::resolve_groups(&loaded_policy, &groups, &mut caps)?;
+    debug!("Resolved {} policy groups", resolved.names.len());
+
+    let fs = &profile.filesystem;
+
+    for path_template in &fs.allow {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_dir(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile path '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    for path_template in &fs.read {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_dir(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile path '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    for path_template in &fs.write {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_dir(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile path '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_dir(&path, AccessMode::Write, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    for path_template in &fs.allow_file {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_file(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile file '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_file(&path, AccessMode::ReadWrite, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    for path_template in &fs.read_file {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_file(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile file '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_file(&path, AccessMode::Read, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    for path_template in &fs.write_file {
+        let path = expand_vars(path_template, workdir)?;
+        validate_requested_file(&path, "Profile", &protected_roots)?;
+        let label = format!("Profile file '{}' does not exist, skipping", path_template);
+        if let Some(mut cap) = try_new_file(&path, AccessMode::Write, &label)? {
+            cap.source = CapabilitySource::Profile;
+            caps.add_fs(cap);
+        }
+    }
+
+    apply_profile_dir_allows(
+        &profile.policy.add_allow_readwrite,
+        AccessMode::ReadWrite,
+        workdir,
+        &protected_roots,
+        &mut caps,
+        "Profile policy path",
+    )?;
+    apply_profile_dir_allows(
+        &profile.policy.add_allow_read,
+        AccessMode::Read,
+        workdir,
+        &protected_roots,
+        &mut caps,
+        "Profile policy path",
+    )?;
+    apply_profile_dir_allows(
+        &profile.policy.add_allow_write,
+        AccessMode::Write,
+        workdir,
+        &protected_roots,
+        &mut caps,
+        "Profile policy path",
+    )?;
+
+    for path_template in &profile.policy.add_deny_access {
+        let path = expand_vars(path_template, workdir)?;
+        let path_str = path.to_str().ok_or_else(|| {
+            NonoError::ConfigParse(format!(
+                "Profile policy deny path contains non-UTF-8 bytes: {}",
+                path.display()
+            ))
+        })?;
+        policy::add_deny_access_rules(path_str, &mut caps, &mut resolved.deny_paths)?;
+    }
+    for path in expand_profile_deny_globs(&profile.policy.add_deny_globs, workdir)? {
+        let path_str = path.to_str().ok_or_else(|| {
+            NonoError::ConfigParse(format!(
+                "Profile deny glob matched non-UTF-8 path: {}",
+                path.display()
+            ))
+        })?;
+        policy::add_deny_access_rules(path_str, &mut caps, &mut resolved.deny_paths)?;
+    }
+
+    if profile.network.block {
+        caps.set_network_blocked(true);
+    } else if profile.network.has_proxy_flags() {
+        let bind_ports = crate::merge_dedup_ports(&profile.network.listen_port, &args.allow_bind);
+        caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports,
+        });
+    }
+
+    for port in &profile.network.open_port {
+        caps.add_localhost_port(*port);
+    }
+    for cmd in &profile.security.allowed_commands {
+        caps.add_allowed_command(cmd.as_str());
+    }
+
+    let mode = profile
+        .security
+        .signal_mode
+        .map(nono::SignalMode::from)
+        .unwrap_or_default();
+    caps = caps.set_signal_mode(mode);
+
+    let process_info_mode = profile
+        .security
+        .process_info_mode
+        .map(nono::ProcessInfoMode::from)
+        .unwrap_or_default();
+    caps.set_process_info_mode_mut(process_info_mode);
+
+    let ipc_mode = profile
+        .security
+        .ipc_mode
+        .map(nono::IpcMode::from)
+        .unwrap_or_default();
+    caps.set_ipc_mode_mut(ipc_mode);
+
+    add_cli_overrides(&mut caps, args)?;
+
+    let mut profile_overrides = Vec::with_capacity(profile.policy.override_deny.len());
+    for path_template in &profile.policy.override_deny {
+        let path = expand_vars(path_template, workdir)?;
+        profile_overrides.push(path);
+    }
+
+    finalize_caps(
+        &mut caps,
+        &mut resolved,
+        &loaded_policy,
+        args,
+        &profile_overrides,
+    )?;
+
+    Ok(BuiltCapabilities {
+        caps,
+        needs_unlink_overrides: resolved.needs_unlink_overrides,
+        deny_paths: resolved.deny_paths,
+    })
 }
 
 /// Shared finalization: deny overrides, overlap validation, keychain exception, dedup.
@@ -780,6 +879,142 @@ mod tests {
 
         let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
             .expect_err("profile deny overlap should fail on linux");
+        assert!(
+            err.to_string().contains("Landlock deny-overlap"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_add_deny_globs_removes_matching_file_grants() {
+        let workdir = tempdir().expect("workdir");
+        let cfg_dir = workdir.path().join("service");
+        std::fs::create_dir_all(&cfg_dir).expect("mkdir cfg dir");
+        let denied = cfg_dir.join("appsettings.production.json");
+        let allowed = cfg_dir.join("notes.txt");
+        std::fs::write(&denied, "{}").expect("write denied file");
+        std::fs::write(&allowed, "notes").expect("write allowed file");
+        let denied_canonical = denied.canonicalize().expect("canonicalize denied");
+        let allowed_canonical = allowed.canonicalize().expect("canonicalize allowed");
+
+        let profile_path = workdir.path().join("deny-globs.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "deny-globs" }},
+                    "filesystem": {{
+                        "read_file": ["{}", "{}"]
+                    }},
+                    "policy": {{
+                        "add_deny_globs": ["**/appsettings*.json"]
+                    }}
+                }}"#,
+                denied.display(),
+                allowed.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let args = sandbox_args();
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            !caps
+                .fs_capabilities()
+                .iter()
+                .any(|cap| cap.is_file && cap.resolved == denied_canonical),
+            "deny glob should remove matching file grant"
+        );
+        assert!(
+            caps.fs_capabilities()
+                .iter()
+                .any(|cap| cap.is_file && cap.resolved == allowed_canonical),
+            "deny glob must not remove non-matching file grant"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_add_deny_globs_rejects_non_workdir_patterns() {
+        let workdir = tempdir().expect("workdir");
+        let profile_path = workdir.path().join("deny-globs-bad.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "deny-globs-bad" },
+                "policy": {
+                    "add_deny_globs": ["$HOME/**/appsettings*.json"]
+                }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let args = sandbox_args();
+
+        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+            .expect_err("non-workdir deny glob should fail");
+        assert!(
+            err.to_string().contains("must be relative to $WORKDIR"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_policy_add_deny_globs_rejects_zero_matches() {
+        let workdir = tempdir().expect("workdir");
+        let profile_path = workdir.path().join("deny-globs-empty.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "deny-globs-empty" },
+                "policy": {
+                    "add_deny_globs": ["**/appsettings*.json"]
+                }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let args = sandbox_args();
+
+        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+            .expect_err("zero-match deny glob should fail");
+        assert!(
+            err.to_string().contains("matched no paths under $WORKDIR"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_final_deny_validation_catches_post_cwd_overlap_for_deny_globs() {
+        let workdir = tempdir().expect("workdir");
+        let denied = workdir.path().join("appsettings.json");
+        std::fs::write(&denied, "{}").expect("write denied");
+
+        let profile_path = workdir.path().join("deny-globs-final.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "deny-globs-final" },
+                "policy": {
+                    "add_deny_globs": ["**/appsettings*.json"]
+                }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let args = sandbox_args();
+
+        let mut built = build_caps_from_profile(&profile, workdir.path(), &args).expect("build");
+        let cwd_cap =
+            FsCapability::new_dir(workdir.path(), AccessMode::ReadWrite).expect("cwd cap");
+        built.caps.add_fs(cwd_cap);
+        built.caps.deduplicate();
+
+        let err = crate::policy::validate_deny_overlaps(&built.deny_paths, &built.caps)
+            .expect_err("final validation should reject post-CWD overlap");
         assert!(
             err.to_string().contains("Landlock deny-overlap"),
             "unexpected error: {err}"

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -198,6 +198,8 @@ pub struct ExecConfig<'a> {
 pub struct SupervisorConfig<'a> {
     /// Protected nono state roots that must never be granted dynamically.
     pub protected_roots: &'a [std::path::PathBuf],
+    /// Deny paths that must be rejected before any approval prompt.
+    pub deny_paths: &'a [std::path::PathBuf],
     /// Backend for approval decisions (terminal prompt, webhook, policy engine)
     pub approval_backend: &'a dyn ApprovalBackend,
     /// Session identifier used for audit correlation.
@@ -210,6 +212,20 @@ pub struct SupervisorConfig<'a> {
     /// Whether direct LaunchServices opening is enabled for this session.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub allow_launch_services_active: bool,
+}
+
+fn canonicalize_for_deny_check(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Ok(parent_canonical) = parent.canonicalize() {
+            return parent_canonical.join(path.file_name().unwrap_or_default());
+        }
+    }
+
+    path.to_path_buf()
 }
 
 #[cfg(target_os = "macos")]
@@ -1519,6 +1535,8 @@ fn handle_supervisor_message(
             // Set by the trust interceptor branch when an instruction file is verified.
             let mut verified_digest: Option<String> = None;
 
+            let canonical_request_path = canonicalize_for_deny_check(&request.path);
+
             let decision = if let Some(protected_root) =
                 crate::protected_paths::overlapping_protected_root(
                     &request.path,
@@ -1542,6 +1560,29 @@ fn handle_supervisor_message(
                     reason: format!(
                         "Path overlaps protected nono state root '{}': {}",
                         protected_root.display(),
+                        request.path.display()
+                    ),
+                }
+            } else if let Some(deny_path) =
+                crate::policy::matching_deny_path(&canonical_request_path, config.deny_paths)
+            {
+                debug!(
+                    "Supervisor: path {} blocked by deny path {}",
+                    canonical_request_path.display(),
+                    deny_path.display()
+                );
+                record_denial(
+                    denials,
+                    DenialRecord {
+                        path: request.path.clone(),
+                        access: request.access,
+                        reason: DenialReason::PolicyBlocked,
+                    },
+                );
+                ApprovalDecision::Denied {
+                    reason: format!(
+                        "Path is denied by active sandbox policy '{}': {}",
+                        deny_path.display(),
                         request.path.display()
                     ),
                 }
@@ -2512,6 +2553,7 @@ mod tests {
         let backend = DenyAll;
         let sup_cfg = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test-session",
             open_url_origins: &[],
@@ -2565,6 +2607,88 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_handle_supervisor_message_denied_path_skips_prompt() {
+        use std::os::unix::net::UnixStream;
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        struct CountingBackend {
+            calls: Arc<AtomicUsize>,
+        }
+
+        impl ApprovalBackend for CountingBackend {
+            fn request_capability(
+                &self,
+                _req: &nono::supervisor::CapabilityRequest,
+            ) -> nono::Result<ApprovalDecision> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(ApprovalDecision::Granted)
+            }
+
+            fn backend_name(&self) -> &str {
+                "counting-backend"
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let denied = dir.path().join("appsettings.json");
+        std::fs::write(&denied, "{}").expect("write denied");
+        let denied_canonical = denied.canonicalize().expect("canonicalize denied");
+        let deny_paths = if denied_canonical == denied {
+            vec![denied.clone()]
+        } else {
+            vec![denied.clone(), denied_canonical]
+        };
+        let calls = Arc::new(AtomicUsize::new(0));
+        let backend = CountingBackend {
+            calls: Arc::clone(&calls),
+        };
+        let config = SupervisorConfig {
+            protected_roots: &[],
+            deny_paths: &deny_paths,
+            approval_backend: &backend,
+            session_id: "test-session",
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+            allow_launch_services_active: false,
+        };
+        let (stream_a, _stream_b) = UnixStream::pair().expect("socketpair");
+        let mut sock = SupervisorSocket::from_stream(stream_a);
+        let mut denials = Vec::new();
+        let mut seen = HashSet::new();
+        let request = nono::CapabilityRequest {
+            request_id: "req-1".to_string(),
+            path: denied.clone(),
+            access: nono::AccessMode::Read,
+            reason: Some("test".to_string()),
+            child_pid: std::process::id(),
+            session_id: "sess-1".to_string(),
+        };
+
+        handle_supervisor_message(
+            &mut sock,
+            SupervisorMessage::Request(request),
+            Pid::from_raw(std::process::id() as i32),
+            &config,
+            &mut denials,
+            &mut seen,
+            None,
+        )
+        .expect("handle request");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "deny path should be rejected before approval backend is invoked"
+        );
+        assert!(denials
+            .iter()
+            .any(|d| d.reason == DenialReason::PolicyBlocked));
+    }
+
     struct TestDenyBackend;
     impl ApprovalBackend for TestDenyBackend {
         fn request_capability(
@@ -2586,6 +2710,7 @@ mod tests {
         let origins = vec!["https://claude.ai".to_string()];
         let config = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &origins,
@@ -2612,6 +2737,7 @@ mod tests {
         let backend = TestDenyBackend;
         let config = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &[],
@@ -2636,6 +2762,7 @@ mod tests {
         let backend = TestDenyBackend;
         let config_allow = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &[],
@@ -2644,6 +2771,7 @@ mod tests {
         };
         let config_deny = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &[],
@@ -2673,6 +2801,7 @@ mod tests {
         let backend = TestDenyBackend;
         let config = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &[],
@@ -2779,6 +2908,7 @@ mod tests {
         let backend = TestBackend;
         let config = SupervisorConfig {
             protected_roots: &[],
+            deny_paths: &[],
             approval_backend: &backend,
             session_id: "test",
             open_url_origins: &[],

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -219,6 +219,26 @@ pub(super) fn handle_seccomp_notification(
         return Ok(());
     }
 
+    let deny_path = crate::policy::matching_deny_path(&canonicalized, config.deny_paths)
+        .or_else(|| crate::policy::matching_deny_path(&resolved_path, config.deny_paths));
+    if let Some(deny_path) = deny_path {
+        debug!(
+            "Seccomp: path {} blocked by deny path {}",
+            canonicalized.display(),
+            deny_path.display()
+        );
+        record_denial(
+            denials,
+            DenialRecord {
+                path: canonicalized.clone(),
+                access,
+                reason: DenialReason::PolicyBlocked,
+            },
+        );
+        let _ = deny_notif(notify_fd, notif.id);
+        return Ok(());
+    }
+
     // 5. Fast-path: check if path is in the initial capability set.
     // File capabilities require exact match; directory capabilities allow subpaths.
     let in_initial_set = initial_caps.iter().any(|(cap_path, is_file)| {

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -32,7 +32,6 @@ mod trust_keystore;
 mod trust_scan;
 mod update_check;
 
-use capability_ext::CapabilitySetExt;
 use clap::Parser;
 use cli::{
     Cli, Commands, LearnArgs, OpenUrlHelperArgs, RunArgs, SandboxArgs, SetupArgs, ShellArgs,
@@ -474,12 +473,17 @@ fn run_why(args: WhyArgs) -> Result<()> {
     // Build capability set from args or load from sandbox state.
     // Also collect overridden paths so the query can skip sensitive-path checks
     // for paths that have been exempted via override_deny.
-    let (caps, overridden_paths): (CapabilitySet, Vec<std::path::PathBuf>) = if args.self_query {
+    let (caps, overridden_paths, deny_paths): (
+        CapabilitySet,
+        Vec<std::path::PathBuf>,
+        Vec<std::path::PathBuf>,
+    ) = if args.self_query {
         // Inside sandbox - load from state file
         match load_sandbox_state() {
             Some(state) => {
-                let paths = state.override_deny_as_paths();
-                (state.to_caps()?, paths)
+                let override_paths = state.override_deny_as_paths();
+                let deny_paths = state.deny_as_paths();
+                (state.to_caps()?, override_paths, deny_paths)
             }
             None => {
                 let result = QueryResult::NotSandboxed {
@@ -530,11 +534,12 @@ fn run_why(args: WhyArgs) -> Result<()> {
             }
         }
 
-        let (mut caps, needs_unlink) = CapabilitySet::from_profile(&prof, &workdir, &sandbox_args)?;
-        if needs_unlink {
-            crate::policy::apply_unlink_overrides(&mut caps);
+        let mut built =
+            crate::capability_ext::build_caps_from_profile(&prof, &workdir, &sandbox_args)?;
+        if built.needs_unlink_overrides {
+            crate::policy::apply_unlink_overrides(&mut built.caps);
         }
-        (caps, override_paths)
+        (built.caps, override_paths, built.deny_paths)
     } else {
         let sandbox_args = SandboxArgs {
             allow: args.allow.clone(),
@@ -548,11 +553,11 @@ fn run_why(args: WhyArgs) -> Result<()> {
             ..SandboxArgs::default()
         };
 
-        let (mut caps, needs_unlink) = CapabilitySet::from_args(&sandbox_args)?;
-        if needs_unlink {
-            crate::policy::apply_unlink_overrides(&mut caps);
+        let mut built = crate::capability_ext::build_caps_from_args(&sandbox_args)?;
+        if built.needs_unlink_overrides {
+            crate::policy::apply_unlink_overrides(&mut built.caps);
         }
-        (caps, vec![])
+        (built.caps, vec![], built.deny_paths)
     };
 
     // Execute the query
@@ -563,7 +568,7 @@ fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
             None => AccessMode::Read, // Default to read
         };
-        query_path(path, op, &caps, &overridden_paths)?
+        query_path(path, op, &caps, &overridden_paths, &deny_paths)?
     } else if let Some(ref host) = args.host {
         query_network(host, args.port, &caps)
     } else {
@@ -876,6 +881,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             open_url_allow_localhost: prepared.open_url_allow_localhost,
             allow_launch_services_active: prepared.allow_launch_services_active,
             override_deny_paths: prepared.override_deny_paths,
+            deny_paths: prepared.deny_paths,
         },
     )
 }
@@ -947,6 +953,7 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             no_diagnostics: true,
             capability_elevation: prepared.capability_elevation,
             override_deny_paths: prepared.override_deny_paths,
+            deny_paths: prepared.deny_paths,
             ..ExecutionFlags::defaults(silent)?
         },
     )
@@ -1015,6 +1022,7 @@ fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
                 .unwrap_or_else(|| std::path::PathBuf::from(".")),
             no_diagnostics,
             override_deny_paths: prepared.override_deny_paths,
+            deny_paths: prepared.deny_paths,
             ..ExecutionFlags::defaults(silent)?
         },
     )
@@ -1078,6 +1086,8 @@ struct ExecutionFlags {
     allow_launch_services_active: bool,
     /// Canonicalized paths exempted from deny groups via override_deny
     override_deny_paths: Vec<std::path::PathBuf>,
+    /// Canonicalized deny paths enforced for this session after overrides
+    deny_paths: Vec<std::path::PathBuf>,
 }
 
 impl ExecutionFlags {
@@ -1119,6 +1129,7 @@ impl ExecutionFlags {
             open_url_allow_localhost: false,
             allow_launch_services_active: false,
             override_deny_paths: Vec::new(),
+            deny_paths: Vec::new(),
         })
     }
 }
@@ -1335,7 +1346,12 @@ fn execute_sandboxed(
     let resolved_program = exec_strategy::resolve_program(&command[0])?;
 
     // Write capability state file BEFORE applying sandbox
-    let cap_file = write_capability_state_file(&caps, &flags.override_deny_paths, flags.silent);
+    let cap_file = write_capability_state_file(
+        &caps,
+        &flags.override_deny_paths,
+        &flags.deny_paths,
+        flags.silent,
+    );
     let cap_file_path = cap_file.unwrap_or_else(|| std::path::PathBuf::from("/dev/null"));
 
     // Validate that secret env var names are not dangerous (e.g. LD_PRELOAD).
@@ -1672,6 +1688,7 @@ fn execute_sandboxed(
                 });
             let supervisor_cfg = exec_strategy::SupervisorConfig {
                 protected_roots: protected_roots.as_paths(),
+                deny_paths: &flags.deny_paths,
                 approval_backend: &approval_backend,
                 session_id: &supervisor_session_id,
                 open_url_origins: &flags.open_url_origins,
@@ -1854,6 +1871,8 @@ struct PreparedSandbox {
     open_url_allow_localhost: bool,
     /// Canonicalized paths exempted from deny groups via override_deny
     override_deny_paths: Vec<std::path::PathBuf>,
+    /// Canonicalized deny paths enforced for this session after overrides
+    deny_paths: Vec<std::path::PathBuf>,
 }
 
 fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, String)>> {
@@ -2141,11 +2160,14 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
 
     // Build capabilities from profile or arguments.
     // Unlink overrides are deferred so they can cover the CWD path added below.
-    let (mut caps, needs_unlink_overrides) = if let Some(ref prof) = loaded_profile {
-        CapabilitySet::from_profile(prof, &workdir, args)?
+    let built = if let Some(ref prof) = loaded_profile {
+        crate::capability_ext::build_caps_from_profile(prof, &workdir, args)?
     } else {
-        CapabilitySet::from_args(args)?
+        crate::capability_ext::build_caps_from_args(args)?
     };
+    let mut caps = built.caps;
+    let needs_unlink_overrides = built.needs_unlink_overrides;
+    let deny_paths = built.deny_paths;
 
     let allow_launch_services_active = maybe_enable_macos_launch_services(
         &mut caps,
@@ -2205,16 +2227,6 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
     // Final deny/allow overlap validation after ALL path grants are finalized,
     // including auto-included CWD. This closes the Linux Landlock blind spot
     // where deny-within-allow cannot be enforced.
-    let active_groups = if let Some(prof) = loaded_profile
-        .as_ref()
-        .filter(|p| !p.security.groups.is_empty())
-    {
-        prof.security.groups.clone()
-    } else {
-        crate::capability_ext::default_profile_groups()?
-    };
-    let loaded_policy = policy::load_embedded_policy()?;
-    let deny_paths = policy::resolve_deny_paths_for_groups(&loaded_policy, &active_groups)?;
     policy::validate_deny_overlaps(&deny_paths, &caps)?;
     let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
     protected_paths::validate_caps_against_protected_roots(&caps, protected_roots.as_paths())?;
@@ -2333,6 +2345,7 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         open_url_origins,
         open_url_allow_localhost,
         override_deny_paths,
+        deny_paths,
     })
 }
 
@@ -2430,11 +2443,12 @@ fn enforce_rollback_limits(silent: bool) {
 fn write_capability_state_file(
     caps: &CapabilitySet,
     override_deny_paths: &[std::path::PathBuf],
+    deny_paths: &[std::path::PathBuf],
     silent: bool,
 ) -> Option<std::path::PathBuf> {
     // Write sandbox state for `nono why --self`.
     let cap_file = std::env::temp_dir().join(format!(".nono-{}.json", std::process::id()));
-    let state = sandbox_state::SandboxState::from_caps(caps, override_deny_paths);
+    let state = sandbox_state::SandboxState::from_caps(caps, override_deny_paths, deny_paths);
     if let Err(e) = state.write_to_file(&cap_file) {
         error!(
             "Failed to write capability state file: {}. \
@@ -2560,6 +2574,7 @@ mod tests {
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
+            deny_paths: Vec::new(),
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -2599,6 +2614,7 @@ mod tests {
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
+            deny_paths: Vec::new(),
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -745,6 +745,7 @@ pub fn apply_unlink_overrides(caps: &mut CapabilitySet) {
 }
 
 /// Resolve deny.access paths for a group list without mutating caller capabilities.
+#[cfg(test)]
 pub fn resolve_deny_paths_for_groups(
     policy: &Policy,
     group_names: &[String],
@@ -821,6 +822,18 @@ pub fn validate_deny_overlaps(deny_paths: &[PathBuf], caps: &CapabilitySet) -> R
          Conflicts:\n{}{}",
         preview, more
     )))
+}
+
+/// Return the deny path that blocks `path`, if any.
+#[must_use]
+pub fn matching_deny_path(path: &Path, deny_paths: &[PathBuf]) -> Option<PathBuf> {
+    for deny_path in deny_paths {
+        if path == deny_path || path.starts_with(deny_path) {
+            return Some(deny_path.clone());
+        }
+    }
+
+    None
 }
 
 /// Get the list of all group names defined in the policy

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -522,6 +522,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         || !pp.add_allow_write.is_empty()
         || !pp.add_allow_readwrite.is_empty()
         || !pp.add_deny_access.is_empty()
+        || !pp.add_deny_globs.is_empty()
         || !pp.override_deny.is_empty();
 
     if has_policy {
@@ -538,6 +539,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         print_fs_paths("add_allow_write", &pp.add_allow_write, t, args.raw);
         print_fs_paths("add_allow_readwrite", &pp.add_allow_readwrite, t, args.raw);
         print_fs_paths("add_deny_access", &pp.add_deny_access, t, args.raw);
+        print_fs_paths("add_deny_globs", &pp.add_deny_globs, t, args.raw);
         if !pp.override_deny.is_empty() {
             println!(
                 "    {}: {}",
@@ -727,6 +729,7 @@ fn profile_to_json(
         "add_allow_write": profile.policy.add_allow_write,
         "add_allow_readwrite": profile.policy.add_allow_readwrite,
         "add_deny_access": profile.policy.add_deny_access,
+        "add_deny_globs": profile.policy.add_deny_globs,
         "override_deny": profile.policy.override_deny,
     });
 
@@ -899,6 +902,11 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
             "add_deny_access",
             &p1.policy.add_deny_access,
             &p2.policy.add_deny_access,
+        ),
+        (
+            "add_deny_globs",
+            &p1.policy.add_deny_globs,
+            &p2.policy.add_deny_globs,
         ),
         (
             "override_deny",

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -72,6 +72,12 @@ pub struct PolicyPatchConfig {
     /// Additional deny.access paths to apply.
     #[serde(default)]
     pub add_deny_access: Vec<String>,
+    /// Additional deny glob patterns rooted under $WORKDIR.
+    ///
+    /// Patterns are expanded once at sandbox startup into concrete deny paths.
+    /// They do not match files created later in the session.
+    #[serde(default)]
+    pub add_deny_globs: Vec<String>,
     /// Paths to exempt from deny groups.
     /// Each path must also be explicitly granted via `filesystem` or `policy.add_allow_*`.
     /// Does not implicitly grant access; only removes the deny rule.
@@ -1228,6 +1234,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.policy.add_deny_access,
                 &child.policy.add_deny_access,
             ),
+            add_deny_globs: dedup_append(&base.policy.add_deny_globs, &child.policy.add_deny_globs),
             override_deny: dedup_append(&base.policy.override_deny, &child.policy.override_deny),
         },
         network: NetworkConfig {
@@ -2302,6 +2309,7 @@ mod tests {
                 add_allow_write: vec![],
                 add_allow_readwrite: vec![],
                 add_deny_access: vec!["/base/policy-deny".to_string()],
+                add_deny_globs: vec!["**/base-secret.json".to_string()],
                 override_deny: vec!["/base/override-deny".to_string()],
             },
             network: NetworkConfig {
@@ -2368,6 +2376,7 @@ mod tests {
                 add_allow_write: vec!["/child/policy-write".to_string()],
                 add_allow_readwrite: vec!["/child/policy-rw".to_string()],
                 add_deny_access: vec!["/child/policy-deny".to_string()],
+                add_deny_globs: vec!["**/child-secret.json".to_string()],
                 override_deny: vec!["/child/override-deny".to_string()],
             },
             network: NetworkConfig {
@@ -3312,6 +3321,7 @@ mod tests {
                     "add_allow_write": ["/tmp/write"],
                     "add_allow_readwrite": ["/tmp/rw"],
                     "add_deny_access": ["/tmp/deny"],
+                    "add_deny_globs": ["**/appsettings*.json"],
                     "override_deny": ["~/.docker"]
                 }
             }"#,
@@ -3323,6 +3333,7 @@ mod tests {
         assert_eq!(profile.policy.add_allow_write, vec!["/tmp/write"]);
         assert_eq!(profile.policy.add_allow_readwrite, vec!["/tmp/rw"]);
         assert_eq!(profile.policy.add_deny_access, vec!["/tmp/deny"]);
+        assert_eq!(profile.policy.add_deny_globs, vec!["**/appsettings*.json"]);
         assert_eq!(profile.policy.override_deny, vec!["~/.docker"]);
     }
 

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -207,6 +207,10 @@ fn build_skeleton(args: &ProfileInitArgs) -> serde_json::Value {
             serde_json::Value::Array(vec![]),
         );
         pol.insert(
+            "add_deny_globs".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
+        pol.insert(
             "override_deny".to_string(),
             serde_json::Value::Array(vec![]),
         );
@@ -553,6 +557,7 @@ mod tests {
         // Full policy has add_deny_access
         let full_pol = full_obj["policy"].as_object().expect("policy object");
         assert!(full_pol.contains_key("add_deny_access"));
+        assert!(full_pol.contains_key("add_deny_globs"));
 
         // Full network has all fields
         let full_net = full_obj["network"].as_object().expect("network object");

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -64,6 +64,7 @@ pub fn query_path(
     requested: AccessMode,
     caps: &CapabilitySet,
     overridden_paths: &[std::path::PathBuf],
+    deny_paths: &[std::path::PathBuf],
 ) -> Result<QueryResult> {
     // Canonicalize the path for proper comparison
     let canonical = if path.exists() {
@@ -96,6 +97,21 @@ pub fn query_path(
     let is_overridden = overridden_paths
         .iter()
         .any(|op| canonical == *op || canonical.starts_with(op));
+
+    if !is_overridden {
+        if let Some(matched) = crate::policy::matching_deny_path(&canonical, deny_paths) {
+            return Ok(QueryResult::Denied {
+                reason: "deny_path".to_string(),
+                details: Some(format!(
+                    "Path is denied by active sandbox policy: {}",
+                    matched.display()
+                )),
+                policy_source: Some(matched.display().to_string()),
+                matching_capability: None,
+                suggested_flag: None,
+            });
+        }
+    }
 
     // Check if this is a sensitive path (CLI security policy), but skip
     // the check for paths that have been explicitly overridden.
@@ -325,7 +341,8 @@ mod tests {
             .canonicalize()
             .expect("Failed to canonicalize dir");
 
-        let result = query_path(&test_file, AccessMode::Read, &caps, &[]).expect("Query failed");
+        let result =
+            query_path(&test_file, AccessMode::Read, &caps, &[], &[]).expect("Query failed");
         match result {
             QueryResult::Allowed {
                 source,
@@ -349,7 +366,7 @@ mod tests {
         let caps = CapabilitySet::new();
         let path = PathBuf::from("/some/random/path");
 
-        let result = query_path(&path, AccessMode::Read, &caps, &[]).expect("Query failed");
+        let result = query_path(&path, AccessMode::Read, &caps, &[], &[]).expect("Query failed");
         match result {
             QueryResult::Denied {
                 reason,
@@ -397,7 +414,8 @@ mod tests {
         let test_file = dir_canon.join("test.txt");
         std::fs::write(&test_file, "test").expect("Failed to write test file");
 
-        let result = query_path(&test_file, AccessMode::Write, &caps, &[]).expect("Query failed");
+        let result =
+            query_path(&test_file, AccessMode::Write, &caps, &[], &[]).expect("Query failed");
         assert!(matches!(result, QueryResult::Allowed { .. }));
     }
 
@@ -420,7 +438,8 @@ mod tests {
             source: CapabilitySource::Group("dev".to_string()),
         });
 
-        let result = query_path(&test_file, AccessMode::Write, &caps, &[]).expect("Query failed");
+        let result =
+            query_path(&test_file, AccessMode::Write, &caps, &[], &[]).expect("Query failed");
         match result {
             QueryResult::Denied {
                 reason,
@@ -451,7 +470,8 @@ mod tests {
         ));
         let caps = CapabilitySet::new();
 
-        let result = query_path(&ssh_path, AccessMode::Read, &caps, &[]).expect("Query failed");
+        let result =
+            query_path(&ssh_path, AccessMode::Read, &caps, &[], &[]).expect("Query failed");
         match result {
             QueryResult::Denied {
                 reason,
@@ -472,6 +492,28 @@ mod tests {
         let caps = CapabilitySet::new(); // Network allowed by default
         let result = query_network("example.com", 443, &caps);
         assert!(matches!(result, QueryResult::Allowed { .. }));
+    }
+
+    #[test]
+    fn test_query_path_denied_by_active_deny_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let denied = dir.path().join("appsettings.json");
+        std::fs::write(&denied, "{}").expect("write denied");
+        let denied_canonical = denied.canonicalize().expect("canonicalize denied");
+        let caps = CapabilitySet::new();
+
+        let result = query_path(
+            &denied,
+            AccessMode::Read,
+            &caps,
+            &[],
+            std::slice::from_ref(&denied_canonical),
+        )
+        .expect("query");
+        match result {
+            QueryResult::Denied { reason, .. } => assert_eq!(reason, "deny_path"),
+            other => panic!("expected deny_path result, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -98,21 +98,6 @@ pub fn query_path(
         .iter()
         .any(|op| canonical == *op || canonical.starts_with(op));
 
-    if !is_overridden {
-        if let Some(matched) = crate::policy::matching_deny_path(&canonical, deny_paths) {
-            return Ok(QueryResult::Denied {
-                reason: "deny_path".to_string(),
-                details: Some(format!(
-                    "Path is denied by active sandbox policy: {}",
-                    matched.display()
-                )),
-                policy_source: Some(matched.display().to_string()),
-                matching_capability: None,
-                suggested_flag: None,
-            });
-        }
-    }
-
     // Check if this is a sensitive path (CLI security policy), but skip
     // the check for paths that have been explicitly overridden.
     if !is_overridden {
@@ -124,6 +109,21 @@ pub fn query_path(
                     matched
                 )),
                 policy_source: Some(matched),
+                matching_capability: None,
+                suggested_flag: None,
+            });
+        }
+    }
+
+    if !is_overridden {
+        if let Some(matched) = crate::policy::matching_deny_path(&canonical, deny_paths) {
+            return Ok(QueryResult::Denied {
+                reason: "deny_path".to_string(),
+                details: Some(format!(
+                    "Path is denied by active sandbox policy: {}",
+                    matched.display()
+                )),
+                policy_source: Some(matched.display().to_string()),
                 matching_capability: None,
                 suggested_flag: None,
             });

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -28,6 +28,9 @@ pub struct SandboxState {
     /// Paths exempted from deny groups via override_deny (canonicalized)
     #[serde(default)]
     pub override_deny_paths: Vec<String>,
+    /// Active deny paths after overrides are applied (canonicalized)
+    #[serde(default)]
+    pub deny_paths: Vec<String>,
 }
 
 /// Serializable filesystem capability state
@@ -45,7 +48,11 @@ pub struct FsCapState {
 
 impl SandboxState {
     /// Create sandbox state from a CapabilitySet and override_deny paths
-    pub fn from_caps(caps: &CapabilitySet, override_deny_paths: &[PathBuf]) -> Self {
+    pub fn from_caps(
+        caps: &CapabilitySet,
+        override_deny_paths: &[PathBuf],
+        deny_paths: &[PathBuf],
+    ) -> Self {
         Self {
             fs: caps
                 .fs_capabilities()
@@ -68,12 +75,18 @@ impl SandboxState {
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect(),
+            deny_paths: deny_paths.iter().map(|p| p.display().to_string()).collect(),
         }
     }
 
     /// Get override_deny paths as PathBufs for query use
     pub fn override_deny_as_paths(&self) -> Vec<PathBuf> {
         self.override_deny_paths.iter().map(PathBuf::from).collect()
+    }
+
+    /// Get deny paths as PathBufs for query use
+    pub fn deny_as_paths(&self) -> Vec<PathBuf> {
+        self.deny_paths.iter().map(PathBuf::from).collect()
     }
 
     /// Convert back to a CapabilitySet
@@ -358,7 +371,7 @@ mod tests {
         let mut caps = CapabilitySet::new().block_network();
         caps.add_allowed_command("pip".to_string());
 
-        let state = SandboxState::from_caps(&caps, &[]);
+        let state = SandboxState::from_caps(&caps, &[], &[]);
         assert!(state.net_blocked);
         assert_eq!(state.allowed_commands, vec!["pip"]);
 
@@ -376,7 +389,7 @@ mod tests {
 
         let caps = CapabilitySet::new().block_network();
 
-        let state = SandboxState::from_caps(&caps, &[]);
+        let state = SandboxState::from_caps(&caps, &[], &[]);
         state
             .write_to_file(&file_path)
             .expect("Failed to write state");
@@ -385,5 +398,6 @@ mod tests {
         let loaded: SandboxState = serde_json::from_str(&content).expect("Failed to parse state");
 
         assert!(loaded.net_blocked);
+        assert!(loaded.deny_paths.is_empty());
     }
 }


### PR DESCRIPTION
Implement profile-level `add_deny_globs` for denying classes of files across monorepos. Patterns are expanded once at sandbox startup into concrete deny paths, which are then enforced in both seccomp-notify (Linux) and supervisor IPC loops (macOS). Glob matches are validated to prevent empty-match no-ops and restricted to $WORKDIR for security.

Key changes:
- Add `add_deny_globs` field to PolicyPatchConfig with globset-based expansion
- Normalize and validate deny glob patterns (must contain metacharacters, stay within $WORKDIR)
- Expand globs via WalkDir into concrete paths at capability build time
- Return `BuiltCapabilities` struct (caps, needs_unlink_overrides, deny_paths) from build_caps_from_profile/args
- Thread deny_paths through SupervisorConfig and supervisor message handlers
- Add matching_deny_path() utility for fast deny lookups in approval loops
- Update SandboxState to persist deny_paths for nono why --self queries
- Extend query_ext.rs to check deny_paths before approval prompts
- Add schema documentation and authoring guide with monorepo example

Tests cover glob matching, pattern validation (no-match rejection, non-$WORKDIR rejection), and deny enforcement before approval prompts.