### PR TITLE
feat(cli): add --rollback-dest flag for custom snapshot storage

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -797,13 +797,19 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     // symlinks are resolved consistently with capability resolved paths.
     if let Some(ref dest) = run_args.rollback_dest {
         let dest_abs = {
-            let mut p = dest.clone();
+            let mut p = if dest.is_absolute() {
+                dest.clone()
+            } else {
+                std::env::current_dir()
+                    .map_err(|e| NonoError::SandboxInit(format!("Failed to get cwd: {e}")))?
+                    .join(dest)
+            };
             loop {
                 match p.canonicalize() {
                     Ok(canonical) => break canonical,
                     Err(_) => match p.parent() {
                         Some(parent) => p = parent.to_path_buf(),
-                        None => break dest.clone(),
+                        None => break p,
                     },
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `--rollback-dest <PATH>` CLI flag to redirect rollback snapshot storage to a custom directory (e.g., Docker volume mounts or shared storage) instead of the default `~/.nono/rollbacks/`
- Includes a pre-sandbox permission check that verifies the destination is covered by sandbox write capabilities, failing with an actionable error message if not
- Adds integration tests and edge-case coverage for the new flag

## Changed files
- `crates/nono-cli/src/cli.rs` — new `--rollback-dest` arg on `RunArgs`
- `crates/nono-cli/src/main.rs` — pre-sandbox write permission check + plumbing through `ExecutionFlags`
- `crates/nono-cli/src/rollback_session.rs` — `rollback_root_with_override()` helper
- `tests/integration/test_rollback.sh` — integration tests for the happy/sad path
- `tests/integration/test_rollback_dest_edge_cases.sh` — edge-case tests (nested dirs, symlinks, relative paths, etc.)

## Test plan
- [x] `make test` passes
- [x] Integration test: `--rollback-dest` stores session under custom dir
- [x] Integration test: `--rollback-dest` without write permission fails with clear error
- [x] Edge-case tests pass (nested paths, symlinks, relative paths)
- [ ] Luke to review security implications of the pre-sandbox permission check