### PR TITLE
fix: (launch service) keyring read-write access to macOS keychain files

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -430,8 +430,9 @@
       "description": "Claude Code macOS-specific state and credential paths",
       "platform": "macos",
       "allow": {
-        "read": [
-          "$HOME/Library/Keychains/login.keychain-db"
+        "readwrite": [
+          "$HOME/Library/Keychains/login.keychain-db",
+          "$HOME/Library/Keychains/metadata.keychain-db"
         ]
       }
     },
@@ -448,8 +449,9 @@
       "description": "Codex macOS-specific state and credential paths",
       "platform": "macos",
       "allow": {
-        "read": [
-          "$HOME/Library/Keychains/login.keychain-db"
+        "readwrite": [
+          "$HOME/Library/Keychains/login.keychain-db",
+          "$HOME/Library/Keychains/metadata.keychain-db"
         ]
       }
     },
@@ -665,7 +667,11 @@
       },
       "filesystem": {
         "allow": ["$HOME/.claude", "$HOME/.cache/claude"],
-        "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"]
+        "allow_file": [
+          "$HOME/.claude.json",
+          "$HOME/.claude.json.lock",
+          "$HOME/.claude.lock"
+        ]
       },
       "network": { "block": false },
       "workdir": { "access": "readwrite" },

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -77,26 +77,15 @@ fn new_future_file_capability(path: &Path, access: AccessMode) -> Result<FsCapab
 
 #[cfg(target_os = "macos")]
 fn resolve_missing_leaf_path(path: &Path) -> Result<PathBuf> {
-    let mut suffix = Vec::new();
-    let mut current = path;
-
-    loop {
-        match current.canonicalize() {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
             Ok(mut canonical) => {
-                for part in suffix.iter().rev() {
-                    canonical.push(part);
+                if let Ok(relative) = path.strip_prefix(ancestor) {
+                    canonical.push(relative);
                 }
                 return Ok(canonical);
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                let name = current
-                    .file_name()
-                    .ok_or_else(|| NonoError::PathNotFound(path.to_path_buf()))?;
-                suffix.push(name.to_os_string());
-                current = current
-                    .parent()
-                    .ok_or_else(|| NonoError::PathNotFound(path.to_path_buf()))?;
-            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
             Err(err) => {
                 return Err(NonoError::PathCanonicalization {
                     path: path.to_path_buf(),
@@ -105,6 +94,8 @@ fn resolve_missing_leaf_path(path: &Path) -> Result<PathBuf> {
             }
         }
     }
+
+    Err(NonoError::PathNotFound(path.to_path_buf()))
 }
 
 fn apply_profile_dir_allows(

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -29,11 +29,81 @@ fn try_new_dir(path: &Path, access: AccessMode, label: &str) -> Result<Option<Fs
 fn try_new_file(path: &Path, access: AccessMode, label: &str) -> Result<Option<FsCapability>> {
     match FsCapability::new_file(path, access) {
         Ok(cap) => Ok(Some(cap)),
-        Err(NonoError::PathNotFound(_)) => {
-            warn!("{}: {}", label, path.display());
-            Ok(None)
-        }
+        Err(NonoError::PathNotFound(_)) => handle_missing_file_capability(path, access, label),
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn handle_missing_file_capability(
+    path: &Path,
+    access: AccessMode,
+    _label: &str,
+) -> Result<Option<FsCapability>> {
+    let cap = new_future_file_capability(path, access)?;
+    debug!(
+        "Granting future exact file capability on macOS for missing path: {}",
+        path.display()
+    );
+    Ok(Some(cap))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn handle_missing_file_capability(
+    path: &Path,
+    _access: AccessMode,
+    label: &str,
+) -> Result<Option<FsCapability>> {
+    warn!("{}: {}", label, path.display());
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn new_future_file_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_err(NonoError::Io)?.join(path)
+    };
+
+    Ok(FsCapability {
+        original: path.to_path_buf(),
+        resolved: resolve_missing_leaf_path(&absolute)?,
+        access,
+        is_file: true,
+        source: CapabilitySource::User,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_missing_leaf_path(path: &Path) -> Result<PathBuf> {
+    let mut suffix = Vec::new();
+    let mut current = path;
+
+    loop {
+        match current.canonicalize() {
+            Ok(mut canonical) => {
+                for part in suffix.iter().rev() {
+                    canonical.push(part);
+                }
+                return Ok(canonical);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let name = current
+                    .file_name()
+                    .ok_or_else(|| NonoError::PathNotFound(path.to_path_buf()))?;
+                suffix.push(name.to_os_string());
+                current = current
+                    .parent()
+                    .ok_or_else(|| NonoError::PathNotFound(path.to_path_buf()))?;
+            }
+            Err(err) => {
+                return Err(NonoError::PathCanonicalization {
+                    path: path.to_path_buf(),
+                    source: err,
+                });
+            }
+        }
     }
 }
 
@@ -90,6 +160,11 @@ pub(crate) fn default_profile_groups() -> Result<Vec<String>> {
     let profile = crate::policy::get_policy_profile("default")?
         .ok_or_else(|| NonoError::ProfileNotFound("default".to_string()))?;
     Ok(profile.security.groups)
+}
+
+#[must_use]
+pub(crate) fn retains_missing_exact_file_grants() -> bool {
+    cfg!(target_os = "macos")
 }
 
 /// Extension trait for CapabilitySet to add CLI-specific construction methods.
@@ -764,6 +839,79 @@ mod tests {
                 cap.is_file && cap.access == AccessMode::Read && cap.resolved == resolved_file
             }),
             "filesystem.read file entries should be granted as read-only file capabilities"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_from_profile_allow_file_keeps_missing_exact_file_on_macos() {
+        let dir = tempdir().expect("tmpdir");
+        let missing_file = dir.path().join("future.lock");
+        let expected_resolved = dir.path().canonicalize().expect("canonicalize dir").join(
+            missing_file
+                .file_name()
+                .expect("future file should have file name"),
+        );
+
+        let profile_path = dir.path().join("missing-file-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                "meta": {{ "name": "missing-file-profile" }},
+                "filesystem": {{ "allow_file": ["{}"] }}
+            }}"#,
+                missing_file.display()
+            ),
+        )
+        .expect("write profile");
+
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            caps.fs_capabilities().iter().any(|cap| {
+                cap.is_file
+                    && cap.access == AccessMode::ReadWrite
+                    && cap.original == missing_file
+                    && cap.resolved == expected_resolved
+            }),
+            "macOS profiles should preserve explicit missing exact-file grants"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_from_args_allow_file_resolves_parent_symlinks_for_missing_file_on_macos() {
+        let dir = tempdir().expect("tmpdir");
+        let target_dir = dir.path().join("target");
+        let link_dir = dir.path().join("link");
+        std::fs::create_dir_all(&target_dir).expect("create target dir");
+        std::os::unix::fs::symlink(&target_dir, &link_dir).expect("create symlink");
+
+        let missing_file = link_dir.join("future.lock");
+        let resolved_file = target_dir
+            .canonicalize()
+            .expect("canonicalize target dir")
+            .join("future.lock");
+        let args = SandboxArgs {
+            allow_file: vec![missing_file.clone()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("build caps");
+
+        assert!(
+            caps.fs_capabilities().iter().any(|cap| {
+                cap.is_file
+                    && cap.access == AccessMode::ReadWrite
+                    && cap.original == missing_file
+                    && cap.resolved == resolved_file
+            }),
+            "macOS CLI exact-file grants should preserve original path and resolve parent symlinks"
         );
     }
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -513,8 +513,8 @@ fn finalize_caps(
     policy::validate_deny_overlaps(&resolved.deny_paths, caps)?;
 
     // Keep broad keychain deny groups active, but allow explicit
-    // login.keychain-db read grants (profile/CLI) on macOS.
-    policy::apply_macos_login_keychain_exception(caps);
+    // keychain DB read grants (profile/CLI) on macOS.
+    policy::apply_macos_keychain_db_exception(caps);
 
     // Deduplicate capabilities
     caps.deduplicate();

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1283,8 +1283,16 @@ mod tests {
             .contains(&"$HOME/.local/share/claude".to_string()));
         assert!(!profile
             .filesystem
-            .read_file
+            .allow_file
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+        assert!(!profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        assert!(profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/.claude.lock".to_string()));
     }
 
     #[test]
@@ -1296,12 +1304,15 @@ mod tests {
             .get("claude_code_macos")
             .expect("claude_code_macos group missing");
         assert_eq!(claude_code_macos.platform.as_deref(), Some("macos"));
-        assert!(claude_code_macos
+        let claude_code_macos_paths = &claude_code_macos
             .allow
             .as_ref()
             .expect("claude_code_macos allow missing")
-            .read
+            .readwrite;
+        assert!(claude_code_macos_paths
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+        assert!(claude_code_macos_paths
+            .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
 
         let claude_code_linux = policy
             .groups

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -674,26 +674,35 @@ pub(crate) fn add_deny_access_rules(
     Ok(())
 }
 
-/// Add a narrow macOS exception for explicit login.keychain-db file grants.
+/// Add a narrow macOS exception for explicit keychain DB file grants.
 ///
 /// This keeps broad keychain deny groups active while allowing only the exact
 /// file capability intended by a profile or CLI flag.
-pub fn apply_macos_login_keychain_exception(caps: &mut CapabilitySet) {
+pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
     if !cfg!(target_os = "macos") {
         return;
     }
 
-    let user_login_db = std::env::var("HOME")
-        .ok()
-        .map(|home| Path::new(&home).join("Library/Keychains/login.keychain-db"));
-    let system_login_db = Path::new("/Library/Keychains/login.keychain-db");
+    let user_keychain_dbs = std::env::var("HOME").ok().map(|home| {
+        [
+            Path::new(&home).join("Library/Keychains/login.keychain-db"),
+            Path::new(&home).join("Library/Keychains/metadata.keychain-db"),
+        ]
+    });
+    let system_keychain_dbs = [
+        Path::new("/Library/Keychains/login.keychain-db").to_path_buf(),
+        Path::new("/Library/Keychains/metadata.keychain-db").to_path_buf(),
+    ];
 
-    let is_login_db = |path: &Path| -> bool {
-        if path == system_login_db {
+    let is_keychain_db = |path: &Path| -> bool {
+        if system_keychain_dbs
+            .iter()
+            .any(|candidate| path == candidate)
+        {
             return true;
         }
-        if let Some(ref user_login_db) = user_login_db {
-            if path == user_login_db {
+        if let Some(ref user_keychain_dbs) = user_keychain_dbs {
+            if user_keychain_dbs.iter().any(|candidate| path == candidate) {
                 return true;
             }
         }
@@ -706,13 +715,13 @@ pub fn apply_macos_login_keychain_exception(caps: &mut CapabilitySet) {
         .filter(|cap| cap.is_file)
         .filter(|cap| matches!(cap.access, AccessMode::Read | AccessMode::ReadWrite))
         .map(|cap| cap.resolved.clone())
-        .filter(|path| is_login_db(path))
+        .filter(|path| is_keychain_db(path))
         .filter_map(|path| {
             let path_str = match path_to_utf8(&path) {
                 Ok(s) => s,
                 Err(e) => {
                     warn!(
-                        "Skipping login keychain exception for {}: {}",
+                        "Skipping keychain DB exception for {}: {}",
                         path.display(),
                         e
                     );
@@ -723,7 +732,7 @@ pub fn apply_macos_login_keychain_exception(caps: &mut CapabilitySet) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!(
-                        "Skipping login keychain exception for {}: {}",
+                        "Skipping keychain DB exception for {}: {}",
                         path.display(),
                         e
                     );
@@ -736,7 +745,7 @@ pub fn apply_macos_login_keychain_exception(caps: &mut CapabilitySet) {
 
     for rule in allow_rules {
         if let Err(e) = caps.add_platform_rule(rule) {
-            warn!("Failed to add login keychain exception rule: {}", e);
+            warn!("Failed to add keychain DB exception rule: {}", e);
         }
     }
 }
@@ -2459,6 +2468,61 @@ mod tests {
         assert!(
             rules.contains("subpath"),
             "should use subpath for directory, got: {}",
+            rules
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_macos_keychain_db_exception_adds_login_db_allow_rule() {
+        let mut caps = CapabilitySet::new();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
+        let login_db = PathBuf::from(home).join("Library/Keychains/login.keychain-db");
+        caps.add_fs(FsCapability {
+            original: login_db.clone(),
+            resolved: login_db.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Profile,
+        });
+
+        apply_macos_keychain_db_exception(&mut caps);
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            rules.contains(&format!(
+                "(allow file-read-data (literal \"{}\"))",
+                escape_seatbelt_path(login_db.to_str().expect("utf8 path")).expect("escaped path")
+            )),
+            "expected login keychain DB exception rule, got: {}",
+            rules
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_macos_keychain_db_exception_adds_metadata_db_allow_rule() {
+        let mut caps = CapabilitySet::new();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
+        let metadata_db = PathBuf::from(home).join("Library/Keychains/metadata.keychain-db");
+        caps.add_fs(FsCapability {
+            original: metadata_db.clone(),
+            resolved: metadata_db.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Profile,
+        });
+
+        apply_macos_keychain_db_exception(&mut caps);
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            rules.contains(&format!(
+                "(allow file-read-data (literal \"{}\"))",
+                escape_seatbelt_path(metadata_db.to_str().expect("utf8 path"))
+                    .expect("escaped path")
+            )),
+            "expected metadata keychain DB exception rule, got: {}",
             rules
         );
     }

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -35,6 +35,10 @@ mod tests {
             .filesystem
             .allow
             .contains(&"$HOME/.cache/claude".to_string()));
+        assert!(profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/.claude.lock".to_string()));
     }
 
     #[test]
@@ -71,8 +75,16 @@ mod tests {
             .contains(&"$HOME/.local/share/claude".to_string()));
         assert!(!profile
             .filesystem
-            .read_file
+            .allow_file
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+        assert!(!profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        assert!(profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/.claude.lock".to_string()));
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -34,17 +34,17 @@ fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {
         }
     }
     for path in &args.allow_file {
-        if !path.exists() {
+        if !path.exists() && !capability_ext::retains_missing_exact_file_grants() {
             missing.push(format!("--allow-file {}", path.display()));
         }
     }
     for path in &args.read_file {
-        if !path.exists() {
+        if !path.exists() && !capability_ext::retains_missing_exact_file_grants() {
             missing.push(format!("--read-file {}", path.display()));
         }
     }
     for path in &args.write_file {
-        if !path.exists() {
+        if !path.exists() && !capability_ext::retains_missing_exact_file_grants() {
             missing.push(format!("--write-file {}", path.display()));
         }
     }
@@ -411,4 +411,42 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         args,
         silent,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn missing_exact_file_cli_grants_are_not_reported_as_skipped() {
+        let dir = tempdir().expect("tmpdir");
+        let args = SandboxArgs {
+            allow_file: vec![dir.path().join("future.lock")],
+            ..SandboxArgs::default()
+        };
+
+        assert!(
+            collect_missing_cli_requested_paths(&args).is_empty(),
+            "macOS exact-file grants should not be reported as skipped when the file is absent"
+        );
+    }
+
+    #[test]
+    fn missing_directory_cli_grants_are_reported_as_skipped() {
+        let dir = tempdir().expect("tmpdir");
+        let args = SandboxArgs {
+            allow: vec![dir.path().join("future-dir")],
+            ..SandboxArgs::default()
+        };
+
+        assert_eq!(
+            collect_missing_cli_requested_paths(&args),
+            vec![format!(
+                "--allow {}",
+                dir.path().join("future-dir").display()
+            )]
+        );
+    }
 }

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -247,21 +247,30 @@ fn path_filters_for_cap(cap: &crate::capability::FsCapability) -> Result<Vec<Str
     Ok(filters)
 }
 
-/// Returns true if the capability set explicitly grants access to the login keychain DB.
+/// Returns true if the capability set explicitly grants access to a keychain DB.
 ///
 /// This is a narrow opt-in for tools that need OAuth/session refresh via macOS Keychain.
-fn has_explicit_login_keychain_db_access(caps: &CapabilitySet) -> bool {
-    let user_login_db = std::env::var("HOME")
-        .ok()
-        .map(|home| Path::new(&home).join("Library/Keychains/login.keychain-db"));
-    let system_login_db = Path::new("/Library/Keychains/login.keychain-db");
+fn has_explicit_keychain_db_access(caps: &CapabilitySet) -> bool {
+    let user_keychain_dbs = std::env::var("HOME").ok().map(|home| {
+        [
+            Path::new(&home).join("Library/Keychains/login.keychain-db"),
+            Path::new(&home).join("Library/Keychains/metadata.keychain-db"),
+        ]
+    });
+    let system_keychain_dbs = [
+        Path::new("/Library/Keychains/login.keychain-db").to_path_buf(),
+        Path::new("/Library/Keychains/metadata.keychain-db").to_path_buf(),
+    ];
 
-    let is_login_db = |path: &Path| -> bool {
-        if path == system_login_db {
+    let is_keychain_db = |path: &Path| -> bool {
+        if system_keychain_dbs
+            .iter()
+            .any(|candidate| path == candidate)
+        {
             return true;
         }
-        if let Some(ref user_login_db) = user_login_db {
-            if path == user_login_db {
+        if let Some(ref user_keychain_dbs) = user_keychain_dbs {
+            if user_keychain_dbs.iter().any(|candidate| path == candidate) {
                 return true;
             }
         }
@@ -270,7 +279,7 @@ fn has_explicit_login_keychain_db_access(caps: &CapabilitySet) -> bool {
 
     caps.fs_capabilities()
         .iter()
-        .any(|cap| is_login_db(&cap.original) || is_login_db(&cap.resolved))
+        .any(|cap| is_keychain_db(&cap.original) || is_keychain_db(&cap.resolved))
 }
 
 /// Escape a path for use in Seatbelt profile strings.
@@ -344,13 +353,13 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     profile.push_str("(allow sysctl-read)\n");
 
     // Mach IPC: allow service resolution. Deny Keychain/security services by default.
-    // If login.keychain-db is explicitly granted, skip these denies so profiles that
+    // If a keychain DB is explicitly granted, skip these denies so profiles that
     // intentionally rely on macOS Keychain OAuth refresh can work.
     //
     // Without these denies, blanket mach-lookup can permit Keychain retrieval via
     // Mach IPC, bypassing file-level deny rules in profiles that do NOT opt in.
     profile.push_str("(allow mach-lookup)\n");
-    if !has_explicit_login_keychain_db_access(caps) {
+    if !has_explicit_keychain_db_access(caps) {
         profile.push_str("(deny mach-lookup (global-name \"com.apple.SecurityServer\"))\n");
         profile.push_str("(deny mach-lookup (global-name \"com.apple.securityd\"))\n");
     }
@@ -957,14 +966,14 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_profile_keeps_keychain_mach_deny_for_non_login_keychain_paths() {
+    fn test_generate_profile_skips_keychain_mach_deny_for_metadata_keychain_db() {
         let mut caps = CapabilitySet::new();
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
-        let other_keychain_file =
+        let metadata_keychain_db =
             PathBuf::from(home).join("Library/Keychains/metadata.keychain-db");
         caps.add_fs(FsCapability {
-            original: other_keychain_file.clone(),
-            resolved: other_keychain_file,
+            original: metadata_keychain_db.clone(),
+            resolved: metadata_keychain_db,
             access: AccessMode::Read,
             is_file: true,
             source: CapabilitySource::Profile,
@@ -972,8 +981,8 @@ mod tests {
 
         let profile = generate_profile(&caps).unwrap();
 
-        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.SecurityServer\"))"));
-        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.securityd\"))"));
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.SecurityServer\"))"));
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.securityd\"))"));
     }
 
     #[test]

--- a/scripts/claude-auth-state.sh
+++ b/scripts/claude-auth-state.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# Inspect and mutate Claude auth state using the same path rules Claude uses.
+#
+# This script mirrors Claude's auth storage resolution closely enough to test:
+# - access-token expiry (forces refresh)
+# - refresh-token failure
+# - missing access token
+# - local logout state
+#
+# The `--claude-config-dir` flag models `CLAUDE_CONFIG_DIR` being explicitly
+# set. That matters even when the value is "$HOME/.claude", because Claude
+# hashes the explicit config dir into the macOS keychain service name and also
+# changes the fallback global config path.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/claude-auth-state.sh --mode MODE [--claude-config-dir DIR]
+
+Modes:
+  show
+      Print the resolved Claude auth paths and keychain service names.
+
+  expire-access
+      Set claudeAiOauth.expiresAt=0 to force Claude into its refresh path.
+
+  break-refresh
+      Set expiresAt=0 and replace refreshToken with an invalid value.
+
+  drop-access-token
+      Remove claudeAiOauth.accessToken so Claude treats stored OAuth as absent.
+
+  logout-local
+      Delete local OAuth storage, remove the legacy API key, and clear
+      oauthAccount/primaryApiKey in global config.
+
+Notes:
+  - If --claude-config-dir is omitted, this script uses the default Claude
+    config layout rooted at "$HOME/.claude".
+  - If --claude-config-dir is provided, this script models
+    CLAUDE_CONFIG_DIR=DIR being set for Claude itself, even if DIR is
+    "$HOME/.claude".
+  - On macOS, the keychain entry is primary and plaintext credentials are the
+    fallback. Mutation modes update both when both exist.
+
+Examples:
+  ./scripts/claude-auth-state.sh --mode show
+  ./scripts/claude-auth-state.sh --mode expire-access
+  ./scripts/claude-auth-state.sh --mode break-refresh --claude-config-dir /tmp/claude-auth
+  ./scripts/claude-auth-state.sh --mode logout-local
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+note() {
+    printf '%s\n' "$*"
+}
+
+is_truthy() {
+    local value
+    value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+    case "$value" in
+        1|true|yes|on)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+hash_prefix() {
+    local input="$1"
+
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$input" | shasum -a 256 | awk '{print substr($1, 1, 8)}'
+        return
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$input" | sha256sum | awk '{print substr($1, 1, 8)}'
+        return
+    fi
+
+    perl -MDigest::SHA=sha256_hex -e '
+        use strict;
+        use warnings;
+        local $/;
+        my $value = <STDIN>;
+        print substr(sha256_hex($value // q{}), 0, 8);
+    '
+}
+
+oauth_file_suffix() {
+    if [[ -n "${CLAUDE_CODE_CUSTOM_OAUTH_URL:-}" ]]; then
+        printf '%s' '-custom-oauth'
+        return
+    fi
+
+    if [[ "${USER_TYPE:-}" == "ant" ]]; then
+        if is_truthy "${USE_LOCAL_OAUTH:-}"; then
+            printf '%s' '-local-oauth'
+            return
+        fi
+        if is_truthy "${USE_STAGING_OAUTH:-}"; then
+            printf '%s' '-staging-oauth'
+            return
+        fi
+    fi
+
+    printf '%s' ''
+}
+
+get_username() {
+    if [[ -n "${USER:-}" ]]; then
+        printf '%s' "$USER"
+        return
+    fi
+
+    if id -un >/dev/null 2>&1; then
+        id -un
+        return
+    fi
+
+    printf '%s' 'claude-code-user'
+}
+
+is_macos() {
+    [[ "$(uname -s)" == "Darwin" ]]
+}
+
+config_dir="$HOME/.claude"
+config_dir_explicit=0
+mode=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode)
+            [[ $# -ge 2 ]] || fail "--mode requires a value"
+            mode="$2"
+            shift 2
+            ;;
+        --claude-config-dir)
+            [[ $# -ge 2 ]] || fail "--claude-config-dir requires a value"
+            config_dir="$2"
+            config_dir_explicit=1
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ -n "$mode" ]] || fail "--mode is required"
+
+oauth_suffix="$(oauth_file_suffix)"
+credentials_path="$config_dir/.credentials.json"
+legacy_config_path="$config_dir/.config.json"
+
+global_config_path() {
+    if [[ -f "$legacy_config_path" ]]; then
+        printf '%s' "$legacy_config_path"
+        return
+    fi
+
+    if [[ "$config_dir_explicit" -eq 1 ]]; then
+        printf '%s/.claude%s.json' "$config_dir" "$oauth_suffix"
+        return
+    fi
+
+    printf '%s/.claude%s.json' "$HOME" "$oauth_suffix"
+}
+
+keychain_service_name() {
+    local service_suffix="$1"
+    local dir_hash=""
+
+    if [[ "$config_dir_explicit" -eq 1 ]]; then
+        dir_hash="-$(hash_prefix "$config_dir")"
+    fi
+
+    printf 'Claude Code%s%s%s' "$oauth_suffix" "$service_suffix" "$dir_hash"
+}
+
+oauth_keychain_service="$(keychain_service_name '-credentials')"
+api_key_keychain_service="$(keychain_service_name '')"
+username="$(get_username)"
+global_config="$(global_config_path)"
+
+backup_dir=""
+
+ensure_backup_dir() {
+    if [[ -n "$backup_dir" ]]; then
+        return
+    fi
+
+    local old_umask
+    old_umask="$(umask)"
+    umask 077
+    backup_dir="$(mktemp -d "${TMPDIR:-/tmp}/claude-auth-state.XXXXXX")"
+    umask "$old_umask"
+}
+
+backup_contents() {
+    local name="$1"
+    local contents="$2"
+    ensure_backup_dir
+    printf '%s' "$contents" > "$backup_dir/$name"
+    chmod 600 "$backup_dir/$name" 2>/dev/null || true
+}
+
+backup_file() {
+    local path="$1"
+    local name="$2"
+    [[ -f "$path" ]] || return 0
+
+    ensure_backup_dir
+    cp "$path" "$backup_dir/$name"
+    chmod 600 "$backup_dir/$name" 2>/dev/null || true
+}
+
+keychain_item_exists() {
+    local service_name="$1"
+
+    is_macos || return 1
+    security find-generic-password -a "$username" -w -s "$service_name" >/dev/null 2>&1
+}
+
+read_keychain_item() {
+    local service_name="$1"
+    security find-generic-password -a "$username" -w -s "$service_name"
+}
+
+write_keychain_item() {
+    local service_name="$1"
+    local value="$2"
+    local hex_value
+
+    hex_value="$(
+        printf '%s' "$value" | perl -e '
+            use strict;
+            use warnings;
+            local $/;
+            my $input = <STDIN>;
+            print unpack("H*", $input // q{});
+        '
+    )"
+
+    security add-generic-password -U -a "$username" -s "$service_name" -X "$hex_value" >/dev/null
+}
+
+delete_keychain_item() {
+    local service_name="$1"
+    security delete-generic-password -a "$username" -s "$service_name" >/dev/null 2>&1
+}
+
+mutate_oauth_storage_json() {
+    local requested_mode="$1"
+
+    perl -MJSON::PP -e '
+        use strict;
+        use warnings;
+
+        my $mode = shift @ARGV;
+        local $/;
+        my $input = <STDIN>;
+        die "missing JSON input\n" if !defined($input) || $input eq q{};
+
+        my $json = JSON::PP->new->ascii->canonical->pretty;
+        my $data = $json->decode($input);
+        die "expected JSON object\n" if ref($data) ne q{HASH};
+
+        my $oauth = $data->{claudeAiOauth};
+        die "claudeAiOauth is missing\n" if ref($oauth) ne q{HASH};
+
+        if ($mode eq q{expire-access}) {
+            $oauth->{expiresAt} = 0;
+        } elsif ($mode eq q{break-refresh}) {
+            $oauth->{expiresAt} = 0;
+            $oauth->{refreshToken} = q{invalid-refresh-token};
+        } elsif ($mode eq q{drop-access-token}) {
+            delete $oauth->{accessToken};
+        } else {
+            die "unsupported mode: $mode\n";
+        }
+
+        print $json->encode($data);
+    ' "$requested_mode"
+}
+
+clear_global_auth_json() {
+    perl -MJSON::PP -e '
+        use strict;
+        use warnings;
+
+        local $/;
+        my $input = <STDIN>;
+        die "missing JSON input\n" if !defined($input) || $input eq q{};
+
+        my $json = JSON::PP->new->ascii->canonical->pretty;
+        my $data = $json->decode($input);
+        die "expected JSON object\n" if ref($data) ne q{HASH};
+
+        delete $data->{oauthAccount};
+        delete $data->{primaryApiKey};
+
+        print $json->encode($data);
+    '
+}
+
+write_credentials_file() {
+    local contents="$1"
+    mkdir -p "$config_dir"
+    printf '%s' "$contents" > "$credentials_path"
+    chmod 600 "$credentials_path" 2>/dev/null || true
+}
+
+show_state() {
+    note "Mode: show"
+    note "Config dir: $config_dir"
+    if [[ "$config_dir_explicit" -eq 1 ]]; then
+        note "CLAUDE_CONFIG_DIR semantics: explicit"
+    else
+        note "CLAUDE_CONFIG_DIR semantics: default"
+    fi
+    note "OAuth suffix: ${oauth_suffix:-<prod>}"
+    note "Credentials file: $credentials_path"
+    if [[ -f "$credentials_path" ]]; then
+        note "Credentials file exists: yes"
+    else
+        note "Credentials file exists: no"
+    fi
+    note "Global config file: $global_config"
+    if [[ -f "$global_config" ]]; then
+        note "Global config exists: yes"
+    else
+        note "Global config exists: no"
+    fi
+
+    if is_macos; then
+        note "OAuth keychain service: $oauth_keychain_service"
+        if keychain_item_exists "$oauth_keychain_service"; then
+            note "OAuth keychain entry exists: yes"
+        else
+            note "OAuth keychain entry exists: no"
+        fi
+
+        note "Legacy API key keychain service: $api_key_keychain_service"
+        if keychain_item_exists "$api_key_keychain_service"; then
+            note "Legacy API key keychain entry exists: yes"
+        else
+            note "Legacy API key keychain entry exists: no"
+        fi
+    else
+        note "Keychain inspection: skipped (non-macOS)"
+    fi
+
+    if [[ "$config_dir_explicit" -eq 1 ]]; then
+        printf 'Run Claude with: CLAUDE_CONFIG_DIR=%q claude\n' "$config_dir"
+    else
+        note "Run Claude with its default config dir."
+    fi
+}
+
+mutate_oauth_state() {
+    local requested_mode="$1"
+    local keychain_present=0
+    local keychain_original=""
+    local keychain_updated=""
+    local file_present=0
+    local file_original=""
+    local file_updated=""
+
+    if keychain_item_exists "$oauth_keychain_service"; then
+        keychain_present=1
+        keychain_original="$(read_keychain_item "$oauth_keychain_service")"
+        keychain_updated="$(printf '%s' "$keychain_original" | mutate_oauth_storage_json "$requested_mode")"
+    fi
+
+    if [[ -f "$credentials_path" ]]; then
+        file_present=1
+        file_original="$(cat "$credentials_path")"
+        file_updated="$(printf '%s' "$file_original" | mutate_oauth_storage_json "$requested_mode")"
+    fi
+
+    if [[ "$keychain_present" -eq 0 && "$file_present" -eq 0 ]]; then
+        fail "no stored OAuth credentials were found in keychain or $credentials_path"
+    fi
+
+    if [[ "$keychain_present" -eq 1 ]]; then
+        backup_contents "oauth-keychain.json" "$keychain_original"
+        write_keychain_item "$oauth_keychain_service" "$keychain_updated"
+        note "Updated OAuth keychain entry: $oauth_keychain_service"
+    fi
+
+    if [[ "$file_present" -eq 1 ]]; then
+        backup_file "$credentials_path" "credentials.json"
+        write_credentials_file "$file_updated"
+        note "Updated plaintext credentials: $credentials_path"
+    fi
+
+    note "Backup dir: $backup_dir (contains secrets)"
+}
+
+logout_local() {
+    local changed=0
+
+    if keychain_item_exists "$oauth_keychain_service"; then
+        backup_contents "oauth-keychain.json" "$(read_keychain_item "$oauth_keychain_service")"
+        delete_keychain_item "$oauth_keychain_service"
+        note "Deleted OAuth keychain entry: $oauth_keychain_service"
+        changed=1
+    fi
+
+    if keychain_item_exists "$api_key_keychain_service"; then
+        backup_contents "api-key-keychain.txt" "$(read_keychain_item "$api_key_keychain_service")"
+        delete_keychain_item "$api_key_keychain_service"
+        note "Deleted legacy API key keychain entry: $api_key_keychain_service"
+        changed=1
+    fi
+
+    if [[ -f "$credentials_path" ]]; then
+        backup_file "$credentials_path" "credentials.json"
+        rm -f "$credentials_path"
+        note "Deleted plaintext credentials: $credentials_path"
+        changed=1
+    fi
+
+    if [[ -f "$global_config" ]]; then
+        local global_original
+        local global_updated
+        global_original="$(cat "$global_config")"
+        global_updated="$(printf '%s' "$global_original" | clear_global_auth_json)"
+        backup_file "$global_config" "$(basename "$global_config")"
+        mkdir -p "$(dirname "$global_config")"
+        printf '%s' "$global_updated" > "$global_config"
+        chmod 600 "$global_config" 2>/dev/null || true
+        note "Cleared oauthAccount and primaryApiKey in: $global_config"
+        changed=1
+    fi
+
+    if [[ "$changed" -eq 0 ]]; then
+        note "No local Claude auth state was found to clear."
+        return
+    fi
+
+    note "Backup dir: $backup_dir (contains secrets)"
+}
+
+case "$mode" in
+    show)
+        show_state
+        ;;
+    expire-access|break-refresh|drop-access-token)
+        mutate_oauth_state "$mode"
+        ;;
+    logout-local)
+        logout_local
+        ;;
+    *)
+        fail "unsupported mode: $mode"
+        ;;
+esac

--- a/tests/integration/test_edge_cases.sh
+++ b/tests/integration/test_edge_cases.sh
@@ -130,8 +130,15 @@ echo "--- Non-existent Paths ---"
 expect_output_contains "grant non-existent directory is skipped with warning" "Skipping non-existent path" \
     "$NONO_BIN" run --allow /nonexistent/path/that/does/not/exist/anywhere -- echo "should run"
 
-expect_output_contains "grant non-existent file is skipped with warning" "Skipping non-existent file" \
-    "$NONO_BIN" run --read-file /nonexistent/file.txt -- echo "should run"
+if is_macos; then
+    expect_success "grant non-existent file is retained on macOS" \
+        "$NONO_BIN" run --read-file /nonexistent/file.txt -- echo "should run"
+    expect_output_not_contains "grant non-existent file does not warn on macOS" "Skipping non-existent file" \
+        "$NONO_BIN" run --read-file /nonexistent/file.txt -- echo "should run"
+else
+    expect_output_contains "grant non-existent file is skipped with warning" "Skipping non-existent file" \
+        "$NONO_BIN" run --read-file /nonexistent/file.txt -- echo "should run"
+fi
 
 # Reading a file that doesn't exist (but directory is allowed) should give normal "not found" error
 expect_failure "read non-existent file in allowed dir gives file error" \


### PR DESCRIPTION

- Update claude_code_macos and codex_macos policies to grant read-write access to macOS keychain files (login.keychain-db, metadata.keychain-db).
- This allows macOS applications to securely manage credentials using the system keychain.
- Add $HOME/.claude.lock to the claude policy's allow_file list.
- CLI-requested exact-file grants on macOS will no longer be reported as skipped if the file is missing.

Some fixes were rolled in that this work surfaced

- On macOS, grant file system capabilities for explicitly allowed files even if they do not exist yet.
- Previously, capabilities for non-existent files were skipped, causing issues for applications that create files like lock files or credential stores on demand.
- This change ensures that applications can create files such as $HOME/.claude.lock within their sandboxed environment.
- When a missing file path is granted, its parent directory is canonicalized, and the file name is appended.

Resolves: #559