### PR TITLE
fix(proxy): handle route prefixes with leading slashes

### DIFF
--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -73,7 +73,7 @@ fn default_bind_addr() -> IpAddr {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteConfig {
     /// Path prefix for routing (e.g., "openai").
-    /// Must NOT include a leading slash — it is a bare service name, not a URL path.
+    /// Must NOT include leading or trailing slashes — it is a bare service name, not a URL path.
     pub prefix: String,
 
     /// Upstream URL to forward to (e.g., "https://api.openai.com")

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -72,7 +72,8 @@ fn default_bind_addr() -> IpAddr {
 /// Configuration for a reverse proxy credential route.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteConfig {
-    /// Path prefix for routing (e.g., "/openai")
+    /// Path prefix for routing (e.g., "openai").
+    /// Must NOT include a leading slash — it is a bare service name, not a URL path.
     pub prefix: String,
 
     /// Upstream URL to forward to (e.g., "https://api.openai.com")
@@ -541,7 +542,7 @@ mod tests {
     #[test]
     fn test_endpoint_rule_serde_default() {
         let json = r#"{
-            "prefix": "/test",
+            "prefix": "test",
             "upstream": "https://example.com"
         }"#;
         let route: RouteConfig = serde_json::from_str(json).unwrap();
@@ -552,7 +553,7 @@ mod tests {
     #[test]
     fn test_tls_ca_serde_roundtrip() {
         let json = r#"{
-            "prefix": "/k8s",
+            "prefix": "k8s",
             "upstream": "https://kubernetes.local:6443",
             "tls_ca": "/run/secrets/k8s-ca.crt"
         }"#;

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -90,10 +90,15 @@ impl CredentialStore {
         let mut credentials = HashMap::new();
 
         for route in routes {
+            // Normalize prefix: strip leading/trailing slashes so it matches
+            // the bare service name returned by parse_service_prefix() in
+            // the reverse proxy path (e.g., "/anthropic" -> "anthropic").
+            let normalized_prefix = route.prefix.trim_matches('/').to_string();
+
             if let Some(ref key) = route.credential_key {
                 debug!(
                     "Loading credential for route prefix: {} (mode: {:?})",
-                    route.prefix, route.inject_mode
+                    normalized_prefix, route.inject_mode
                 );
 
                 let secret = match nono::keystore::load_secret_by_ref(KEYRING_SERVICE, key) {
@@ -101,7 +106,7 @@ impl CredentialStore {
                     Err(nono::NonoError::SecretNotFound(msg)) => {
                         debug!(
                             "Credential '{}' not available, skipping route: {}",
-                            route.prefix, msg
+                            normalized_prefix, msg
                         );
                         continue;
                     }
@@ -138,7 +143,7 @@ impl CredentialStore {
                     Some(ref ca_path) => {
                         debug!(
                             "Building TLS connector with custom CA for route '{}': {}",
-                            route.prefix, ca_path
+                            normalized_prefix, ca_path
                         );
                         Some(build_tls_connector_with_ca(ca_path)?)
                     }
@@ -146,7 +151,7 @@ impl CredentialStore {
                 };
 
                 credentials.insert(
-                    route.prefix.clone(),
+                    normalized_prefix.clone(),
                     LoadedCredential {
                         inject_mode: route.inject_mode.clone(),
                         upstream: route.upstream.clone(),
@@ -158,7 +163,10 @@ impl CredentialStore {
                         query_param_name: route.query_param_name.clone(),
                         endpoint_rules: CompiledEndpointRules::compile(&route.endpoint_rules)
                             .map_err(|e| {
-                                ProxyError::Credential(format!("route '{}': {}", route.prefix, e))
+                                ProxyError::Credential(format!(
+                                    "route '{}': {}",
+                                    normalized_prefix, e
+                                ))
                             })?,
                         tls_connector,
                     },

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -124,11 +124,11 @@ impl ProxyHandle {
     pub fn credential_env_vars(&self, config: &ProxyConfig) -> Vec<(String, String)> {
         let mut vars = Vec::new();
         for route in &config.routes {
-            // Strip any leading '/' from the prefix — prefix should be a bare
-            // service name (e.g., "anthropic"), not a URL path ("/anthropic").
+            // Strip any leading or trailing '/' from the prefix — prefix should
+            // be a bare service name (e.g., "anthropic"), not a URL path.
             // Defensively handle both forms to prevent malformed env var names
-            // (e.g., "/ANTHROPIC_BASE_URL") and double-slashed URLs.
-            let prefix = route.prefix.strip_prefix('/').unwrap_or(&route.prefix);
+            // and double-slashed URLs.
+            let prefix = route.prefix.trim_matches('/');
 
             // Base URL override (e.g., OPENAI_BASE_URL)
             let base_url_name = format!("{}_BASE_URL", prefix.to_uppercase());
@@ -139,7 +139,7 @@ impl ProxyHandle {
             // were actually loaded. If a credential was unavailable (e.g.,
             // GITHUB_TOKEN env var not set), injecting a phantom token would
             // shadow valid credentials from other sources (keyring, gh auth).
-            if !self.loaded_routes.contains(&route.prefix) {
+            if !self.loaded_routes.contains(prefix) {
                 continue;
             }
 
@@ -777,9 +777,9 @@ mod tests {
     }
 
     #[test]
-    fn test_proxy_credential_env_vars_strips_leading_slash() {
-        // When prefix includes a leading slash (e.g., "/anthropic"), the env
-        // var name must not contain the slash and the URL must not double-slash.
+    fn test_proxy_credential_env_vars_strips_slashes() {
+        // When prefix includes leading/trailing slashes, the env var name
+        // must not contain slashes and the URL must not double-slash.
         // Regression test for user-reported bug where "/anthropic" produced
         // "/ANTHROPIC_BASE_URL=http://127.0.0.1:PORT//anthropic".
         let (shutdown_tx, _) = tokio::sync::watch::channel(false);
@@ -791,6 +791,8 @@ mod tests {
             loaded_routes: std::collections::HashSet::new(),
             no_proxy_hosts: Vec::new(),
         };
+
+        // Test leading slash
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
                 prefix: "/anthropic".to_string(),
@@ -818,6 +820,35 @@ mod tests {
         assert_eq!(
             vars[0].1, "http://127.0.0.1:58406/anthropic",
             "URL must not have double slash"
+        );
+
+        // Test trailing slash
+        let config = ProxyConfig {
+            routes: vec![crate::config::RouteConfig {
+                prefix: "openai/".to_string(),
+                upstream: "https://api.openai.com".to_string(),
+                credential_key: None,
+                inject_mode: crate::config::InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                tls_ca: None,
+            }],
+            ..Default::default()
+        };
+
+        let vars = handle.credential_env_vars(&config);
+        assert_eq!(
+            vars[0].0, "OPENAI_BASE_URL",
+            "env var name must not have trailing slash"
+        );
+        assert_eq!(
+            vars[0].1, "http://127.0.0.1:58406/openai",
+            "URL must not have trailing slash in path"
         );
     }
 

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -124,9 +124,15 @@ impl ProxyHandle {
     pub fn credential_env_vars(&self, config: &ProxyConfig) -> Vec<(String, String)> {
         let mut vars = Vec::new();
         for route in &config.routes {
+            // Strip any leading '/' from the prefix — prefix should be a bare
+            // service name (e.g., "anthropic"), not a URL path ("/anthropic").
+            // Defensively handle both forms to prevent malformed env var names
+            // (e.g., "/ANTHROPIC_BASE_URL") and double-slashed URLs.
+            let prefix = route.prefix.strip_prefix('/').unwrap_or(&route.prefix);
+
             // Base URL override (e.g., OPENAI_BASE_URL)
-            let base_url_name = format!("{}_BASE_URL", route.prefix.to_uppercase());
-            let url = format!("http://127.0.0.1:{}/{}", self.port, route.prefix);
+            let base_url_name = format!("{}_BASE_URL", prefix.to_uppercase());
+            let url = format!("http://127.0.0.1:{}/{}", self.port, prefix);
             vars.push((base_url_name, url));
 
             // Only inject phantom token env vars for routes whose credentials
@@ -767,6 +773,51 @@ mod tests {
         assert!(
             github_token.is_none(),
             "unloaded route must not inject phantom GITHUB_TOKEN"
+        );
+    }
+
+    #[test]
+    fn test_proxy_credential_env_vars_strips_leading_slash() {
+        // When prefix includes a leading slash (e.g., "/anthropic"), the env
+        // var name must not contain the slash and the URL must not double-slash.
+        // Regression test for user-reported bug where "/anthropic" produced
+        // "/ANTHROPIC_BASE_URL=http://127.0.0.1:PORT//anthropic".
+        let (shutdown_tx, _) = tokio::sync::watch::channel(false);
+        let handle = ProxyHandle {
+            port: 58406,
+            token: Zeroizing::new("test_token".to_string()),
+            audit_log: audit::new_audit_log(),
+            shutdown_tx,
+            loaded_routes: std::collections::HashSet::new(),
+            no_proxy_hosts: Vec::new(),
+        };
+        let config = ProxyConfig {
+            routes: vec![crate::config::RouteConfig {
+                prefix: "/anthropic".to_string(),
+                upstream: "https://api.anthropic.com".to_string(),
+                credential_key: None,
+                inject_mode: crate::config::InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                tls_ca: None,
+            }],
+            ..Default::default()
+        };
+
+        let vars = handle.credential_env_vars(&config);
+        assert_eq!(vars.len(), 1);
+        assert_eq!(
+            vars[0].0, "ANTHROPIC_BASE_URL",
+            "env var name must not have leading slash"
+        );
+        assert_eq!(
+            vars[0].1, "http://127.0.0.1:58406/anthropic",
+            "URL must not have double slash"
         );
     }
 


### PR DESCRIPTION
- Update RouteConfig to clarify that the 'prefix' field should not include a leading slash, as it represents a bare service name.
- Modify the credential_env_vars logic to defensively strip any leading slash from the route prefix before generating environment variable names and proxy URLs.
- Add a regression test to ensure that prefixes like "/anthropic" correctly produce "ANTHROPIC_BASE_URL" and avoid double-slashed URLs.
- Fixes a bug where a leading slash in the prefix could result in malformed environment variable names (e.g., "/ANTHROPIC_BASE_URL") and incorrect proxy URLs.

Resolves: #606 