### PR TITLE
feat(policy): split linux system groups for granular host compatibility

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -183,8 +183,8 @@
         "/tmp": "/private/tmp"
       }
     },
-    "system_read_linux": {
-      "description": "Linux system paths required for executables to function",
+    "system_read_linux_core": {
+      "description": "Linux core system paths required for normal CLI execution",
       "platform": "linux",
       "allow": {
         "read": [
@@ -245,12 +245,35 @@
           "/proc/stat",
           "/proc/loadavg",
           "/proc/version",
-          "/proc/filesystems",
-          "/sys",
+          "/proc/filesystems"
+        ]
+      }
+    },
+    "linux_runtime_state": {
+      "description": "Linux runtime state paths for host session and service integration",
+      "platform": "linux",
+      "allow": {
+        "read": [
           "/run",
-          "/var/run",
-          "/tmp",
-          "/nix"
+          "/var/run"
+        ]
+      }
+    },
+    "linux_sysfs_read": {
+      "description": "Linux sysfs paths for kernel and device state inspection",
+      "platform": "linux",
+      "allow": {
+        "read": [
+          "/sys"
+        ]
+      }
+    },
+    "linux_temp_read": {
+      "description": "Linux shared temporary directory read access",
+      "platform": "linux",
+      "allow": {
+        "read": [
+          "/tmp"
         ]
       }
     },
@@ -301,14 +324,11 @@
       }
     },
     "user_caches_linux": {
-      "description": "User cache and log directories for Linux programs (XDG)",
+      "description": "User cache directories for Linux programs (XDG)",
       "platform": "linux",
       "allow": {
         "readwrite": [
           "~/.cache"
-        ],
-        "read": [
-          "~/.local/state"
         ]
       }
     },
@@ -330,9 +350,6 @@
           "~/.local/share/man",
           "~/.local/share/bash-completion",
           "~/.local/share/zsh"
-        ],
-        "readwrite": [
-          "~/.local/state"
         ]
       }
     },
@@ -569,7 +586,7 @@
           "deny_shell_history",
           "deny_shell_configs",
           "system_read_macos",
-          "system_read_linux",
+          "system_read_linux_core",
           "system_write_macos",
           "system_write_linux",
           "user_tools",
@@ -577,6 +594,27 @@
           "dangerous_commands",
           "dangerous_commands_macos",
           "dangerous_commands_linux"
+        ],
+        "signal_mode": "isolated"
+      },
+      "filesystem": {},
+      "network": { "block": false },
+      "workdir": { "access": "none" },
+      "interactive": false
+    },
+    "linux-host-compat": {
+      "extends": "default",
+      "meta": {
+        "name": "linux-host-compat",
+        "version": "1.0.0",
+        "description": "Linux compatibility profile for host runtime, sysfs, and temp access",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": [
+          "linux_runtime_state",
+          "linux_sysfs_read",
+          "linux_temp_read"
         ],
         "signal_mode": "isolated"
       },
@@ -604,6 +642,7 @@
           "python_runtime",
           "vscode_macos",
           "vscode_linux",
+          "linux_sysfs_read",
           "nix_runtime",
           "git_config",
           "unlink_protection"
@@ -651,6 +690,7 @@
           "node_runtime",
           "rust_runtime",
           "python_runtime",
+          "linux_sysfs_read",
           "nix_runtime",
           "git_config",
           "unlink_protection"
@@ -708,7 +748,7 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "git_config", "unlink_protection"],
+        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "linux_sysfs_read", "git_config", "unlink_protection"],
         "signal_mode": "isolated"
       },
       "filesystem": {
@@ -810,6 +850,7 @@
           "node_runtime",
           "user_caches_macos",
           "user_caches_linux",
+          "linux_sysfs_read",
           "git_config",
           "unlink_protection"
         ],

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -264,6 +264,23 @@ To replace inherited URL-opening permissions, provide `open_urls` with an explic
 }
 ```
 
+### Linux host compatibility
+
+On Linux, the built-in `default` profile keeps host runtime, sysfs, and shared temp reads out of the base policy. If your tool needs access to paths like `/run`, `/var/run`, `/sys`, or `/tmp`, extend the built-in compatibility preset:
+
+```json
+{
+  "extends": "linux-host-compat",
+  "meta": {
+    "name": "linux-desktop-agent",
+    "description": "Agent with Linux host runtime compatibility"
+  },
+  "workdir": {
+    "access": "readwrite"
+  }
+}
+```
+
 ### Profile with deny overrides
 
 When a deny group blocks a path you need access to, use `override_deny` together with an explicit grant:

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1967,11 +1967,11 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_embedded_policy_includes_device_files() {
-        // The system_read_linux group lists /dev/urandom, /dev/null, etc.
+        // The system_read_linux_core group lists /dev/urandom, /dev/null, etc.
         // Verify they survive policy resolution and end up in the capability set.
         let policy = load_embedded_policy().expect("embedded policy");
         let mut caps = CapabilitySet::new();
-        resolve_groups(&policy, &["system_read_linux".to_string()], &mut caps)
+        resolve_groups(&policy, &["system_read_linux_core".to_string()], &mut caps)
             .expect("resolve failed");
 
         let resolved_paths: Vec<PathBuf> = caps
@@ -1983,7 +1983,7 @@ mod tests {
         for device in &["/dev/urandom", "/dev/null", "/dev/zero", "/dev/random"] {
             assert!(
                 resolved_paths.iter().any(|p| p == Path::new(device)),
-                "{} must be included in system_read_linux capabilities, got: {:?}",
+                "{} must be included in system_read_linux_core capabilities, got: {:?}",
                 device,
                 resolved_paths
             );
@@ -2010,12 +2010,12 @@ mod tests {
     }
 
     #[test]
-    fn test_system_read_linux_does_not_grant_bare_etc_or_proc() {
+    fn test_system_read_linux_core_does_not_grant_bare_etc_or_proc() {
         let policy = load_embedded_policy().expect("embedded policy must parse");
         let group = policy
             .groups
-            .get("system_read_linux")
-            .expect("system_read_linux group must exist");
+            .get("system_read_linux_core")
+            .expect("system_read_linux_core group must exist");
         let read_paths = group
             .allow
             .as_ref()
@@ -2024,13 +2024,117 @@ mod tests {
 
         assert!(
             !read_paths.iter().any(|p| p == "/etc"),
-            "system_read_linux must not grant bare '/etc'; use specific paths instead. Found: {:?}",
+            "system_read_linux_core must not grant bare '/etc'; use specific paths instead. Found: {:?}",
             read_paths
         );
         assert!(
             !read_paths.iter().any(|p| p == "/proc"),
-            "system_read_linux must not grant bare '/proc'; use specific paths instead. Found: {:?}",
+            "system_read_linux_core must not grant bare '/proc'; use specific paths instead. Found: {:?}",
             read_paths
+        );
+    }
+
+    #[test]
+    fn test_linux_core_excludes_runtime_state_sysfs_temp_and_nix() {
+        let policy = load_embedded_policy().expect("embedded policy must parse");
+        let group = policy
+            .groups
+            .get("system_read_linux_core")
+            .expect("system_read_linux_core group must exist");
+        let read_paths = group
+            .allow
+            .as_ref()
+            .map(|a| a.read.as_slice())
+            .unwrap_or(&[]);
+
+        for disallowed in ["/run", "/var/run", "/sys", "/tmp", "/nix"] {
+            assert!(
+                !read_paths.iter().any(|p| p == disallowed),
+                "system_read_linux_core must not include '{}'. Found: {:?}",
+                disallowed,
+                read_paths
+            );
+        }
+    }
+
+    #[test]
+    fn test_linux_compat_groups_expose_expected_paths() {
+        let policy = load_embedded_policy().expect("embedded policy must parse");
+
+        let runtime = policy
+            .groups
+            .get("linux_runtime_state")
+            .expect("linux_runtime_state group must exist");
+        let runtime_paths = runtime
+            .allow
+            .as_ref()
+            .map(|a| a.read.as_slice())
+            .unwrap_or(&[]);
+        assert!(runtime_paths.iter().any(|p| p == "/run"));
+        assert!(runtime_paths.iter().any(|p| p == "/var/run"));
+
+        let sysfs = policy
+            .groups
+            .get("linux_sysfs_read")
+            .expect("linux_sysfs_read group must exist");
+        let sysfs_paths = sysfs
+            .allow
+            .as_ref()
+            .map(|a| a.read.as_slice())
+            .unwrap_or(&[]);
+        assert_eq!(sysfs_paths, ["/sys"]);
+
+        let temp = policy
+            .groups
+            .get("linux_temp_read")
+            .expect("linux_temp_read group must exist");
+        let temp_paths = temp
+            .allow
+            .as_ref()
+            .map(|a| a.read.as_slice())
+            .unwrap_or(&[]);
+        assert_eq!(temp_paths, ["/tmp"]);
+    }
+
+    #[test]
+    fn test_default_user_groups_do_not_grant_local_state() {
+        let policy = load_embedded_policy().expect("embedded policy must parse");
+
+        let user_tools = policy
+            .groups
+            .get("user_tools")
+            .expect("user_tools group must exist");
+        let user_tools_allow = user_tools.allow.as_ref().expect("user_tools allow rules");
+        assert!(
+            !user_tools_allow.read.iter().any(|p| p == "~/.local/state"),
+            "user_tools must not grant ~/.local/state"
+        );
+        assert!(
+            !user_tools_allow
+                .readwrite
+                .iter()
+                .any(|p| p == "~/.local/state"),
+            "user_tools must not grant ~/.local/state"
+        );
+
+        let user_caches_linux = policy
+            .groups
+            .get("user_caches_linux")
+            .expect("user_caches_linux group must exist");
+        let user_caches_allow = user_caches_linux
+            .allow
+            .as_ref()
+            .expect("user_caches_linux allow rules");
+        assert!(
+            !user_caches_allow.read.iter().any(|p| p == "~/.local/state"),
+            "user_caches_linux must not grant ~/.local/state"
+        );
+        assert!(
+            !user_caches_allow
+                .readwrite
+                .iter()
+                .any(|p| p == "~/.local/state"),
+            "user_caches_linux must not grant ~/.local/state"
         );
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -158,6 +158,7 @@ mod tests {
     fn test_list_builtin() {
         let profiles = list_builtin();
         assert!(profiles.contains(&"default".to_string()));
+        assert!(profiles.contains(&"linux-host-compat".to_string()));
         assert!(profiles.contains(&"claude-code".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
         assert!(profiles.contains(&"openclaw".to_string()));
@@ -220,7 +221,7 @@ mod tests {
             "deny_shell_configs".to_string(),
             "deny_shell_history".to_string(),
             "homebrew".to_string(),
-            "system_read_linux".to_string(),
+            "system_read_linux_core".to_string(),
             "system_read_macos".to_string(),
             "system_write_linux".to_string(),
             "system_write_macos".to_string(),
@@ -243,6 +244,54 @@ mod tests {
                 def.extends.as_deref(),
                 Some("default"),
                 "embedded profile '{}' should extend default",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_linux_host_compat_profile_groups() {
+        let profile = get_builtin("linux-host-compat").expect("Profile not found");
+        assert!(profile
+            .security
+            .groups
+            .contains(&"linux_runtime_state".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"linux_sysfs_read".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"linux_temp_read".to_string()));
+    }
+
+    #[test]
+    fn test_linux_interactive_profiles_include_sysfs_but_not_runtime_state_or_temp() {
+        for name in ["claude-code", "codex", "opencode", "swival"] {
+            let profile = get_builtin(name).expect("Profile not found");
+            assert!(
+                !profile
+                    .security
+                    .groups
+                    .contains(&"linux_runtime_state".to_string()),
+                "{} should not include linux_runtime_state",
+                name
+            );
+            assert!(
+                profile
+                    .security
+                    .groups
+                    .contains(&"linux_sysfs_read".to_string()),
+                "{} should include linux_sysfs_read",
+                name
+            );
+            assert!(
+                !profile
+                    .security
+                    .groups
+                    .contains(&"linux_temp_read".to_string()),
+                "{} should not include linux_temp_read",
                 name
             );
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1859,7 +1859,7 @@ mod tests {
                 || profile
                     .security
                     .groups
-                    .contains(&"system_read_linux".to_string()),
+                    .contains(&"system_read_linux_core".to_string()),
             "Expected platform system_read group"
         );
 


### PR DESCRIPTION
Refactor `system_read_linux` into three focused groups:
- `system_read_linux_core`: device files and essential proc paths
- `linux_runtime_state`: /run and /var/run for host session integration
- `linux_sysfs_read`: /sys for kernel and device state
- `linux_temp_read`: /tmp for shared temporary access

Add `linux-host-compat` builtin profile composing these three groups, and update interactive profiles (claude-code, codex, opencode, swival) to include `linux_sysfs_read` while keeping runtime/temp access opt-in.

Remove `/nix` from core and `~/.local/state` from user cache/tools groups to maintain separation of concerns. Add profile authoring guide section on Linux host compatibility patterns.