### PR TITLE
refactor(proxy): decouple L7 endpoint filtering from credential injection

### DIFF
--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -4,21 +4,26 @@
 //! Credentials are stored in `Zeroizing<String>` and injected into
 //! requests via headers, URL paths, query parameters, or Basic Auth.
 //! The sandboxed agent never sees the real credentials.
+//!
+//! Route-level configuration (upstream URL, L7 endpoint rules, custom TLS CA)
+//! is handled by [`crate::route::RouteStore`], which loads independently of
+//! credentials. This module handles only credential-specific concerns.
 
-use crate::config::{CompiledEndpointRules, InjectMode, RouteConfig};
+use crate::config::{InjectMode, RouteConfig};
 use crate::error::{ProxyError, Result};
 use base64::Engine;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::debug;
 use zeroize::Zeroizing;
 
 /// A loaded credential ready for injection.
+///
+/// Contains only credential-specific fields (injection mode, header name/value,
+/// raw secret). Route-level configuration (upstream URL, L7 endpoint rules,
+/// custom TLS CA) is stored in [`crate::route::LoadedRoute`].
 pub struct LoadedCredential {
     /// Injection mode
     pub inject_mode: InjectMode,
-    /// Upstream URL (e.g., "https://api.openai.com")
-    pub upstream: String,
     /// Raw credential value from keystore (for modes that need it directly)
     pub raw_credential: Zeroizing<String>,
 
@@ -37,17 +42,6 @@ pub struct LoadedCredential {
     // --- Query param mode ---
     /// Query parameter name
     pub query_param_name: Option<String>,
-
-    // --- L7 endpoint filtering ---
-    /// Pre-compiled endpoint rules for method+path filtering.
-    /// Compiled once at load time to avoid per-request glob compilation.
-    pub endpoint_rules: CompiledEndpointRules,
-
-    // --- Custom CA TLS ---
-    /// Per-route TLS connector with custom CA trust, if configured.
-    /// Built once at startup from the route's `tls_ca` certificate file.
-    /// When `None`, the shared default connector (webpki roots only) is used.
-    pub tls_connector: Option<tokio_rustls::TlsConnector>,
 }
 
 /// Custom Debug impl that redacts secret values to prevent accidental leakage
@@ -56,15 +50,12 @@ impl std::fmt::Debug for LoadedCredential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LoadedCredential")
             .field("inject_mode", &self.inject_mode)
-            .field("upstream", &self.upstream)
             .field("raw_credential", &"[REDACTED]")
             .field("header_name", &self.header_name)
             .field("header_value", &"[REDACTED]")
             .field("path_pattern", &self.path_pattern)
             .field("path_replacement", &self.path_replacement)
             .field("query_param_name", &self.query_param_name)
-            .field("endpoint_rules", &self.endpoint_rules)
-            .field("has_custom_tls_ca", &self.tls_connector.is_some())
             .finish()
     }
 }
@@ -138,37 +129,16 @@ impl CredentialStore {
                     InjectMode::UrlPath | InjectMode::QueryParam => Zeroizing::new(String::new()),
                 };
 
-                // Build per-route TLS connector if a custom CA is configured
-                let tls_connector = match route.tls_ca {
-                    Some(ref ca_path) => {
-                        debug!(
-                            "Building TLS connector with custom CA for route '{}': {}",
-                            normalized_prefix, ca_path
-                        );
-                        Some(build_tls_connector_with_ca(ca_path)?)
-                    }
-                    None => None,
-                };
-
                 credentials.insert(
                     normalized_prefix.clone(),
                     LoadedCredential {
                         inject_mode: route.inject_mode.clone(),
-                        upstream: route.upstream.clone(),
                         raw_credential: secret,
                         header_name: route.inject_header.clone(),
                         header_value,
                         path_pattern: route.path_pattern.clone(),
                         path_replacement: route.path_replacement.clone(),
                         query_param_name: route.query_param_name.clone(),
-                        endpoint_rules: CompiledEndpointRules::compile(&route.endpoint_rules)
-                            .map_err(|e| {
-                                ProxyError::Credential(format!(
-                                    "route '{}': {}",
-                                    normalized_prefix, e
-                                ))
-                            })?,
-                        tls_connector,
                     },
                 );
             }
@@ -208,113 +178,6 @@ impl CredentialStore {
     pub fn loaded_prefixes(&self) -> std::collections::HashSet<String> {
         self.credentials.keys().cloned().collect()
     }
-
-    /// Check whether `host_port` (e.g. `"gitlab.example.com:443"`) matches
-    /// any credential upstream. Used to block CONNECT tunnels that would
-    /// bypass L7 path filtering.
-    #[must_use]
-    pub fn is_credential_upstream(&self, host_port: &str) -> bool {
-        let normalised = host_port.to_lowercase();
-        self.credentials.values().any(|cred| {
-            extract_host_port(&cred.upstream)
-                .map(|hp| hp == normalised)
-                .unwrap_or(false)
-        })
-    }
-
-    /// Return the set of normalised `host:port` strings for all credential
-    /// upstreams. Used to compute smart `NO_PROXY` — hosts in this set must
-    /// NOT be bypassed because they need reverse proxy credential injection.
-    #[must_use]
-    pub fn credential_upstream_hosts(&self) -> std::collections::HashSet<String> {
-        self.credentials
-            .values()
-            .filter_map(|cred| extract_host_port(&cred.upstream))
-            .collect()
-    }
-}
-
-/// Extract and normalise `host:port` from a URL string.
-///
-/// Defaults to port 443 for `https://` and 80 for `http://` when no
-/// explicit port is present. Returns `None` if the URL cannot be parsed.
-fn extract_host_port(url: &str) -> Option<String> {
-    let parsed = url::Url::parse(url).ok()?;
-    let host = parsed.host_str()?;
-    let default_port = match parsed.scheme() {
-        "https" => 443,
-        "http" => 80,
-        _ => return None,
-    };
-    let port = parsed.port().unwrap_or(default_port);
-    Some(format!("{}:{}", host.to_lowercase(), port))
-}
-
-/// Build a `TlsConnector` that trusts the system roots plus a custom CA certificate.
-///
-/// The CA file must be PEM-encoded and contain at least one certificate.
-/// Returns an error if the file cannot be read, contains no valid certificates,
-/// or the TLS configuration fails.
-fn build_tls_connector_with_ca(ca_path: &str) -> Result<tokio_rustls::TlsConnector> {
-    let ca_path = std::path::Path::new(ca_path);
-
-    let ca_pem = Zeroizing::new(std::fs::read(ca_path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            ProxyError::Config(format!(
-                "CA certificate file not found: '{}'",
-                ca_path.display()
-            ))
-        } else {
-            ProxyError::Config(format!(
-                "failed to read CA certificate '{}': {}",
-                ca_path.display(),
-                e
-            ))
-        }
-    })?);
-
-    let mut root_store = rustls::RootCertStore::empty();
-
-    // Add system roots first
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-    // Parse and add custom CA certificates from PEM file
-    let certs: Vec<_> = rustls_pemfile::certs(&mut ca_pem.as_slice())
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| {
-            ProxyError::Config(format!(
-                "failed to parse CA certificate '{}': {}",
-                ca_path.display(),
-                e
-            ))
-        })?;
-
-    if certs.is_empty() {
-        return Err(ProxyError::Config(format!(
-            "CA certificate file '{}' contains no valid PEM certificates",
-            ca_path.display()
-        )));
-    }
-
-    for cert in certs {
-        root_store.add(cert).map_err(|e| {
-            ProxyError::Config(format!(
-                "invalid CA certificate in '{}': {}",
-                ca_path.display(),
-                e
-            ))
-        })?;
-    }
-
-    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::ring::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .map_err(|e| ProxyError::Config(format!("TLS config error: {}", e)))?
-    .with_root_certificates(root_store)
-    .with_no_client_auth();
-
-    Ok(tokio_rustls::TlsConnector::from(Arc::new(tls_config)))
 }
 
 /// The keyring service name used by nono for all credentials.
@@ -331,7 +194,7 @@ mod tests {
         let store = CredentialStore::empty();
         assert!(store.is_empty());
         assert_eq!(store.len(), 0);
-        assert!(store.get("/openai").is_none());
+        assert!(store.get("openai").is_none());
     }
 
     #[test]
@@ -341,15 +204,12 @@ mod tests {
         // tracing output at debug level.
         let cred = LoadedCredential {
             inject_mode: InjectMode::Header,
-            upstream: "https://api.openai.com".to_string(),
             raw_credential: Zeroizing::new("sk-secret-12345".to_string()),
             header_name: "Authorization".to_string(),
             header_value: Zeroizing::new("Bearer sk-secret-12345".to_string()),
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
-            endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
-            tls_connector: None,
         };
 
         let debug_output = format!("{:?}", cred);
@@ -370,116 +230,7 @@ mod tests {
             "Debug output must not contain the formatted secret"
         );
         // Non-secret fields should still be visible
-        assert!(debug_output.contains("api.openai.com"));
         assert!(debug_output.contains("Authorization"));
-    }
-
-    #[test]
-    fn test_extract_host_port_https_no_port() {
-        assert_eq!(
-            extract_host_port("https://api.openai.com"),
-            Some("api.openai.com:443".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_https_with_port() {
-        assert_eq!(
-            extract_host_port("https://api.openai.com:8443"),
-            Some("api.openai.com:8443".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_http_no_port() {
-        assert_eq!(
-            extract_host_port("http://internal:4096"),
-            Some("internal:4096".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_http_default_port() {
-        assert_eq!(
-            extract_host_port("http://internal-service"),
-            Some("internal-service:80".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_normalises_case() {
-        assert_eq!(
-            extract_host_port("https://GitLab-PRD.Home.Example.COM"),
-            Some("gitlab-prd.home.example.com:443".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_with_path() {
-        assert_eq!(
-            extract_host_port("https://api.example.com/v1/endpoint"),
-            Some("api.example.com:443".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_host_port_no_scheme() {
-        assert_eq!(extract_host_port("api.openai.com"), None);
-    }
-
-    #[test]
-    fn test_is_credential_upstream() {
-        let mut credentials = HashMap::new();
-        credentials.insert(
-            "gitlab".to_string(),
-            LoadedCredential {
-                inject_mode: InjectMode::Header,
-                upstream: "https://gitlab.example.com".to_string(),
-                raw_credential: Zeroizing::new("token".to_string()),
-                header_name: "PRIVATE-TOKEN".to_string(),
-                header_value: Zeroizing::new("token".to_string()),
-                path_pattern: None,
-                path_replacement: None,
-                query_param_name: None,
-                endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
-                tls_connector: None,
-            },
-        );
-        let store = CredentialStore { credentials };
-
-        assert!(store.is_credential_upstream("gitlab.example.com:443"));
-        assert!(!store.is_credential_upstream("unrelated.example.com:443"));
-    }
-
-    #[test]
-    fn test_is_credential_upstream_empty_store() {
-        let store = CredentialStore::empty();
-        assert!(!store.is_credential_upstream("anything:443"));
-    }
-
-    #[test]
-    fn test_credential_upstream_hosts() {
-        let mut credentials = HashMap::new();
-        credentials.insert(
-            "gitlab".to_string(),
-            LoadedCredential {
-                inject_mode: InjectMode::Header,
-                upstream: "https://gitlab.example.com".to_string(),
-                raw_credential: Zeroizing::new("token".to_string()),
-                header_name: "PRIVATE-TOKEN".to_string(),
-                header_value: Zeroizing::new("token".to_string()),
-                path_pattern: None,
-                path_replacement: None,
-                query_param_name: None,
-                endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
-                tls_connector: None,
-            },
-        );
-        let store = CredentialStore { credentials };
-
-        let hosts = store.credential_upstream_hosts();
-        assert!(hosts.contains("gitlab.example.com:443"));
-        assert_eq!(hosts.len(), 1);
     }
 
     #[test]
@@ -502,101 +253,5 @@ mod tests {
         assert!(store.is_ok());
         let store = store.unwrap_or_else(|_| CredentialStore::empty());
         assert!(store.is_empty());
-    }
-
-    /// Self-signed CA for testing. Generated with:
-    /// openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
-    ///   -keyout /dev/null -nodes -days 36500 -subj '/CN=nono-test-ca' -out -
-    const TEST_CA_PEM: &str = "\
------BEGIN CERTIFICATE-----
-MIIBnjCCAUWgAwIBAgIUT0bpOJJvHdOdZt+gW1stR8VBgXowCgYIKoZIzj0EAwIw
-FzEVMBMGA1UEAwwMbm9uby10ZXN0LWNhMCAXDTI1MDEwMTAwMDAwMFoYDzIxMjQx
-MjA3MDAwMDAwWjAXMRUwEwYDVQQDDAxub25vLXRlc3QtY2EwWTATBgcqhkjOPQIB
-BggqhkjOPQMBBwNCAAR8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAo1MwUTAdBgNVHQ4EFgQUAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAMB8GA1UdIwQYMBaAFAAAAAAAAAAAAAAAAAAAAAAAAAAAADAPBgNVHRMBAf8E
-BTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAICAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
------END CERTIFICATE-----";
-
-    #[test]
-    fn test_build_tls_connector_with_valid_ca() {
-        let dir = tempfile::tempdir().unwrap();
-        let ca_path = dir.path().join("ca.pem");
-        std::fs::write(&ca_path, TEST_CA_PEM).unwrap();
-
-        // The test CA has dummy key material so rustls will reject it,
-        // but we test the file-reading and PEM-parsing path separately.
-        // A valid CA cert would succeed; here we verify the error is from
-        // certificate validation, not file I/O or PEM parsing.
-        let result = build_tls_connector_with_ca(ca_path.to_str().unwrap());
-        // Either succeeds (if rustls accepts the cert) or fails with a
-        // certificate validation error — both are acceptable since we're
-        // testing the plumbing, not the cert content.
-        match result {
-            Ok(connector) => {
-                // Connector was built — custom CA was accepted
-                drop(connector);
-            }
-            Err(ProxyError::Config(msg)) => {
-                // Expected: invalid certificate content in test fixture
-                assert!(
-                    msg.contains("invalid CA certificate") || msg.contains("CA certificate"),
-                    "unexpected error: {}",
-                    msg
-                );
-            }
-            Err(e) => panic!("unexpected error type: {}", e),
-        }
-    }
-
-    #[test]
-    fn test_build_tls_connector_missing_file() {
-        let result = build_tls_connector_with_ca("/nonexistent/path/ca.pem");
-        let err = result
-            .err()
-            .expect("should fail for missing file")
-            .to_string();
-        assert!(
-            err.contains("CA certificate file not found"),
-            "unexpected error: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn test_build_tls_connector_empty_pem() {
-        let dir = tempfile::tempdir().unwrap();
-        let ca_path = dir.path().join("empty.pem");
-        std::fs::write(&ca_path, "not a certificate\n").unwrap();
-
-        let result = build_tls_connector_with_ca(ca_path.to_str().unwrap());
-        let err = result
-            .err()
-            .expect("should fail for invalid PEM")
-            .to_string();
-        assert!(
-            err.contains("no valid PEM certificates"),
-            "unexpected error: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn test_build_tls_connector_empty_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let ca_path = dir.path().join("empty.pem");
-        std::fs::write(&ca_path, "").unwrap();
-
-        let result = build_tls_connector_with_ca(ca_path.to_str().unwrap());
-        let err = result
-            .err()
-            .expect("should fail for empty file")
-            .to_string();
-        assert!(
-            err.contains("no valid PEM certificates"),
-            "unexpected error: {}",
-            err
-        );
     }
 }

--- a/crates/nono-proxy/src/lib.rs
+++ b/crates/nono-proxy/src/lib.rs
@@ -25,6 +25,7 @@ pub mod error;
 pub mod external;
 pub mod filter;
 pub mod reverse;
+pub mod route;
 pub mod server;
 pub mod token;
 

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -113,8 +113,12 @@ pub async fn handle_reverse_proxy(
     // Look up credential for service (optional — not all routes inject credentials)
     let cred = ctx.credential_store.get(&service);
 
-    // Validate phantom token and transform path if credential injection is active.
+    // Authenticate the request. Every reverse proxy request must prove
+    // possession of the session token, regardless of whether a credential
+    // is configured — this is the localhost auth boundary.
     if let Some(cred) = cred {
+        // Credential route: validate phantom token from the service's auth
+        // header (mode-dependent: header, url_path, query_param, basic_auth).
         if let Err(e) = validate_phantom_token_for_mode(
             &cred.inject_mode,
             remaining_header,
@@ -132,6 +136,21 @@ pub async fn handle_reverse_proxy(
                 &e.to_string(),
             );
             send_error(stream, 401, "Unauthorized").await?;
+            return Ok(());
+        }
+    } else {
+        // No-credential route (L7 filtering only): validate session token
+        // via Proxy-Authorization header. This is the same auth path that
+        // CONNECT tunnels use — the token arrives via HTTPS_PROXY userinfo.
+        if let Err(e) = token::validate_proxy_auth(remaining_header, ctx.session_token) {
+            audit::log_denied(
+                ctx.audit_log,
+                audit::ProxyMode::Reverse,
+                &service,
+                0,
+                &e.to_string(),
+            );
+            send_error(stream, 407, "Proxy Authentication Required").await?;
             return Ok(());
         }
     }
@@ -178,12 +197,14 @@ pub async fn handle_reverse_proxy(
         return Ok(());
     }
 
-    // Collect remaining request headers (excluding X-Nono-Token and Host).
-    // When a credential is present, also strip the credential header.
-    let cred_header_name = cred
-        .map(|c| c.header_name.as_str())
-        .unwrap_or("Authorization");
-    let filtered_headers = filter_headers(remaining_header, cred_header_name);
+    // Collect remaining request headers (excluding Host, Content-Length,
+    // and Proxy-Authorization which is proxy-hop-only).
+    // When a credential is present, also strip the credential's auth header
+    // (it contains the phantom token, not a real credential).
+    // When no credential is present, pass all other headers through —
+    // the caller may have a real Authorization header for the upstream.
+    let strip_header = cred.map(|c| c.header_name.as_str()).unwrap_or("");
+    let filtered_headers = filter_headers(remaining_header, strip_header);
     let content_length = extract_content_length(remaining_header);
 
     // Read request body if present, with size limit.
@@ -248,17 +269,10 @@ pub async fn handle_reverse_proxy(
         inject_credential_for_mode(cred, &mut request);
     }
 
-    // Forward filtered headers (excluding auth headers that we're replacing)
-    let auth_header_lower = cred_header_name.to_lowercase();
+    // Forward filtered headers. The credential's auth header was already
+    // stripped by filter_headers() when a credential is present, so no
+    // additional skipping is needed here.
     for (name, value) in &filtered_headers {
-        // Skip the auth header if we're using header/basic_auth mode
-        // (we already injected our own)
-        if cred.is_some_and(|c| {
-            matches!(c.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
-                && name.to_lowercase() == auth_header_lower
-        }) {
-            continue;
-        }
         request.push_str(&format!("{}: {}\r\n", name, value));
     }
 
@@ -386,21 +400,32 @@ fn validate_phantom_token(
     Err(ProxyError::InvalidToken)
 }
 
-/// Filter headers, removing Host, Content-Length, and the credential header.
+/// Filter headers, removing hop-by-hop and proxy-internal headers.
 ///
-/// Content-Length is re-added after body is read, and Host is rewritten
-/// to the upstream. The route's configured credential header is stripped
-/// so the phantom token is not forwarded alongside the real credential.
+/// Always strips:
+/// - `Host` (rewritten to upstream)
+/// - `Content-Length` (re-added after body is read)
+/// - `Proxy-Authorization` (hop-by-hop, contains session token)
+///
+/// When `cred_header` is non-empty, also strips that header (it contains
+/// the phantom token that must not be forwarded alongside the real credential).
+/// When `cred_header` is empty (no-credential route), all other headers
+/// including `Authorization` are passed through to the upstream.
 fn filter_headers(header_bytes: &[u8], cred_header: &str) -> Vec<(String, String)> {
     let header_str = std::str::from_utf8(header_bytes).unwrap_or("");
-    let cred_header_lower = format!("{}:", cred_header.to_lowercase());
+    let cred_header_lower = if cred_header.is_empty() {
+        String::new()
+    } else {
+        format!("{}:", cred_header.to_lowercase())
+    };
     let mut headers = Vec::new();
 
     for line in header_str.lines() {
         let lower = line.to_lowercase();
         if lower.starts_with("host:")
             || lower.starts_with("content-length:")
-            || lower.starts_with(&cred_header_lower)
+            || lower.starts_with("proxy-authorization:")
+            || (!cred_header_lower.is_empty() && lower.starts_with(&cred_header_lower))
             || line.trim().is_empty()
         {
             continue;

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -19,6 +19,7 @@ use crate::config::InjectMode;
 use crate::credential::{CredentialStore, LoadedCredential};
 use crate::error::{ProxyError, Result};
 use crate::filter::ProxyFilter;
+use crate::route::RouteStore;
 use crate::token;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -40,7 +41,9 @@ const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 /// a configured route, injects credentials, and forwards to the upstream.
 /// Shared context passed from the server to the reverse proxy handler.
 pub struct ReverseProxyCtx<'a> {
-    /// Credential store for service lookups
+    /// Route store for upstream URL, L7 filtering, and per-route TLS
+    pub route_store: &'a RouteStore,
+    /// Credential store for service lookups (optional injection)
     pub credential_store: &'a CredentialStore,
     /// Session token for authentication
     pub session_token: &'a Zeroizing<String>,
@@ -79,9 +82,9 @@ pub async fn handle_reverse_proxy(
     // Extract service prefix from path (e.g., "/openai/v1/chat" -> ("openai", "/v1/chat"))
     let (service, upstream_path) = parse_service_prefix(&path)?;
 
-    // Look up credential for service
-    let cred = ctx
-        .credential_store
+    // Look up route for service (required — provides upstream URL and L7 filtering)
+    let route = ctx
+        .route_store
         .get(&service)
         .ok_or_else(|| ProxyError::UnknownService {
             prefix: service.clone(),
@@ -89,7 +92,8 @@ pub async fn handle_reverse_proxy(
 
     // L7 endpoint filtering: check method+path against rules before any
     // credential operations. Denied endpoints get 403 immediately.
-    if !cred.endpoint_rules.is_allowed(&method, &upstream_path) {
+    // This check runs regardless of whether a credential is configured.
+    if !route.endpoint_rules.is_allowed(&method, &upstream_path) {
         let reason = format!(
             "endpoint denied: {} {} on service '{}'",
             method, upstream_path, service
@@ -106,44 +110,52 @@ pub async fn handle_reverse_proxy(
         return Ok(());
     }
 
-    // Validate phantom token based on injection mode.
-    // For header/basic_auth modes: validate from Authorization/x-api-key header
-    // For url_path mode: validate from URL path pattern
-    // For query_param mode: validate from query parameter
-    if let Err(e) = validate_phantom_token_for_mode(
-        &cred.inject_mode,
-        remaining_header,
-        &upstream_path,
-        &cred.header_name,
-        cred.path_pattern.as_deref(),
-        cred.query_param_name.as_deref(),
-        ctx.session_token,
-    ) {
-        audit::log_denied(
-            ctx.audit_log,
-            audit::ProxyMode::Reverse,
-            &service,
-            0,
-            &e.to_string(),
-        );
-        send_error(stream, 401, "Unauthorized").await?;
-        return Ok(());
+    // Look up credential for service (optional — not all routes inject credentials)
+    let cred = ctx.credential_store.get(&service);
+
+    // Validate phantom token and transform path if credential injection is active.
+    if let Some(cred) = cred {
+        if let Err(e) = validate_phantom_token_for_mode(
+            &cred.inject_mode,
+            remaining_header,
+            &upstream_path,
+            &cred.header_name,
+            cred.path_pattern.as_deref(),
+            cred.query_param_name.as_deref(),
+            ctx.session_token,
+        ) {
+            audit::log_denied(
+                ctx.audit_log,
+                audit::ProxyMode::Reverse,
+                &service,
+                0,
+                &e.to_string(),
+            );
+            send_error(stream, 401, "Unauthorized").await?;
+            return Ok(());
+        }
     }
 
-    // Transform the path based on injection mode (url_path and query_param modes)
-    let transformed_path = transform_path_for_mode(
-        &cred.inject_mode,
-        &upstream_path,
-        cred.path_pattern.as_deref(),
-        cred.path_replacement.as_deref(),
-        cred.query_param_name.as_deref(),
-        &cred.raw_credential,
-    )?;
+    // Transform the path based on injection mode (url_path and query_param modes).
+    // When no credential is configured, the path is forwarded unchanged.
+    let transformed_path = if let Some(cred) = cred {
+        transform_path_for_mode(
+            &cred.inject_mode,
+            &upstream_path,
+            cred.path_pattern.as_deref(),
+            cred.path_replacement.as_deref(),
+            cred.query_param_name.as_deref(),
+            &cred.raw_credential,
+        )?
+    } else {
+        upstream_path.clone()
+    };
 
-    // Parse upstream URL with potentially transformed path
+    // Parse upstream URL with potentially transformed path.
+    // Upstream URL comes from the route, not the credential.
     let upstream_url = format!(
         "{}{}",
-        cred.upstream.trim_end_matches('/'),
+        route.upstream.trim_end_matches('/'),
         transformed_path
     );
     debug!("Forwarding to upstream: {} {}", method, upstream_url);
@@ -166,8 +178,12 @@ pub async fn handle_reverse_proxy(
         return Ok(());
     }
 
-    // Collect remaining request headers (excluding X-Nono-Token and Host)
-    let filtered_headers = filter_headers(remaining_header, &cred.header_name);
+    // Collect remaining request headers (excluding X-Nono-Token and Host).
+    // When a credential is present, also strip the credential header.
+    let cred_header_name = cred
+        .map(|c| c.header_name.as_str())
+        .unwrap_or("Authorization");
+    let filtered_headers = filter_headers(remaining_header, cred_header_name);
     let content_length = extract_content_length(remaining_header);
 
     // Read request body if present, with size limit.
@@ -195,7 +211,7 @@ pub async fn handle_reverse_proxy(
     // Connect to upstream over TLS using pre-resolved addresses.
     // Use the per-route TLS connector (with custom CA) if configured,
     // otherwise fall back to the shared default connector.
-    let connector = cred.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
+    let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
     let upstream_result = connect_upstream_tls(
         &upstream_host,
         upstream_port,
@@ -227,17 +243,20 @@ pub async fn handle_reverse_proxy(
         method, upstream_path_full, version, upstream_host
     ));
 
-    // Inject credential based on mode
-    inject_credential_for_mode(cred, &mut request);
+    // Inject credential based on mode (only if credential is configured)
+    if let Some(cred) = cred {
+        inject_credential_for_mode(cred, &mut request);
+    }
 
     // Forward filtered headers (excluding auth headers that we're replacing)
-    let auth_header_lower = cred.header_name.to_lowercase();
+    let auth_header_lower = cred_header_name.to_lowercase();
     for (name, value) in &filtered_headers {
         // Skip the auth header if we're using header/basic_auth mode
         // (we already injected our own)
-        if matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
-            && name.to_lowercase() == auth_header_lower
-        {
+        if cred.is_some_and(|c| {
+            matches!(c.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
+                && name.to_lowercase() == auth_header_lower
+        }) {
             continue;
         }
         request.push_str(&format!("{}: {}\r\n", name, value));

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -26,6 +26,11 @@ pub struct LoadedRoute {
     /// Upstream URL (e.g., "https://api.openai.com")
     pub upstream: String,
 
+    /// Pre-normalised `host:port` extracted from `upstream` at load time.
+    /// Used for O(1) lookups in `is_route_upstream()` without per-request
+    /// URL parsing. `None` if the upstream URL cannot be parsed.
+    pub upstream_host_port: Option<String>,
+
     /// Pre-compiled L7 endpoint rules for method+path filtering.
     /// When non-empty, only matching requests are allowed (default-deny).
     /// When empty, all method+path combinations are permitted.
@@ -41,6 +46,7 @@ impl std::fmt::Debug for LoadedRoute {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LoadedRoute")
             .field("upstream", &self.upstream)
+            .field("upstream_host_port", &self.upstream_host_port)
             .field("endpoint_rules", &self.endpoint_rules)
             .field("has_custom_tls_ca", &self.tls_connector.is_some())
             .finish()
@@ -88,10 +94,13 @@ impl RouteStore {
                 None => None,
             };
 
+            let upstream_host_port = extract_host_port(&route.upstream);
+
             loaded.insert(
                 normalized_prefix,
                 LoadedRoute {
                     upstream: route.upstream.clone(),
+                    upstream_host_port,
                     endpoint_rules,
                     tls_connector,
                 },
@@ -128,26 +137,26 @@ impl RouteStore {
     }
 
     /// Check whether `host_port` (e.g. `"api.openai.com:443"`) matches
-    /// any route's upstream URL. Used to determine whether a CONNECT tunnel
-    /// should be MITM'd for L7 filtering or passed through transparently.
+    /// any route's upstream URL. Uses pre-normalised `host:port` strings
+    /// computed at load time to avoid per-request URL parsing.
     #[must_use]
     pub fn is_route_upstream(&self, host_port: &str) -> bool {
         let normalised = host_port.to_lowercase();
         self.routes.values().any(|route| {
-            extract_host_port(&route.upstream)
-                .map(|hp| hp == normalised)
-                .unwrap_or(false)
+            route
+                .upstream_host_port
+                .as_ref()
+                .is_some_and(|hp| *hp == normalised)
         })
     }
 
     /// Return the set of normalised `host:port` strings for all route
-    /// upstreams. Used to compute smart `NO_PROXY` — hosts in this set must
-    /// NOT be bypassed because they need reverse proxy routing.
+    /// upstreams. Uses pre-normalised values computed at load time.
     #[must_use]
     pub fn route_upstream_hosts(&self) -> std::collections::HashSet<String> {
         self.routes
             .values()
-            .filter_map(|route| extract_host_port(&route.upstream))
+            .filter_map(|route| route.upstream_host_port.clone())
             .collect()
     }
 }
@@ -410,6 +419,7 @@ mod tests {
     fn test_loaded_route_debug() {
         let route = LoadedRoute {
             upstream: "https://api.openai.com".to_string(),
+            upstream_host_port: Some("api.openai.com:443".to_string()),
             endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
             tls_connector: None,
         };

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -1,0 +1,489 @@
+//! Route store: per-route configuration independent of credentials.
+//!
+//! `RouteStore` holds the route-level configuration (upstream URL, L7 endpoint
+//! rules, custom TLS CA) for **all** configured routes, regardless of whether
+//! they have a credential attached. This decouples L7 filtering from credential
+//! injection — a route can enforce endpoint restrictions without injecting any
+//! secret.
+//!
+//! The `CredentialStore` remains responsible for credential-specific fields
+//! (inject mode, header name/value, raw secret). Both stores are keyed by the
+//! normalised route prefix and are consulted independently by the proxy handlers.
+
+use crate::config::{CompiledEndpointRules, RouteConfig};
+use crate::error::{ProxyError, Result};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::debug;
+use zeroize::Zeroizing;
+
+/// Route-level configuration loaded at proxy startup.
+///
+/// Contains everything needed to forward and filter a request for a route,
+/// but no credential material. Credential injection is handled separately
+/// by `CredentialStore`.
+pub struct LoadedRoute {
+    /// Upstream URL (e.g., "https://api.openai.com")
+    pub upstream: String,
+
+    /// Pre-compiled L7 endpoint rules for method+path filtering.
+    /// When non-empty, only matching requests are allowed (default-deny).
+    /// When empty, all method+path combinations are permitted.
+    pub endpoint_rules: CompiledEndpointRules,
+
+    /// Per-route TLS connector with custom CA trust, if configured.
+    /// Built once at startup from the route's `tls_ca` certificate file.
+    /// When `None`, the shared default connector (webpki roots only) is used.
+    pub tls_connector: Option<tokio_rustls::TlsConnector>,
+}
+
+impl std::fmt::Debug for LoadedRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoadedRoute")
+            .field("upstream", &self.upstream)
+            .field("endpoint_rules", &self.endpoint_rules)
+            .field("has_custom_tls_ca", &self.tls_connector.is_some())
+            .finish()
+    }
+}
+
+/// Store of all configured routes, keyed by normalised prefix.
+///
+/// Loaded at proxy startup for **all** routes in the config, not just those
+/// with credentials. This ensures L7 endpoint filtering and upstream routing
+/// work independently of credential presence.
+#[derive(Debug)]
+pub struct RouteStore {
+    routes: HashMap<String, LoadedRoute>,
+}
+
+impl RouteStore {
+    /// Load route configuration for all configured routes.
+    ///
+    /// Each route's endpoint rules are compiled at startup so the hot path
+    /// does a regex match, not a glob compile. Routes with a `tls_ca` field
+    /// get a per-route TLS connector built from the custom CA certificate.
+    pub fn load(routes: &[RouteConfig]) -> Result<Self> {
+        let mut loaded = HashMap::new();
+
+        for route in routes {
+            let normalized_prefix = route.prefix.trim_matches('/').to_string();
+
+            debug!(
+                "Loading route '{}' -> {}",
+                normalized_prefix, route.upstream
+            );
+
+            let endpoint_rules = CompiledEndpointRules::compile(&route.endpoint_rules)
+                .map_err(|e| ProxyError::Config(format!("route '{}': {}", normalized_prefix, e)))?;
+
+            let tls_connector = match route.tls_ca {
+                Some(ref ca_path) => {
+                    debug!(
+                        "Building TLS connector with custom CA for route '{}': {}",
+                        normalized_prefix, ca_path
+                    );
+                    Some(build_tls_connector_with_ca(ca_path)?)
+                }
+                None => None,
+            };
+
+            loaded.insert(
+                normalized_prefix,
+                LoadedRoute {
+                    upstream: route.upstream.clone(),
+                    endpoint_rules,
+                    tls_connector,
+                },
+            );
+        }
+
+        Ok(Self { routes: loaded })
+    }
+
+    /// Create an empty route store (no routes configured).
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            routes: HashMap::new(),
+        }
+    }
+
+    /// Get a loaded route by normalised prefix, if configured.
+    #[must_use]
+    pub fn get(&self, prefix: &str) -> Option<&LoadedRoute> {
+        self.routes.get(prefix)
+    }
+
+    /// Check if any routes are loaded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+
+    /// Number of loaded routes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.routes.len()
+    }
+
+    /// Check whether `host_port` (e.g. `"api.openai.com:443"`) matches
+    /// any route's upstream URL. Used to determine whether a CONNECT tunnel
+    /// should be MITM'd for L7 filtering or passed through transparently.
+    #[must_use]
+    pub fn is_route_upstream(&self, host_port: &str) -> bool {
+        let normalised = host_port.to_lowercase();
+        self.routes.values().any(|route| {
+            extract_host_port(&route.upstream)
+                .map(|hp| hp == normalised)
+                .unwrap_or(false)
+        })
+    }
+
+    /// Return the set of normalised `host:port` strings for all route
+    /// upstreams. Used to compute smart `NO_PROXY` — hosts in this set must
+    /// NOT be bypassed because they need reverse proxy routing.
+    #[must_use]
+    pub fn route_upstream_hosts(&self) -> std::collections::HashSet<String> {
+        self.routes
+            .values()
+            .filter_map(|route| extract_host_port(&route.upstream))
+            .collect()
+    }
+}
+
+/// Extract and normalise `host:port` from a URL string.
+///
+/// Defaults to port 443 for `https://` and 80 for `http://` when no
+/// explicit port is present. Returns `None` if the URL cannot be parsed.
+fn extract_host_port(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    let host = parsed.host_str()?;
+    let default_port = match parsed.scheme() {
+        "https" => 443,
+        "http" => 80,
+        _ => return None,
+    };
+    let port = parsed.port().unwrap_or(default_port);
+    Some(format!("{}:{}", host.to_lowercase(), port))
+}
+
+/// Build a `TlsConnector` that trusts the system roots plus a custom CA certificate.
+///
+/// The CA file must be PEM-encoded and contain at least one certificate.
+/// Returns an error if the file cannot be read, contains no valid certificates,
+/// or the TLS configuration fails.
+fn build_tls_connector_with_ca(ca_path: &str) -> Result<tokio_rustls::TlsConnector> {
+    let ca_path = std::path::Path::new(ca_path);
+
+    let ca_pem = Zeroizing::new(std::fs::read(ca_path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            ProxyError::Config(format!(
+                "CA certificate file not found: '{}'",
+                ca_path.display()
+            ))
+        } else {
+            ProxyError::Config(format!(
+                "failed to read CA certificate '{}': {}",
+                ca_path.display(),
+                e
+            ))
+        }
+    })?);
+
+    let mut root_store = rustls::RootCertStore::empty();
+
+    // Add system roots first
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    // Parse and add custom CA certificates from PEM file
+    let certs: Vec<_> = rustls_pemfile::certs(&mut ca_pem.as_slice())
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| {
+            ProxyError::Config(format!(
+                "failed to parse CA certificate '{}': {}",
+                ca_path.display(),
+                e
+            ))
+        })?;
+
+    if certs.is_empty() {
+        return Err(ProxyError::Config(format!(
+            "CA certificate file '{}' contains no valid PEM certificates",
+            ca_path.display()
+        )));
+    }
+
+    for cert in certs {
+        root_store.add(cert).map_err(|e| {
+            ProxyError::Config(format!(
+                "invalid CA certificate in '{}': {}",
+                ca_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| ProxyError::Config(format!("TLS config error: {}", e)))?
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+
+    Ok(tokio_rustls::TlsConnector::from(Arc::new(tls_config)))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::EndpointRule;
+
+    #[test]
+    fn test_empty_route_store() {
+        let store = RouteStore::empty();
+        assert!(store.is_empty());
+        assert_eq!(store.len(), 0);
+        assert!(store.get("openai").is_none());
+    }
+
+    #[test]
+    fn test_load_routes_without_credentials() {
+        // Routes without credential_key should still be loaded into RouteStore
+        let routes = vec![RouteConfig {
+            prefix: "/openai".to_string(),
+            upstream: "https://api.openai.com".to_string(),
+            credential_key: None,
+            inject_mode: Default::default(),
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: None,
+            endpoint_rules: vec![
+                EndpointRule {
+                    method: "POST".to_string(),
+                    path: "/v1/chat/completions".to_string(),
+                },
+                EndpointRule {
+                    method: "GET".to_string(),
+                    path: "/v1/models".to_string(),
+                },
+            ],
+            tls_ca: None,
+        }];
+
+        let store = RouteStore::load(&routes).unwrap();
+        assert_eq!(store.len(), 1);
+
+        let route = store.get("openai").unwrap();
+        assert_eq!(route.upstream, "https://api.openai.com");
+        assert!(route
+            .endpoint_rules
+            .is_allowed("POST", "/v1/chat/completions"));
+        assert!(route.endpoint_rules.is_allowed("GET", "/v1/models"));
+        assert!(!route
+            .endpoint_rules
+            .is_allowed("DELETE", "/v1/files/file-123"));
+    }
+
+    #[test]
+    fn test_load_routes_normalises_prefix() {
+        let routes = vec![RouteConfig {
+            prefix: "/anthropic/".to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            credential_key: None,
+            inject_mode: Default::default(),
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: None,
+            endpoint_rules: vec![],
+            tls_ca: None,
+        }];
+
+        let store = RouteStore::load(&routes).unwrap();
+        assert!(store.get("anthropic").is_some());
+        assert!(store.get("/anthropic/").is_none());
+    }
+
+    #[test]
+    fn test_is_route_upstream() {
+        let routes = vec![RouteConfig {
+            prefix: "openai".to_string(),
+            upstream: "https://api.openai.com".to_string(),
+            credential_key: None,
+            inject_mode: Default::default(),
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: None,
+            endpoint_rules: vec![],
+            tls_ca: None,
+        }];
+
+        let store = RouteStore::load(&routes).unwrap();
+        assert!(store.is_route_upstream("api.openai.com:443"));
+        assert!(!store.is_route_upstream("github.com:443"));
+    }
+
+    #[test]
+    fn test_route_upstream_hosts() {
+        let routes = vec![
+            RouteConfig {
+                prefix: "openai".to_string(),
+                upstream: "https://api.openai.com".to_string(),
+                credential_key: None,
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                tls_ca: None,
+            },
+            RouteConfig {
+                prefix: "anthropic".to_string(),
+                upstream: "https://api.anthropic.com".to_string(),
+                credential_key: None,
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                tls_ca: None,
+            },
+        ];
+
+        let store = RouteStore::load(&routes).unwrap();
+        let hosts = store.route_upstream_hosts();
+        assert!(hosts.contains("api.openai.com:443"));
+        assert!(hosts.contains("api.anthropic.com:443"));
+        assert_eq!(hosts.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_host_port_https() {
+        assert_eq!(
+            extract_host_port("https://api.openai.com"),
+            Some("api.openai.com:443".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_host_port_with_port() {
+        assert_eq!(
+            extract_host_port("https://api.example.com:8443"),
+            Some("api.example.com:8443".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_host_port_http() {
+        assert_eq!(
+            extract_host_port("http://internal-service"),
+            Some("internal-service:80".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_host_port_normalises_case() {
+        assert_eq!(
+            extract_host_port("https://API.Example.COM"),
+            Some("api.example.com:443".to_string())
+        );
+    }
+
+    #[test]
+    fn test_loaded_route_debug() {
+        let route = LoadedRoute {
+            upstream: "https://api.openai.com".to_string(),
+            endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
+            tls_connector: None,
+        };
+        let debug_output = format!("{:?}", route);
+        assert!(debug_output.contains("api.openai.com"));
+        assert!(debug_output.contains("has_custom_tls_ca"));
+    }
+
+    /// Self-signed CA for testing. Generated with:
+    /// openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    ///   -keyout /dev/null -nodes -days 36500 -subj '/CN=nono-test-ca' -out -
+    const TEST_CA_PEM: &str = "\
+-----BEGIN CERTIFICATE-----
+MIIBnjCCAUWgAwIBAgIUT0bpOJJvHdOdZt+gW1stR8VBgXowCgYIKoZIzj0EAwIw
+FzEVMBMGA1UEAwwMbm9uby10ZXN0LWNhMCAXDTI1MDEwMTAwMDAwMFoYDzIxMjQx
+MjA3MDAwMDAwWjAXMRUwEwYDVQQDDAxub25vLXRlc3QtY2EwWTATBgcqhkjOPQIB
+BggqhkjOPQMBBwNCAAR8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAo1MwUTAdBgNVHQ4EFgQUAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAMB8GA1UdIwQYMBaAFAAAAAAAAAAAAAAAAAAAAAAAAAAAADAPBgNVHRMBAf8E
+BTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAICAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+-----END CERTIFICATE-----";
+
+    #[test]
+    fn test_build_tls_connector_with_valid_ca() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("ca.pem");
+        std::fs::write(&ca_path, TEST_CA_PEM).unwrap();
+
+        let result = build_tls_connector_with_ca(ca_path.to_str().unwrap());
+        match result {
+            Ok(connector) => {
+                drop(connector);
+            }
+            Err(ProxyError::Config(msg)) => {
+                assert!(
+                    msg.contains("invalid CA certificate") || msg.contains("CA certificate"),
+                    "unexpected error: {}",
+                    msg
+                );
+            }
+            Err(e) => panic!("unexpected error type: {}", e),
+        }
+    }
+
+    #[test]
+    fn test_build_tls_connector_missing_file() {
+        let result = build_tls_connector_with_ca("/nonexistent/path/ca.pem");
+        let err = result
+            .err()
+            .expect("should fail for missing file")
+            .to_string();
+        assert!(
+            err.contains("CA certificate file not found"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_build_tls_connector_empty_pem() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("empty.pem");
+        std::fs::write(&ca_path, "not a certificate\n").unwrap();
+
+        let result = build_tls_connector_with_ca(ca_path.to_str().unwrap());
+        let err = result
+            .err()
+            .expect("should fail for invalid PEM")
+            .to_string();
+        assert!(
+            err.contains("no valid PEM certificates"),
+            "unexpected error: {}",
+            err
+        );
+    }
+}

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -15,6 +15,7 @@ use crate::error::{ProxyError, Result};
 use crate::external;
 use crate::filter::ProxyFilter;
 use crate::reverse;
+use crate::route::RouteStore;
 use crate::token;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -161,6 +162,9 @@ impl ProxyHandle {
 struct ProxyState {
     filter: ProxyFilter,
     session_token: Zeroizing<String>,
+    /// Route-level configuration (upstream, L7 filtering, custom TLS CA) for all routes.
+    route_store: RouteStore,
+    /// Credential-specific configuration (inject mode, headers, secrets) for routes with credentials.
     credential_store: CredentialStore,
     config: ProxyConfig,
     /// Shared TLS connector for upstream connections (reverse proxy mode).
@@ -203,7 +207,15 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
 
     info!("Proxy server listening on {}", local_addr);
 
-    // Load credentials for reverse proxy routes
+    // Load route-level configuration (upstream, L7 filtering, custom TLS CA)
+    // for ALL routes, regardless of credential presence.
+    let route_store = if config.routes.is_empty() {
+        RouteStore::empty()
+    } else {
+        RouteStore::load(&config.routes)?
+    };
+
+    // Load credentials for reverse proxy routes (only routes with credential_key)
     let credential_store = if config.routes.is_empty() {
         CredentialStore::empty()
     } else {
@@ -243,10 +255,10 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let audit_log = audit::new_audit_log();
 
-    // Compute NO_PROXY hosts: allowed_hosts minus credential upstreams.
-    // Non-credential hosts bypass the proxy (direct connection, still
-    // Landlock-enforced). Credential upstreams must go through the proxy
-    // for L7 path filtering and credential injection.
+    // Compute NO_PROXY hosts: allowed_hosts minus route upstreams.
+    // Non-route hosts bypass the proxy (direct connection, still
+    // Landlock-enforced). Route upstreams must go through the proxy
+    // for L7 path filtering and/or credential injection.
     //
     // On macOS this MUST be empty: Seatbelt's ProxyOnly mode generates
     // `(deny network*) (allow network-outbound (remote tcp "localhost:PORT"))`
@@ -256,7 +268,7 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     let no_proxy_hosts: Vec<String> = if cfg!(target_os = "macos") {
         Vec::new()
     } else {
-        let credential_hosts = credential_store.credential_upstream_hosts();
+        let route_hosts = route_store.route_upstream_hosts();
         config
             .allowed_hosts
             .iter()
@@ -276,7 +288,7 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
                         format!("{}:443", h)
                     }
                 };
-                !credential_hosts.contains(&normalised)
+                !route_hosts.contains(&normalised)
             })
             .cloned()
             .collect()
@@ -289,6 +301,7 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     let state = Arc::new(ProxyState {
         filter,
         session_token: session_token.clone(),
+        route_store,
         credential_store,
         config,
         tls_connector,
@@ -405,11 +418,11 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
 
     // Dispatch by method
     if first_line.starts_with("CONNECT ") {
-        // Block CONNECT tunnels to credential upstreams. These must go
+        // Block CONNECT tunnels to route upstreams. These must go
         // through the reverse proxy path so L7 path filtering and
         // credential injection are enforced. A CONNECT tunnel would
         // bypass both (raw TLS pipe, proxy never sees HTTP method/path).
-        if !state.credential_store.is_empty() {
+        if !state.route_store.is_empty() {
             if let Some(authority) = first_line.split_whitespace().nth(1) {
                 // Normalise authority to host:port. Handle IPv6 brackets:
                 // "[::1]:443" already has port, "[::1]" needs default, "host:443" has port.
@@ -425,13 +438,13 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                 } else {
                     format!("{}:443", authority.to_lowercase())
                 };
-                if state.credential_store.is_credential_upstream(&host_port) {
+                if state.route_store.is_route_upstream(&host_port) {
                     let (host, port) = host_port
                         .rsplit_once(':')
                         .map(|(h, p)| (h, p.parse::<u16>().unwrap_or(443)))
                         .unwrap_or((&host_port, 443));
                     warn!(
-                        "Blocked CONNECT to credential upstream {} — use reverse proxy path instead",
+                        "Blocked CONNECT to route upstream {} — use reverse proxy path instead",
                         authority
                     );
                     audit::log_denied(
@@ -439,7 +452,7 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                         audit::ProxyMode::Connect,
                         host,
                         port,
-                        "credential upstream: CONNECT bypasses L7 filtering",
+                        "route upstream: CONNECT bypasses L7 filtering",
                     );
                     let response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n";
                     stream.write_all(response.as_bytes()).await?;
@@ -512,9 +525,10 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
             )
             .await
         }
-    } else if !state.credential_store.is_empty() {
-        // Non-CONNECT request with credential routes -> reverse proxy
+    } else if !state.route_store.is_empty() {
+        // Non-CONNECT request with routes configured -> reverse proxy
         let ctx = reverse::ReverseProxyCtx {
+            route_store: &state.route_store,
             credential_store: &state.credential_store,
             session_token: &state.session_token,
             filter: &state.filter,
@@ -523,7 +537,7 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
         };
         reverse::handle_reverse_proxy(first_line, &mut stream, &header_bytes, &ctx, &buffered).await
     } else {
-        // No credential routes configured, reject non-CONNECT requests
+        // No routes configured, reject non-CONNECT requests
         let response = "HTTP/1.1 400 Bad Request\r\n\r\n";
         stream.write_all(response.as_bytes()).await?;
         Ok(())

--- a/qa-profiles/01-credential-with-rules.json
+++ b/qa-profiles/01-credential-with-rules.json
@@ -1,0 +1,19 @@
+{
+    "meta": { "name": "qa-credential-with-rules" },
+    "filesystem": { "allow": ["."] },
+    "network": {
+        "allow_domain": ["example.com"],
+        "credentials": ["openai"],
+        "custom_credentials": {
+            "openai": {
+                "upstream": "https://api.openai.com",
+                "credential_key": "openai_api_key",
+                "env_var": "OPENAI_API_KEY",
+                "endpoint_rules": [
+                    { "method": "POST", "path": "/v1/chat/completions" },
+                    { "method": "GET", "path": "/v1/models" }
+                ]
+            }
+        }
+    }
+}

--- a/qa-profiles/02-rules-without-credential.json
+++ b/qa-profiles/02-rules-without-credential.json
@@ -1,0 +1,19 @@
+{
+    "meta": { "name": "qa-rules-without-credential" },
+    "filesystem": { "allow": ["."] },
+    "network": {
+        "allow_domain": ["example.com"],
+        "credentials": ["httpbin"],
+        "custom_credentials": {
+            "httpbin": {
+                "upstream": "https://httpbin.org",
+                "credential_key": "httpbin_dummy_unused",
+                "env_var": "HTTPBIN_API_KEY",
+                "endpoint_rules": [
+                    { "method": "GET", "path": "/get" },
+                    { "method": "GET", "path": "/ip" }
+                ]
+            }
+        }
+    }
+}

--- a/qa-profiles/03-mixed-routes.json
+++ b/qa-profiles/03-mixed-routes.json
@@ -1,0 +1,28 @@
+{
+    "meta": { "name": "qa-mixed-routes" },
+    "filesystem": { "allow": ["."] },
+    "network": {
+        "allow_domain": ["example.com", "github.com"],
+        "credentials": ["openai", "httpbin"],
+        "custom_credentials": {
+            "openai": {
+                "upstream": "https://api.openai.com",
+                "credential_key": "openai_api_key",
+                "env_var": "OPENAI_API_KEY",
+                "endpoint_rules": [
+                    { "method": "POST", "path": "/v1/chat/completions" },
+                    { "method": "GET", "path": "/v1/models" }
+                ]
+            },
+            "httpbin": {
+                "upstream": "https://httpbin.org",
+                "credential_key": "httpbin_dummy_unused",
+                "env_var": "HTTPBIN_API_KEY",
+                "endpoint_rules": [
+                    { "method": "GET", "path": "/get" },
+                    { "method": "GET", "path": "/ip" }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce RouteStore to hold per-route configuration (upstream URL, L7
endpoint rules, custom TLS CA) independently of CredentialStore. Previously,
endpoint rules were only compiled and checked when a credential was present,
meaning routes without credentials could not enforce L7 path filtering.

This separation enables three route configurations:
- L7 filtering + credential injection (existing behavior, unchanged)
- L7 filtering without credentials (new: restrict endpoints without secrets)
- Credential injection without L7 filtering (existing: empty rules = allow all)

The RouteStore loads ALL configured routes at startup regardless of
credential_key presence. The reverse proxy handler checks RouteStore first
for filtering and upstream routing, then optionally consults CredentialStore
for credential injection. CONNECT blocking of route upstreams now uses
RouteStore instead of CredentialStore.

Functions moved from credential.rs to route.rs:
- extract_host_port(), build_tls_connector_with_ca()
- is_credential_upstream() → is_route_upstream()
- credential_upstream_hosts() → route_upstream_hosts()
 
Resolves: #554

Signed-off-by: Luke Hinds <lukehinds@gmail.com>