### PR TITLE
fix(proxy): disable NO_PROXY bypass on macOS (#580)

### DIFF
--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -257,7 +257,14 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
             .filter(|host| {
                 let normalised = {
                     let h = host.to_lowercase();
-                    if h.contains(':') {
+                    if h.starts_with('[') {
+                        // IPv6 literal: "[::1]:443" has port, "[::1]" needs default
+                        if h.contains("]:") {
+                            h
+                        } else {
+                            format!("{}:443", h)
+                        }
+                    } else if h.contains(':') {
                         h
                     } else {
                         format!("{}:443", h)

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -241,23 +241,33 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     // Non-credential hosts bypass the proxy (direct connection, still
     // Landlock-enforced). Credential upstreams must go through the proxy
     // for L7 path filtering and credential injection.
-    let credential_hosts = credential_store.credential_upstream_hosts();
-    let no_proxy_hosts: Vec<String> = config
-        .allowed_hosts
-        .iter()
-        .filter(|host| {
-            let normalised = {
-                let h = host.to_lowercase();
-                if h.contains(':') {
-                    h
-                } else {
-                    format!("{}:443", h)
-                }
-            };
-            !credential_hosts.contains(&normalised)
-        })
-        .cloned()
-        .collect();
+    //
+    // On macOS this MUST be empty: Seatbelt's ProxyOnly mode generates
+    // `(deny network*) (allow network-outbound (remote tcp "localhost:PORT"))`
+    // which blocks ALL direct outbound. Tools that respect NO_PROXY would
+    // attempt direct connections that the sandbox denies (DNS lookup fails).
+    // All traffic must route through the proxy on macOS. See #580.
+    let no_proxy_hosts: Vec<String> = if cfg!(target_os = "macos") {
+        Vec::new()
+    } else {
+        let credential_hosts = credential_store.credential_upstream_hosts();
+        config
+            .allowed_hosts
+            .iter()
+            .filter(|host| {
+                let normalised = {
+                    let h = host.to_lowercase();
+                    if h.contains(':') {
+                        h
+                    } else {
+                        format!("{}:443", h)
+                    }
+                };
+                !credential_hosts.contains(&normalised)
+            })
+            .cloned()
+            .collect()
+    };
 
     if !no_proxy_hosts.is_empty() {
         debug!("Smart NO_PROXY bypass hosts: {:?}", no_proxy_hosts);


### PR DESCRIPTION
Seatbelt's ProxyOnly mode blocks all direct outbound connections via (deny network*), only allowing traffic to the local proxy port. Putting allowed hosts in NO_PROXY caused HTTP clients to attempt direct connections which the sandbox denied, resulting in DNS resolution failures. On macOS, all traffic must route through the proxy. The NO_PROXY optimization remains on Linux where Landlock can enforce per-host network rules directly.

Closes #580