### PR TITLE
feat(nix): improve NixOS compatibility for /nix/store path

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -482,7 +482,8 @@
           "~/.nix-defexpr",
           "/run/current-system/sw",
           "/etc/profiles/per-user",
-          "/nix/var/nix/profiles"
+          "/nix/var/nix/profiles",
+          "/nix/store"
         ]
       }
     },

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1038,9 +1038,17 @@ pub fn get_sensitive_paths(policy: &Policy) -> Result<Vec<SensitivePathRule>> {
                 // If the deny path is a symlink, also mark the resolved target
                 // as sensitive. Without this, querying a symlinked path like
                 // ~/.zshrc -> ~/dev/dotfiles/.zshrc would miss the deny.
+                //
+                // Exception: on Linux, skip resolved targets inside /nix/store.
+                // NixOS home-manager creates symlinks from shell configs into the
+                // immutable Nix store, and the sandbox correctly allows reading
+                // those paths (see add_deny_access_rules). Marking the Nix store
+                // target as sensitive would cause `nono why` to report a false
+                // denial for paths the sandbox actually permits.
                 if expanded.is_symlink() {
                     if let Ok(resolved) = expanded.canonicalize() {
-                        if resolved != expanded {
+                        let skip = cfg!(target_os = "linux") && is_nix_store_path(&resolved);
+                        if resolved != expanded && !skip {
                             result.push(SensitivePathRule {
                                 expanded_path: resolved.to_string_lossy().into_owned(),
                                 group_name: group_name.clone(),
@@ -1740,6 +1748,52 @@ mod tests {
             paths.contains(&link_canonical.to_str().expect("utf8")),
             "sensitive paths must contain resolved target"
         );
+    }
+
+    #[test]
+    fn test_sensitive_paths_skips_nix_store_symlink_target_on_linux() {
+        // Simulate a NixOS home-manager scenario: a deny-listed shell config
+        // file is a symlink whose canonical target is inside /nix/store.
+        // We can't create real /nix/store paths in tests, so we test the
+        // is_nix_store_path helper indirectly and verify the branching logic.
+
+        // Part 1: non-nix symlink targets ARE included (baseline)
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("real_zshrc");
+        std::fs::write(&target, "config").expect("write");
+        let link = dir.path().join("linked_zshrc");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        let link_str = link.to_str().expect("utf8");
+        let json = format!(
+            r#"{{
+              "meta": {{ "version": 1, "schema_version": "1.0" }},
+              "groups": {{
+                "test_deny": {{
+                  "description": "Test deny",
+                  "deny": {{ "access": ["{}"] }}
+                }}
+              }}
+            }}"#,
+            link_str
+        );
+        let policy = load_policy(&json).expect("parse");
+        let sensitive = get_sensitive_paths(&policy).expect("sensitive paths");
+        let canonical = link.canonicalize().expect("canonicalize");
+        let paths: Vec<&str> = sensitive.iter().map(|r| r.expanded_path.as_str()).collect();
+
+        // Non-nix symlink: canonical target should always be included
+        assert!(
+            paths.contains(&canonical.to_str().expect("utf8")),
+            "non-nix canonical target must be in sensitive paths"
+        );
+
+        // Part 2: verify is_nix_store_path correctly identifies store paths
+        // (used by get_sensitive_paths to skip canonical targets on Linux)
+        assert!(is_nix_store_path(Path::new(
+            "/nix/store/abc123-home-manager-files/.zshrc"
+        )));
+        assert!(!is_nix_store_path(&canonical));
     }
 
     #[test]

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -222,6 +222,20 @@ fn is_nix_store_path(path: &Path) -> bool {
     path.starts_with("/nix/store")
 }
 
+/// Decide whether a resolved (canonical) deny target should be skipped.
+///
+/// On Linux, symlink targets inside `/nix/store` are immutable and cannot
+/// hold runtime secrets, so adding them to the deny list is both unnecessary
+/// and harmful (causes Landlock deny-overlap errors when `/nix/store` is
+/// allowed by the `nix_runtime` group). The original symlink path is still
+/// denied, so the security posture is unchanged for non-Nix environments.
+///
+/// On macOS this always returns `false` — Seatbelt handles deny-within-allow
+/// natively, and the canonical form is needed for correct kernel matching.
+fn should_skip_resolved_deny_target(resolved: &Path) -> bool {
+    cfg!(target_os = "linux") && is_nix_store_path(resolved)
+}
+
 /// Convert a PathBuf to a UTF-8 string, returning an error for non-UTF-8 paths.
 ///
 /// Non-UTF-8 paths would produce incorrect Seatbelt rules via lossy conversion,
@@ -567,13 +581,7 @@ pub(crate) fn add_deny_access_rules(
     let canonical = path.canonicalize().ok();
     if let Some(ref canonical) = canonical {
         if *canonical != path {
-            // On NixOS with home-manager, shell config files (e.g. ~/.zshrc) are
-            // symlinks into /nix/store/..., which is immutable. Adding the canonical
-            // path to deny_paths would cause a Landlock deny-overlap error when
-            // /nix/store is allowed for read. Since Nix store paths are immutable
-            // and cannot contain runtime secrets, skip adding the canonical form
-            // to deny_paths on Linux — the original symlink path is still denied.
-            if cfg!(target_os = "linux") && is_nix_store_path(canonical) {
+            if should_skip_resolved_deny_target(canonical) {
                 debug!(
                     "Skipping deny canonical path '{}' (Nix store immutable symlink target of '{}')",
                     canonical.display(),
@@ -1047,8 +1055,7 @@ pub fn get_sensitive_paths(policy: &Policy) -> Result<Vec<SensitivePathRule>> {
                 // denial for paths the sandbox actually permits.
                 if expanded.is_symlink() {
                     if let Ok(resolved) = expanded.canonicalize() {
-                        let skip = cfg!(target_os = "linux") && is_nix_store_path(&resolved);
-                        if resolved != expanded && !skip {
+                        if resolved != expanded && !should_skip_resolved_deny_target(&resolved) {
                             result.push(SensitivePathRule {
                                 expanded_path: resolved.to_string_lossy().into_owned(),
                                 group_name: group_name.clone(),
@@ -1751,13 +1758,57 @@ mod tests {
     }
 
     #[test]
-    fn test_sensitive_paths_skips_nix_store_symlink_target_on_linux() {
-        // Simulate a NixOS home-manager scenario: a deny-listed shell config
-        // file is a symlink whose canonical target is inside /nix/store.
-        // We can't create real /nix/store paths in tests, so we test the
-        // is_nix_store_path helper indirectly and verify the branching logic.
+    fn test_should_skip_resolved_deny_target() {
+        // Directly exercise the shared predicate used by both
+        // add_deny_access_rules and get_sensitive_paths.
 
-        // Part 1: non-nix symlink targets ARE included (baseline)
+        let nix_paths = [
+            Path::new("/nix/store/abc123-home-manager-files/.zshrc"),
+            Path::new("/nix/store/xyz789-zsh-5.9/share/zsh"),
+            Path::new("/nix/store"),
+        ];
+
+        let non_nix_paths = [
+            Path::new("/home/user/.zshrc"),
+            Path::new("/nix/var/nix/profiles/default"),
+            Path::new("/nix"),
+            Path::new("/nix/stored-elsewhere"),
+            Path::new("/tmp/nix/store/fake"),
+        ];
+
+        for p in &nix_paths {
+            if cfg!(target_os = "linux") {
+                assert!(
+                    should_skip_resolved_deny_target(p),
+                    "Linux must skip Nix store target: {}",
+                    p.display()
+                );
+            } else {
+                assert!(
+                    !should_skip_resolved_deny_target(p),
+                    "macOS must NOT skip Nix store target (Seatbelt needs it): {}",
+                    p.display()
+                );
+            }
+        }
+
+        for p in &non_nix_paths {
+            assert!(
+                !should_skip_resolved_deny_target(p),
+                "must never skip non-Nix-store path: {}",
+                p.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_sensitive_paths_nix_store_symlink_end_to_end() {
+        // End-to-end: a symlinked deny target whose canonical form is NOT
+        // in /nix/store is included. We cannot create real /nix/store files
+        // in tests, but should_skip_resolved_deny_target (tested above)
+        // covers the /nix/store branch directly. Here we verify that the
+        // integration between get_sensitive_paths and the predicate works:
+        // non-skipped symlink targets must appear in the result.
         let dir = tempfile::tempdir().expect("create tempdir");
         let target = dir.path().join("real_zshrc");
         std::fs::write(&target, "config").expect("write");
@@ -1782,18 +1833,19 @@ mod tests {
         let canonical = link.canonicalize().expect("canonicalize");
         let paths: Vec<&str> = sensitive.iter().map(|r| r.expanded_path.as_str()).collect();
 
-        // Non-nix symlink: canonical target should always be included
+        // The canonical target is not in /nix/store, so it must be included
+        assert!(
+            !should_skip_resolved_deny_target(&canonical),
+            "precondition: tempdir canonical is not a nix store path"
+        );
+        assert!(
+            paths.contains(&link_str),
+            "sensitive paths must contain the symlink path"
+        );
         assert!(
             paths.contains(&canonical.to_str().expect("utf8")),
             "non-nix canonical target must be in sensitive paths"
         );
-
-        // Part 2: verify is_nix_store_path correctly identifies store paths
-        // (used by get_sensitive_paths to skip canonical targets on Linux)
-        assert!(is_nix_store_path(Path::new(
-            "/nix/store/abc123-home-manager-files/.zshrc"
-        )));
-        assert!(!is_nix_store_path(&canonical));
     }
 
     #[test]
@@ -2590,25 +2642,10 @@ mod tests {
     }
 
     #[test]
-    fn test_is_nix_store_path() {
-        assert!(is_nix_store_path(Path::new(
-            "/nix/store/abc123-some-package/bin/zsh"
-        )));
-        assert!(is_nix_store_path(Path::new("/nix/store/hash123-.zshrc")));
-        assert!(is_nix_store_path(Path::new("/nix/store")));
-
-        assert!(!is_nix_store_path(Path::new("/nix/var/nix/profiles")));
-        assert!(!is_nix_store_path(Path::new("/home/user/.zshrc")));
-        assert!(!is_nix_store_path(Path::new("/nix")));
-        assert!(!is_nix_store_path(Path::new("/nix/stored")));
-    }
-
-    #[test]
     fn test_deny_access_skips_nix_store_canonical_on_linux() {
-        // Create a temp dir to simulate a nix store symlink scenario.
-        // We can't create /nix/store in tests, so we test the helper
-        // function directly and verify the logic in add_deny_access_rules
-        // for non-nix paths still works correctly.
+        // Verify that add_deny_access_rules still includes canonical paths
+        // for non-Nix-store symlinks (the skip logic only fires for
+        // /nix/store targets, tested via should_skip_resolved_deny_target).
         let dir = tempfile::tempdir().expect("create tempdir");
         let target = dir.path().join("real_file");
         std::fs::write(&target, "content").expect("write target");
@@ -2620,8 +2657,15 @@ mod tests {
         let link_str = link.to_str().expect("valid utf8");
         add_deny_access_rules(link_str, &mut caps, &mut deny_paths).expect("add deny rules");
 
-        // For non-nix-store symlinks, both paths should still be in deny_paths
         let link_canonical = link.canonicalize().expect("canonicalize");
+
+        // Precondition: the canonical is not a nix store path
+        assert!(
+            !should_skip_resolved_deny_target(&link_canonical),
+            "precondition: tempdir canonical is not a nix store path"
+        );
+
+        // Both the symlink and its canonical target should be in deny_paths
         assert!(
             deny_paths.contains(&link),
             "deny_paths must contain the symlink path"

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -211,6 +211,17 @@ pub(crate) fn expand_path(path_str: &str) -> Result<PathBuf> {
     Ok(PathBuf::from(expanded))
 }
 
+/// Check whether a path resides inside the Nix store (`/nix/store`).
+///
+/// The Nix store is immutable by design — its contents are content-addressed
+/// and read-only. On NixOS with home-manager, shell config files such as
+/// `~/.zshrc` are often symlinks into `/nix/store/...`. Because these paths
+/// cannot be modified at runtime, deny rules targeting them for secret
+/// protection are unnecessary.
+fn is_nix_store_path(path: &Path) -> bool {
+    path.starts_with("/nix/store")
+}
+
 /// Convert a PathBuf to a UTF-8 string, returning an error for non-UTF-8 paths.
 ///
 /// Non-UTF-8 paths would produce incorrect Seatbelt rules via lossy conversion,
@@ -556,7 +567,21 @@ pub(crate) fn add_deny_access_rules(
     let canonical = path.canonicalize().ok();
     if let Some(ref canonical) = canonical {
         if *canonical != path {
-            deny_paths.push(canonical.clone());
+            // On NixOS with home-manager, shell config files (e.g. ~/.zshrc) are
+            // symlinks into /nix/store/..., which is immutable. Adding the canonical
+            // path to deny_paths would cause a Landlock deny-overlap error when
+            // /nix/store is allowed for read. Since Nix store paths are immutable
+            // and cannot contain runtime secrets, skip adding the canonical form
+            // to deny_paths on Linux — the original symlink path is still denied.
+            if cfg!(target_os = "linux") && is_nix_store_path(canonical) {
+                debug!(
+                    "Skipping deny canonical path '{}' (Nix store immutable symlink target of '{}')",
+                    canonical.display(),
+                    path.display(),
+                );
+            } else {
+                deny_paths.push(canonical.clone());
+            }
         }
     }
 
@@ -2507,6 +2532,68 @@ mod tests {
             deny_paths.is_empty(),
             "both symlink and target deny paths should be removed, remaining: {:?}",
             deny_paths
+        );
+    }
+
+    #[test]
+    fn test_is_nix_store_path() {
+        assert!(is_nix_store_path(Path::new(
+            "/nix/store/abc123-some-package/bin/zsh"
+        )));
+        assert!(is_nix_store_path(Path::new("/nix/store/hash123-.zshrc")));
+        assert!(is_nix_store_path(Path::new("/nix/store")));
+
+        assert!(!is_nix_store_path(Path::new("/nix/var/nix/profiles")));
+        assert!(!is_nix_store_path(Path::new("/home/user/.zshrc")));
+        assert!(!is_nix_store_path(Path::new("/nix")));
+        assert!(!is_nix_store_path(Path::new("/nix/stored")));
+    }
+
+    #[test]
+    fn test_deny_access_skips_nix_store_canonical_on_linux() {
+        // Create a temp dir to simulate a nix store symlink scenario.
+        // We can't create /nix/store in tests, so we test the helper
+        // function directly and verify the logic in add_deny_access_rules
+        // for non-nix paths still works correctly.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("real_file");
+        std::fs::write(&target, "content").expect("write target");
+        let link = dir.path().join("link_file");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let mut caps = CapabilitySet::new();
+        let mut deny_paths = Vec::new();
+        let link_str = link.to_str().expect("valid utf8");
+        add_deny_access_rules(link_str, &mut caps, &mut deny_paths).expect("add deny rules");
+
+        // For non-nix-store symlinks, both paths should still be in deny_paths
+        let link_canonical = link.canonicalize().expect("canonicalize");
+        assert!(
+            deny_paths.contains(&link),
+            "deny_paths must contain the symlink path"
+        );
+        assert!(
+            deny_paths.contains(&link_canonical),
+            "non-nix-store canonical should still be added to deny_paths"
+        );
+    }
+
+    #[test]
+    fn test_nix_runtime_group_includes_nix_store() {
+        let json = crate::config::embedded::embedded_policy_json();
+        let policy = load_policy(json).expect("parse policy.json");
+        let group = policy
+            .groups
+            .get("nix_runtime")
+            .expect("nix_runtime group must exist");
+        let read_paths = &group
+            .allow
+            .as_ref()
+            .expect("nix_runtime must have allow block")
+            .read;
+        assert!(
+            read_paths.contains(&"/nix/store".to_string()),
+            "nix_runtime group must include /nix/store for NixOS compatibility"
         );
     }
 }

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -478,7 +478,7 @@ nono ships with 32 built-in groups:
 - `rust_runtime` - rustup, cargo
 - `python_runtime` - pyenv, conda, pip, uv
 - `go_runtime` - ~/go, /usr/local/go
-- `nix_runtime` - Nix profile paths, /nix/var (Linux only)
+- `nix_runtime` - Nix profile paths, /nix/store, /nix/var (Linux only)
 - `user_tools` - Local bins, .desktop files, man pages, shell completions
 - `homebrew` - /opt/homebrew, /usr/local/Cellar, /usr/local/opt (macOS only)
 


### PR DESCRIPTION
- Add /nix/store to the nix_runtime group's allowed read paths in policy.json.
- The Nix store is immutable, making its contents safe to read and necessary for various runtime components on NixOS.
- Introduce `is_nix_store_path` helper to detect paths residing within `/nix/store`.
- Update `add_deny_access_rules` to skip adding canonical symlink targets in `/nix/store` to deny rules on Linux.
- This prevents Landlock deny-overlap errors when `/nix/store` is globally allowed for read, as Nix store paths are immutable and cannot contain runtime secrets.
- Update documentation for the `nix_runtime` group to reflect the `/nix/store` allowance.
- Add new unit tests for `is_nix_store_path` and `nix_runtime` group content.

Signed-off-by: Luke Hinds <lukehinds@gmail.com>