### PR TITLE
fix(profile): add missing $TMPDIR read and state dir to opencode profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -769,7 +769,9 @@
           "$HOME/.config/opencode",
           "$HOME/.cache/opencode",
           "$HOME/.local/share/opencode",
-          "$HOME/.local/share/opentui"
+          "$HOME/.local/share/opentui",
+          "$HOME/.local/state/opencode",
+          "$TMPDIR"
         ]
       },
       "network": { "block": false },

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -302,6 +302,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_opencode_profile_includes_tmpdir_and_state_dir() {
+        let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
+        let opencode = policy.profiles.get("opencode").expect("opencode profile");
+        assert!(
+            opencode.filesystem.allow.contains(&"$TMPDIR".to_string()),
+            "opencode profile should allow $TMPDIR for Bun TUI runtime extraction"
+        );
+        assert!(
+            opencode
+                .filesystem
+                .allow
+                .contains(&"$HOME/.local/state/opencode".to_string()),
+            "opencode profile should allow $HOME/.local/state/opencode"
+        );
+    }
+
     /// Regression test: verifies that all built-in profiles — regardless of
     /// their signal_mode setting — will produce Seatbelt rules that allow
     /// signaling child processes within the same sandbox.


### PR DESCRIPTION
Bun extracts libopentui.so into $TMPDIR at startup and needs to read it back, causing a blank-screen hang without linux_temp_read. OpenCode also writes model.json and prompt-history.jsonl to ~/.local/state/opencode.

Closes #581