### PR TITLE
fix(policy): remove broad ~/.local allow from openclaw profile on Linux

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -747,7 +747,6 @@
         "allow": [
           "$HOME/.openclaw",
           "$HOME/.config/openclaw",
-          "$HOME/.local",
           "$TMPDIR/openclaw-$UID"
         ]
       },


### PR DESCRIPTION
## Problem

Fixes #597.

`nono run --profile openclaw -- openclaw gateway` fails immediately on Linux:

```
WARN Landlock cannot enforce deny '/home/user/.local/share/keyrings' overlaps allowed parent '/home/user/.local' (source: profile). This deny has no effect on Linux.
ERROR Sandbox initialization failed: Landlock deny-overlap is not enforceable on Linux. Refusing to start with conflicting policy.
```

The `openclaw` profile allowed `$HOME/.local` broadly. The `deny_keychains_linux` required group (inherited from `default`) denies `~/.local/share/keyrings` — a subdirectory of that allowed path. Landlock cannot enforce a deny inside an allowed parent, so nono refuses to start.

## Fix

Remove `$HOME/.local` from the openclaw profile's `filesystem.allow`. The specific subdirs openclaw actually uses are already covered by existing groups:

| Path | Covered by |
|------|-----------|
| `~/.local/bin` | `user_tools` group |
| `~/.local/state` | `user_tools` group |
| `~/.local/share/pnpm` | `node_runtime` group |
| `~/.local/share/fnm` | `node_runtime` group |

## Testing

Tested on a Lima Ubuntu 24.04 VM (kernel 6.8.0-106-generic, Landlock V4) — matching the environment in the issue report.

**Before (bug reproduced):**
```
WARN Landlock cannot enforce deny '/home/advaithsujith.guest/.local/share/keyrings' overlaps allowed parent '/home/advaithsujith.guest/.local' (source: profile). This deny has no effect on Linux.
ERROR Sandbox initialization failed: Landlock deny-overlap is not enforceable on Linux. Refusing to start with conflicting policy.
Conflicts:
- deny '/home/advaithsujith.guest/.local/share/keyrings' overlaps allowed parent '/home/advaithsujith.guest/.local' (source: profile)
```

**After (fix applied):**
```
  nono v0.30.1
  Capabilities:
  ────────────────────────────────────────────────────
   r+w  /home/advaithsujith.guest/.openclaw (dir)
   r+w  /tmp/openclaw-501 (dir)
       + 45 system/group paths (-v to show)
   net  outbound allowed
  ────────────────────────────────────────────────────

   kernel  Landlock V4 (File rename across directories (Refer), File truncation (Truncate), TCP network filtering)
  Applying sandbox...
[gateway] ready (5 plugins, 1.1s)
```

Gateway starts cleanly with Landlock enforced — no policy conflicts.