### PR TITLE
feat(policy): check credentials Option with is_some_and instead of field access

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -32,6 +32,9 @@ mod trust_keystore;
 mod trust_scan;
 mod update_check;
 
+#[cfg(test)]
+mod test_env;
+
 use capability_ext::CapabilitySetExt;
 use clap::Parser;
 use cli::{

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -2039,11 +2039,7 @@ fn resolve_to_manifest(
         manifest::NetworkMode::Blocked
     } else if prof.network.resolved_network_profile().is_some()
         || !prof.network.allow_domain.is_empty()
-        || prof
-            .network
-            .credentials
-            .as_ref()
-            .is_some_and(|c| !c.is_empty())
+        || !prof.network.resolved_credentials().is_empty()
         || !prof.network.custom_credentials.is_empty()
     {
         manifest::NetworkMode::Proxy

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -2039,7 +2039,11 @@ fn resolve_to_manifest(
         manifest::NetworkMode::Blocked
     } else if prof.network.resolved_network_profile().is_some()
         || !prof.network.allow_domain.is_empty()
-        || !prof.network.credentials.is_empty()
+        || prof
+            .network
+            .credentials
+            .as_ref()
+            .is_some_and(|c| !c.is_empty())
         || !prof.network.custom_credentials.is_empty()
     {
         manifest::NetworkMode::Proxy

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1640,6 +1640,7 @@ mod tests {
 
     #[test]
     fn test_expand_vars_xdg_state_home() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         // $XDG_STATE_HOME must be expanded so that profiles and deny rules
         // can reference it portably. Without this, users cannot write
         // add_deny_access: ["$XDG_STATE_HOME"] and the variable is treated

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1620,6 +1620,7 @@ mod tests {
 
     #[test]
     fn test_expand_vars() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         // Save original HOME to restore after test (avoid polluting other parallel tests)
         let original_home = env::var("HOME").ok();
 
@@ -1671,6 +1672,7 @@ mod tests {
 
     #[test]
     fn test_expand_vars_xdg_cache_home() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let original_home = env::var("HOME").ok();
         let original_cache = env::var("XDG_CACHE_HOME").ok();
 
@@ -1697,6 +1699,7 @@ mod tests {
 
     #[test]
     fn test_expand_vars_xdg_runtime_dir() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let original_runtime = env::var("XDG_RUNTIME_DIR").ok();
 
         env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
@@ -1723,6 +1726,7 @@ mod tests {
 
     #[test]
     fn test_resolve_user_config_dir_uses_valid_absolute_xdg() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let tmp = tempdir().expect("tmpdir");
         env::set_var("XDG_CONFIG_HOME", tmp.path());
         let resolved = resolve_user_config_dir().expect("resolve user config dir");
@@ -1735,6 +1739,7 @@ mod tests {
 
     #[test]
     fn test_resolve_user_config_dir_falls_back_on_relative_xdg() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let expected_home = home_dir().expect("home dir");
         env::set_var("XDG_CONFIG_HOME", "relative/path");
 

--- a/crates/nono-cli/src/test_env.rs
+++ b/crates/nono-cli/src/test_env.rs
@@ -1,0 +1,9 @@
+/// Process-global lock for tests that mutate environment variables.
+///
+/// Rust unit tests run in parallel within the same process, so concurrent
+/// `env::set_var` / `env::remove_var` calls race against each other.
+/// All env-mutating tests must acquire this lock before touching env vars.
+///
+/// See <https://github.com/always-further/nono/issues/567> for the plan to
+/// eliminate env var mutation from tests entirely.
+pub static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -1197,6 +1197,7 @@ mod tests {
 
     #[test]
     fn load_scan_policy_with_trust_override_skips_verification() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         // Isolate from the real user config dir so a stale trust-policy.json
         // on the developer's machine doesn't interfere with the test.

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -1224,6 +1224,7 @@ mod tests {
 
     #[test]
     fn load_scan_policy_skips_policy_verification_without_signed_artifacts() {
+        let _guard = crate::test_env::ENV_LOCK.lock().unwrap();
         let scan_dir = tempfile::tempdir().unwrap();
         let include_pattern = "*.arbitrary";
         let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();


### PR DESCRIPTION
credentials is Option<Vec<String>> (changed in 791764f), but policy_cmd.rs:2042 calls .is_empty() on the Option - this was test CI failure.