### PR TITLE
fix(learn): make Enter actually skip profile save prompt

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -408,10 +408,7 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
         })?;
 
     eprintln!();
-    eprint!(
-        "Save as profile? Enter a name (or press Enter to skip) [{}]: ",
-        cmd_name
-    );
+    eprint!("Save as profile? Enter a name (or press Enter to skip): ");
 
     let mut input = String::new();
     std::io::stdin()
@@ -419,7 +416,12 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
         .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
 
     let input = input.trim();
-    let profile_name = if input.is_empty() { cmd_name } else { input };
+
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let profile_name = input;
 
     // Validate profile name: alphanumeric, hyphens, underscores only
     if !profile_name


### PR DESCRIPTION
## Summary
- Fixes #431: `nono learn` profile save prompt says "press Enter to skip" but pressing Enter saves a profile named after the command instead of skipping
- Removed the misleading `[claude]` default hint from the prompt
- Empty input now returns early without saving, matching the stated behavior

## Test plan
- [ ] `cargo build -p nono-cli` compiles cleanly
- [ ] `cargo test -p nono-cli` — all 533 tests pass
- [ ] `cargo clippy --workspace` — no new warnings
- [ ] Manual: `nono learn -- echo hello` → press Enter → no profile created
- [ ] Manual: `nono learn -- echo hello` → type `my-profile` → profile saved as `my-profile`
