### PR TITLE
feat(trust): add skip_dirs support to trust scanning and rollback preflight

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -859,6 +859,11 @@ pub struct RunArgs {
     #[arg(long, conflicts_with = "rollback_include", help_heading = "ROLLBACK")]
     pub rollback_all: bool,
 
+    /// Skip large directory trees during trust scanning and rollback preflight.
+    /// Matched as an exact path component name. Repeatable.
+    #[arg(long, value_name = "DIR_NAME", help_heading = "OPTIONS")]
+    pub skip_dir: Vec<String>,
+
     /// Override the rollback snapshot destination directory.
     /// By default, snapshots are stored in ~/.nono/rollbacks/.
     /// The destination must be within a path already granted write access

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -618,6 +618,8 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
     }
 
     let mut prepared = prepare_sandbox(&args, silent)?;
+    let mut merged_skip_dirs = prepared.skip_dirs.clone();
+    merged_skip_dirs.extend(run_args.skip_dir.iter().cloned());
 
     if prepared.allow_launch_services_active {
         print_allow_launch_services_warning(silent);
@@ -648,8 +650,9 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
         }
         (None, None)
     } else {
-        let trust_policy = trust_scan::load_scan_policy(&scan_root, false)?;
-        let result = trust_scan::run_pre_exec_scan(&scan_root, &trust_policy, silent)?;
+        let trust_policy = trust_scan::load_scan_policy(&scan_root, false, &merged_skip_dirs)?;
+        let result =
+            trust_scan::run_pre_exec_scan(&scan_root, &trust_policy, silent, &merged_skip_dirs)?;
         if !result.results.is_empty() {
             info!(
                 "Trust scan: {} verified, {} blocked, {} warned ({} total files)",
@@ -868,6 +871,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             protected_paths: verified_protected_paths,
             rollback_exclude_patterns: merged_patterns,
             rollback_exclude_globs: merged_globs,
+            skip_dirs: merged_skip_dirs,
             capability_elevation: prepared.capability_elevation,
             proxy_active,
             network_profile,
@@ -1055,6 +1059,8 @@ struct ExecutionFlags {
     rollback_exclude_patterns: Vec<String>,
     /// Profile-specific rollback exclusion globs (filename matching)
     rollback_exclude_globs: Vec<String>,
+    /// Directory names to skip during trust scanning and rollback preflight.
+    skip_dirs: Vec<String>,
     /// Whether runtime capability elevation is enabled (seccomp-notify + PTY mux).
     /// When false, supervised mode runs with static capabilities only.
     capability_elevation: bool,
@@ -1111,6 +1117,7 @@ impl ExecutionFlags {
             protected_paths: Vec::new(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
+            skip_dirs: Vec::new(),
             capability_elevation: false,
             proxy_active: false,
             network_profile: None,
@@ -1597,8 +1604,11 @@ fn execute_sandboxed(
                         // and print a one-line notice. This ensures zero-flag usage Just Works.
                         // Directories listed in --rollback-include are kept (not auto-excluded).
                         if !flags.rollback_all {
-                            let preflight_result =
-                                rollback_preflight::run_preflight(&tracked_paths, &exclusion);
+                            let preflight_result = rollback_preflight::run_preflight(
+                                &tracked_paths,
+                                &exclusion,
+                                &flags.skip_dirs,
+                            );
 
                             if preflight_result.needs_warning() {
                                 // Filter out any dirs the user explicitly wants to include
@@ -1836,6 +1846,8 @@ struct PreparedSandbox {
     rollback_exclude_patterns: Vec<String>,
     /// Profile-specific rollback exclusion globs (filename matching)
     rollback_exclude_globs: Vec<String>,
+    /// Directory names to skip during trust scanning and rollback preflight.
+    skip_dirs: Vec<String>,
     /// Network profile name from profile config (if any)
     network_profile: Option<String>,
     /// Additional proxy-allowed domains from profile config
@@ -2068,6 +2080,10 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
     let profile_rollback_globs = loaded_profile
         .as_ref()
         .map(|p| p.rollback.exclude_globs.clone())
+        .unwrap_or_default();
+    let profile_skip_dirs = loaded_profile
+        .as_ref()
+        .map(|p| p.skipdirs.clone())
         .unwrap_or_default();
     let profile_network_profile = loaded_profile.as_ref().and_then(|p| {
         p.network
@@ -2327,6 +2343,7 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         secrets: loaded_secrets,
         rollback_exclude_patterns: profile_rollback_patterns,
         rollback_exclude_globs: profile_rollback_globs,
+        skip_dirs: profile_skip_dirs,
         network_profile: profile_network_profile,
         allow_domain: profile_allow_domain,
         credentials: profile_credentials,
@@ -2554,6 +2571,7 @@ mod tests {
             secrets: Vec::new(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
+            skip_dirs: Vec::new(),
             network_profile: Some("developer".to_string()),
             allow_domain: vec!["docs.python.org".to_string()],
             credentials: vec!["github".to_string()],
@@ -2593,6 +2611,7 @@ mod tests {
             secrets: Vec::new(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
+            skip_dirs: Vec::new(),
             network_profile: Some("developer".to_string()),
             allow_domain: vec!["docs.python.org".to_string()],
             credentials: vec!["github".to_string()],

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -152,6 +152,7 @@ impl ProfileDef {
             open_urls: self.open_urls.clone(),
             allow_launch_services: self.allow_launch_services,
             interactive: self.interactive,
+            skipdirs: Vec::new(),
         }
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -901,6 +901,10 @@ pub struct Profile {
     /// Supervised mode preserves TTY by default, making this unnecessary.
     #[serde(default)]
     pub interactive: bool,
+    /// Directory names to skip during trust scanning and rollback preflight.
+    /// Treated like built-in heavy directories (for example `target`).
+    #[serde(default)]
+    pub skipdirs: Vec<String>,
 }
 
 /// Check whether a profile name is loaded from a user file rather than the built-in set.
@@ -1299,6 +1303,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
         },
         allow_launch_services: child.allow_launch_services.or(base.allow_launch_services),
         interactive: base.interactive || child.interactive,
+        skipdirs: dedup_append(&base.skipdirs, &child.skipdirs),
     }
 }
 
@@ -2348,6 +2353,7 @@ mod tests {
             }),
             allow_launch_services: Some(false),
             interactive: false,
+            skipdirs: vec!["vendor".to_string()],
         }
     }
 
@@ -2415,6 +2421,7 @@ mod tests {
             }),
             allow_launch_services: Some(true),
             interactive: false,
+            skipdirs: vec!["dist".to_string()],
         }
     }
 

--- a/crates/nono-cli/src/rollback_preflight.rs
+++ b/crates/nono-cli/src/rollback_preflight.rs
@@ -80,12 +80,15 @@ impl PreflightResult {
 /// Phase 1 checks immediate children for known heavy directory names that are
 /// not already excluded. If none are found, returns early with an empty result.
 /// Phase 2 performs a bounded walk to estimate total file count.
+///
+/// `extra_skip_dirs` are user-supplied names treated like built-in heavy dirs.
 pub(crate) fn run_preflight(
     tracked_paths: &[PathBuf],
     exclusion: &ExclusionFilter,
+    extra_skip_dirs: &[String],
 ) -> PreflightResult {
     // Phase 1: sentinel check
-    let heavy_dirs = detect_heavy_dirs(tracked_paths, exclusion);
+    let heavy_dirs = detect_heavy_dirs(tracked_paths, exclusion, extra_skip_dirs);
 
     if heavy_dirs.is_empty() {
         return PreflightResult {
@@ -133,7 +136,11 @@ pub(crate) fn run_preflight(
 
 /// Phase 1: check immediate children of tracked dirs for known heavy names
 /// and size-based detection of unknown large directories.
-fn detect_heavy_dirs(tracked_paths: &[PathBuf], exclusion: &ExclusionFilter) -> Vec<HeavyDir> {
+fn detect_heavy_dirs(
+    tracked_paths: &[PathBuf],
+    exclusion: &ExclusionFilter,
+    extra_skip_dirs: &[String],
+) -> Vec<HeavyDir> {
     let mut found = Vec::new();
     let mut size_check_candidates = Vec::new();
 
@@ -172,6 +179,12 @@ fn detect_heavy_dirs(tracked_paths: &[PathBuf], exclusion: &ExclusionFilter) -> 
                     path,
                     name: name_str,
                     description: (*description).to_string(),
+                });
+            } else if extra_skip_dirs.iter().any(|dir| dir == &name_str) {
+                found.push(HeavyDir {
+                    path,
+                    name: name_str,
+                    description: "user-defined skip directory".to_string(),
                 });
             } else {
                 // Not a known name — candidate for size-based check
@@ -337,7 +350,7 @@ mod tests {
         std::fs::create_dir_all(tracked.join("src")).expect("create src");
 
         let filter = make_filter(vec![]);
-        let heavy = detect_heavy_dirs(&[tracked], &filter);
+        let heavy = detect_heavy_dirs(&[tracked], &filter, &[]);
 
         let names: Vec<&str> = heavy.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"target"), "Should detect target/");
@@ -357,7 +370,7 @@ mod tests {
 
         // Pre-exclude target
         let filter = make_filter(vec!["target"]);
-        let heavy = detect_heavy_dirs(&[tracked], &filter);
+        let heavy = detect_heavy_dirs(&[tracked], &filter, &[]);
 
         let names: Vec<&str> = heavy.iter().map(|d| d.name.as_str()).collect();
         assert!(
@@ -377,7 +390,7 @@ mod tests {
         std::fs::create_dir_all(&tracked).expect("create empty dir");
 
         let filter = make_filter(vec![]);
-        let result = run_preflight(&[tracked], &filter);
+        let result = run_preflight(&[tracked], &filter, &[]);
 
         assert!(!result.needs_warning());
     }
@@ -385,7 +398,7 @@ mod tests {
     #[test]
     fn preflight_nonexistent_path_no_warning() {
         let filter = make_filter(vec![]);
-        let result = run_preflight(&[PathBuf::from("/nonexistent/path/xyz")], &filter);
+        let result = run_preflight(&[PathBuf::from("/nonexistent/path/xyz")], &filter, &[]);
 
         assert!(!result.needs_warning());
         assert_eq!(result.probe_file_count, 0);

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -29,7 +29,11 @@ use std::path::{Path, PathBuf};
 ///
 /// Returns `NonoError::TrustPolicy` if a found policy file is malformed, or
 /// `NonoError::TrustVerification` if signature verification fails.
-pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy> {
+pub fn load_scan_policy(
+    root: &Path,
+    trust_override: bool,
+    skip_dirs: &[String],
+) -> Result<TrustPolicy> {
     let cwd_policy = root.join("trust-policy.json");
     let project_policy_path = cwd_policy.exists().then_some(cwd_policy);
 
@@ -76,7 +80,7 @@ pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy
         (None, None) => Ok(TrustPolicy::default()),
     }?;
 
-    if !trust_override && scan_has_signed_artifacts(root, &effective)? {
+    if !trust_override && scan_has_signed_artifacts(root, &effective, skip_dirs)? {
         verify_scan_policy_signatures(
             project_policy_path.as_deref(),
             user_policy_path.map(PathBuf::as_path),
@@ -91,12 +95,20 @@ pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy
 /// This probes for per-file `.bundle` sidecars for included files and for the
 /// multi-subject `.nono-trust.bundle`. Unsigned files are still scanned later,
 /// but they do not require keystore access up front.
-fn scan_has_signed_artifacts(scan_root: &Path, policy: &TrustPolicy) -> Result<bool> {
+fn scan_has_signed_artifacts(
+    scan_root: &Path,
+    policy: &TrustPolicy,
+    skip_dirs: &[String],
+) -> Result<bool> {
     if trust::multi_subject_bundle_path(scan_root).exists() {
         return Ok(true);
     }
 
-    let files = trust::find_included_files(policy, scan_root)?;
+    if policy.includes.is_empty() {
+        return Ok(false);
+    }
+
+    let files = trust::find_included_files_with_skip_dirs(policy, scan_root, skip_dirs)?;
     Ok(files
         .iter()
         .any(|file_path| trust::bundle_path_for(file_path).exists()))
@@ -313,10 +325,20 @@ pub fn run_pre_exec_scan(
     scan_root: &Path,
     policy: &TrustPolicy,
     silent: bool,
+    skip_dirs: &[String],
 ) -> Result<ScanResult> {
-    let files = trust::find_included_files(policy, scan_root)?;
     let multi_bundle = trust::multi_subject_bundle_path(scan_root);
     let has_multi_bundle = multi_bundle.exists();
+    if policy.includes.is_empty() && !has_multi_bundle {
+        return Ok(ScanResult {
+            results: Vec::new(),
+            verified: 0,
+            blocked: 0,
+            warned: 0,
+        });
+    }
+
+    let files = trust::find_included_files_with_skip_dirs(policy, scan_root, skip_dirs)?;
 
     // Check for literal patterns (no glob characters) that matched zero files.
     // A missing literal file is a security concern: on macOS, there is no
@@ -969,7 +991,7 @@ mod tests {
     fn scan_empty_dir_returns_empty_result() {
         let dir = tempfile::tempdir().unwrap();
         let policy = TrustPolicy::default();
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(result.should_proceed());
         assert_eq!(result.verified, 0);
         assert_eq!(result.blocked, 0);
@@ -988,7 +1010,18 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let has_signed_artifacts = scan_has_signed_artifacts(dir.path(), &policy).unwrap();
+        let has_signed_artifacts = scan_has_signed_artifacts(dir.path(), &policy, &[]).unwrap();
+        assert!(!has_signed_artifacts);
+    }
+
+    #[test]
+    fn scan_has_signed_artifacts_empty_policy_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("SKILLS.md"), "content").unwrap();
+
+        let has_signed_artifacts =
+            scan_has_signed_artifacts(dir.path(), &TrustPolicy::default(), &[]).unwrap();
+
         assert!(!has_signed_artifacts);
     }
 
@@ -1009,8 +1042,28 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let has_signed_artifacts = scan_has_signed_artifacts(dir.path(), &policy).unwrap();
+        let has_signed_artifacts = scan_has_signed_artifacts(dir.path(), &policy, &[]).unwrap();
         assert!(has_signed_artifacts);
+    }
+
+    #[test]
+    fn run_pre_exec_scan_respects_skip_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("generated")).unwrap();
+        std::fs::write(dir.path().join("generated").join("SKILLS.md"), "generated").unwrap();
+        std::fs::write(dir.path().join("SKILLS.md"), "root").unwrap();
+
+        let policy = TrustPolicy {
+            includes: vec!["SKILLS*".to_string()],
+            enforcement: Enforcement::Audit,
+            ..TrustPolicy::default()
+        };
+
+        let result =
+            run_pre_exec_scan(dir.path(), &policy, true, &[String::from("generated")]).unwrap();
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].path, dir.path().join("SKILLS.md"));
     }
 
     #[test]
@@ -1024,7 +1077,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(result.should_proceed());
         assert_eq!(result.verified, 0);
         assert_eq!(result.warned, 1);
@@ -1041,7 +1094,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(!result.should_proceed());
         assert_eq!(result.blocked, 1);
     }
@@ -1068,7 +1121,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(!result.should_proceed());
         assert_eq!(result.blocked, 1);
     }
@@ -1085,7 +1138,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(result.should_proceed());
         assert_eq!(result.warned, 2);
     }
@@ -1159,7 +1212,7 @@ mod tests {
         )
         .unwrap();
 
-        let policy = load_scan_policy(dir.path(), true).unwrap();
+        let policy = load_scan_policy(dir.path(), true, &[]).unwrap();
         assert_eq!(policy.enforcement, Enforcement::Warn);
 
         match orig_xdg {
@@ -1188,7 +1241,7 @@ mod tests {
         )
         .unwrap();
 
-        let policy = load_scan_policy(scan_dir.path(), false).unwrap();
+        let policy = load_scan_policy(scan_dir.path(), false, &[]).unwrap();
         assert!(policy.includes.contains(&include_pattern.to_string()));
 
         match orig_xdg {
@@ -1251,7 +1304,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(result.should_proceed());
         assert_eq!(result.verified, 2);
         assert_eq!(result.blocked, 0);
@@ -1299,7 +1352,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         // a.md verified, b.py mismatch
         assert_eq!(result.verified, 1);
         assert_eq!(result.blocked, 1);
@@ -1343,7 +1396,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert_eq!(result.verified, 1); // a.md passes
         assert_eq!(result.blocked, 1); // b.py missing = fail
     }
@@ -1380,7 +1433,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         let paths = result.verified_paths();
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], dir.path().join("script.py"));
@@ -1422,7 +1475,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         // Crypto verification will fail (wrong key), so blocked
         assert!(!result.should_proceed());
         assert_eq!(result.blocked, 1);
@@ -1435,7 +1488,7 @@ mod tests {
         std::fs::write(dir.path().join("src.rs"), "fn main() {}").unwrap();
 
         let policy = TrustPolicy::default();
-        let result = run_pre_exec_scan(dir.path(), &policy, true).unwrap();
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]).unwrap();
         assert!(result.should_proceed());
         assert!(result.results.is_empty());
     }
@@ -1450,7 +1503,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]);
 
         if cfg!(target_os = "linux") {
             assert!(result.is_ok());
@@ -1476,7 +1529,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]);
         assert!(result.is_ok());
     }
 
@@ -1490,7 +1543,7 @@ mod tests {
             ..TrustPolicy::default()
         };
 
-        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]);
         assert!(result.is_ok());
     }
 
@@ -1507,7 +1560,7 @@ mod tests {
 
         // This will fail at verification (unsigned), not at the missing-file check.
         // The point is: the literal check itself passes because the file exists.
-        let result = run_pre_exec_scan(dir.path(), &policy, true);
+        let result = run_pre_exec_scan(dir.path(), &policy, true, &[]);
         assert!(result.is_ok());
     }
 

--- a/crates/nono/src/trust/mod.rs
+++ b/crates/nono/src/trust/mod.rs
@@ -52,7 +52,8 @@ pub use dsse::{
     NONO_POLICY_PREDICATE_TYPE, NONO_PREDICATE_TYPE,
 };
 pub use policy::{
-    evaluate_file, find_included_files, load_policy_from_file, load_policy_from_str, merge_policies,
+    evaluate_file, find_included_files, find_included_files_with_skip_dirs, load_policy_from_file,
+    load_policy_from_str, merge_policies,
 };
 pub use signing::{
     export_public_key, generate_signing_key, key_id_hex, sign_bytes, sign_files,

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -233,65 +233,144 @@ fn is_publisher_blocked(policy: &TrustPolicy, identity: &SignerIdentity) -> bool
         })
 }
 
+/// Well-known directory names that never contain instruction files and are
+/// typically very large. Sorted for binary search.
+const SKIP_DIRS: &[&str] = &[
+    ".cache",
+    ".git",
+    ".gradle",
+    ".hg",
+    ".mypy_cache",
+    ".next",
+    ".nuxt",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".svn",
+    ".terraform",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "node_modules",
+    "target",
+    "vendor",
+    "venv",
+];
+
 /// Scan a directory for files matching instruction patterns.
 ///
 /// Returns the list of paths that match any pattern in the trust policy.
-/// Does not recurse into hidden directories (prefixed with `.`) except
-/// `.claude/` which is explicitly included by standard instruction patterns.
+/// Hidden directories are scanned unless they are explicitly listed in the
+/// built-in heavy-directory skip set or provided via `extra_skip_dirs`.
 ///
 /// # Errors
 ///
 /// Returns `NonoError::TrustPolicy` if patterns cannot be compiled, or
 /// `NonoError::Io` if directory traversal fails.
 pub fn find_included_files<P: AsRef<Path>>(policy: &TrustPolicy, root: P) -> Result<Vec<PathBuf>> {
-    use ignore::WalkBuilder;
+    find_included_files_with_skip_dirs(policy, root, &[])
+}
 
+/// Scan a directory for files matching instruction patterns, skipping extra
+/// directory names in addition to the built-in heavy-directory list.
+pub fn find_included_files_with_skip_dirs<P: AsRef<Path>>(
+    policy: &TrustPolicy,
+    root: P,
+    extra_skip_dirs: &[String],
+) -> Result<Vec<PathBuf>> {
     let root = root.as_ref();
     let matcher = policy.include_matcher()?;
-
-    // Trust file discovery must NOT respect .gitignore. An attacker who adds
-    // an instruction file to .gitignore could bypass pre-exec trust enforcement.
-    // We use WalkBuilder only for its built-in directory filtering (.git/, etc.)
-    // and symlink cycle detection, not for gitignore integration.
-    let walker = WalkBuilder::new(root)
-        .hidden(false) // don't skip hidden — .claude/ contains instruction files
-        .git_ignore(false) // DO NOT respect .gitignore — security boundary
-        .git_global(false) // DO NOT respect global gitignore
-        .git_exclude(false) // DO NOT respect .git/info/exclude
-        .follow_links(true) // follow symlinks (symlinked SKILLS.md must not be skipped)
-        .max_depth(Some(16)) // guard against very deep trees
-        .build();
-
     let mut results = Vec::new();
+    let mut visited = std::collections::HashSet::new();
 
-    for entry in walker {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue, // permission error, dangling symlink, etc.
+    if policy.includes.is_empty() {
+        return Ok(results);
+    }
+
+    find_files_recursive(
+        root,
+        root,
+        &matcher,
+        extra_skip_dirs,
+        &mut results,
+        &mut visited,
+        0,
+    )?;
+
+    results.sort();
+    Ok(results)
+}
+
+fn should_skip_dir(name: &str, extra_skip_dirs: &[String]) -> bool {
+    SKIP_DIRS.binary_search(&name).is_ok() || extra_skip_dirs.iter().any(|dir| dir == name)
+}
+
+fn find_files_recursive(
+    root: &Path,
+    dir: &Path,
+    matcher: &super::types::IncludePatterns,
+    extra_skip_dirs: &[String],
+    results: &mut Vec<PathBuf>,
+    visited: &mut std::collections::HashSet<u64>,
+    depth: u32,
+) -> Result<()> {
+    const MAX_DEPTH: u32 = 16;
+    if depth > MAX_DEPTH {
+        return Ok(());
+    }
+
+    let entries = std::fs::read_dir(dir).map_err(NonoError::Io)?;
+
+    for entry in entries {
+        let entry = entry.map_err(NonoError::Io)?;
+        let path = entry.path();
+        let meta = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
         };
 
-        // Skip directories and the root itself
-        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            continue;
-        }
+        if meta.is_dir() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if should_skip_dir(&name_str, extra_skip_dirs) {
+                continue;
+            }
 
-        let path = entry.path();
+            #[cfg(unix)]
+            let inode = {
+                use std::os::unix::fs::MetadataExt;
+                meta.ino()
+            };
+            #[cfg(not(unix))]
+            let inode = 0u64;
 
-        // Skip Sigstore sidecar bundles
-        if path.to_string_lossy().ends_with(".bundle") {
-            continue;
-        }
+            if inode != 0 && !visited.insert(inode) {
+                continue;
+            }
 
-        // Match against relative path from root
-        if let Ok(relative) = path.strip_prefix(root) {
-            if matcher.is_match(relative) {
-                results.push(path.to_path_buf());
+            find_files_recursive(
+                root,
+                &path,
+                matcher,
+                extra_skip_dirs,
+                results,
+                visited,
+                depth + 1,
+            )?;
+        } else if meta.is_file() {
+            if path.to_string_lossy().ends_with(".bundle") {
+                continue;
+            }
+
+            if let Ok(relative) = path.strip_prefix(root) {
+                if matcher.is_match(relative) {
+                    results.push(path);
+                }
             }
         }
     }
 
-    results.sort();
-    Ok(results)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -812,7 +891,7 @@ mod tests {
     }
 
     #[test]
-    fn find_included_files_skips_hidden_dirs() {
+    fn find_included_files_skips_git_dir() {
         let dir = tempfile::tempdir().unwrap();
         let hidden = dir.path().join(".git");
         std::fs::create_dir_all(&hidden).unwrap();
@@ -821,6 +900,50 @@ mod tests {
         let policy = make_policy(Enforcement::Deny, vec![], vec![]);
         let files = find_included_files(&policy, dir.path()).unwrap();
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn find_included_files_in_non_special_hidden_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let hidden = dir.path().join(".hidden").join("commands");
+        std::fs::create_dir_all(&hidden).unwrap();
+        std::fs::write(hidden.join("deploy.md"), "content").unwrap();
+
+        let mut policy = make_policy(Enforcement::Deny, vec![], vec![]);
+        policy.includes.push(".hidden/**/*.md".to_string());
+
+        let files = find_included_files(&policy, dir.path()).unwrap();
+        assert_eq!(files, vec![hidden.join("deploy.md")]);
+    }
+
+    #[test]
+    fn find_included_files_skips_well_known_heavy_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let node_modules = dir.path().join("node_modules");
+        std::fs::create_dir_all(&node_modules).unwrap();
+        std::fs::write(node_modules.join("SKILLS.md"), "content").unwrap();
+        std::fs::write(dir.path().join("SKILLS.md"), "content").unwrap();
+
+        let policy = make_policy(Enforcement::Deny, vec![], vec![]);
+        let files = find_included_files(&policy, dir.path()).unwrap();
+
+        assert_eq!(files, vec![dir.path().join("SKILLS.md")]);
+    }
+
+    #[test]
+    fn find_included_files_respects_extra_skip_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let generated = dir.path().join("generated");
+        std::fs::create_dir_all(&generated).unwrap();
+        std::fs::write(generated.join("SKILLS.md"), "content").unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "content").unwrap();
+
+        let policy = make_policy(Enforcement::Deny, vec![], vec![]);
+        let files =
+            find_included_files_with_skip_dirs(&policy, dir.path(), &[String::from("generated")])
+                .unwrap();
+
+        assert_eq!(files, vec![dir.path().join("CLAUDE.md")]);
     }
 
     #[test]

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -280,6 +280,8 @@ pub fn find_included_files_with_skip_dirs<P: AsRef<Path>>(
 ) -> Result<Vec<PathBuf>> {
     let root = root.as_ref();
     let matcher = policy.include_matcher()?;
+    let extra_skip_dirs: std::collections::HashSet<&str> =
+        extra_skip_dirs.iter().map(String::as_str).collect();
     let mut results = Vec::new();
     let mut visited = std::collections::HashSet::new();
 
@@ -291,7 +293,7 @@ pub fn find_included_files_with_skip_dirs<P: AsRef<Path>>(
         root,
         root,
         &matcher,
-        extra_skip_dirs,
+        &extra_skip_dirs,
         &mut results,
         &mut visited,
         0,
@@ -301,17 +303,17 @@ pub fn find_included_files_with_skip_dirs<P: AsRef<Path>>(
     Ok(results)
 }
 
-fn should_skip_dir(name: &str, extra_skip_dirs: &[String]) -> bool {
-    SKIP_DIRS.binary_search(&name).is_ok() || extra_skip_dirs.iter().any(|dir| dir == name)
+fn should_skip_dir(name: &str, extra_skip_dirs: &std::collections::HashSet<&str>) -> bool {
+    SKIP_DIRS.binary_search(&name).is_ok() || extra_skip_dirs.contains(name)
 }
 
 fn find_files_recursive(
     root: &Path,
     dir: &Path,
     matcher: &super::types::IncludePatterns,
-    extra_skip_dirs: &[String],
+    extra_skip_dirs: &std::collections::HashSet<&str>,
     results: &mut Vec<PathBuf>,
-    visited: &mut std::collections::HashSet<u64>,
+    visited: &mut std::collections::HashSet<(u64, u64)>,
     depth: u32,
 ) -> Result<()> {
     const MAX_DEPTH: u32 = 16;
@@ -337,15 +339,17 @@ fn find_files_recursive(
             }
 
             #[cfg(unix)]
-            let inode = {
+            let file_id = Some({
                 use std::os::unix::fs::MetadataExt;
-                meta.ino()
-            };
+                (meta.dev(), meta.ino())
+            });
             #[cfg(not(unix))]
-            let inode = 0u64;
+            let file_id: Option<(u64, u64)> = None;
 
-            if inode != 0 && !visited.insert(inode) {
-                continue;
+            if let Some(file_id) = file_id {
+                if !visited.insert(file_id) {
+                    continue;
+                }
             }
 
             find_files_recursive(

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -313,6 +313,18 @@ The `rollback` section controls which files are excluded from [atomic rollback](
 
 These exclusions are combined with gitignore patterns from the working directory.
 
+### Skip Directories
+
+Use `skipdirs` to extend the built-in heavy-directory skip list for pre-exec trust scanning and rollback preflight:
+
+```json
+{
+  "skipdirs": ["generated", "vendor-cache"]
+}
+```
+
+Entries are matched as exact path component names. They do not grant or deny sandbox access; they only prune traversal during trust discovery and rollback heuristics.
+
 ### Environment Variables
 
 Profiles support these environment variables in path values:

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -477,6 +477,8 @@ nono trust sign-policy --user
 
 When `nono run` launches a command, it scans the working directory for files matching `includes` before applying the sandbox. File discovery does **not** respect `.gitignore` — this prevents hiding files from verification.
 
+To keep startup latency bounded in large repositories, the scan prunes a small built-in set of regenerable heavy directories such as `.git`, `node_modules`, `target`, `dist`, and common cache directories. Hidden directories are otherwise still scanned. You can extend the skip set for a session with `--skip-dir <name>` or persist it in a profile with `skipdirs`.
+
 ```
 nono run --profile claude-code -- claude
   -> Scan CWD for files matching includes patterns

--- a/docs/cli/internals/signing.mdx
+++ b/docs/cli/internals/signing.mdx
@@ -122,7 +122,7 @@ For keyed bundles, the public key is loaded from the system keystore and the ECD
 
 ### Pre-exec Scan
 
-Before fork/exec, nono scans the working directory for files matching `includes`. File discovery intentionally does **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
+Before fork/exec, nono scans the working directory for files matching `includes`. File discovery intentionally does **not** respect `.gitignore` — adding a file to `.gitignore` cannot bypass trust verification. To avoid pathological startup cost in large repos, the walker skips a fixed set of heavy directories such as `.git`, `node_modules`, `target`, `dist`, and common caches, plus any user-configured `--skip-dir` / `skipdirs` entries. Other hidden directories remain visible to the scan. This is the baseline -- it catches files present at session start. If any file fails verification and enforcement is `deny`, the process never starts.
 
 The pre-exec scan also verifies the trust policy's own signature before trusting it.
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -698,6 +698,22 @@ Include ALL directories in rollback snapshots, overriding all auto-exclusions. T
 nono run --rollback --rollback-all -- cargo test
 ```
 
+#### `--skip-dir`
+
+Skip a directory name during pre-exec trust scanning and rollback preflight. Repeatable. Matches exact path components, not full paths. This is useful for large generated trees that are safe to exclude in your workflow.
+
+```bash
+# Skip a generated docs tree for this run
+nono run --skip-dir docs-build --allow-cwd -- my-agent
+
+# Skip multiple large trees
+nono run --skip-dir vendor-cache --skip-dir generated --allow-cwd -- my-agent
+```
+
+<Note>
+  `--skip-dir` does not change sandbox permissions. It only prunes trust discovery and rollback preflight traversal. Hidden directories are still scanned unless they are in the built-in heavy-dir list or explicitly named here.
+</Note>
+
 #### `--no-diagnostics`
 
 Suppress the diagnostic footer when the command exits non-zero. Useful for scripts that parse stderr and need stable output.


### PR DESCRIPTION
Clarify that pre-exec trust scanning now prunes a fixed heavy-dir set
while still ignoring `.gitignore` and scanning non-special hidden dirs.

Add docs for the new `--skip-dir` flag and profile-level `skipdirs` field.

Resolves: #497