### PR TITLE
feat(policy): skip system temp grants when HOME is nested under TMPDIR

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -544,6 +544,26 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn with_env_lock<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        f()
+    }
+
+    fn from_args_locked(args: &SandboxArgs) -> Result<(CapabilitySet, bool)> {
+        with_env_lock(|| CapabilitySet::from_args(args))
+    }
+
+    fn from_profile_locked(
+        profile: &crate::profile::Profile,
+        workdir: &Path,
+        args: &SandboxArgs,
+    ) -> Result<(CapabilitySet, bool)> {
+        with_env_lock(|| CapabilitySet::from_profile(profile, workdir, args))
+    }
+
     fn sandbox_args() -> SandboxArgs {
         SandboxArgs::default()
     }
@@ -557,7 +577,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
+        let (caps, _) = from_args_locked(&args).expect("Failed to build caps");
         assert!(caps.has_fs());
         assert!(!caps.is_network_blocked());
     }
@@ -569,7 +589,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
+        let (caps, _) = from_args_locked(&args).expect("Failed to build caps");
         assert!(caps.is_network_blocked());
     }
 
@@ -582,7 +602,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) = CapabilitySet::from_args(&args).expect("Failed to build caps");
+        let (caps, _) = from_args_locked(&args).expect("Failed to build caps");
         assert!(caps.allowed_commands().contains(&"rm".to_string()));
         assert!(caps.blocked_commands().contains(&"custom".to_string()));
     }
@@ -597,7 +617,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let err = CapabilitySet::from_args(&args).expect_err("must reject protected state path");
+        let err = from_args_locked(&args).expect_err("must reject protected state path");
         assert!(
             err.to_string()
                 .contains("overlaps protected nono state root"),
@@ -607,16 +627,18 @@ mod tests {
 
     #[test]
     fn test_from_args_uses_default_profile_groups_for_runtime_policy() {
-        let args = sandbox_args();
-        let (caps, _) = CapabilitySet::from_args(&args).expect("build caps from args");
+        with_env_lock(|| {
+            let args = sandbox_args();
+            let (caps, _) = CapabilitySet::from_args(&args).expect("build caps from args");
 
-        let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
-        let default_groups = default_profile_groups().expect("get default profile groups");
-        let deny_paths = crate::policy::resolve_deny_paths_for_groups(&policy, &default_groups)
-            .expect("resolve deny paths");
+            let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
+            let default_groups = default_profile_groups().expect("get default profile groups");
+            let deny_paths = crate::policy::resolve_deny_paths_for_groups(&policy, &default_groups)
+                .expect("resolve deny paths");
 
-        crate::policy::validate_deny_overlaps(&deny_paths, &caps)
-            .expect("from_args caps should match default profile deny policy");
+            crate::policy::validate_deny_overlaps(&deny_paths, &caps)
+                .expect("from_args caps should match default profile deny policy");
+        });
     }
 
     #[cfg(target_os = "linux")]
@@ -626,8 +648,6 @@ mod tests {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        let original_home = std::env::var("HOME").ok();
-        let original_tmpdir = std::env::var("TMPDIR").ok();
 
         let temp_root = tempdir().expect("tmpdir");
         let home = temp_root.path().join("home");
@@ -635,8 +655,12 @@ mod tests {
         std::fs::create_dir_all(&home).expect("create home");
         std::fs::create_dir_all(&allowed).expect("create allowed dir");
 
-        std::env::set_var("HOME", &home);
-        std::env::set_var("TMPDIR", temp_root.path());
+        let home_str = home.to_string_lossy().into_owned();
+        let tmpdir_str = temp_root.path().to_string_lossy().into_owned();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", home_str.as_str()),
+            ("TMPDIR", tmpdir_str.as_str()),
+        ]);
 
         let args = SandboxArgs {
             allow: vec![allowed.clone()],
@@ -644,15 +668,6 @@ mod tests {
         };
 
         let result = CapabilitySet::from_args(&args);
-
-        match original_home {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
-        match original_tmpdir {
-            Some(value) => std::env::set_var("TMPDIR", value),
-            None => std::env::remove_var("TMPDIR"),
-        }
 
         let (caps, _) = result.expect(
             "from_args should succeed when HOME is nested under TMPDIR and the user grants a sibling path",
@@ -684,8 +699,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert!(
             caps.allowed_commands().contains(&"rm".to_string()),
             "profile allowed_commands should include 'rm'"
@@ -716,8 +730,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert!(
             !caps.blocked_commands().contains(&"rm".to_string()),
             "excluded dangerous_commands should remove rm from blocked commands"
@@ -752,8 +765,7 @@ mod tests {
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert!(
             !caps.blocked_commands().contains(&"rm".to_string()),
@@ -798,8 +810,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let read_canonical = read_dir.canonicalize().expect("canonicalize read");
         let write_canonical = write_dir.canonicalize().expect("canonicalize write");
@@ -855,7 +866,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+        let err = from_profile_locked(&profile, workdir.path(), &args)
             .expect_err("profile deny overlap should fail on linux");
         assert!(
             err.to_string().contains("Landlock deny-overlap"),
@@ -895,7 +906,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+        let err = from_profile_locked(&profile, workdir.path(), &args)
             .expect_err("symlinked deny overlap should fail on linux");
         assert!(
             err.to_string().contains("Landlock deny-overlap"),
@@ -936,8 +947,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert!(
             !caps
@@ -982,8 +992,7 @@ mod tests {
         let mut args = sandbox_args();
         args.override_deny = vec![target.clone()];
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert!(
             caps.fs_capabilities()
@@ -1027,8 +1036,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert!(
             caps.fs_capabilities()
@@ -1059,8 +1067,7 @@ mod tests {
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
 
         let args = sandbox_args();
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let rules = caps.platform_rules().join("\n");
         // On macOS, tempdir is under /var/folders which is a symlink to /private/var/folders.
@@ -1122,8 +1129,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let rules = caps.platform_rules().join("\n");
         assert!(
@@ -1165,8 +1171,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         // The allow should survive because override_deny punches through the deny
         let canonical = denied.canonicalize().expect("canonicalize");
@@ -1207,7 +1212,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let err = CapabilitySet::from_profile(&profile, workdir.path(), &args)
+        let err = from_profile_locked(&profile, workdir.path(), &args)
             .expect_err("override_deny without user-intent grant should fail");
         assert!(
             err.to_string().contains("no matching grant"),
@@ -1224,7 +1229,7 @@ mod tests {
         let args = sandbox_args();
 
         let (mut caps, needs_unlink_overrides) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("Failed to build");
+            from_profile_locked(&profile, workdir.path(), &args).expect("Failed to build");
 
         // Simulate what main.rs does: apply unlink overrides after all paths finalized
         if needs_unlink_overrides {
@@ -1291,8 +1296,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let canonical = target.canonicalize().expect("canonicalize target");
         let cap = caps
@@ -1337,8 +1341,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let canonical = target.canonicalize().expect("canonicalize target");
         let cap = caps
@@ -1365,8 +1368,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert_eq!(*caps.network_mode(), nono::NetworkMode::AllowAll);
     }
@@ -1392,8 +1394,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         assert_eq!(*caps.network_mode(), nono::NetworkMode::AllowAll);
     }
@@ -1414,8 +1415,7 @@ mod tests {
         let workdir = tempdir().expect("tmpdir");
         let args = sandbox_args();
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert_eq!(
             caps.process_info_mode(),
             nono::ProcessInfoMode::AllowSameSandbox,
@@ -1439,8 +1439,7 @@ mod tests {
         let workdir = tempdir().expect("tmpdir");
         let args = sandbox_args();
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert_eq!(
             caps.ipc_mode(),
             nono::IpcMode::Full,
@@ -1464,8 +1463,7 @@ mod tests {
         let workdir = tempdir().expect("tmpdir");
         let args = sandbox_args();
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert_eq!(
             caps.ipc_mode(),
             nono::IpcMode::SharedMemoryOnly,
@@ -1489,8 +1487,7 @@ mod tests {
         let workdir = tempdir().expect("tmpdir");
         let args = sandbox_args();
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
         assert_eq!(
             caps.ipc_mode(),
             nono::IpcMode::SharedMemoryOnly,
@@ -1541,8 +1538,7 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let (caps, _) =
-            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
 
         let ports = caps.tcp_connect_ports();
         assert!(
@@ -1572,7 +1568,7 @@ mod tests {
             ..sandbox_args()
         };
 
-        let (caps, _) = CapabilitySet::from_args(&args).expect("build caps");
+        let (caps, _) = from_args_locked(&args).expect("build caps");
 
         let ports = caps.tcp_connect_ports();
         assert!(

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -619,6 +619,53 @@ mod tests {
             .expect("from_args caps should match default profile deny policy");
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_from_args_skips_linux_temp_root_when_home_is_nested() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let original_home = std::env::var("HOME").ok();
+        let original_tmpdir = std::env::var("TMPDIR").ok();
+
+        let temp_root = tempdir().expect("tmpdir");
+        let home = temp_root.path().join("home");
+        let allowed = temp_root.path().join("other");
+        std::fs::create_dir_all(&home).expect("create home");
+        std::fs::create_dir_all(&allowed).expect("create allowed dir");
+
+        std::env::set_var("HOME", &home);
+        std::env::set_var("TMPDIR", temp_root.path());
+
+        let args = SandboxArgs {
+            allow: vec![allowed.clone()],
+            ..sandbox_args()
+        };
+
+        let result = CapabilitySet::from_args(&args);
+
+        match original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match original_tmpdir {
+            Some(value) => std::env::set_var("TMPDIR", value),
+            None => std::env::remove_var("TMPDIR"),
+        }
+
+        let (caps, _) = result.expect(
+            "from_args should succeed when HOME is nested under TMPDIR and the user grants a sibling path",
+        );
+        let allowed_canonical = allowed.canonicalize().expect("canonicalize allowed dir");
+        assert!(
+            caps.fs_capabilities()
+                .iter()
+                .any(|cap| !cap.is_file && cap.resolved == allowed_canonical),
+            "explicit user grant under TMPDIR should still be present"
+        );
+    }
+
     #[test]
     fn test_from_profile_allowed_commands() {
         let dir = tempdir().expect("tmpdir");

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -339,13 +339,13 @@ fn resolve_single_group(
     // Process allow operations
     if let Some(allow) = &group.allow {
         for path_str in &allow.read {
-            add_fs_capability(path_str, AccessMode::Read, &source, caps)?;
+            add_fs_capability(group_name, path_str, AccessMode::Read, &source, caps)?;
         }
         for path_str in &allow.write {
-            add_fs_capability(path_str, AccessMode::Write, &source, caps)?;
+            add_fs_capability(group_name, path_str, AccessMode::Write, &source, caps)?;
         }
         for path_str in &allow.readwrite {
-            add_fs_capability(path_str, AccessMode::ReadWrite, &source, caps)?;
+            add_fs_capability(group_name, path_str, AccessMode::ReadWrite, &source, caps)?;
         }
     }
 
@@ -386,8 +386,48 @@ fn resolve_single_group(
     Ok(needs_unlink_overrides)
 }
 
+fn canonicalize_for_comparison(path: &Path) -> PathBuf {
+    match path.canonicalize() {
+        Ok(canonical) => canonical,
+        Err(_) => path.to_path_buf(),
+    }
+}
+
+/// Skip implicit Linux temp-root grants that would cover HOME.
+///
+/// Landlock cannot enforce deny paths beneath an allowed parent. When HOME is
+/// nested under `/tmp` or `$TMPDIR`, the broad system temp grants from
+/// `system_write_linux` would silently disable default deny rules such as
+/// `~/.aws` and `~/.bash_history`. In that environment, fail secure by dropping
+/// the broad system grant and requiring explicit user/profile grants instead.
+fn should_skip_group_allow_path(group_name: &str, path: &Path) -> Result<bool> {
+    if !cfg!(target_os = "linux") || group_name != "system_write_linux" || !path.is_dir() {
+        return Ok(false);
+    }
+
+    let home = PathBuf::from(crate::config::validated_home()?);
+    let home_raw_overlaps = home.starts_with(path);
+    let home_canonical = canonicalize_for_comparison(&home);
+    let path_canonical = canonicalize_for_comparison(path);
+    let home_canonical_overlaps = home_canonical.starts_with(&path_canonical);
+
+    if !home_raw_overlaps && !home_canonical_overlaps {
+        return Ok(false);
+    }
+
+    warn!(
+        "Skipping Linux system temp grant '{}' from group '{}' because HOME '{}' is nested \
+         inside it. Landlock cannot enforce deny rules beneath an allowed parent.",
+        path.display(),
+        group_name,
+        home.display()
+    );
+    Ok(true)
+}
+
 /// Add a filesystem capability from a group path, handling expansion and existence checks
 fn add_fs_capability(
+    group_name: &str,
     path_str: &str,
     mode: AccessMode,
     source: &CapabilitySource,
@@ -401,6 +441,10 @@ fn add_fs_capability(
             path_str,
             path.display()
         );
+        return Ok(());
+    }
+
+    if should_skip_group_allow_path(group_name, &path)? {
         return Ok(());
     }
 
@@ -1780,6 +1824,47 @@ mod tests {
         validate_deny_overlaps(&deny_paths, &caps).expect("No overlap should succeed");
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_should_skip_system_write_linux_tmp_grant_when_home_is_nested() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let original_home = std::env::var("HOME").ok();
+        let original_tmpdir = std::env::var("TMPDIR").ok();
+
+        let temp_root = tempfile::tempdir().expect("tmpdir");
+        let home = temp_root.path().join("home");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        std::env::set_var("HOME", &home);
+        std::env::set_var("TMPDIR", temp_root.path());
+
+        let skip_tmp = should_skip_group_allow_path("system_write_linux", Path::new("/tmp"))
+            .expect("check /tmp skip");
+        let skip_tmpdir = should_skip_group_allow_path("system_write_linux", temp_root.path())
+            .expect("check TMPDIR skip");
+
+        match original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match original_tmpdir {
+            Some(value) => std::env::set_var("TMPDIR", value),
+            None => std::env::remove_var("TMPDIR"),
+        }
+
+        assert!(
+            skip_tmp,
+            "/tmp should be skipped when HOME is nested under it"
+        );
+        assert!(
+            skip_tmpdir,
+            "$TMPDIR should be skipped when HOME is nested under it"
+        );
+    }
+
     #[test]
     #[cfg(target_os = "linux")]
     fn test_validate_deny_overlaps_group_overlap_is_fatal() {
@@ -1852,6 +1937,15 @@ mod tests {
                     let expanded = expand_path(p).unwrap_or_else(|e| {
                         panic!("expand_path({p}) failed in group '{name}': {e}")
                     });
+                    if should_skip_group_allow_path(name, &expanded).unwrap_or_else(|e| {
+                        panic!(
+                            "should_skip_group_allow_path({}, {}) failed: {e}",
+                            name,
+                            expanded.display()
+                        )
+                    }) {
+                        continue;
+                    }
                     allow_paths.push((name.clone(), expanded));
                 }
             }


### PR DESCRIPTION
Add `should_skip_group_allow_path()` to prevent Landlock parent-path override when HOME is nested under `/tmp` or `$TMPDIR`. This closes the security gap where broad system temp grants would silently disable default deny rules like `~/.aws`. On Linux, the `system_write_linux` group now validates HOME nesting (both raw and canonical paths) and skips grants that would cover it, forcing explicit user/profile grants instead.

Thread group_name through `add_fs_capability()` to enable per-group skip logic. Add test coverage for both capability_ext and policy modules to verify the skip behavior and that explicit user grants remain present.