### PR TITLE
feat(supervisor): enriched filename capture for denied operations (PoC)

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1134,6 +1134,8 @@ pub fn execute_supervised(
             };
 
             // Analyze PTY screen content for sandbox-related errors.
+            // Use both the vt100 screen state (for visual content) and the
+            // denial capture buffer (for raw byte-level path matching).
             let error_observation = pty_proxy
                 .as_ref()
                 .map(|p| {
@@ -1145,6 +1147,42 @@ pub fn execute_supervised(
                 })
                 .unwrap_or_default();
 
+            // Enrich denials with stderr observations and deduplicate.
+            // This merges seccomp-notify denials with paths inferred from
+            // stderr, and cross-references to remove duplicates.
+            let child_pid = match status {
+                WaitStatus::Exited(pid, _) | WaitStatus::Signaled(pid, _, _) => pid.as_raw() as u32,
+                _ => 0,
+            };
+            let enriched_denials = nono::diagnostic::enrich_with_stderr_hints(
+                &denials,
+                &error_observation.path_hints,
+                child_pid,
+            );
+            let enriched_denials = nono::diagnostic::deduplicate_denials(&enriched_denials);
+
+            // Cross-reference seccomp-notify denials with PTY capture buffer.
+            // Log which denials are confirmed by the child's error output and
+            // scan the capture for Landlock-level denials not caught by seccomp.
+            if let Some(ref p) = pty_proxy {
+                for denial in &enriched_denials {
+                    if p.denial_capture_contains_path(&denial.path) {
+                        debug!(
+                            "Denial for {} confirmed in PTY capture (source: {})",
+                            denial.path.display(),
+                            denial.source,
+                        );
+                    }
+                }
+                let capture_text = p.denial_capture_plaintext();
+                if !capture_text.is_empty() {
+                    debug!(
+                        "Denial capture buffer: {} bytes of child output available for analysis",
+                        capture_text.len(),
+                    );
+                }
+            }
+
             let mode = if supervisor.is_some() {
                 DiagnosticMode::Supervised
             } else {
@@ -1152,7 +1190,9 @@ pub fn execute_supervised(
             };
 
             let should_print_diagnostics = !config.no_diagnostics
-                && (exit_code != 0 || !denials.is_empty() || error_observation.has_findings());
+                && (exit_code != 0
+                    || !enriched_denials.is_empty()
+                    || error_observation.has_findings());
 
             // Print diagnostic footer on non-zero exit or when the PTY
             // output shows a likely sandbox-related issue.
@@ -1170,7 +1210,7 @@ pub fn execute_supervised(
 
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
-                    .with_denials(&denials)
+                    .with_denials(&enriched_denials)
                     .with_sandbox_violations(&sandbox_violations)
                     .with_protected_paths(config.protected_paths)
                     .with_error_observation(error_observation)
@@ -2080,11 +2120,12 @@ fn handle_supervisor_message(
             if let Some(reason) = replay_denial_reason {
                 record_denial(
                     denials,
-                    DenialRecord {
-                        path: request.path.clone(),
-                        access: request.access,
-                        reason: DenialReason::PolicyBlocked,
-                    },
+                    DenialRecord::from_ipc(
+                        request.path.clone(),
+                        request.access,
+                        DenialReason::PolicyBlocked,
+                        request.child_pid,
+                    ),
                 );
                 let response = SupervisorResponse::Decision {
                     request_id: request.request_id,
@@ -2113,11 +2154,12 @@ fn handle_supervisor_message(
                 );
                 record_denial(
                     denials,
-                    DenialRecord {
-                        path: request.path.clone(),
-                        access: request.access,
-                        reason: DenialReason::PolicyBlocked,
-                    },
+                    DenialRecord::from_ipc(
+                        request.path.clone(),
+                        request.access,
+                        DenialReason::PolicyBlocked,
+                        request.child_pid,
+                    ),
                 );
                 ApprovalDecision::Denied {
                     reason: format!(
@@ -2146,11 +2188,12 @@ fn handle_supervisor_message(
                                 if d.is_denied() {
                                     record_denial(
                                         denials,
-                                        DenialRecord {
-                                            path: request.path.clone(),
-                                            access: request.access,
-                                            reason: DenialReason::UserDenied,
-                                        },
+                                        DenialRecord::from_ipc(
+                                            request.path.clone(),
+                                            request.access,
+                                            DenialReason::UserDenied,
+                                            request.child_pid,
+                                        ),
                                     );
                                 }
                                 d
@@ -2159,11 +2202,12 @@ fn handle_supervisor_message(
                                 warn!("Approval backend error: {}", e);
                                 record_denial(
                                     denials,
-                                    DenialRecord {
-                                        path: request.path.clone(),
-                                        access: request.access,
-                                        reason: DenialReason::BackendError,
-                                    },
+                                    DenialRecord::from_ipc(
+                                        request.path.clone(),
+                                        request.access,
+                                        DenialReason::BackendError,
+                                        request.child_pid,
+                                    ),
                                 );
                                 ApprovalDecision::Denied {
                                     reason: format!("Approval backend error: {e}"),
@@ -2180,11 +2224,12 @@ fn handle_supervisor_message(
                         );
                         record_denial(
                             denials,
-                            DenialRecord {
-                                path: request.path.clone(),
-                                access: request.access,
-                                reason: DenialReason::PolicyBlocked,
-                            },
+                            DenialRecord::from_ipc(
+                                request.path.clone(),
+                                request.access,
+                                DenialReason::PolicyBlocked,
+                                request.child_pid,
+                            ),
                         );
                         ApprovalDecision::Denied {
                             reason: format!("Instruction file failed trust verification: {reason}"),
@@ -2198,11 +2243,12 @@ fn handle_supervisor_message(
                         if d.is_denied() {
                             record_denial(
                                 denials,
-                                DenialRecord {
-                                    path: request.path.clone(),
-                                    access: request.access,
-                                    reason: DenialReason::UserDenied,
-                                },
+                                DenialRecord::from_ipc(
+                                    request.path.clone(),
+                                    request.access,
+                                    DenialReason::UserDenied,
+                                    request.child_pid,
+                                ),
                             );
                         }
                         d
@@ -2211,11 +2257,12 @@ fn handle_supervisor_message(
                         warn!("Approval backend error: {}", e);
                         record_denial(
                             denials,
-                            DenialRecord {
-                                path: request.path.clone(),
-                                access: request.access,
-                                reason: DenialReason::BackendError,
-                            },
+                            DenialRecord::from_ipc(
+                                request.path.clone(),
+                                request.access,
+                                DenialReason::BackendError,
+                                request.child_pid,
+                            ),
                         );
                         ApprovalDecision::Denied {
                             reason: format!("Approval backend error: {e}"),
@@ -3054,11 +3101,11 @@ mod tests {
         for _ in 0..(MAX_DENIAL_RECORDS + 10) {
             record_denial(
                 &mut denials,
-                DenialRecord {
-                    path: "/tmp/test".into(),
-                    access: nono::AccessMode::Read,
-                    reason: DenialReason::PolicyBlocked,
-                },
+                DenialRecord::basic(
+                    "/tmp/test".into(),
+                    nono::AccessMode::Read,
+                    DenialReason::PolicyBlocked,
+                ),
             );
         }
         assert_eq!(denials.len(), MAX_DENIAL_RECORDS);

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -113,10 +113,11 @@ pub(super) fn handle_seccomp_notification(
     denials: &mut Vec<DenialRecord>,
     mut trust_interceptor: Option<&mut TrustInterceptor>,
 ) -> Result<()> {
+    use nono::diagnostic::DeniedSyscall;
     use nono::sandbox::{
-        classify_access_from_flags, continue_notif, deny_notif, inject_fd, notif_id_valid,
-        read_notif_path, read_open_how, recv_notif, resolve_notif_path, respond_notif_errno,
-        validate_openat2_size, SYS_OPENAT, SYS_OPENAT2,
+        classify_access_for_fs_syscall, classify_access_from_flags, continue_notif, deny_notif,
+        inject_fd, notif_id_valid, read_notif_path, read_open_how, recv_notif, resolve_notif_path,
+        respond_notif_errno, syscall_to_denied, validate_openat2_size, SYS_OPENAT, SYS_OPENAT2,
     };
 
     // 1. Receive the notification
@@ -153,13 +154,17 @@ pub(super) fn handle_seccomp_notification(
         return Ok(());
     }
 
-    // Determine access mode from open flags. The two syscalls have different layouts:
+    // Determine access mode and syscall type from the notification.
+    // The two open syscalls have different layouts:
     //   - openat(dirfd, pathname, flags, mode): args[2] is the flags integer
     //   - openat2(dirfd, pathname, how, size): args[2] is a pointer to struct open_how
-    let access = match notif.data.nr {
+    let (access, syscall_type) = match notif.data.nr {
         SYS_OPENAT => {
             // openat: args[2] is the flags integer directly
-            classify_access_from_flags(notif.data.args[2] as i32)
+            (
+                classify_access_from_flags(notif.data.args[2] as i32),
+                DeniedSyscall::Openat,
+            )
         }
         SYS_OPENAT2 => {
             // openat2: args[2] is a pointer to struct open_how, args[3] is the size
@@ -174,7 +179,10 @@ pub(super) fn handle_seccomp_notification(
             }
 
             match read_open_how(notif.pid, notif.data.args[2]) {
-                Ok(open_how) => classify_access_from_flags(open_how.flags as i32),
+                Ok(open_how) => (
+                    classify_access_from_flags(open_how.flags as i32),
+                    DeniedSyscall::Openat2,
+                ),
                 Err(e) => {
                     // Fail closed: deny when flags cannot be determined
                     warn!("Failed to read open_how struct for openat2, denying: {}", e);
@@ -184,12 +192,22 @@ pub(super) fn handle_seccomp_notification(
             }
         }
         other => {
-            // Unexpected syscall (shouldn't happen with our BPF filter)
-            warn!("Unexpected syscall {} in seccomp handler, denying", other);
-            let _ = deny_notif(notify_fd, notif.id);
-            return Ok(());
+            // Extended syscall set (unlinkat, renameat2, mkdirat, etc.)
+            // These all have the path in args[1] and are write operations.
+            if let Some(denied_syscall) = syscall_to_denied(other) {
+                (classify_access_for_fs_syscall(other), denied_syscall)
+            } else {
+                // Truly unexpected syscall (shouldn't happen with our BPF filter)
+                warn!("Unexpected syscall {} in seccomp handler, denying", other);
+                let _ = deny_notif(notify_fd, notif.id);
+                return Ok(());
+            }
         }
     };
+
+    // Track whether this is an open-type syscall (needs fd injection) or a
+    // non-open syscall (uses continue_notif for allow).
+    let is_open_syscall = matches!(syscall_type, DeniedSyscall::Openat | DeniedSyscall::Openat2);
 
     let procfs_context = ProcfsAccessContext::new(child.as_raw() as u32, Some(notif.pid));
     let resolved_path = match resolve_procfs_path_for_child(&path, Some(procfs_context)) {
@@ -224,11 +242,13 @@ pub(super) fn handle_seccomp_notification(
         );
         record_denial(
             denials,
-            DenialRecord {
-                path: canonicalized.clone(),
+            DenialRecord::from_seccomp(
+                canonicalized.clone(),
                 access,
-                reason: DenialReason::PolicyBlocked,
-            },
+                DenialReason::PolicyBlocked,
+                syscall_type,
+                child.as_raw() as u32,
+            ),
         );
         let _ = deny_notif(notify_fd, notif.id);
         return Ok(());
@@ -248,11 +268,13 @@ pub(super) fn handle_seccomp_notification(
             );
             record_denial(
                 denials,
-                DenialRecord {
-                    path: canonicalized.clone(),
+                DenialRecord::from_seccomp(
+                    canonicalized.clone(),
                     access,
-                    reason: DenialReason::InsufficientAccess,
-                },
+                    DenialReason::InsufficientAccess,
+                    syscall_type,
+                    child.as_raw() as u32,
+                ),
             );
             let _ = deny_notif(notify_fd, notif.id);
             return Ok(());
@@ -287,11 +309,13 @@ pub(super) fn handle_seccomp_notification(
                         if e.is_policy_blocked() {
                             record_denial(
                                 denials,
-                                DenialRecord {
-                                    path: canonicalized.clone(),
+                                DenialRecord::from_seccomp(
+                                    canonicalized.clone(),
                                     access,
-                                    reason: DenialReason::PolicyBlocked,
-                                },
+                                    DenialReason::PolicyBlocked,
+                                    syscall_type,
+                                    child.as_raw() as u32,
+                                ),
                             );
                             let _ = deny_notif(notify_fd, notif.id);
                         } else {
@@ -345,11 +369,13 @@ pub(super) fn handle_seccomp_notification(
         debug!("Rate limited seccomp notification for {}", path.display());
         record_denial(
             denials,
-            DenialRecord {
-                path: path.clone(),
+            DenialRecord::from_seccomp(
+                path.clone(),
                 access,
-                reason: DenialReason::RateLimited,
-            },
+                DenialReason::RateLimited,
+                syscall_type,
+                child.as_raw() as u32,
+            ),
         );
         let _ = deny_notif(notify_fd, notif.id);
         return Ok(());
@@ -380,11 +406,13 @@ pub(super) fn handle_seccomp_notification(
                 );
                 record_denial(
                     denials,
-                    DenialRecord {
-                        path: path.clone(),
+                    DenialRecord::from_seccomp(
+                        path.clone(),
                         access,
-                        reason: DenialReason::PolicyBlocked,
-                    },
+                        DenialReason::PolicyBlocked,
+                        syscall_type,
+                        child.as_raw() as u32,
+                    ),
                 );
                 let _ = deny_notif(notify_fd, notif.id);
                 return Ok(());
@@ -409,11 +437,13 @@ pub(super) fn handle_seccomp_notification(
             if d.is_denied() {
                 record_denial(
                     denials,
-                    DenialRecord {
-                        path: path.clone(),
+                    DenialRecord::from_seccomp(
+                        path.clone(),
                         access,
-                        reason: DenialReason::UserDenied,
-                    },
+                        DenialReason::UserDenied,
+                        syscall_type,
+                        child.as_raw() as u32,
+                    ),
                 );
             }
             d
@@ -422,11 +452,13 @@ pub(super) fn handle_seccomp_notification(
             warn!("Approval backend error for seccomp notification: {}", e);
             record_denial(
                 denials,
-                DenialRecord {
-                    path: path.clone(),
+                DenialRecord::from_seccomp(
+                    path.clone(),
                     access,
-                    reason: DenialReason::BackendError,
-                },
+                    DenialReason::BackendError,
+                    syscall_type,
+                    child.as_raw() as u32,
+                ),
             );
             let _ = deny_notif(notify_fd, notif.id);
             return Ok(());
@@ -440,36 +472,53 @@ pub(super) fn handle_seccomp_notification(
     }
 
     // 10. Act on the decision
-    // Pass verified_digest to enable TOCTOU re-verification for instruction files
     if decision.is_granted() {
-        match open_path_for_access(
-            &path,
-            &access,
-            config.protected_roots,
-            verified_digest.as_deref(),
-            Some(procfs_context),
-        ) {
-            Ok(file) => {
-                if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
-                    debug!(
-                        "inject_fd failed for approved path {}: {}",
+        if is_open_syscall {
+            // Open-type syscalls: open the path in the supervisor and inject the fd.
+            // Pass verified_digest to enable TOCTOU re-verification for instruction files.
+            match open_path_for_access(
+                &path,
+                &access,
+                config.protected_roots,
+                verified_digest.as_deref(),
+                Some(procfs_context),
+            ) {
+                Ok(file) => {
+                    if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
+                        debug!(
+                            "inject_fd failed for approved path {}: {}",
+                            canonicalized.display(),
+                            e
+                        );
+                        let _ = deny_notif(notify_fd, notif.id);
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to open approved path {}: {}",
                         canonicalized.display(),
                         e
                     );
-                    let _ = deny_notif(notify_fd, notif.id);
+                    if e.is_policy_blocked() {
+                        let _ = deny_notif(notify_fd, notif.id);
+                    } else {
+                        let _ = respond_notif_errno(notify_fd, notif.id, e.errno());
+                    }
                 }
             }
-            Err(e) => {
-                warn!(
-                    "Failed to open approved path {}: {}",
+        } else {
+            // Non-open syscalls (unlinkat, renameat2, etc.): let the kernel
+            // execute the original syscall. SECCOMP_USER_NOTIF_FLAG_CONTINUE is
+            // safe here because Landlock has already validated the path by the
+            // time the syscall reaches seccomp.
+            if let Err(e) = continue_notif(notify_fd, notif.id) {
+                debug!(
+                    "continue_notif failed for approved {} on {}: {}",
+                    syscall_type,
                     canonicalized.display(),
                     e
                 );
-                if e.is_policy_blocked() {
-                    let _ = deny_notif(notify_fd, notif.id);
-                } else {
-                    let _ = respond_notif_errno(notify_fd, notif.id, e.errno());
-                }
+                let _ = deny_notif(notify_fd, notif.id);
             }
         }
     } else {

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -146,6 +146,13 @@ impl ScreenState {
     }
 }
 
+/// Maximum size of the denial capture ring buffer (64 KB).
+///
+/// Keeps the last N bytes of PTY output for cross-referencing with seccomp-notify
+/// denials. When a denial occurs, the supervisor can scan this buffer for the
+/// denied path to correlate kernel-level denials with user-visible error messages.
+const DENIAL_CAPTURE_LIMIT: usize = 64 * 1024;
+
 /// The running PTY proxy state managed by the supervisor.
 pub struct PtyProxy {
     /// PTY master fd
@@ -174,6 +181,13 @@ pub struct PtyProxy {
     pending_detach_escape: Vec<u8>,
     /// In-band detach requested from the attached client.
     detach_requested: bool,
+    /// Ring buffer of recent PTY output for denial cross-referencing.
+    ///
+    /// Captures the last [`DENIAL_CAPTURE_LIMIT`] bytes of raw child output.
+    /// When a seccomp-notify denial occurs, the supervisor can search this
+    /// buffer for the denied path to correlate kernel denials with the
+    /// child's error messages (e.g. "Permission denied: /path/to/file").
+    denial_capture: VecDeque<u8>,
 }
 
 /// Open a PTY pair, inheriting the current terminal's window size.
@@ -296,6 +310,7 @@ impl PtyProxy {
             pending_detach_match_len: 0,
             pending_detach_escape: Vec::new(),
             detach_requested: false,
+            denial_capture: VecDeque::with_capacity(DENIAL_CAPTURE_LIMIT),
         })
     }
 
@@ -718,6 +733,9 @@ impl PtyProxy {
         let first_output = self.scrollback.is_empty();
         self.screen.apply_bytes(bytes);
 
+        // Feed the denial capture ring buffer (used for cross-referencing).
+        self.feed_denial_capture(bytes);
+
         if bytes.len() >= SCROLLBACK_LIMIT_BYTES {
             self.scrollback.clear();
             self.scrollback.extend(
@@ -751,6 +769,62 @@ impl PtyProxy {
                 bytes.len()
             );
         }
+    }
+
+    /// Feed bytes into the denial capture ring buffer.
+    fn feed_denial_capture(&mut self, bytes: &[u8]) {
+        if bytes.len() >= DENIAL_CAPTURE_LIMIT {
+            // Input larger than the buffer: keep only the tail.
+            self.denial_capture.clear();
+            self.denial_capture.extend(
+                bytes[bytes.len().saturating_sub(DENIAL_CAPTURE_LIMIT)..]
+                    .iter()
+                    .copied(),
+            );
+            return;
+        }
+        let overflow = self
+            .denial_capture
+            .len()
+            .saturating_add(bytes.len())
+            .saturating_sub(DENIAL_CAPTURE_LIMIT);
+        if overflow > 0 {
+            drop(self.denial_capture.drain(..overflow));
+        }
+        self.denial_capture.extend(bytes.iter().copied());
+    }
+
+    /// Check whether the denial capture buffer contains a reference to the given path.
+    ///
+    /// This is used by the denial pipeline to cross-reference seccomp-notify denials
+    /// with the child's stderr output. If a denied path appears in the recent PTY
+    /// output alongside an error keyword, the denial record's confidence is higher
+    /// and can be presented to the user with more context.
+    ///
+    /// Returns `true` if the path string appears in the captured output.
+    pub fn denial_capture_contains_path(&self, path: &std::path::Path) -> bool {
+        let path_bytes = path.as_os_str().as_encoded_bytes();
+        if path_bytes.is_empty() {
+            return false;
+        }
+        // Convert the ring buffer to a contiguous slice pair and search both.
+        let (front, back) = self.denial_capture.as_slices();
+        contains_subsequence(front, path_bytes)
+            || contains_subsequence(back, path_bytes)
+            || cross_boundary_contains(front, back, path_bytes)
+    }
+
+    /// Render the denial capture buffer as a lossy UTF-8 string for analysis.
+    ///
+    /// Called by the denial pipeline after child exit to scan for error patterns
+    /// that weren't caught by seccomp-notify (e.g. Landlock denials that produce
+    /// "Permission denied" in stderr but never trigger a seccomp notification).
+    pub fn denial_capture_plaintext(&self) -> String {
+        let (front, back) = self.denial_capture.as_slices();
+        let mut buf = Vec::with_capacity(front.len().saturating_add(back.len()));
+        buf.extend_from_slice(front);
+        buf.extend_from_slice(back);
+        String::from_utf8_lossy(&buf).into_owned()
     }
 
     fn scrollback_snapshot(&self) -> Vec<u8> {
@@ -1939,11 +2013,48 @@ fn run_attach_loop(
     Ok(())
 }
 
+/// Check if `haystack` contains `needle` as a contiguous subsequence.
+fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if haystack.len() < needle.len() {
+        return false;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+/// Check if `needle` spans the boundary between `front` and `back`.
+///
+/// This handles the case where the VecDeque's ring buffer wraps around and
+/// the path string straddles the two contiguous slices.
+fn cross_boundary_contains(front: &[u8], back: &[u8], needle: &[u8]) -> bool {
+    if needle.len() <= 1 || front.is_empty() || back.is_empty() {
+        return false;
+    }
+    // Check each possible split point where the needle spans front/back.
+    for split in 1..needle.len() {
+        let prefix = &needle[..split];
+        let suffix = &needle[split..];
+        if front.len() >= prefix.len()
+            && back.len() >= suffix.len()
+            && front[front.len() - prefix.len()..] == *prefix
+            && back[..suffix.len()] == *suffix
+        {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        read_fd_once, select_attach_replay_bytes, terminal_restore_escape, write_all_fd,
-        AttachedClient, PtyProxy, ReadFdOutcome, ScreenState, DEFAULT_DETACH_SEQUENCE,
+        contains_subsequence, cross_boundary_contains, read_fd_once, select_attach_replay_bytes,
+        terminal_restore_escape, write_all_fd, AttachedClient, PtyProxy, ReadFdOutcome,
+        ScreenState, DEFAULT_DETACH_SEQUENCE,
     };
     use nix::libc;
     use std::collections::VecDeque;
@@ -1973,6 +2084,7 @@ mod tests {
             pending_detach_match_len: 0,
             pending_detach_escape: Vec::new(),
             detach_requested: false,
+            denial_capture: VecDeque::new(),
         }
     }
 
@@ -2271,5 +2383,67 @@ mod tests {
 
         assert!(proxy.proxy_master_to_client());
         assert!(proxy.client.is_none());
+    }
+
+    // --- Denial capture ring buffer tests ---
+
+    #[test]
+    fn test_contains_subsequence_basic() {
+        assert!(contains_subsequence(b"hello world", b"world"));
+        assert!(contains_subsequence(b"hello world", b"hello"));
+        assert!(!contains_subsequence(b"hello world", b"xyz"));
+        assert!(contains_subsequence(b"abc", b""));
+        assert!(!contains_subsequence(b"ab", b"abc"));
+    }
+
+    #[test]
+    fn test_cross_boundary_contains() {
+        // Path spans across front/back boundary
+        assert!(cross_boundary_contains(
+            b"Permission denied: /etc/sha",
+            b"dow",
+            b"/etc/shadow"
+        ));
+        // Entire needle in front — should not match (that's contains_subsequence's job)
+        assert!(!cross_boundary_contains(
+            b"/etc/shadow",
+            b"extra",
+            b"/etc/shadow"
+        ));
+        // Empty slices
+        assert!(!cross_boundary_contains(b"", b"", b"/etc/shadow"));
+        assert!(!cross_boundary_contains(b"a", b"b", b"x"));
+    }
+
+    #[test]
+    fn test_denial_capture_feed_and_search() {
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+
+        // Feed some output simulating an error message
+        proxy.feed_denial_capture(b"bash: /etc/shadow: Permission denied\n");
+
+        // The denied path should be findable
+        assert!(proxy.denial_capture_contains_path(std::path::Path::new("/etc/shadow")));
+        // A path that wasn't mentioned should not be found
+        assert!(!proxy.denial_capture_contains_path(std::path::Path::new("/etc/passwd")));
+    }
+
+    #[test]
+    fn test_denial_capture_ring_buffer_overflow() {
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+
+        // Fill the buffer beyond DENIAL_CAPTURE_LIMIT
+        let big_chunk = vec![b'X'; super::DENIAL_CAPTURE_LIMIT + 100];
+        proxy.feed_denial_capture(&big_chunk);
+
+        assert_eq!(proxy.denial_capture.len(), super::DENIAL_CAPTURE_LIMIT);
+    }
+
+    #[test]
+    fn test_denial_capture_plaintext() {
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+        proxy.feed_denial_capture(b"error: Permission denied\n");
+        let text = proxy.denial_capture_plaintext();
+        assert!(text.contains("Permission denied"));
     }
 }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -16,6 +16,7 @@
 
 use crate::capability::{AccessMode, CapabilitySet, CapabilitySource};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 /// Why a path access was denied during a supervised session.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +33,104 @@ pub enum DenialReason {
     BackendError,
 }
 
+/// The syscall that triggered a denial, when known.
+///
+/// Enriches denial records beyond just the path and access mode so diagnostics
+/// can report *what operation* was attempted (e.g. "unlink /tmp/data.db" vs
+/// the generic "write access denied for /tmp/data.db").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeniedSyscall {
+    /// openat(dirfd, pathname, flags, mode)
+    Openat,
+    /// openat2(dirfd, pathname, how, size)
+    Openat2,
+    /// unlinkat(dirfd, pathname, flags)
+    Unlinkat,
+    /// renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
+    Renameat2,
+    /// mkdirat(dirfd, pathname, mode)
+    Mkdirat,
+    /// fchmodat(dirfd, pathname, mode, flags)
+    Fchmodat,
+    /// symlinkat(target, newdirfd, linkpath)
+    Symlinkat,
+    /// linkat(olddirfd, oldpath, newdirfd, newpath, flags)
+    Linkat,
+    /// statx / newfstatat
+    Stat,
+    /// readlinkat(dirfd, pathname, buf, bufsiz)
+    Readlinkat,
+    /// faccessat2(dirfd, pathname, mode, flags)
+    Faccessat,
+}
+
+impl DeniedSyscall {
+    /// Human-readable verb describing the denied operation.
+    #[must_use]
+    pub fn action_verb(self) -> &'static str {
+        match self {
+            Self::Openat | Self::Openat2 => "open",
+            Self::Unlinkat => "delete",
+            Self::Renameat2 => "rename",
+            Self::Mkdirat => "create directory",
+            Self::Fchmodat => "change permissions on",
+            Self::Symlinkat => "create symlink to",
+            Self::Linkat => "create hard link to",
+            Self::Stat => "stat",
+            Self::Readlinkat => "read symlink",
+            Self::Faccessat => "access-check",
+        }
+    }
+
+    /// Human-readable syscall name for diagnostic output.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Openat => "openat",
+            Self::Openat2 => "openat2",
+            Self::Unlinkat => "unlinkat",
+            Self::Renameat2 => "renameat2",
+            Self::Mkdirat => "mkdirat",
+            Self::Fchmodat => "fchmodat",
+            Self::Symlinkat => "symlinkat",
+            Self::Linkat => "linkat",
+            Self::Stat => "statx",
+            Self::Readlinkat => "readlinkat",
+            Self::Faccessat => "faccessat2",
+        }
+    }
+}
+
+impl std::fmt::Display for DeniedSyscall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// How a denial was detected, for cross-referencing and deduplication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenialSource {
+    /// Captured via Linux seccomp-notify (authoritative, exact path).
+    SeccompNotify,
+    /// Inferred from the child's PTY/stderr output (best-effort).
+    PtyStderr,
+    /// Recovered from macOS Seatbelt unified log (asynchronous).
+    SeatbeltLog,
+    /// From an explicit IPC capability request over the supervisor socket.
+    SupervisorIpc,
+}
+
+impl std::fmt::Display for DenialSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SeccompNotify => f.write_str("seccomp-notify"),
+            Self::PtyStderr => f.write_str("stderr"),
+            Self::SeatbeltLog => f.write_str("seatbelt-log"),
+            Self::SupervisorIpc => f.write_str("ipc"),
+        }
+    }
+}
+
 /// Record of a denied access attempt during a supervised session.
 #[derive(Debug, Clone)]
 pub struct DenialRecord {
@@ -41,6 +140,190 @@ pub struct DenialRecord {
     pub access: AccessMode,
     /// Why it was denied
     pub reason: DenialReason,
+    /// The syscall that triggered the denial, when known.
+    pub syscall: Option<DeniedSyscall>,
+    /// How the denial was detected.
+    pub source: DenialSource,
+    /// When the denial occurred (monotonic clock for deduplication).
+    pub timestamp: Instant,
+    /// PID of the child process that triggered the denial.
+    pub child_pid: u32,
+}
+
+impl DenialRecord {
+    /// Create a new denial record from a seccomp-notify interception.
+    #[must_use]
+    pub fn from_seccomp(
+        path: PathBuf,
+        access: AccessMode,
+        reason: DenialReason,
+        syscall: DeniedSyscall,
+        child_pid: u32,
+    ) -> Self {
+        Self {
+            path,
+            access,
+            reason,
+            syscall: Some(syscall),
+            source: DenialSource::SeccompNotify,
+            timestamp: Instant::now(),
+            child_pid,
+        }
+    }
+
+    /// Create a new denial record from a supervisor IPC request.
+    #[must_use]
+    pub fn from_ipc(
+        path: PathBuf,
+        access: AccessMode,
+        reason: DenialReason,
+        child_pid: u32,
+    ) -> Self {
+        Self {
+            path,
+            access,
+            reason,
+            syscall: None,
+            source: DenialSource::SupervisorIpc,
+            timestamp: Instant::now(),
+            child_pid,
+        }
+    }
+
+    /// Create a new denial record inferred from PTY/stderr output.
+    #[must_use]
+    pub fn from_stderr(path: PathBuf, access: AccessMode, child_pid: u32) -> Self {
+        Self {
+            path,
+            access,
+            reason: DenialReason::PolicyBlocked,
+            syscall: None,
+            source: DenialSource::PtyStderr,
+            timestamp: Instant::now(),
+            child_pid,
+        }
+    }
+
+    /// Create a basic denial record with only path, access, and reason.
+    ///
+    /// Sets source to `SeccompNotify`, syscall to `None`, child_pid to 0, and
+    /// timestamp to now. Useful for contexts where the enriched fields are not
+    /// available (e.g. IPC-based denials before the PoC migration is complete).
+    #[must_use]
+    pub fn basic(path: PathBuf, access: AccessMode, reason: DenialReason) -> Self {
+        Self {
+            path,
+            access,
+            reason,
+            syscall: None,
+            source: DenialSource::SeccompNotify,
+            timestamp: Instant::now(),
+            child_pid: 0,
+        }
+    }
+}
+
+/// Deduplicate denial records by path, merging access modes.
+///
+/// When multiple sources report denials for the same path within a short time
+/// window, this function merges them into a single record, preferring the most
+/// authoritative source (SeccompNotify > SupervisorIpc > SeatbeltLog > PtyStderr)
+/// and preserving the syscall type from the most specific record.
+///
+/// # Deduplication rules
+///
+/// - Records with the same path are grouped together.
+/// - Access modes are merged (Read + Write → ReadWrite).
+/// - The syscall field is preserved from the first record that has one.
+/// - The source field is set to the most authoritative source in the group.
+/// - The timestamp is set to the earliest in the group.
+/// - The child_pid is preserved from the first record.
+#[must_use]
+pub fn deduplicate_denials(denials: &[DenialRecord]) -> Vec<DenialRecord> {
+    use std::collections::HashMap;
+
+    // Group by (path, reason_tag) to avoid merging PolicyBlocked with UserDenied for the same path.
+    // We use a u8 tag since Discriminant doesn't implement Hash/Ord for non-Hash enums.
+    let mut groups: HashMap<(PathBuf, u8), DenialRecord> = HashMap::new();
+
+    for denial in denials {
+        let key = (denial.path.clone(), denial_reason_tag(&denial.reason));
+        groups
+            .entry(key)
+            .and_modify(|existing| {
+                // Merge access modes
+                existing.access = merge_access_modes(existing.access, denial.access);
+                // Prefer the most specific syscall
+                if existing.syscall.is_none() {
+                    existing.syscall = denial.syscall;
+                }
+                // Prefer the most authoritative source
+                if source_priority(denial.source) > source_priority(existing.source) {
+                    existing.source = denial.source;
+                }
+                // Use earliest timestamp
+                if denial.timestamp < existing.timestamp {
+                    existing.timestamp = denial.timestamp;
+                }
+            })
+            .or_insert_with(|| denial.clone());
+    }
+
+    groups.into_values().collect()
+}
+
+/// Map a `DenialReason` to a stable numeric tag for use as a hash map key.
+fn denial_reason_tag(reason: &DenialReason) -> u8 {
+    match reason {
+        DenialReason::PolicyBlocked => 0,
+        DenialReason::InsufficientAccess => 1,
+        DenialReason::UserDenied => 2,
+        DenialReason::RateLimited => 3,
+        DenialReason::BackendError => 4,
+    }
+}
+
+/// Priority ordering for denial sources (higher = more authoritative).
+fn source_priority(source: DenialSource) -> u8 {
+    match source {
+        DenialSource::SeccompNotify => 4,
+        DenialSource::SupervisorIpc => 3,
+        DenialSource::SeatbeltLog => 2,
+        DenialSource::PtyStderr => 1,
+    }
+}
+
+/// Enrich denial records with cross-referenced stderr observations.
+///
+/// For each `ObservedPathHint` from stderr analysis that does NOT already have a
+/// corresponding denial record from a more authoritative source (seccomp-notify,
+/// IPC), create a `DenialRecord` with `DenialSource::PtyStderr`. This captures
+/// Landlock denials that produce "Permission denied" in stderr but never trigger
+/// a seccomp notification.
+///
+/// Returns the original denials plus any new stderr-inferred records.
+#[must_use]
+pub fn enrich_with_stderr_hints(
+    denials: &[DenialRecord],
+    stderr_hints: &[ObservedPathHint],
+    child_pid: u32,
+) -> Vec<DenialRecord> {
+    let mut enriched = denials.to_vec();
+
+    for hint in stderr_hints {
+        let already_recorded = denials
+            .iter()
+            .any(|d| d.path == hint.path && d.access == hint.access);
+        if !already_recorded {
+            enriched.push(DenialRecord::from_stderr(
+                hint.path.clone(),
+                hint.access,
+                child_pid,
+            ));
+        }
+    }
+
+    enriched
 }
 
 /// Best-effort sandbox violation recovered from OS-native logging.
@@ -999,7 +1282,8 @@ impl<'a> DiagnosticFormatter<'a> {
                 if !policy_blocked.is_empty() {
                     for denial in &policy_blocked {
                         lines.push(format!(
-                            "[nono]   {} ({}) - blocked by security policy",
+                            "[nono]   {} {} ({}) - blocked by security policy",
+                            syscall_prefix(denial.syscall),
                             denial.path.display(),
                             access_str(denial.access),
                         ));
@@ -1008,7 +1292,8 @@ impl<'a> DiagnosticFormatter<'a> {
                 if !insufficient_access.is_empty() {
                     for denial in &insufficient_access {
                         lines.push(format!(
-                            "[nono]   {} ({}) - path matched the sandbox, but the access mode was not granted",
+                            "[nono]   {} {} ({}) - path matched the sandbox, but the access mode was not granted",
+                            syscall_prefix(denial.syscall),
                             denial.path.display(),
                             access_str(denial.access),
                         ));
@@ -1027,7 +1312,8 @@ impl<'a> DiagnosticFormatter<'a> {
                 if !user_denied.is_empty() {
                     for denial in &user_denied {
                         lines.push(format!(
-                            "[nono]   {} ({}) - access declined at the prompt",
+                            "[nono]   {} {} ({}) - access declined at the prompt",
+                            syscall_prefix(denial.syscall),
                             denial.path.display(),
                             access_str(denial.access),
                         ));
@@ -1036,7 +1322,8 @@ impl<'a> DiagnosticFormatter<'a> {
                 if !rate_limited.is_empty() {
                     for denial in &rate_limited {
                         lines.push(format!(
-                            "[nono]   {} ({}) - denied after too many approval requests",
+                            "[nono]   {} {} ({}) - denied after too many approval requests",
+                            syscall_prefix(denial.syscall),
                             denial.path.display(),
                             access_str(denial.access),
                         ));
@@ -1045,7 +1332,8 @@ impl<'a> DiagnosticFormatter<'a> {
                 if !backend_errors.is_empty() {
                     for denial in &backend_errors {
                         lines.push(format!(
-                            "[nono]   {} ({}) - denied because the approval backend failed",
+                            "[nono]   {} {} ({}) - denied because the approval backend failed",
+                            syscall_prefix(denial.syscall),
                             denial.path.display(),
                             access_str(denial.access),
                         ));
@@ -1103,6 +1391,10 @@ impl<'a> DiagnosticFormatter<'a> {
                 path,
                 access,
                 reason: reason.clone(),
+                syscall: None,
+                source: DenialSource::SeccompNotify,
+                timestamp: Instant::now(),
+                child_pid: 0,
             })
             .collect()
     }
@@ -1595,6 +1887,26 @@ fn access_str(access: AccessMode) -> &'static str {
         AccessMode::Read => "read",
         AccessMode::Write => "write",
         AccessMode::ReadWrite => "read+write",
+    }
+}
+
+/// Format a syscall name as a prefix for denial messages.
+///
+/// Returns the syscall's action verb (e.g. "delete", "rename") followed by a colon
+/// when a syscall is known, or an empty string for generic open operations or when
+/// the syscall is unknown. This gives users context like:
+///
+///   `delete /tmp/data.db (write) - blocked by security policy`
+///
+/// instead of the generic:
+///
+///   `/tmp/data.db (write) - blocked by security policy`
+fn syscall_prefix(syscall: Option<DeniedSyscall>) -> &'static str {
+    match syscall {
+        // Don't prefix open operations — they're the common case and
+        // the access mode (read/write) already conveys enough information.
+        Some(DeniedSyscall::Openat | DeniedSyscall::Openat2) | None => "",
+        Some(s) => s.action_verb(),
     }
 }
 
@@ -2573,11 +2885,11 @@ mod tests {
     #[test]
     fn test_supervised_policy_blocked_denial() {
         let caps = make_test_caps();
-        let denials = vec![DenialRecord {
-            path: PathBuf::from("/etc/shadow"),
-            access: AccessMode::Read,
-            reason: DenialReason::PolicyBlocked,
-        }];
+        let denials = vec![DenialRecord::basic(
+            PathBuf::from("/etc/shadow"),
+            AccessMode::Read,
+            DenialReason::PolicyBlocked,
+        )];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
             .with_denials(&denials);
@@ -2594,11 +2906,11 @@ mod tests {
         let dir = tempdir().expect("tempdir should be created");
         let denied_path = dir.path().join("secret.txt");
         std::fs::write(&denied_path, "secret").expect("denied file should be created");
-        let denials = vec![DenialRecord {
-            path: denied_path.clone(),
-            access: AccessMode::Read,
-            reason: DenialReason::UserDenied,
-        }];
+        let denials = vec![DenialRecord::basic(
+            denied_path.clone(),
+            AccessMode::Read,
+            DenialReason::UserDenied,
+        )];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
             .with_denials(&denials);
@@ -2614,16 +2926,16 @@ mod tests {
     fn test_supervised_mixed_denials() {
         let caps = make_test_caps();
         let denials = vec![
-            DenialRecord {
-                path: PathBuf::from("/etc/shadow"),
-                access: AccessMode::Read,
-                reason: DenialReason::PolicyBlocked,
-            },
-            DenialRecord {
-                path: PathBuf::from("/home/user/data.txt"),
-                access: AccessMode::Read,
-                reason: DenialReason::UserDenied,
-            },
+            DenialRecord::basic(
+                PathBuf::from("/etc/shadow"),
+                AccessMode::Read,
+                DenialReason::PolicyBlocked,
+            ),
+            DenialRecord::basic(
+                PathBuf::from("/home/user/data.txt"),
+                AccessMode::Read,
+                DenialReason::UserDenied,
+            ),
         ];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
@@ -2640,16 +2952,16 @@ mod tests {
     fn test_supervised_deduplicates_paths() {
         let caps = make_test_caps();
         let denials = vec![
-            DenialRecord {
-                path: PathBuf::from("/etc/shadow"),
-                access: AccessMode::Read,
-                reason: DenialReason::PolicyBlocked,
-            },
-            DenialRecord {
-                path: PathBuf::from("/etc/shadow"),
-                access: AccessMode::Read,
-                reason: DenialReason::PolicyBlocked,
-            },
+            DenialRecord::basic(
+                PathBuf::from("/etc/shadow"),
+                AccessMode::Read,
+                DenialReason::PolicyBlocked,
+            ),
+            DenialRecord::basic(
+                PathBuf::from("/etc/shadow"),
+                AccessMode::Read,
+                DenialReason::PolicyBlocked,
+            ),
         ];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
@@ -2665,11 +2977,11 @@ mod tests {
     #[test]
     fn test_supervised_has_block_header() {
         let caps = make_test_caps();
-        let denials = vec![DenialRecord {
-            path: PathBuf::from("/etc/shadow"),
-            access: AccessMode::Read,
-            reason: DenialReason::PolicyBlocked,
-        }];
+        let denials = vec![DenialRecord::basic(
+            PathBuf::from("/etc/shadow"),
+            AccessMode::Read,
+            DenialReason::PolicyBlocked,
+        )];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
             .with_denials(&denials);
@@ -2682,11 +2994,11 @@ mod tests {
     #[test]
     fn test_supervised_rate_limited_denial() {
         let caps = make_test_caps();
-        let denials = vec![DenialRecord {
-            path: PathBuf::from("/tmp/flood"),
-            access: AccessMode::Read,
-            reason: DenialReason::RateLimited,
-        }];
+        let denials = vec![DenialRecord::basic(
+            PathBuf::from("/tmp/flood"),
+            AccessMode::Read,
+            DenialReason::RateLimited,
+        )];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
             .with_denials(&denials);
@@ -2715,11 +3027,11 @@ mod tests {
             source: CapabilitySource::Group("project_read".to_string()),
         });
 
-        let denials = vec![DenialRecord {
-            path: denied_path.clone(),
-            access: AccessMode::Write,
-            reason: DenialReason::InsufficientAccess,
-        }];
+        let denials = vec![DenialRecord::basic(
+            denied_path.clone(),
+            AccessMode::Write,
+            DenialReason::InsufficientAccess,
+        )];
         let formatter = DiagnosticFormatter::new(&caps)
             .with_mode(DiagnosticMode::Supervised)
             .with_denials(&denials);

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -65,8 +65,8 @@ pub use capability::{
     ProcessInfoMode, SignalMode,
 };
 pub use diagnostic::{
-    CommandContext, DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode,
-    SandboxViolation,
+    CommandContext, DenialReason, DenialRecord, DenialSource, DeniedSyscall, DiagnosticFormatter,
+    DiagnosticMode, SandboxViolation,
 };
 pub use error::{NonoError, Result};
 pub use keystore::{

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -795,6 +795,22 @@ pub const SYS_OPENAT: i32 = 56;
 #[cfg(target_arch = "aarch64")]
 pub const SYS_OPENAT2: i32 = 437;
 
+// Extended syscall numbers for enriched filename capture (PoC).
+// These are intercepted by the extended BPF filter to report *which* operation
+// was denied, not just that access to a path was blocked.
+#[cfg(target_os = "linux")]
+pub const SYS_UNLINKAT: i32 = libc::SYS_unlinkat as i32;
+#[cfg(target_os = "linux")]
+pub const SYS_RENAMEAT2: i32 = libc::SYS_renameat2 as i32;
+#[cfg(target_os = "linux")]
+pub const SYS_MKDIRAT: i32 = libc::SYS_mkdirat as i32;
+#[cfg(target_os = "linux")]
+pub const SYS_FCHMODAT: i32 = libc::SYS_fchmodat as i32;
+#[cfg(target_os = "linux")]
+pub const SYS_SYMLINKAT: i32 = libc::SYS_symlinkat as i32;
+#[cfg(target_os = "linux")]
+pub const SYS_LINKAT: i32 = libc::SYS_linkat as i32;
+
 #[cfg(target_os = "linux")]
 const SYS_SOCKET: i32 = libc::SYS_socket as i32;
 #[cfg(target_os = "linux")]
@@ -1001,6 +1017,216 @@ pub fn install_seccomp_notify() -> Result<std::os::fd::OwnedFd> {
     // SAFETY: The fd returned by seccomp() with NEW_LISTENER is a valid,
     // newly-created file descriptor that we now own.
     Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(notify_fd) })
+}
+
+/// Install an extended seccomp-notify BPF filter that intercepts openat/openat2
+/// plus destructive filesystem syscalls (unlinkat, renameat2, mkdirat, etc.).
+///
+/// This is the PoC for enriched filename capture. The extended filter routes
+/// additional path-bearing syscalls to `SECCOMP_RET_USER_NOTIF` so the supervisor
+/// can record the exact syscall type and path in `DenialRecord`.
+///
+/// Returns the notify fd. Must be called BEFORE `Sandbox::apply()`.
+///
+/// # Syscalls intercepted
+///
+/// | Syscall | Path arg position | Notes |
+/// |---------|-------------------|-------|
+/// | openat | args[1] | Already in base filter |
+/// | openat2 | args[1] | Already in base filter |
+/// | unlinkat | args[1] | Destructive: delete file/dir |
+/// | renameat2 | args[1], args[3] | Two paths (old, new) |
+/// | mkdirat | args[1] | Create directory |
+/// | fchmodat | args[1] | Change permissions |
+/// | symlinkat | args[1] (target) | Create symbolic link |
+/// | linkat | args[1] (old), args[3] (new) | Create hard link |
+///
+/// # Errors
+///
+/// Returns an error if the kernel doesn't support seccomp user notifications.
+pub fn install_seccomp_notify_extended() -> Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
+
+    // Extended BPF program: check syscall number against all intercepted syscalls.
+    // BPF jump targets are relative to the *next* instruction.
+    let filter = [
+        // 0: Load syscall number
+        SockFilterInsn {
+            code: BPF_LD | BPF_W | BPF_ABS,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_DATA_NR_OFFSET,
+        },
+        // 1: If openat -> jump to notify (instruction 10, offset = 8)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 8,
+            jf: 0,
+            k: SYS_OPENAT as u32,
+        },
+        // 2: If openat2 -> notify (offset = 7)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 7,
+            jf: 0,
+            k: SYS_OPENAT2 as u32,
+        },
+        // 3: If unlinkat -> notify (offset = 6)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 6,
+            jf: 0,
+            k: SYS_UNLINKAT as u32,
+        },
+        // 4: If renameat2 -> notify (offset = 5)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 5,
+            jf: 0,
+            k: SYS_RENAMEAT2 as u32,
+        },
+        // 5: If mkdirat -> notify (offset = 4)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 4,
+            jf: 0,
+            k: SYS_MKDIRAT as u32,
+        },
+        // 6: If fchmodat -> notify (offset = 3)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 3,
+            jf: 0,
+            k: SYS_FCHMODAT as u32,
+        },
+        // 7: If symlinkat -> notify (offset = 2)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 2,
+            jf: 0,
+            k: SYS_SYMLINKAT as u32,
+        },
+        // 8: If linkat -> notify (offset = 1)
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 1,
+            jf: 0,
+            k: SYS_LINKAT as u32,
+        },
+        // 9: Allow all other syscalls
+        SockFilterInsn {
+            code: BPF_RET | BPF_K,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_ALLOW,
+        },
+        // 10: Route to user notification
+        SockFilterInsn {
+            code: BPF_RET | BPF_K,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_USER_NOTIF,
+        },
+    ];
+
+    let prog = SockFprog {
+        len: filter.len() as u16,
+        filter: filter.as_ptr(),
+    };
+
+    // SAFETY: prctl with PR_SET_NO_NEW_PRIVS is always safe to call.
+    // SAFETY: `prctl(PR_SET_NO_NEW_PRIVS)` is process-local, takes only scalar
+    // arguments here, and does not dereference pointers.
+    let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if ret != 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "prctl(PR_SET_NO_NEW_PRIVS) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    // Try with WAIT_KILLABLE_RECV first (kernel 5.19+) for Go runtime compatibility.
+    let flags = SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV;
+
+    // SAFETY: seccomp() with SECCOMP_SET_MODE_FILTER installs a BPF filter.
+    // The prog pointer is valid for the duration of the syscall. The filter
+    // array is stack-allocated and outlives the syscall.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_seccomp,
+            SECCOMP_SET_MODE_FILTER,
+            flags,
+            &prog as *const SockFprog,
+        )
+    };
+
+    let notify_fd = if ret < 0 {
+        // Retry without WAIT_KILLABLE_RECV (kernel < 5.19)
+        let flags = SECCOMP_FILTER_FLAG_NEW_LISTENER;
+        // SAFETY: Same as above, retrying with fewer flags.
+        let ret = unsafe {
+            libc::syscall(
+                libc::SYS_seccomp,
+                SECCOMP_SET_MODE_FILTER,
+                flags,
+                &prog as *const SockFprog,
+            )
+        };
+        if ret < 0 {
+            return Err(NonoError::SandboxInit(format!(
+                "seccomp(SECCOMP_SET_MODE_FILTER) extended filter failed: {}. \
+                 Requires kernel >= 5.0 with SECCOMP_FILTER_FLAG_NEW_LISTENER.",
+                std::io::Error::last_os_error()
+            )));
+        }
+        ret as i32
+    } else {
+        ret as i32
+    };
+
+    // SAFETY: The fd returned by seccomp() with NEW_LISTENER is a valid,
+    // newly-created file descriptor that we now own.
+    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(notify_fd) })
+}
+
+/// Classify the intended access mode for a non-open filesystem syscall.
+///
+/// Unlike openat/openat2 where flags encode the access mode, destructive
+/// syscalls have fixed semantics (all are write operations).
+#[must_use]
+pub fn classify_access_for_fs_syscall(syscall_nr: i32) -> crate::AccessMode {
+    match syscall_nr {
+        nr if nr == SYS_UNLINKAT
+            || nr == SYS_RENAMEAT2
+            || nr == SYS_MKDIRAT
+            || nr == SYS_FCHMODAT
+            || nr == SYS_SYMLINKAT
+            || nr == SYS_LINKAT =>
+        {
+            crate::AccessMode::Write
+        }
+        // Default to ReadWrite for unknown — fail conservative
+        _ => crate::AccessMode::ReadWrite,
+    }
+}
+
+/// Map a syscall number to the corresponding `DeniedSyscall` variant.
+///
+/// Returns `None` for unrecognized syscall numbers.
+#[must_use]
+pub fn syscall_to_denied(syscall_nr: i32) -> Option<crate::diagnostic::DeniedSyscall> {
+    use crate::diagnostic::DeniedSyscall;
+    match syscall_nr {
+        nr if nr == SYS_OPENAT => Some(DeniedSyscall::Openat),
+        nr if nr == SYS_OPENAT2 => Some(DeniedSyscall::Openat2),
+        nr if nr == SYS_UNLINKAT => Some(DeniedSyscall::Unlinkat),
+        nr if nr == SYS_RENAMEAT2 => Some(DeniedSyscall::Renameat2),
+        nr if nr == SYS_MKDIRAT => Some(DeniedSyscall::Mkdirat),
+        nr if nr == SYS_FCHMODAT => Some(DeniedSyscall::Fchmodat),
+        nr if nr == SYS_SYMLINKAT => Some(DeniedSyscall::Symlinkat),
+        nr if nr == SYS_LINKAT => Some(DeniedSyscall::Linkat),
+        _ => None,
+    }
 }
 
 /// Install a seccomp filter that blocks non-Unix socket creation.

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -29,11 +29,13 @@ pub use linux::is_wsl2;
 // Re-export Linux seccomp-notify primitives for supervisor use
 #[cfg(target_os = "linux")]
 pub use linux::{
-    classify_access_from_flags, continue_notif, deny_notif, inject_fd, install_seccomp_notify,
+    classify_access_for_fs_syscall, classify_access_from_flags, continue_notif, deny_notif,
+    inject_fd, install_seccomp_notify, install_seccomp_notify_extended,
     install_seccomp_proxy_filter, notif_id_valid, probe_seccomp_block_network_support,
     read_notif_path, read_notif_sockaddr, read_open_how, recv_notif, resolve_notif_path,
-    respond_notif_errno, validate_openat2_size, OpenHow, SeccompData, SeccompNetFallback,
-    SeccompNotif, SockaddrInfo, SYS_BIND, SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2,
+    respond_notif_errno, syscall_to_denied, validate_openat2_size, OpenHow, SeccompData,
+    SeccompNetFallback, SeccompNotif, SockaddrInfo, SYS_BIND, SYS_CONNECT, SYS_FCHMODAT,
+    SYS_LINKAT, SYS_MKDIRAT, SYS_OPENAT, SYS_OPENAT2, SYS_RENAMEAT2, SYS_SYMLINKAT, SYS_UNLINKAT,
 };
 
 /// Information about sandbox support on this platform


### PR DESCRIPTION
Implement a proof-of-concept system to capture actual file names and
operation types when sandbox denials occur, replacing generic "operation
denied" messages with specific context like "delete /tmp/data.db (write)
- blocked by security policy".

Key changes:

Library (crates/nono/):
- Add DeniedSyscall enum to identify which syscall triggered a denial
  (openat, unlinkat, renameat2, mkdirat, fchmodat, symlinkat, linkat)
- Add DenialSource enum to track how denials are detected
  (SeccompNotify, PtyStderr, SeatbeltLog, SupervisorIpc)
- Expand DenialRecord with syscall, source, timestamp, child_pid fields
- Add constructors: from_seccomp(), from_ipc(), from_stderr(), basic()
- Add denial pipeline: deduplicate_denials() and enrich_with_stderr_hints()
  for merging records from multiple sources
- Add extended BPF filter (install_seccomp_notify_extended) intercepting
  6 additional destructive syscalls beyond openat/openat2
- Add classify_access_for_fs_syscall() and syscall_to_denied() helpers

CLI (crates/nono-cli/):
- Update supervisor handler to classify syscall type alongside access mode
- Use continue_notif for non-open syscalls (vs inject_fd for opens)
- Add 64KB PTY capture ring buffer for cross-referencing denials with
  child stderr output
- Wire denial pipeline into diagnostics: enrich with stderr hints,
  deduplicate, and cross-reference with PTY capture
- Display syscall action verbs in denial listings (e.g. "delete", "rename")
