### PR TITLE
feat(cli): introduce pre-flight CWD prompt for detached launches

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -14,6 +14,7 @@ mod env_sanitization;
 #[cfg(target_os = "linux")]
 mod supervisor_linux;
 
+use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV};
 use nix::libc;
 use nix::sys::signal::{self, Signal};
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
@@ -344,7 +345,16 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
     cmd.current_dir(config.current_dir);
 
     for (key, value) in std::env::vars() {
-        if !should_skip_env_var(&key, &config.env_vars, &["NONO_CAP_FILE"]) {
+        if !should_skip_env_var(
+            &key,
+            &config.env_vars,
+            &[
+                "NONO_CAP_FILE",
+                DETACHED_LAUNCH_ENV,
+                DETACHED_SESSION_ID_ENV,
+                DETACHED_CWD_PROMPT_RESPONSE_ENV,
+            ],
+        ) {
             cmd.env(&key, &value);
         }
     }
@@ -459,7 +469,13 @@ pub fn execute_supervised(
             let should_skip = should_skip_env_var(
                 k,
                 &config.env_vars,
-                &["NONO_CAP_FILE", "NONO_SUPERVISOR_FD"],
+                &[
+                    "NONO_CAP_FILE",
+                    "NONO_SUPERVISOR_FD",
+                    DETACHED_LAUNCH_ENV,
+                    DETACHED_SESSION_ID_ENV,
+                    DETACHED_CWD_PROMPT_RESPONSE_ENV,
+                ],
             );
             if !should_skip {
                 if let Ok(cstr) = CString::new(format!("{}={}", k, v)) {

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -65,6 +65,7 @@ use nono::Result;
 use tracing::error;
 
 const DETACHED_LAUNCH_ENV: &str = "NONO_DETACHED_LAUNCH";
+const DETACHED_CWD_PROMPT_RESPONSE_ENV: &str = "NONO_DETACHED_CWD_PROMPT_RESPONSE";
 const DETACHED_SESSION_ID_ENV: &str = "NONO_DETACHED_SESSION_ID";
 
 pub(crate) use launch_runtime::rollback_base_exclusions;

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -25,6 +25,12 @@ pub(crate) struct PreparedProfile {
     pub(crate) override_deny_paths: Vec<PathBuf>,
 }
 
+#[derive(Clone, Copy)]
+struct PrepareProfileOptions {
+    install_hooks: bool,
+    hook_output_silent: bool,
+}
+
 fn install_profile_hooks(profile: &profile::Profile, silent: bool) {
     if profile.hooks.hooks.is_empty() {
         return;
@@ -107,14 +113,16 @@ fn collect_override_deny_paths(
     paths
 }
 
-pub(crate) fn prepare_profile(
+fn prepare_profile_with_options(
     args: &SandboxArgs,
-    silent: bool,
     workdir: &Path,
+    options: PrepareProfileOptions,
 ) -> crate::Result<PreparedProfile> {
     let loaded_profile = if let Some(ref profile_name) = args.profile {
         let profile = profile::load_profile(profile_name)?;
-        install_profile_hooks(&profile, silent);
+        if options.install_hooks {
+            install_profile_hooks(&profile, options.hook_output_silent);
+        }
         Some(profile)
     } else {
         None
@@ -195,4 +203,139 @@ pub(crate) fn prepare_profile(
         ),
         loaded_profile,
     })
+}
+
+pub(crate) fn prepare_profile(
+    args: &SandboxArgs,
+    silent: bool,
+    workdir: &Path,
+) -> crate::Result<PreparedProfile> {
+    prepare_profile_with_options(
+        args,
+        workdir,
+        PrepareProfileOptions {
+            install_hooks: true,
+            hook_output_silent: silent,
+        },
+    )
+}
+
+pub(crate) fn prepare_profile_for_preflight(
+    args: &SandboxArgs,
+    workdir: &Path,
+) -> crate::Result<PreparedProfile> {
+    prepare_profile_with_options(
+        args,
+        workdir,
+        PrepareProfileOptions {
+            install_hooks: false,
+            hook_output_silent: true,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn prepare_profile_for_preflight_matches_runtime_resolution() {
+        let workdir = match tempdir() {
+            Ok(dir) => dir,
+            Err(err) => panic!("failed to create tempdir: {err}"),
+        };
+        let cli_override = workdir.path().join("cli-override");
+        if let Err(err) = fs::create_dir_all(&cli_override) {
+            panic!("failed to create CLI override path: {err}");
+        }
+
+        let profile_path = workdir.path().join("preflight-profile.json");
+        if let Err(err) = fs::write(
+            &profile_path,
+            r#"{
+                "extends": "default",
+                "meta": { "name": "preflight-profile" },
+                "workdir": { "access": "write" },
+                "rollback": { "exclude_patterns": ["target"] },
+                "network": {
+                    "allow_domain": ["example.com"],
+                    "upstream_bypass": ["localhost"],
+                    "listen_port": [8080]
+                },
+                "policy": {
+                    "override_deny": ["$WORKDIR/.git"]
+                }
+            }"#,
+        ) {
+            panic!("failed to write profile: {err}");
+        }
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            override_deny: vec![cli_override],
+            ..SandboxArgs::default()
+        };
+
+        let runtime = match prepare_profile(&args, true, workdir.path()) {
+            Ok(profile) => profile,
+            Err(err) => panic!("runtime prepare_profile failed: {err}"),
+        };
+        let preflight = match prepare_profile_for_preflight(&args, workdir.path()) {
+            Ok(profile) => profile,
+            Err(err) => panic!("preflight prepare_profile failed: {err}"),
+        };
+
+        assert_eq!(runtime.capability_elevation, preflight.capability_elevation);
+        #[cfg(target_os = "linux")]
+        assert_eq!(runtime.wsl2_proxy_policy, preflight.wsl2_proxy_policy);
+        assert_eq!(runtime.workdir_access, preflight.workdir_access);
+        assert_eq!(
+            runtime.rollback_exclude_patterns,
+            preflight.rollback_exclude_patterns
+        );
+        assert_eq!(
+            runtime.rollback_exclude_globs,
+            preflight.rollback_exclude_globs
+        );
+        assert_eq!(runtime.network_profile, preflight.network_profile);
+        assert_eq!(runtime.allow_domain, preflight.allow_domain);
+        assert_eq!(runtime.credentials, preflight.credentials);
+        assert_eq!(runtime.custom_credentials, preflight.custom_credentials);
+        assert_eq!(runtime.upstream_proxy, preflight.upstream_proxy);
+        assert_eq!(runtime.upstream_bypass, preflight.upstream_bypass);
+        assert_eq!(runtime.listen_ports, preflight.listen_ports);
+        assert_eq!(runtime.open_url_origins, preflight.open_url_origins);
+        assert_eq!(
+            runtime.open_url_allow_localhost,
+            preflight.open_url_allow_localhost
+        );
+        assert_eq!(
+            runtime.allow_launch_services,
+            preflight.allow_launch_services
+        );
+        assert_eq!(runtime.allow_gpu, preflight.allow_gpu);
+        assert_eq!(runtime.override_deny_paths, preflight.override_deny_paths);
+        assert_eq!(
+            runtime.loaded_profile.as_ref().map(|profile| {
+                (
+                    profile.meta.name.clone(),
+                    profile.extends.clone(),
+                    profile.security.groups.clone(),
+                    profile.workdir.access.clone(),
+                    profile.filesystem.allow.clone(),
+                )
+            }),
+            preflight.loaded_profile.as_ref().map(|profile| {
+                (
+                    profile.meta.name.clone(),
+                    profile.extends.clone(),
+                    profile.security.groups.clone(),
+                    profile.workdir.access.clone(),
+                    profile.filesystem.allow.clone(),
+                )
+            })
+        );
+    }
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -5,7 +5,7 @@ use crate::config;
 use crate::credential_runtime::load_env_credentials;
 use crate::profile;
 use crate::profile::WorkdirAccess;
-use crate::profile_runtime::prepare_profile;
+use crate::profile_runtime::{prepare_profile, prepare_profile_for_preflight};
 use crate::{output, policy, protected_paths, sandbox_state};
 use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV};
 use colored::Colorize;
@@ -167,11 +167,11 @@ pub(crate) fn resolve_detached_cwd_prompt_response(
     }
 
     let workdir = resolved_workdir(args);
-    let loaded_profile = if let Some(ref profile_name) = args.profile {
-        Some(profile::load_profile(profile_name)?)
-    } else {
-        None
-    };
+    let crate::profile_runtime::PreparedProfile {
+        loaded_profile,
+        workdir_access: profile_workdir_access,
+        ..
+    } = prepare_profile_for_preflight(args, &workdir)?;
 
     let (caps, _) = if let Some(ref profile) = loaded_profile {
         CapabilitySet::from_profile(profile, &workdir, args)?
@@ -179,13 +179,8 @@ pub(crate) fn resolve_detached_cwd_prompt_response(
         CapabilitySet::from_args(args)?
     };
 
-    let Some(request) = pending_cwd_access_request(
-        &caps,
-        &workdir,
-        loaded_profile
-            .as_ref()
-            .map(|profile| &profile.workdir.access),
-    )?
+    let Some(request) =
+        pending_cwd_access_request(&caps, &workdir, profile_workdir_access.as_ref())?
     else {
         return Ok(None);
     };

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -6,14 +6,14 @@ use crate::credential_runtime::load_env_credentials;
 use crate::profile;
 use crate::profile::WorkdirAccess;
 use crate::profile_runtime::prepare_profile;
-use crate::DETACHED_LAUNCH_ENV;
 use crate::{output, policy, protected_paths, sandbox_state};
+use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::OpenOptionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
 fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {
@@ -53,6 +53,35 @@ fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {
     missing
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DetachedCwdPromptResponse {
+    Allow,
+    Deny,
+}
+
+impl DetachedCwdPromptResponse {
+    pub(crate) const fn as_env_value(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+        }
+    }
+
+    fn from_env_value(value: &str) -> Option<Self> {
+        match value {
+            "allow" => Some(Self::Allow),
+            "deny" => Some(Self::Deny),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingCwdAccessRequest {
+    cwd_canonical: PathBuf,
+    access: AccessMode,
+}
+
 /// Result of sandbox preparation.
 pub(crate) struct PreparedSandbox {
     pub(crate) caps: CapabilitySet,
@@ -74,6 +103,99 @@ pub(crate) struct PreparedSandbox {
     pub(crate) open_url_origins: Vec<String>,
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
+}
+
+fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
+    args.workdir
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn cwd_access_requirement(profile_workdir_access: Option<&WorkdirAccess>) -> Option<AccessMode> {
+    if let Some(access) = profile_workdir_access {
+        match access {
+            WorkdirAccess::Read => Some(AccessMode::Read),
+            WorkdirAccess::Write => Some(AccessMode::Write),
+            WorkdirAccess::ReadWrite => Some(AccessMode::ReadWrite),
+            WorkdirAccess::None => None,
+        }
+    } else {
+        Some(AccessMode::Read)
+    }
+}
+
+fn pending_cwd_access_request(
+    caps: &CapabilitySet,
+    workdir: &Path,
+    profile_workdir_access: Option<&WorkdirAccess>,
+) -> Result<Option<PendingCwdAccessRequest>> {
+    let Some(access) = cwd_access_requirement(profile_workdir_access) else {
+        return Ok(None);
+    };
+
+    let cwd_canonical = workdir
+        .canonicalize()
+        .map_err(|e| NonoError::PathCanonicalization {
+            path: workdir.to_path_buf(),
+            source: e,
+        })?;
+
+    if caps.path_covered_with_access(&cwd_canonical, access) {
+        Ok(None)
+    } else {
+        Ok(Some(PendingCwdAccessRequest {
+            cwd_canonical,
+            access,
+        }))
+    }
+}
+
+fn detached_cwd_prompt_response() -> Option<DetachedCwdPromptResponse> {
+    std::env::var(DETACHED_CWD_PROMPT_RESPONSE_ENV)
+        .ok()
+        .as_deref()
+        .and_then(DetachedCwdPromptResponse::from_env_value)
+}
+
+pub(crate) fn resolve_detached_cwd_prompt_response(
+    args: &SandboxArgs,
+    silent: bool,
+) -> Result<Option<DetachedCwdPromptResponse>> {
+    if silent || args.allow_cwd || args.config.is_some() {
+        return Ok(None);
+    }
+
+    let workdir = resolved_workdir(args);
+    let loaded_profile = if let Some(ref profile_name) = args.profile {
+        Some(profile::load_profile(profile_name)?)
+    } else {
+        None
+    };
+
+    let (caps, _) = if let Some(ref profile) = loaded_profile {
+        CapabilitySet::from_profile(profile, &workdir, args)?
+    } else {
+        CapabilitySet::from_args(args)?
+    };
+
+    let Some(request) = pending_cwd_access_request(
+        &caps,
+        &workdir,
+        loaded_profile
+            .as_ref()
+            .map(|profile| &profile.workdir.access),
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let confirmed = output::prompt_cwd_sharing(&request.cwd_canonical, &request.access)?;
+    Ok(Some(if confirmed {
+        DetachedCwdPromptResponse::Allow
+    } else {
+        DetachedCwdPromptResponse::Deny
+    }))
 }
 
 fn finalize_prepared_sandbox(
@@ -236,19 +358,19 @@ pub(crate) fn print_allow_launch_services_warning(silent: bool) {
     eprintln!("  Prefer using it from a trusted directory, not inside an untrusted project.");
 }
 
-fn missing_cwd_prompt_must_fail(silent: bool, detached_launch: bool) -> bool {
-    silent || detached_launch
+fn missing_cwd_prompt_must_fail(
+    silent: bool,
+    detached_launch: bool,
+    detached_prompt_response: Option<DetachedCwdPromptResponse>,
+) -> bool {
+    silent || (detached_launch && detached_prompt_response.is_none())
 }
 
 pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> {
     sandbox_state::cleanup_stale_state_files();
     let detached_launch = std::env::var_os(DETACHED_LAUNCH_ENV).is_some();
-
-    let workdir = args
-        .workdir
-        .clone()
-        .or_else(|| std::env::current_dir().ok())
-        .unwrap_or_else(|| PathBuf::from("."));
+    let detached_prompt_response = detached_cwd_prompt_response();
+    let workdir = resolved_workdir(args);
 
     if let Some(ref config_path) = args.config {
         let json = std::fs::read_to_string(config_path).map_err(|e| {
@@ -396,44 +518,43 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         loaded_profile.is_none() || profile_allow_gpu,
     )?;
 
-    let cwd_access = if let Some(ref access) = profile_workdir_access {
-        match access {
-            WorkdirAccess::Read => Some(AccessMode::Read),
-            WorkdirAccess::Write => Some(AccessMode::Write),
-            WorkdirAccess::ReadWrite => Some(AccessMode::ReadWrite),
-            WorkdirAccess::None => None,
-        }
-    } else {
-        Some(AccessMode::Read)
-    };
-
-    if let Some(access) = cwd_access {
-        let cwd_canonical =
-            workdir
-                .canonicalize()
-                .map_err(|e| NonoError::PathCanonicalization {
-                    path: workdir.clone(),
-                    source: e,
-                })?;
-
-        if !caps.path_covered_with_access(&cwd_canonical, access) {
-            if args.allow_cwd {
-                info!("Auto-including CWD with {} access (--allow-cwd)", access);
-                let cap = FsCapability::new_dir(cwd_canonical.clone(), access)?;
-                caps.add_fs(cap);
-            } else if missing_cwd_prompt_must_fail(silent, detached_launch) {
-                return Err(NonoError::CwdPromptRequired);
+    if let Some(request) =
+        pending_cwd_access_request(&caps, &workdir, profile_workdir_access.as_ref())?
+    {
+        if args.allow_cwd
+            || matches!(
+                detached_prompt_response,
+                Some(DetachedCwdPromptResponse::Allow)
+            )
+        {
+            let reason = if args.allow_cwd {
+                "(--allow-cwd)"
             } else {
-                let confirmed = output::prompt_cwd_sharing(&cwd_canonical, &access)?;
-                if confirmed {
-                    let cap = FsCapability::new_dir(cwd_canonical.clone(), access)?;
-                    caps.add_fs(cap);
-                } else {
-                    info!("User declined CWD sharing. Continuing without automatic CWD access.");
-                }
+                "(detached launch preflight)"
+            };
+            info!(
+                "Auto-including CWD with {} access {}",
+                request.access, reason
+            );
+            let cap = FsCapability::new_dir(request.cwd_canonical.clone(), request.access)?;
+            caps.add_fs(cap);
+        } else if matches!(
+            detached_prompt_response,
+            Some(DetachedCwdPromptResponse::Deny)
+        ) {
+            info!("Detached launch declined CWD sharing. Continuing without automatic CWD access.");
+        } else if missing_cwd_prompt_must_fail(silent, detached_launch, detached_prompt_response) {
+            return Err(NonoError::CwdPromptRequired);
+        } else {
+            let confirmed = output::prompt_cwd_sharing(&request.cwd_canonical, &request.access)?;
+            if confirmed {
+                let cap = FsCapability::new_dir(request.cwd_canonical.clone(), request.access)?;
+                caps.add_fs(cap);
+            } else {
+                info!("User declined CWD sharing. Continuing without automatic CWD access.");
             }
-            caps.deduplicate();
         }
+        caps.deduplicate();
     }
 
     let active_groups = if let Some(profile) = loaded_profile
@@ -529,16 +650,74 @@ mod tests {
 
     #[test]
     fn missing_cwd_prompt_fails_in_silent_mode() {
-        assert!(missing_cwd_prompt_must_fail(true, false));
+        assert!(missing_cwd_prompt_must_fail(true, false, None));
     }
 
     #[test]
-    fn missing_cwd_prompt_fails_for_detached_launches() {
-        assert!(missing_cwd_prompt_must_fail(false, true));
+    fn missing_cwd_prompt_fails_for_unresolved_detached_launches() {
+        assert!(missing_cwd_prompt_must_fail(false, true, None));
+    }
+
+    #[test]
+    fn missing_cwd_prompt_does_not_fail_after_detached_preflight_decision() {
+        assert!(!missing_cwd_prompt_must_fail(
+            false,
+            true,
+            Some(DetachedCwdPromptResponse::Deny)
+        ));
+        assert!(!missing_cwd_prompt_must_fail(
+            false,
+            true,
+            Some(DetachedCwdPromptResponse::Allow)
+        ));
     }
 
     #[test]
     fn missing_cwd_prompt_can_interactively_prompt_when_attached() {
-        assert!(!missing_cwd_prompt_must_fail(false, false));
+        assert!(!missing_cwd_prompt_must_fail(false, false, None));
+    }
+
+    #[test]
+    fn pending_cwd_access_request_uses_default_read_access() {
+        let dir = tempdir().expect("tmpdir");
+        let caps = CapabilitySet::new();
+        let request = pending_cwd_access_request(&caps, dir.path(), None)
+            .expect("request should evaluate")
+            .expect("request should be required");
+
+        assert_eq!(
+            request.cwd_canonical,
+            dir.path().canonicalize().expect("canonical")
+        );
+        assert_eq!(request.access, AccessMode::Read);
+    }
+
+    #[test]
+    fn pending_cwd_access_request_is_skipped_when_caps_cover_workdir() {
+        let dir = tempdir().expect("tmpdir");
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(
+            FsCapability::new_dir(dir.path(), AccessMode::ReadWrite).expect("dir capability"),
+        );
+
+        assert!(pending_cwd_access_request(&caps, dir.path(), None)
+            .expect("request should evaluate")
+            .is_none());
+    }
+
+    #[test]
+    fn detached_cwd_prompt_response_env_values_round_trip() {
+        assert_eq!(
+            DetachedCwdPromptResponse::from_env_value(
+                DetachedCwdPromptResponse::Allow.as_env_value()
+            ),
+            Some(DetachedCwdPromptResponse::Allow)
+        );
+        assert_eq!(
+            DetachedCwdPromptResponse::from_env_value(
+                DetachedCwdPromptResponse::Deny.as_env_value()
+            ),
+            Some(DetachedCwdPromptResponse::Deny)
+        );
     }
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -6,6 +6,7 @@ use crate::credential_runtime::load_env_credentials;
 use crate::profile;
 use crate::profile::WorkdirAccess;
 use crate::profile_runtime::prepare_profile;
+use crate::DETACHED_LAUNCH_ENV;
 use crate::{output, policy, protected_paths, sandbox_state};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
@@ -235,8 +236,13 @@ pub(crate) fn print_allow_launch_services_warning(silent: bool) {
     eprintln!("  Prefer using it from a trusted directory, not inside an untrusted project.");
 }
 
+fn missing_cwd_prompt_must_fail(silent: bool, detached_launch: bool) -> bool {
+    silent || detached_launch
+}
+
 pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> {
     sandbox_state::cleanup_stale_state_files();
+    let detached_launch = std::env::var_os(DETACHED_LAUNCH_ENV).is_some();
 
     let workdir = args
         .workdir
@@ -415,7 +421,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 info!("Auto-including CWD with {} access (--allow-cwd)", access);
                 let cap = FsCapability::new_dir(cwd_canonical.clone(), access)?;
                 caps.add_fs(cap);
-            } else if silent {
+            } else if missing_cwd_prompt_must_fail(silent, detached_launch) {
                 return Err(NonoError::CwdPromptRequired);
             } else {
                 let confirmed = output::prompt_cwd_sharing(&cwd_canonical, &access)?;
@@ -519,5 +525,20 @@ mod tests {
                 dir.path().join("future-dir").display()
             )]
         );
+    }
+
+    #[test]
+    fn missing_cwd_prompt_fails_in_silent_mode() {
+        assert!(missing_cwd_prompt_must_fail(true, false));
+    }
+
+    #[test]
+    fn missing_cwd_prompt_fails_for_detached_launches() {
+        assert!(missing_cwd_prompt_must_fail(false, true));
+    }
+
+    #[test]
+    fn missing_cwd_prompt_can_interactively_prompt_when_attached() {
+        assert!(!missing_cwd_prompt_must_fail(false, false));
     }
 }

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -1,5 +1,9 @@
 use crate::cli::{Commands, RunArgs};
-use crate::{output, session, update_check, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV};
+use crate::sandbox_prepare::resolve_detached_cwd_prompt_response;
+use crate::{
+    output, session, update_check, DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV,
+    DETACHED_SESSION_ID_ENV,
+};
 #[cfg(unix)]
 use nix::libc;
 use nono::{NonoError, Result};
@@ -16,6 +20,7 @@ pub(crate) fn allows_pre_exec_update_check(command: &Commands) -> bool {
 }
 
 pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
+    let cwd_prompt_response = resolve_detached_cwd_prompt_response(&args.sandbox, silent)?;
     let session_id = session::generate_session_id();
     let exe = std::env::current_exe().map_err(|e| {
         NonoError::SandboxInit(format!("Failed to resolve current executable: {e}"))
@@ -25,6 +30,9 @@ pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
     child.args(std::env::args_os().skip(1));
     child.env(DETACHED_LAUNCH_ENV, "1");
     child.env(DETACHED_SESSION_ID_ENV, &session_id);
+    if let Some(response) = cwd_prompt_response {
+        child.env(DETACHED_CWD_PROMPT_RESPONSE_ENV, response.as_env_value());
+    }
     child.stdin(Stdio::null());
     child.stdout(Stdio::null());
     child.stderr(startup_log_stdio);

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -29,7 +29,7 @@ pub enum NonoError {
     #[error("No command specified")]
     NoCommand,
 
-    #[error("CWD access requires --allow-cwd in silent mode")]
+    #[error("CWD access requires --allow-cwd in non-interactive mode")]
     CwdPromptRequired,
 
     // Sandbox errors


### PR DESCRIPTION
`DETACHED_CWD_PROMPT_RESPONSE_ENV` is added to pass the CWD sharing decision, with `resolve_detached_cwd_prompt_response` handling the prompt logic before detaching and forwarding the result as an environment variable to the detached process. 

`prepare_sandbox` is updated to consume this variable and apply the decision, while the new detached environment variables are excluded from child processes to prevent re-prompting. 

The `missing_cwd_prompt_must_fail` logic is now adjusted to account for pre-resolved responses, and a new `DetachedCwdPromptResponse` enum is introduced to represent and serialize the prompt outcome.