### PR TITLE
fix: claude-code $home lockfile slop fix

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -34,6 +34,44 @@ fn try_new_file(path: &Path, access: AccessMode, label: &str) -> Result<Option<F
     }
 }
 
+/// Create a profile capability for an exact path that is usually expected to be a file.
+///
+/// Some clients use lock directories at paths that historically held lock files
+/// (for example `~/.claude.lock`). When that happens, we should grant access to
+/// that exact directory path rather than fail or widen to the whole home
+/// directory.
+fn try_new_profile_exact_path(
+    path: &Path,
+    access: AccessMode,
+    label: &str,
+    protected_roots: &ProtectedRoots,
+) -> Result<Option<FsCapability>> {
+    if std::fs::metadata(path)
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+    {
+        validate_requested_dir(path, "Profile", protected_roots)?;
+        debug!(
+            "Profile exact-file path exists as directory; granting exact directory access: {}",
+            path.display()
+        );
+        return try_new_dir(path, access, label);
+    }
+
+    validate_requested_file(path, "Profile", protected_roots)?;
+    match try_new_file(path, access, label) {
+        Err(NonoError::ExpectedFile(_)) => {
+            validate_requested_dir(path, "Profile", protected_roots)?;
+            debug!(
+                "Profile exact-file path resolved as directory; granting exact directory access: {}",
+                path.display()
+            );
+            try_new_dir(path, access, label)
+        }
+        result => result,
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn handle_missing_file_capability(
     path: &Path,
@@ -325,9 +363,10 @@ impl CapabilitySetExt for CapabilitySet {
         // Single files with read+write access
         for path_template in &fs.allow_file {
             let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::ReadWrite, &label)? {
+            if let Some(mut cap) =
+                try_new_profile_exact_path(&path, AccessMode::ReadWrite, &label, &protected_roots)?
+            {
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
             }
@@ -336,9 +375,10 @@ impl CapabilitySetExt for CapabilitySet {
         // Single files with read-only access
         for path_template in &fs.read_file {
             let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::Read, &label)? {
+            if let Some(mut cap) =
+                try_new_profile_exact_path(&path, AccessMode::Read, &label, &protected_roots)?
+            {
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
             }
@@ -347,9 +387,10 @@ impl CapabilitySetExt for CapabilitySet {
         // Single files with write-only access
         for path_template in &fs.write_file {
             let path = expand_vars(path_template, workdir)?;
-            validate_requested_file(&path, "Profile", &protected_roots)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) = try_new_file(&path, AccessMode::Write, &label)? {
+            if let Some(mut cap) =
+                try_new_profile_exact_path(&path, AccessMode::Write, &label, &protected_roots)?
+            {
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
             }
@@ -903,6 +944,43 @@ mod tests {
                     && cap.resolved == resolved_file
             }),
             "macOS CLI exact-file grants should preserve original path and resolve parent symlinks"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_allow_file_falls_back_to_exact_directory_when_present() {
+        let dir = tempdir().expect("tmpdir");
+        let lock_dir = dir.path().join("claude.lock");
+        std::fs::create_dir_all(&lock_dir).expect("create lock dir");
+        let resolved_dir = lock_dir.canonicalize().expect("canonicalize lock dir");
+
+        let profile_path = dir.path().join("lock-dir-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                "meta": {{ "name": "lock-dir-profile" }},
+                "filesystem": {{ "allow_file": ["{}"] }}
+            }}"#,
+                lock_dir.display()
+            ),
+        )
+        .expect("write profile");
+
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+
+        assert!(
+            caps.fs_capabilities().iter().any(|cap| {
+                !cap.is_file
+                    && cap.access == AccessMode::ReadWrite
+                    && cap.original == lock_dir
+                    && cap.resolved == resolved_dir
+            }),
+            "profiles should allow an exact directory path when an allow_file entry resolves to a directory"
         );
     }
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -37,39 +37,66 @@ fn try_new_file(path: &Path, access: AccessMode, label: &str) -> Result<Option<F
 /// Create a profile capability for an exact path that is usually expected to be a file.
 ///
 /// Some clients use lock directories at paths that historically held lock files
-/// (for example `~/.claude.lock`). When that happens, we should grant access to
-/// that exact directory path rather than fail or widen to the whole home
-/// directory.
+/// (for example `~/.claude.lock`). On macOS we can preserve exact-path semantics
+/// for that directory by emitting a literal path rule instead of widening to a
+/// recursive directory grant. On other platforms, fail closed.
 fn try_new_profile_exact_path(
     path: &Path,
     access: AccessMode,
     label: &str,
     protected_roots: &ProtectedRoots,
 ) -> Result<Option<FsCapability>> {
-    if std::fs::metadata(path)
-        .map(|metadata| metadata.is_dir())
-        .unwrap_or(false)
-    {
-        validate_requested_dir(path, "Profile", protected_roots)?;
-        debug!(
-            "Profile exact-file path exists as directory; granting exact directory access: {}",
-            path.display()
-        );
-        return try_new_dir(path, access, label);
-    }
-
     validate_requested_file(path, "Profile", protected_roots)?;
     match try_new_file(path, access, label) {
         Err(NonoError::ExpectedFile(_)) => {
-            validate_requested_dir(path, "Profile", protected_roots)?;
-            debug!(
-                "Profile exact-file path resolved as directory; granting exact directory access: {}",
-                path.display()
-            );
-            try_new_dir(path, access, label)
+            handle_exact_directory_path(path, access, protected_roots)
         }
         result => result,
     }
+}
+
+#[cfg(target_os = "macos")]
+fn handle_exact_directory_path(
+    path: &Path,
+    access: AccessMode,
+    protected_roots: &ProtectedRoots,
+) -> Result<Option<FsCapability>> {
+    validate_requested_dir(path, "Profile", protected_roots)?;
+    let resolved = path.canonicalize().map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            NonoError::PathNotFound(path.to_path_buf())
+        } else {
+            NonoError::PathCanonicalization {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+
+    debug!(
+        "Profile exact-file path resolved as directory; granting exact macOS literal path access: {}",
+        path.display()
+    );
+
+    Ok(Some(FsCapability {
+        original: path.to_path_buf(),
+        resolved,
+        access,
+        // On macOS, `is_file = true` makes Seatbelt emit a literal path rule
+        // rather than a recursive subpath rule. The target may still be a
+        // directory; the important property is exact-path matching.
+        is_file: true,
+        source: CapabilitySource::Profile,
+    }))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn handle_exact_directory_path(
+    path: &Path,
+    _access: AccessMode,
+    _protected_roots: &ProtectedRoots,
+) -> Result<Option<FsCapability>> {
+    Err(NonoError::ExpectedFile(path.to_path_buf()))
 }
 
 #[cfg(target_os = "macos")]
@@ -947,12 +974,14 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_from_profile_allow_file_falls_back_to_exact_directory_when_present() {
         let dir = tempdir().expect("tmpdir");
         let lock_dir = dir.path().join("claude.lock");
         std::fs::create_dir_all(&lock_dir).expect("create lock dir");
         let resolved_dir = lock_dir.canonicalize().expect("canonicalize lock dir");
+        let child = lock_dir.join("nested.txt");
 
         let profile_path = dir.path().join("lock-dir-profile.json");
         std::fs::write(
@@ -975,12 +1004,47 @@ mod tests {
 
         assert!(
             caps.fs_capabilities().iter().any(|cap| {
-                !cap.is_file
+                cap.is_file
                     && cap.access == AccessMode::ReadWrite
                     && cap.original == lock_dir
                     && cap.resolved == resolved_dir
             }),
-            "profiles should allow an exact directory path when an allow_file entry resolves to a directory"
+            "macOS profiles should preserve exact-path semantics when an allow_file entry resolves to a directory"
+        );
+        assert!(
+            !caps.path_covered(&child),
+            "exact-path fallback must not recursively cover descendants"
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_from_profile_allow_file_rejects_directory_when_exact_dir_unsupported() {
+        let dir = tempdir().expect("tmpdir");
+        let lock_dir = dir.path().join("claude.lock");
+        std::fs::create_dir_all(&lock_dir).expect("create lock dir");
+
+        let profile_path = dir.path().join("lock-dir-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                "meta": {{ "name": "lock-dir-profile" }},
+                "filesystem": {{ "allow_file": ["{}"] }}
+            }}"#,
+                lock_dir.display()
+            ),
+        )
+        .expect("write profile");
+
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let err = from_profile_locked(&profile, workdir.path(), &args).expect_err("should fail");
+        assert!(
+            matches!(err, NonoError::ExpectedFile(ref p) if p == &lock_dir),
+            "expected exact-file entries resolving to directories to fail closed, got: {err}"
         );
     }
 


### PR DESCRIPTION
claude code is writing atomic lock files to the users home directory, the fix is so that ~/.claude.lock does not force access to a whole of the users home folder

- Introduce a new helper function `try_new_profile_exact_path` to handle file capability creation for profile entries.
- This helper checks if an exact path designated for a file actually exists as a directory.
- If the path is a directory, it grants access to the exact directory instead of failing or widening the scope.
- This addresses cases where clients use lock directories at paths historically used for lock files (e.g., `~/.claude.lock`).
- Previously, this would lead to an `ExpectedFile` error or an incorrect capability.
- Update `allow_file`, `read_file`, and `write_file` processing in `CapabilitySetExt` to use this new helper.
- Add a new test case to verify that `allow_file` entries correctly fall back to exact directory access when the path is a directory.

Signed-off-by: Luke Hinds <lukehinds@gmail.com>