### PR TITLE
feat(keystore): add file:// credential source support

### DIFF
--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -72,9 +72,9 @@ pub struct CredentialDef {
     /// Explicit environment variable name for the phantom token.
     ///
     /// Required when `credential_key` is a URI manager reference (`env://`,
-    /// `op://`, `apple-password://`), since uppercasing those produces
-    /// nonsensical env var names. When `None`, the proxy derives the env var
-    /// from `credential_key.to_uppercase()`.
+    /// `op://`, `apple-password://`, `file://`), since uppercasing those
+    /// produces nonsensical env var names. When `None`, the proxy derives
+    /// the env var from `credential_key.to_uppercase()`.
     #[serde(default)]
     pub env_var: Option<String>,
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -142,8 +142,8 @@ pub struct CustomCredentialDef {
     ///
     /// When set, the proxy uses this as the SDK API key env var instead of
     /// deriving it from `credential_key.to_uppercase()`. Required when
-    /// `credential_key` is a URI manager reference (`op://` or
-    /// `apple-password://`).
+    /// `credential_key` is a URI manager reference (`op://`,
+    /// `apple-password://`, or `file://`).
     #[serde(default)]
     pub env_var: Option<String>,
 
@@ -189,6 +189,7 @@ fn is_http_token_char(c: char) -> bool {
 /// - A bare keyring account name (alphanumeric + underscores only)
 /// - A 1Password `op://` URI (validated by `nono::keystore::validate_op_uri`)
 /// - An Apple Passwords `apple-password://` URI
+/// - A `file://` URI pointing to an absolute path (validated by `nono::keystore::validate_file_uri`)
 fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
     if key.is_empty() {
         return Err(NonoError::ProfileParse(format!(
@@ -212,12 +213,19 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
                 context_name, e
             ))
         })
+    } else if nono::keystore::is_file_uri(key) {
+        nono::keystore::validate_file_uri(key).map_err(|e| {
+            NonoError::ProfileParse(format!(
+                "invalid file:// URI for custom credential '{}': {}",
+                context_name, e
+            ))
+        })
     } else {
         // Validate as keyring account name (alphanumeric + underscore)
         if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             return Err(NonoError::ProfileParse(format!(
                 "credential_key '{}' for custom credential '{}' must contain only \
-                 alphanumeric characters and underscores (or use op:// / apple-password:// URI)",
+                 alphanumeric characters and underscores (or use op:// / apple-password:// / file:// URI)",
                 key, context_name
             )));
         }
@@ -229,7 +237,7 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
 ///
 /// Checks:
 /// - `credential_key` must be alphanumeric + underscores only, or a valid
-///   `op://` / `apple-password://` URI
+///   `op://` / `apple-password://` / `file://` URI
 /// - `upstream` must be HTTPS (or HTTP for loopback only)
 /// - Mode-specific validation:
 ///   - `header`: inject_header must be valid HTTP token, credential_format no CRLF
@@ -244,12 +252,13 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
     // cannot be meaningfully uppercased into an env var name (e.g.,
     // "op://vault/item/field" -> "OP://VAULT/ITEM/FIELD" is nonsensical).
     if (nono::keystore::is_op_uri(&cred.credential_key)
-        || nono::keystore::is_apple_password_uri(&cred.credential_key))
+        || nono::keystore::is_apple_password_uri(&cred.credential_key)
+        || nono::keystore::is_file_uri(&cred.credential_key))
         && cred.env_var.is_none()
     {
         return Err(NonoError::ProfileParse(format!(
             "env_var is required for custom credential '{}' when credential_key is a URI \
-             manager reference (op:// or apple-password://); \
+             manager reference (op://, apple-password://, or file://); \
              set it to the SDK API key env var name (e.g., \"OPENAI_API_KEY\")",
             name
         )));
@@ -456,7 +465,7 @@ fn validate_profile_custom_credentials(profile: &Profile) -> Result<()> {
 /// Validate env_credentials keys in a profile.
 ///
 /// Keys can be keyring account names, `op://` URIs, `apple-password://` URIs,
-/// or `env://` URIs.
+/// `env://` URIs, or `file://` URIs.
 /// Keyring account names are validated at load time by the keyring crate itself,
 /// but URI entries need structural validation upfront.
 fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
@@ -475,6 +484,10 @@ fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
         } else if nono::keystore::is_env_uri(key) {
             nono::keystore::validate_env_uri(key).map_err(|e| {
                 NonoError::ProfileParse(format!("invalid env:// URI in env_credentials: {}", e))
+            })?;
+        } else if nono::keystore::is_file_uri(key) {
+            nono::keystore::validate_file_uri(key).map_err(|e| {
+                NonoError::ProfileParse(format!("invalid file:// URI in env_credentials: {}", e))
             })?;
         }
         // Validate destination env var name against dangerous blocklist
@@ -3896,5 +3909,158 @@ mod tests {
                 result.expect_err("already checked is_ok")
             );
         }
+    }
+
+    // ============================================================================
+    // file:// credential key validation tests
+    // ============================================================================
+
+    #[test]
+    fn test_validate_custom_credential_file_uri_accepted() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: "file:///vault/secrets/token".to_string(),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: Some("EXAMPLE_API_KEY".to_string()),
+        };
+        assert!(
+            validate_custom_credential("example", &cred).is_ok(),
+            "file:// URI with env_var should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_validate_custom_credential_file_uri_requires_env_var() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: "file:///vault/secrets/token".to_string(),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: None,
+        };
+        let result = validate_custom_credential("example", &cred);
+        let err = result.expect_err("file:// URI without env_var should be rejected");
+        assert!(
+            err.to_string().contains("env_var is required"),
+            "error should mention env_var is required, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_custom_credential_file_uri_invalid_rejected() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: "file://relative/path".to_string(),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: Some("EXAMPLE_API_KEY".to_string()),
+        };
+        let result = validate_custom_credential("example", &cred);
+        let err = result.expect_err("file:// URI with relative path should be rejected");
+        assert!(
+            err.to_string().contains("file://"),
+            "error should mention file://, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_custom_credential_file_uri_traversal_rejected() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: "file:///vault/secrets/../../../etc/shadow".to_string(),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: Some("EXAMPLE_API_KEY".to_string()),
+        };
+        let result = validate_custom_credential("example", &cred);
+        assert!(
+            result.is_err(),
+            "file:// URI with path traversal should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_env_credentials_accepts_file_uri() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "env_credentials": {
+                "file:///vault/secrets/api_token": "API_TOKEN"
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        assert!(
+            validate_env_credential_keys(&profile).is_ok(),
+            "valid file:// URI in env_credentials should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_validate_env_credentials_rejects_invalid_file_uri() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "env_credentials": {
+                "file://relative/path": "API_TOKEN"
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        let err = validate_env_credential_keys(&profile).expect_err("should reject");
+        assert!(
+            err.to_string().contains("file://"),
+            "error should mention file://, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_profile_json_with_file_uri_custom_credential_parses() {
+        // End-to-end: parse a profile JSON with a file:// custom credential
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("file-cred.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "file-cred-test" },
+                "network": {
+                    "custom_credentials": {
+                        "vault_service": {
+                            "upstream": "https://api.vault-service.com",
+                            "credential_key": "file:///vault/secrets/token",
+                            "env_var": "VAULT_API_KEY"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("write profile");
+
+        let profile = parse_profile_file(&profile_path).expect("profile should parse");
+        let cred = profile
+            .network
+            .custom_credentials
+            .get("vault_service")
+            .expect("vault_service credential should exist");
+        assert_eq!(cred.credential_key, "file:///vault/secrets/token");
+        assert_eq!(cred.env_var, Some("VAULT_API_KEY".to_string()));
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3919,7 +3919,7 @@ mod tests {
     fn test_validate_custom_credential_file_uri_accepted() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///vault/secrets/token".to_string(),
+            credential_key: "file:///run/secrets/api-token".to_string(),
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -3938,7 +3938,7 @@ mod tests {
     fn test_validate_custom_credential_file_uri_requires_env_var() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///vault/secrets/token".to_string(),
+            credential_key: "file:///run/secrets/api-token".to_string(),
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -3982,7 +3982,7 @@ mod tests {
     fn test_validate_custom_credential_file_uri_traversal_rejected() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///vault/secrets/../../../etc/shadow".to_string(),
+            credential_key: "file:///run/secrets/../../../etc/shadow".to_string(),
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -4003,7 +4003,7 @@ mod tests {
         let json_str = r#"{
             "meta": { "name": "test-profile" },
             "env_credentials": {
-                "file:///vault/secrets/api_token": "API_TOKEN"
+                "file:///run/secrets/api-token": "API_TOKEN"
             }
         }"#;
 
@@ -4043,10 +4043,10 @@ mod tests {
                 "meta": { "name": "file-cred-test" },
                 "network": {
                     "custom_credentials": {
-                        "vault_service": {
-                            "upstream": "https://api.vault-service.com",
-                            "credential_key": "file:///vault/secrets/token",
-                            "env_var": "VAULT_API_KEY"
+                        "my_service": {
+                            "upstream": "https://api.example.com",
+                            "credential_key": "file:///run/secrets/api-token",
+                            "env_var": "MY_API_KEY"
                         }
                     }
                 }
@@ -4058,9 +4058,9 @@ mod tests {
         let cred = profile
             .network
             .custom_credentials
-            .get("vault_service")
-            .expect("vault_service credential should exist");
-        assert_eq!(cred.credential_key, "file:///vault/secrets/token");
-        assert_eq!(cred.env_var, Some("VAULT_API_KEY".to_string()));
+            .get("my_service")
+            .expect("my_service credential should exist");
+        assert_eq!(cred.credential_key, "file:///run/secrets/api-token");
+        assert_eq!(cred.env_var, Some("MY_API_KEY".to_string()));
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3926,6 +3926,7 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            endpoint_rules: vec![],
             env_var: Some("EXAMPLE_API_KEY".to_string()),
         };
         assert!(
@@ -3945,6 +3946,7 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            endpoint_rules: vec![],
             env_var: None,
         };
         let result = validate_custom_credential("example", &cred);
@@ -3967,6 +3969,7 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            endpoint_rules: vec![],
             env_var: Some("EXAMPLE_API_KEY".to_string()),
         };
         let result = validate_custom_credential("example", &cred);
@@ -3989,6 +3992,7 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            endpoint_rules: vec![],
             env_var: Some("EXAMPLE_API_KEY".to_string()),
         };
         let result = validate_custom_credential("example", &cred);

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -1026,19 +1026,17 @@ pub(crate) fn load_public_key_bytes(key_id: &str) -> Result<Vec<u8>> {
         other => other,
     })?;
 
-    base64_decode(&b64)
+    base64_decode(b64.as_str())
         .map_err(|e| nono::NonoError::KeystoreAccess(format!("corrupt public key data: {e}")))
 }
 
 pub(crate) fn load_signing_key(key_id: &str) -> Result<trust::KeyPair> {
-    let pkcs8_b64 = Zeroizing::new(trust_keystore::load_secret(TRUST_SERVICE, key_id).map_err(
-        |e| match e {
-            nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
-                "signing key '{key_id}' not found in keystore (run 'nono trust keygen' first)"
-            )),
-            other => other,
-        },
-    )?);
+    let pkcs8_b64 = trust_keystore::load_secret(TRUST_SERVICE, key_id).map_err(|e| match e {
+        nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
+            "signing key '{key_id}' not found in keystore (run 'nono trust keygen' first)"
+        )),
+        other => other,
+    })?;
 
     let pkcs8_bytes = Zeroizing::new(base64_decode(pkcs8_b64.as_str()).map_err(|e| {
         nono::NonoError::KeystoreAccess(format!("corrupt key data in keystore: {e}"))

--- a/crates/nono-cli/src/trust_keystore.rs
+++ b/crates/nono-cli/src/trust_keystore.rs
@@ -5,10 +5,9 @@
 //! avoids interactive keychain prompts on local machines and in CI.
 
 use nono::{NonoError, Result};
-#[cfg(all(unix, feature = "test-trust-overrides"))]
-use std::os::unix::fs::PermissionsExt;
 #[cfg(feature = "test-trust-overrides")]
 use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
 
 /// Test-only override for trust key storage.
 #[cfg(feature = "test-trust-overrides")]
@@ -61,35 +60,36 @@ impl TrustKeyStore {
         }
     }
 
-    fn load(&self, service: &str, account: &str) -> Result<String> {
+    fn load(&self, service: &str, account: &str) -> Result<Zeroizing<String>> {
         match self {
             Self::System => {
                 let entry = keyring::Entry::new(service, account).map_err(|e| {
                     NonoError::KeystoreAccess(format!("failed to access keystore: {e}"))
                 })?;
-                entry.get_password().map_err(|e| match e {
-                    keyring::Error::NoEntry => {
-                        NonoError::SecretNotFound(format!("key '{account}' not found in keystore"))
-                    }
-                    other => NonoError::KeystoreAccess(format!(
-                        "failed to load key '{account}': {other}"
-                    )),
-                })
+                entry
+                    .get_password()
+                    .map(Zeroizing::new)
+                    .map_err(|e| match e {
+                        keyring::Error::NoEntry => NonoError::SecretNotFound(format!(
+                            "key '{account}' not found in keystore"
+                        )),
+                        other => NonoError::KeystoreAccess(format!(
+                            "failed to load key '{account}': {other}"
+                        )),
+                    })
             }
             #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => {
                 let path = file_path(root, service, account);
-                std::fs::read_to_string(&path).map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::NotFound {
-                        NonoError::SecretNotFound(format!(
-                            "key '{account}' not found in test keystore"
-                        ))
-                    } else {
-                        NonoError::KeystoreAccess(format!(
-                            "failed to load key '{account}' from {}: {e}",
-                            path.display()
-                        ))
-                    }
+                nono::load_secret_file(&path).map_err(|e| match e {
+                    NonoError::SecretNotFound(_) => NonoError::SecretNotFound(format!(
+                        "key '{account}' not found in test keystore"
+                    )),
+                    NonoError::KeystoreAccess(_) => NonoError::KeystoreAccess(format!(
+                        "failed to load key '{account}' from {}",
+                        path.display()
+                    )),
+                    other => other,
                 })
             }
         }
@@ -108,33 +108,13 @@ impl TrustKeyStore {
             #[cfg(feature = "test-trust-overrides")]
             Self::File(root) => {
                 let path = file_path(root, service, account);
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).map_err(|e| {
-                        NonoError::KeystoreAccess(format!(
-                            "failed to create test keystore directory {}: {e}",
-                            parent.display()
-                        ))
-                    })?;
-                }
-
-                std::fs::write(&path, secret).map_err(|e| {
-                    NonoError::KeystoreAccess(format!(
-                        "failed to store key '{account}' at {}: {e}",
+                nono::store_secret_file(&path, secret).map_err(|e| match e {
+                    NonoError::KeystoreAccess(_) => NonoError::KeystoreAccess(format!(
+                        "failed to store key '{account}' at {}",
                         path.display()
-                    ))
-                })?;
-
-                #[cfg(unix)]
-                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(
-                    |e| {
-                        NonoError::KeystoreAccess(format!(
-                            "failed to secure test keystore file {}: {e}",
-                            path.display()
-                        ))
-                    },
-                )?;
-
-                Ok(())
+                    )),
+                    other => other,
+                })
             }
         }
     }
@@ -163,7 +143,7 @@ pub(crate) fn contains_secret(service: &str, account: &str) -> Result<bool> {
     TrustKeyStore::selected().contains(service, account)
 }
 
-pub(crate) fn load_secret(service: &str, account: &str) -> Result<String> {
+pub(crate) fn load_secret(service: &str, account: &str) -> Result<Zeroizing<String>> {
     TrustKeyStore::selected().load(service, account)
 }
 
@@ -191,7 +171,7 @@ mod tests {
             Ok(loaded) => loaded,
             Err(e) => panic!("failed to load test secret: {e}"),
         };
-        assert_eq!(loaded, "secret-value");
+        assert_eq!(loaded.as_str(), "secret-value");
     }
 
     #[test]
@@ -231,7 +211,7 @@ mod tests {
             Err(e) => panic!("failed to load service-b secret: {e}"),
         };
 
-        assert_eq!(a, "secret-a");
-        assert_eq!(b, "secret-b");
+        assert_eq!(a.as_str(), "secret-a");
+        assert_eq!(b.as_str(), "secret-b");
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -48,6 +48,10 @@ const APPLE_PASSWORDS_URI_PREFIX: &str = "apple-passwords://";
 /// The `env://` URI scheme prefix, indicating environment variable backend.
 const ENV_URI_PREFIX: &str = "env://";
 
+/// The `file://` URI scheme prefix, indicating a local file credential source.
+/// Read once at startup before sandbox activation; contents zeroed on drop.
+const FILE_URI_PREFIX: &str = "file://";
+
 /// Environment variable names that must never be loaded via `env://`.
 ///
 /// These control linker, interpreter, or shell behavior. Allowing them as
@@ -322,6 +326,12 @@ pub fn is_env_uri(credential_ref: &str) -> bool {
     credential_ref.starts_with(ENV_URI_PREFIX)
 }
 
+/// Check if a credential reference uses the `file://` scheme.
+#[must_use]
+pub fn is_file_uri(credential_ref: &str) -> bool {
+    credential_ref.starts_with(FILE_URI_PREFIX)
+}
+
 /// Validate an `env://VAR_NAME` URI.
 ///
 /// Accepts variable names containing only ASCII alphanumeric characters and
@@ -364,6 +374,58 @@ pub fn validate_env_uri(uri: &str) -> Result<()> {
         return Err(NonoError::ConfigParse(format!(
             "env:// cannot read dangerous environment variable: {}",
             var_name
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate a `file://` URI for local file credential sources.
+///
+/// Expected format: `file:///absolute/path` (triple slash for absolute paths).
+///
+/// Rejects:
+/// - Non-absolute paths (must start with `/` after `file://`)
+/// - Empty or root-only paths
+/// - Path traversal (`..` components)
+/// - Dangerous characters (null, newline, semicolons, backticks, pipes, shell expansion)
+pub fn validate_file_uri(uri: &str) -> Result<()> {
+    let path_str = uri.strip_prefix(FILE_URI_PREFIX).ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "credential reference '{}' does not start with '{}'",
+            uri, FILE_URI_PREFIX
+        ))
+    })?;
+
+    if !path_str.starts_with('/') {
+        return Err(NonoError::ConfigParse(format!(
+            "file:// URI must use an absolute path (file:///path), got: {}",
+            uri
+        )));
+    }
+
+    let meaningful = path_str.trim_end_matches('/');
+    if meaningful.is_empty() || meaningful == "/" {
+        return Err(NonoError::ConfigParse(format!(
+            "file:// URI path is empty: {}",
+            uri
+        )));
+    }
+
+    for component in std::path::Path::new(path_str).components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(NonoError::ConfigParse(format!(
+                "file:// URI must not contain path traversal (..): {}",
+                uri
+            )));
+        }
+    }
+
+    const FORBIDDEN_FILE_CHARS: &[char] = &['\0', '\n', '\r', ';', '`', '|', '$', '&', '>', '<'];
+    if let Some(bad) = path_str.chars().find(|c| FORBIDDEN_FILE_CHARS.contains(c)) {
+        return Err(NonoError::ConfigParse(format!(
+            "file:// URI contains forbidden character {:?}: {}",
+            bad, uri
         )));
     }
 
@@ -1870,5 +1932,53 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged.get("openai_api_key"), Some(&"FROM_MAP".to_string()));
+    }
+
+    // =========================================================================
+    // file:// URI tests
+    // =========================================================================
+
+    #[test]
+    fn test_validate_file_uri_valid_absolute_path() {
+        assert!(validate_file_uri("file:///vault/secrets/gitlab").is_ok());
+        assert!(validate_file_uri("file:///tmp/secret.txt").is_ok());
+        assert!(validate_file_uri("file:///etc/ssl/certs/ca.pem").is_ok());
+    }
+
+    #[test]
+    fn test_validate_file_uri_rejects_empty_path() {
+        assert!(validate_file_uri("file://").is_err());
+        assert!(validate_file_uri("file:///").is_err());
+    }
+
+    #[test]
+    fn test_validate_file_uri_rejects_relative_path() {
+        assert!(validate_file_uri("file://relative/path").is_err());
+        assert!(validate_file_uri("file://./secret").is_err());
+        assert!(validate_file_uri("file://../escape").is_err());
+    }
+
+    #[test]
+    fn test_validate_file_uri_rejects_traversal() {
+        assert!(validate_file_uri("file:///vault/secrets/../../../etc/shadow").is_err());
+        assert!(validate_file_uri("file:///tmp/../../root/.ssh/id_rsa").is_err());
+    }
+
+    #[test]
+    fn test_validate_file_uri_rejects_forbidden_characters() {
+        assert!(validate_file_uri("file:///tmp/secret;rm -rf /").is_err());
+        assert!(validate_file_uri("file:///tmp/secret\nnewline").is_err());
+        assert!(validate_file_uri("file:///tmp/secret\x00null").is_err());
+    }
+
+    #[test]
+    fn test_is_file_uri() {
+        assert!(is_file_uri("file:///vault/secrets/gitlab"));
+        assert!(!is_file_uri("env://MY_VAR"));
+        assert!(!is_file_uri("/vault/secrets/gitlab"));
+        // Note: is_file_uri is a scheme detector, not a validator.
+        // "file://relative" starts with "file://" so it matches the scheme.
+        // Validation (absolute path check) happens in validate_file_uri.
+        assert!(is_file_uri("file://relative"));
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -17,6 +17,7 @@
 
 use crate::error::{NonoError, Result};
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 use zeroize::Zeroizing;
@@ -527,13 +528,34 @@ fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
         .strip_prefix(FILE_URI_PREFIX)
         .ok_or_else(|| NonoError::ConfigParse(format!("invalid file:// URI: {}", uri)))?;
 
-    let content = std::fs::read_to_string(path_str).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
+    let trimmed = load_secret_file(Path::new(path_str)).map_err(|e| match e {
+        NonoError::SecretNotFound(_) => {
             NonoError::SecretNotFound(format!("credential file not found: {}", path_str))
+        }
+        NonoError::KeystoreAccess(_) => {
+            NonoError::KeystoreAccess(format!("failed to read credential file '{}'", path_str))
+        }
+        other => other,
+    })?;
+
+    tracing::debug!("Loaded secret from {}", redact_file_uri(uri));
+    Ok(trimmed)
+}
+
+/// Load a secret from a local file and wrap it in [`Zeroizing`].
+///
+/// Intended for callers that need a common file-backed secret path without
+/// duplicating plaintext handling. The returned string is trimmed; empty or
+/// whitespace-only files are rejected.
+pub fn load_secret_file(path: &Path) -> Result<Zeroizing<String>> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            NonoError::SecretNotFound(format!("secret file not found: {}", path.display()))
         } else {
             NonoError::KeystoreAccess(format!(
-                "failed to read credential file '{}': {}",
-                path_str, e
+                "failed to read secret file '{}': {}",
+                path.display(),
+                e
             ))
         }
     })?;
@@ -541,13 +563,45 @@ fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
     let trimmed = content.trim().to_string();
     if trimmed.is_empty() {
         return Err(NonoError::SecretNotFound(format!(
-            "credential file '{}' is empty or contains only whitespace",
-            path_str
+            "secret file '{}' is empty or contains only whitespace",
+            path.display()
         )));
     }
 
-    tracing::debug!("Loaded secret from {}", redact_file_uri(uri));
     Ok(Zeroizing::new(trimmed))
+}
+
+/// Store a secret in a local file with owner-only permissions on Unix.
+///
+/// This is primarily used by trust-related file-backed keystore adapters and
+/// keeps the file handling consistent with runtime secret loading helpers.
+pub fn store_secret_file(path: &Path, secret: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            NonoError::KeystoreAccess(format!(
+                "failed to create secret directory {}: {e}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    std::fs::write(path, secret).map_err(|e| {
+        NonoError::KeystoreAccess(format!("failed to store secret at {}: {e}", path.display()))
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+            NonoError::KeystoreAccess(format!(
+                "failed to secure secret file {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+
+    Ok(())
 }
 
 /// Load a single secret from the keystore.

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -506,6 +506,47 @@ fn load_from_env(uri: &str) -> Result<Zeroizing<String>> {
     }
 }
 
+/// Load a secret from a local file via `file://` URI.
+///
+/// Reads the file contents at startup (before sandbox activation), trims
+/// whitespace, and wraps the result in `Zeroizing<String>`. The file is
+/// read once — subsequent access is from the in-memory zeroized copy.
+///
+/// # Errors
+///
+/// Returns `SecretNotFound` if the file does not exist or is empty/whitespace-only.
+/// Returns `KeystoreAccess` for other I/O errors (permissions, etc.).
+#[allow(dead_code)] // Wired into load_secret_by_ref in a follow-up task
+fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
+    validate_file_uri(uri)?;
+
+    let path_str = uri
+        .strip_prefix(FILE_URI_PREFIX)
+        .ok_or_else(|| NonoError::ConfigParse(format!("invalid file:// URI: {}", uri)))?;
+
+    let content = std::fs::read_to_string(path_str).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            NonoError::SecretNotFound(format!("credential file not found: {}", path_str))
+        } else {
+            NonoError::KeystoreAccess(format!(
+                "failed to read credential file '{}': {}",
+                path_str, e
+            ))
+        }
+    })?;
+
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(NonoError::SecretNotFound(format!(
+            "credential file '{}' is empty or contains only whitespace",
+            path_str
+        )));
+    }
+
+    tracing::debug!("Loaded secret from file '{}'", path_str);
+    Ok(Zeroizing::new(trimmed))
+}
+
 /// Load a single secret from the keystore.
 ///
 /// The returned value is immediately wrapped in `Zeroizing` so the heap
@@ -1980,5 +2021,56 @@ mod tests {
         // "file://relative" starts with "file://" so it matches the scheme.
         // Validation (absolute path check) happens in validate_file_uri.
         assert!(is_file_uri("file://relative"));
+    }
+
+    // =========================================================================
+    // load_from_file tests
+    // =========================================================================
+
+    #[test]
+    fn test_load_from_file_reads_and_trims() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+        std::fs::write(&path, "my-api-key\n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "my-api-key");
+    }
+
+    #[test]
+    fn test_load_from_file_empty_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        std::fs::write(&path, "").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_from_file_whitespace_only_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("whitespace.txt");
+        std::fs::write(&path, "  \n  \n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_from_file_not_found() {
+        let result = load_from_file("file:///nonexistent/path/secret.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_from_file_multiline_reads_trimmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.txt");
+        std::fs::write(&path, "glpat-xxxxxxxxxxxx\n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri).unwrap();
+        assert_eq!(result.as_str(), "glpat-xxxxxxxxxxxx");
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -146,15 +146,16 @@ pub fn load_secrets(
 /// Load a single secret, dispatching to the appropriate backend.
 ///
 /// Dispatch order:
-/// 1. `env://VAR` — reads from the process environment
-/// 2. `op://vault/item/field` — delegates to the 1Password CLI
-/// 3. `apple-password://server/account` — delegates to macOS `security`
-/// 4. Everything else — loads from the system keyring
+/// 1. `file:///path` — reads from a local file (before sandbox activation)
+/// 2. `env://VAR` — reads from the process environment
+/// 3. `op://vault/item/field` — delegates to the 1Password CLI
+/// 4. `apple-password://server/account` — delegates to macOS `security`
+/// 5. Everything else — loads from the system keyring
 ///
 /// # Arguments
 /// * `service` - Keyring service name (only used for keyring backend)
-/// * `credential_ref` - A keyring account name, `op://` URI, Apple Passwords URI,
-///   or `env://` URI
+/// * `credential_ref` - A keyring account name, `file://` URI, `op://` URI,
+///   Apple Passwords URI, or `env://` URI
 ///
 /// # Security
 /// The returned value is wrapped in `Zeroizing<String>`. For URI-based managers
@@ -164,7 +165,9 @@ pub fn load_secrets(
 /// internal buffers.
 #[must_use = "loaded secret should be used or explicitly dropped"]
 pub fn load_secret_by_ref(service: &str, credential_ref: &str) -> Result<Zeroizing<String>> {
-    if credential_ref.starts_with(ENV_URI_PREFIX) {
+    if credential_ref.starts_with(FILE_URI_PREFIX) {
+        load_from_file(credential_ref)
+    } else if credential_ref.starts_with(ENV_URI_PREFIX) {
         load_from_env(credential_ref)
     } else if credential_ref.starts_with(OP_URI_PREFIX) {
         load_from_op(credential_ref)
@@ -516,7 +519,6 @@ fn load_from_env(uri: &str) -> Result<Zeroizing<String>> {
 ///
 /// Returns `SecretNotFound` if the file does not exist or is empty/whitespace-only.
 /// Returns `KeystoreAccess` for other I/O errors (permissions, etc.).
-#[allow(dead_code)] // Wired into load_secret_by_ref in a follow-up task
 fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
     validate_file_uri(uri)?;
 
@@ -926,6 +928,32 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
                     }
                 };
                 mappings.insert(entry.to_string(), source_var.to_string());
+            }
+        } else if entry.starts_with(FILE_URI_PREFIX) {
+            // file:// URI: must have explicit =VAR_NAME suffix because
+            // you can't derive a meaningful env var name from a file path.
+            // Format: file:///path/to/secret=MY_VAR
+            if let Some(eq_pos) = entry.rfind('=') {
+                let uri = &entry[..eq_pos];
+                let var_name = &entry[eq_pos + 1..];
+
+                if var_name.is_empty() {
+                    return Err(NonoError::ConfigParse(format!(
+                        "file:// credential '{}' has '=' but no variable name. \
+                         Use format: file:///path/to/secret=MY_VAR",
+                        uri
+                    )));
+                }
+
+                validate_file_uri(uri)?;
+                validate_destination_env_var(var_name)?;
+                mappings.insert(uri.to_string(), var_name.to_string());
+            } else {
+                return Err(NonoError::ConfigParse(format!(
+                    "file:// credential '{}' requires an explicit target variable. \
+                     Use format: file:///path/to/secret=MY_VAR",
+                    entry
+                )));
             }
         } else if entry.starts_with(OP_URI_PREFIX) {
             // 1Password URI: must have =VAR_NAME suffix
@@ -2072,5 +2100,37 @@ mod tests {
         let uri = format!("file://{}", path.display());
         let result = load_from_file(&uri).unwrap();
         assert_eq!(result.as_str(), "glpat-xxxxxxxxxxxx");
+    }
+
+    // =========================================================================
+    // file:// dispatch and CLI mapping tests
+    // =========================================================================
+
+    #[test]
+    fn test_load_secret_by_ref_dispatches_file_uri() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token.txt");
+        std::fs::write(&path, "secret-value\n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_secret_by_ref("nono", &uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "secret-value");
+    }
+
+    #[test]
+    fn test_build_mappings_file_uri_requires_explicit_var() {
+        let result = build_mappings_from_list("file:///vault/secrets/gitlab=GITLAB_TOKEN");
+        assert!(result.is_ok());
+        let mappings = result.unwrap();
+        assert_eq!(
+            mappings.get("file:///vault/secrets/gitlab"),
+            Some(&"GITLAB_TOKEN".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_mappings_file_uri_without_var_name_is_error() {
+        let result = build_mappings_from_list("file:///vault/secrets/gitlab");
+        assert!(result.is_err());
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -7,6 +7,7 @@
 //!
 //! Credential references are dispatched by URI scheme:
 //! - `env://VAR_NAME` — reads from the current process environment
+//! - `file:///path/to/secret` — reads from a local file (before sandbox activation)
 //! - `op://vault/item/field` — loaded via the 1Password CLI
 //! - `apple-password://server/account` — loaded via macOS `security`
 //! - Everything else — loaded from the system keyring
@@ -545,7 +546,7 @@ fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
         )));
     }
 
-    tracing::debug!("Loaded secret from file '{}'", path_str);
+    tracing::debug!("Loaded secret from {}", redact_file_uri(uri));
     Ok(Zeroizing::new(trimmed))
 }
 
@@ -803,6 +804,18 @@ pub fn redact_apple_password_uri(uri: &str) -> String {
         }
     }
     "apple-password://***".to_string()
+}
+
+/// Redact a file:// URI for safe logging.
+/// Keeps the directory structure but replaces the filename.
+/// `file:///run/secrets/api-token` → `file:///run/secrets/[REDACTED]`
+fn redact_file_uri(uri: &str) -> String {
+    if let Some(path) = uri.strip_prefix(FILE_URI_PREFIX) {
+        if let Some(last_slash) = path.rfind('/') {
+            return format!("{}{}[REDACTED]", FILE_URI_PREFIX, &path[..=last_slash]);
+        }
+    }
+    format!("{}[REDACTED]", FILE_URI_PREFIX)
 }
 
 /// Wait for a child process with a timeout.
@@ -1082,6 +1095,7 @@ pub fn build_secret_mappings(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -1500,6 +1514,25 @@ mod tests {
             redact_apple_password_uri("apple-password://only-server"),
             "apple-password://***"
         );
+    }
+
+    // --- redact_file_uri tests ---
+
+    #[test]
+    fn test_redact_file_uri() {
+        assert_eq!(
+            redact_file_uri("file:///run/secrets/api-token"),
+            "file:///run/secrets/[REDACTED]"
+        );
+        assert_eq!(
+            redact_file_uri("file:///etc/ssl/cert.pem"),
+            "file:///etc/ssl/[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn test_redact_file_uri_root_path() {
+        assert_eq!(redact_file_uri("file:///secret"), "file:///[REDACTED]");
     }
 
     // --- classify_op_error tests ---
@@ -2009,7 +2042,7 @@ mod tests {
 
     #[test]
     fn test_validate_file_uri_valid_absolute_path() {
-        assert!(validate_file_uri("file:///vault/secrets/gitlab").is_ok());
+        assert!(validate_file_uri("file:///run/secrets/api-token").is_ok());
         assert!(validate_file_uri("file:///tmp/secret.txt").is_ok());
         assert!(validate_file_uri("file:///etc/ssl/certs/ca.pem").is_ok());
     }
@@ -2029,7 +2062,7 @@ mod tests {
 
     #[test]
     fn test_validate_file_uri_rejects_traversal() {
-        assert!(validate_file_uri("file:///vault/secrets/../../../etc/shadow").is_err());
+        assert!(validate_file_uri("file:///run/secrets/../../../etc/shadow").is_err());
         assert!(validate_file_uri("file:///tmp/../../root/.ssh/id_rsa").is_err());
     }
 
@@ -2042,9 +2075,9 @@ mod tests {
 
     #[test]
     fn test_is_file_uri() {
-        assert!(is_file_uri("file:///vault/secrets/gitlab"));
+        assert!(is_file_uri("file:///run/secrets/api-token"));
         assert!(!is_file_uri("env://MY_VAR"));
-        assert!(!is_file_uri("/vault/secrets/gitlab"));
+        assert!(!is_file_uri("/run/secrets/api-token"));
         // Note: is_file_uri is a scheme detector, not a validator.
         // "file://relative" starts with "file://" so it matches the scheme.
         // Validation (absolute path check) happens in validate_file_uri.
@@ -2119,18 +2152,18 @@ mod tests {
 
     #[test]
     fn test_build_mappings_file_uri_requires_explicit_var() {
-        let result = build_mappings_from_list("file:///vault/secrets/gitlab=GITLAB_TOKEN");
+        let result = build_mappings_from_list("file:///run/secrets/api-token=MY_API_KEY");
         assert!(result.is_ok());
         let mappings = result.unwrap();
         assert_eq!(
-            mappings.get("file:///vault/secrets/gitlab"),
-            Some(&"GITLAB_TOKEN".to_string())
+            mappings.get("file:///run/secrets/api-token"),
+            Some(&"MY_API_KEY".to_string())
         );
     }
 
     #[test]
     fn test_build_mappings_file_uri_without_var_name_is_error() {
-        let result = build_mappings_from_list("file:///vault/secrets/gitlab");
+        let result = build_mappings_from_list("file:///run/secrets/api-token");
         assert!(result.is_err());
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -17,6 +17,7 @@
 
 use crate::error::{NonoError, Result};
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -519,7 +520,7 @@ fn load_from_env(uri: &str) -> Result<Zeroizing<String>> {
 ///
 /// # Errors
 ///
-/// Returns `SecretNotFound` if the file does not exist or is empty/whitespace-only.
+/// Returns `SecretNotFound` if the file does not exist or is empty.
 /// Returns `KeystoreAccess` for other I/O errors (permissions, etc.).
 fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
     validate_file_uri(uri)?;
@@ -545,10 +546,11 @@ fn load_from_file(uri: &str) -> Result<Zeroizing<String>> {
 /// Load a secret from a local file and wrap it in [`Zeroizing`].
 ///
 /// Intended for callers that need a common file-backed secret path without
-/// duplicating plaintext handling. The returned string is trimmed; empty or
-/// whitespace-only files are rejected.
+/// duplicating plaintext handling. A single trailing line ending is removed to
+/// match CLI-based secret loaders; other leading/trailing whitespace is
+/// preserved.
 pub fn load_secret_file(path: &Path) -> Result<Zeroizing<String>> {
-    let content = std::fs::read_to_string(path).map_err(|e| {
+    let mut content = Zeroizing::new(std::fs::read_to_string(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             NonoError::SecretNotFound(format!("secret file not found: {}", path.display()))
         } else {
@@ -558,17 +560,24 @@ pub fn load_secret_file(path: &Path) -> Result<Zeroizing<String>> {
                 e
             ))
         }
-    })?;
+    })?);
 
-    let trimmed = content.trim().to_string();
-    if trimmed.is_empty() {
+    if content.ends_with("\r\n") {
+        let new_len = content.len().saturating_sub(2);
+        content.truncate(new_len);
+    } else if content.ends_with('\n') {
+        let new_len = content.len().saturating_sub(1);
+        content.truncate(new_len);
+    }
+
+    if content.is_empty() {
         return Err(NonoError::SecretNotFound(format!(
-            "secret file '{}' is empty or contains only whitespace",
+            "secret file '{}' is empty",
             path.display()
         )));
     }
 
-    Ok(Zeroizing::new(trimmed))
+    Ok(content)
 }
 
 /// Store a secret in a local file with owner-only permissions on Unix.
@@ -585,19 +594,62 @@ pub fn store_secret_file(path: &Path, secret: &str) -> Result<()> {
         })?;
     }
 
-    std::fs::write(path, secret).map_err(|e| {
-        NonoError::KeystoreAccess(format!("failed to store secret at {}: {e}", path.display()))
-    })?;
-
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::fs::OpenOptions;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        if path.exists() {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
+                |e| {
+                    NonoError::KeystoreAccess(format!(
+                        "failed to secure existing secret file {}: {e}",
+                        path.display()
+                    ))
+                },
+            )?;
+        }
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| {
+                NonoError::KeystoreAccess(format!(
+                    "failed to store secret at {}: {e}",
+                    path.display()
+                ))
+            })?;
+
+        file.write_all(secret.as_bytes()).map_err(|e| {
+            NonoError::KeystoreAccess(format!("failed to store secret at {}: {e}", path.display()))
+        })?;
+
+        file.sync_all().map_err(|e| {
+            NonoError::KeystoreAccess(format!(
+                "failed to sync secret file {}: {e}",
+                path.display()
+            ))
+        })?;
 
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
             NonoError::KeystoreAccess(format!(
                 "failed to secure secret file {}: {e}",
                 path.display()
             ))
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let mut file = std::fs::File::create(path).map_err(|e| {
+            NonoError::KeystoreAccess(format!("failed to store secret at {}: {e}", path.display()))
+        })?;
+
+        file.write_all(secret.as_bytes()).map_err(|e| {
+            NonoError::KeystoreAccess(format!("failed to store secret at {}: {e}", path.display()))
         })?;
     }
 
@@ -2170,7 +2222,8 @@ mod tests {
         std::fs::write(&path, "  \n  \n").unwrap();
         let uri = format!("file://{}", path.display());
         let result = load_from_file(&uri);
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "  \n  ");
     }
 
     #[test]
@@ -2187,6 +2240,51 @@ mod tests {
         let uri = format!("file://{}", path.display());
         let result = load_from_file(&uri).unwrap();
         assert_eq!(result.as_str(), "glpat-xxxxxxxxxxxx");
+    }
+
+    #[test]
+    fn test_load_from_file_preserves_significant_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spaces.txt");
+        std::fs::write(&path, "  secret value  \n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri).unwrap();
+        assert_eq!(result.as_str(), "  secret value  ");
+    }
+
+    #[test]
+    fn test_load_from_file_trims_single_trailing_crlf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crlf.txt");
+        std::fs::write(&path, "secret\r\n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri).unwrap();
+        assert_eq!(result.as_str(), "secret");
+    }
+
+    #[test]
+    fn test_load_from_file_newline_only_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("newline-only.txt");
+        std::fs::write(&path, "\n").unwrap();
+        let uri = format!("file://{}", path.display());
+        let result = load_from_file(&uri);
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_store_secret_file_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+
+        store_secret_file(&path, "top-secret").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "top-secret");
     }
 
     // =========================================================================

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -67,9 +67,10 @@ pub use diagnostic::{
 };
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_apple_password_uri, is_env_uri, is_op_uri, load_secret_by_ref, load_secrets,
-    redact_apple_password_uri, redact_op_uri, validate_apple_password_uri,
-    validate_destination_env_var, validate_env_uri, validate_op_uri, LoadedSecret,
+    is_apple_password_uri, is_env_uri, is_op_uri, load_secret_by_ref, load_secret_file,
+    load_secrets, redact_apple_password_uri, redact_op_uri, store_secret_file,
+    validate_apple_password_uri, validate_destination_env_var, validate_env_uri, validate_op_uri,
+    LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
This PR adds local file credential source support via `file://` URIs.

  - `file://` URI validation for local file credentials
  - file-backed secret loading for credential resolution
  - CLI/profile wiring for file credential sources
  - shared file-backed secret helpers
  - zeroized secret handling across the updated codepaths

 This PR is based on the work originally proposed in #515 by @RobertWi