### PR TITLE
fix(test): use real temp directories for env_nono_allow_comma_separated

### DIFF
--- a/crates/nono-cli/tests/env_vars.rs
+++ b/crates/nono-cli/tests/env_vars.rs
@@ -18,15 +18,29 @@ fn combined_output(output: &std::process::Output) -> String {
 
 #[test]
 fn env_nono_allow_comma_separated() {
+    // Create real temporary directories so the paths exist and appear in
+    // the dry-run capability banner.  Non-existent paths are silently
+    // skipped (with a WARN log), which is not visible in all environments
+    // (e.g. NixOS builds with RUST_LOG unset).  See #563.
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path_a = dir.path().join("a");
+    let path_b = dir.path().join("b");
+    std::fs::create_dir(&path_a).expect("create dir a");
+    std::fs::create_dir(&path_b).expect("create dir b");
+
+    let allow_val = format!("{},{}", path_a.display(), path_b.display());
+
     let output = nono_bin()
-        .env("NONO_ALLOW", "/tmp/a,/tmp/b")
+        .env("NONO_ALLOW", &allow_val)
         .args(["run", "--dry-run", "echo"])
         .output()
         .expect("failed to run nono");
 
     let text = combined_output(&output);
+    let a_str = path_a.to_str().expect("valid utf8");
+    let b_str = path_b.to_str().expect("valid utf8");
     assert!(
-        text.contains("/tmp/a") && text.contains("/tmp/b"),
+        text.contains(a_str) && text.contains(b_str),
         "expected both paths in dry-run output, got:\n{text}"
     );
 }

--- a/crates/nono-cli/tests/env_vars.rs
+++ b/crates/nono-cli/tests/env_vars.rs
@@ -40,7 +40,7 @@ fn env_nono_allow_comma_separated() {
     let a_str = path_a.display().to_string();
     let b_str = path_b.display().to_string();
     assert!(
-        text.contains(a_str) && text.contains(b_str),
+        text.contains(a_str.as_str()) && text.contains(b_str.as_str()),
         "expected both paths in dry-run output, got:\n{text}"
     );
 }

--- a/crates/nono-cli/tests/env_vars.rs
+++ b/crates/nono-cli/tests/env_vars.rs
@@ -37,8 +37,8 @@ fn env_nono_allow_comma_separated() {
         .expect("failed to run nono");
 
     let text = combined_output(&output);
-    let a_str = path_a.to_str().expect("valid utf8");
-    let b_str = path_b.to_str().expect("valid utf8");
+    let a_str = path_a.display().to_string();
+    let b_str = path_b.display().to_string();
     assert!(
         text.contains(a_str) && text.contains(b_str),
         "expected both paths in dry-run output, got:\n{text}"


### PR DESCRIPTION
The test relied on non-existent paths /tmp/a and /tmp/b appearing in output via WARN log messages, which are only emitted when RUST_LOG is configured. In clean build environments (e.g. NixOS) the log output is absent, causing the assertion to fail.

Use tempfile::tempdir() to create real directories so the paths are added to the CapabilitySet and appear in the dry-run banner regardless of logging configuration

Resolves: #563 