### PR TITLE
fix(cli): align status and attach columns in ps output

### DIFF
--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -62,22 +62,24 @@ pub fn run_ps(args: &PsArgs) -> Result<()> {
     for session in &filtered {
         let name = session.name.as_deref().unwrap_or("-");
         let status = match session.status {
-            SessionStatus::Running => "running".green().to_string(),
-            SessionStatus::Paused => "paused".yellow().to_string(),
+            SessionStatus::Running => format!("{:<10}", "running").green().to_string(),
+            SessionStatus::Paused => format!("{:<10}", "paused").yellow().to_string(),
             SessionStatus::Exited => {
                 let code = session.exit_code.unwrap_or(-1);
                 if code == 0 {
-                    "exited(0)".to_string()
+                    format!("{:<10}", "exited(0)")
                 } else {
-                    format!("exited({})", code).red().to_string()
+                    format!("{:<10}", format!("exited({})", code))
+                        .red()
+                        .to_string()
                 }
             }
         };
         let attach = match session.status {
-            SessionStatus::Exited => "-".to_string(),
+            SessionStatus::Exited => format!("{:<10}", "-"),
             _ => match session.attachment {
-                SessionAttachment::Attached => "attached".green().to_string(),
-                SessionAttachment::Detached => "detached".yellow().to_string(),
+                SessionAttachment::Attached => format!("{:<10}", "attached").green().to_string(),
+                SessionAttachment::Detached => format!("{:<10}", "detached").yellow().to_string(),
             },
         };
         let pid = session.child_pid;
@@ -86,7 +88,7 @@ pub fn run_ps(args: &PsArgs) -> Result<()> {
         let command = truncate_command(&session.command, 40);
 
         println!(
-            "{:<16} {:<12} {:<10} {:<10} {:<8} {:<10} {:<14} {}",
+            "{:<16} {:<12} {} {} {:<8} {:<10} {:<14} {}",
             session.session_id, name, status, attach, pid, uptime, profile, command
         );
     }

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -55,32 +55,39 @@ pub fn run_ps(args: &PsArgs) -> Result<()> {
 
     // Table header
     println!(
-        "{:<16} {:<12} {:<10} {:<10} {:<8} {:<10} {:<14} COMMAND",
+        "{:<16} {:<12} {:<12} {:<12} {:<8} {:<10} {:<14} COMMAND",
         "SESSION", "NAME", "STATUS", "ATTACH", "PID", "UPTIME", "PROFILE"
     );
 
     for session in &filtered {
         let name = session.name.as_deref().unwrap_or("-");
-        let status = match session.status {
-            SessionStatus::Running => format!("{:<10}", "running").green().to_string(),
-            SessionStatus::Paused => format!("{:<10}", "paused").yellow().to_string(),
-            SessionStatus::Exited => {
-                let code = session.exit_code.unwrap_or(-1);
-                if code == 0 {
-                    format!("{:<10}", "exited(0)")
-                } else {
-                    format!("{:<10}", format!("exited({})", code))
-                        .red()
-                        .to_string()
-                }
-            }
+        let col_width = 12;
+        let exit_code = session.exit_code.unwrap_or(-1);
+        let status_text = match session.status {
+            SessionStatus::Running => "running".to_string(),
+            SessionStatus::Paused => "paused".to_string(),
+            SessionStatus::Exited => format!("exited({exit_code})"),
         };
-        let attach = match session.status {
-            SessionStatus::Exited => format!("{:<10}", "-"),
+        let status_padded = format!("{status_text:<col_width$}");
+        let status = match session.status {
+            SessionStatus::Running => status_padded.green().to_string(),
+            SessionStatus::Paused => status_padded.yellow().to_string(),
+            SessionStatus::Exited if exit_code != 0 => status_padded.red().to_string(),
+            _ => status_padded,
+        };
+
+        let attach_text = match session.status {
+            SessionStatus::Exited => "-".to_string(),
             _ => match session.attachment {
-                SessionAttachment::Attached => format!("{:<10}", "attached").green().to_string(),
-                SessionAttachment::Detached => format!("{:<10}", "detached").yellow().to_string(),
+                SessionAttachment::Attached => "attached".to_string(),
+                SessionAttachment::Detached => "detached".to_string(),
             },
+        };
+        let attach_padded = format!("{attach_text:<col_width$}");
+        let attach = match (&session.status, &session.attachment) {
+            (SessionStatus::Exited, _) => attach_padded,
+            (_, SessionAttachment::Attached) => attach_padded.green().to_string(),
+            (_, SessionAttachment::Detached) => attach_padded.yellow().to_string(),
         };
         let pid = session.child_pid;
         let uptime = format_uptime(&session.started);


### PR DESCRIPTION
The `status` and `attach` columns in the `nono ps` command output were not consistently aligned. This was due to variable string lengths and ANSI color codes interfering with `println!`'s column width calculations.

This change explicitly pads the status and attachment strings to a fixed width of 10 characters *before* printing. This ensures proper column alignment and improves readability of the `ps` command output.