### PR TITLE
refactor(command-blocking): deprecate startup-only command blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Deprecations
+
+- Deprecate startup-only command blocking surfaces in `v0.33.0`, add compatibility warnings, and document the child-process bypass.
+
 ## [0.32.0] - 2026-04-10
 
 ### Features
@@ -900,4 +906,3 @@
 ### 🚀 Features
 
 - First release of seperarate nono and nono-cli packages
-

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -138,9 +138,13 @@ Profiles can form chains (up to 10 levels deep). Circular dependencies are detec
 my-dev.json → team-base.json → claude-code (built-in)
 ```
 
-## Command Blocking
+## Deprecated Command Blocking
 
-Dangerous commands are blocked by default:
+Command blocking is deprecated in `v0.33.0`. It is only checked against the
+directly-invoked startup command, not enforced for child processes, and should
+not be treated as a sandbox security boundary.
+
+Dangerous commands are still startup-blocked by default in `v0.33.x`:
 
 | Category | Commands |
 |----------|----------|
@@ -149,7 +153,7 @@ Dangerous commands are blocked by default:
 | Permission changes | `chmod`, `chown`, `chgrp` |
 | Privilege escalation | `sudo`, `su`, `doas` |
 
-Override per invocation with `--allow-command`, or permanently in a profile with `allowed_commands`:
+Compatibility overrides still exist temporarily:
 
 ```bash
 # Per invocation
@@ -165,6 +169,9 @@ cat > ~/.config/nono/profiles/my-profile.json << 'EOF'
 EOF
 nono run --profile my-profile -- rm /tmp/old-file.txt
 ```
+
+Prefer resource-based controls instead: narrower filesystem grants,
+`add_deny_access`, `unlink_protection`, and network policy.
 
 ## Documentation
 

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -135,7 +135,8 @@
         "allowed_commands": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Commands to allow even when blocked by default policy. Applied before CLI --allow-command overrides."
+          "description": "Deprecated in v0.33.0. Startup-only command allowlist override. Not enforced for child processes; prefer resource-based controls instead.",
+          "deprecated": true
         },
         "signal_mode": {
           "oneOf": [
@@ -260,6 +261,12 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Additional deny.access paths to apply."
+        },
+        "add_deny_commands": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Deprecated in v0.33.0. Startup-only command denylist extension. Not enforced for child processes; prefer resource-based controls instead.",
+          "deprecated": true
         },
         "override_deny": {
           "type": "array",

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -64,7 +64,7 @@ Inherit from another profile by name:
 | Field                 | Type            | Default      | Description |
 |-----------------------|-----------------|--------------|-------------|
 | `groups`              | array of string | `[]`         | Policy group names from `policy.json`. Use `nono policy groups` to list available groups. |
-| `allowed_commands`    | array of string | `[]`         | Commands to allow even when blocked by deny groups (e.g., `["rm"]`). |
+| `allowed_commands`    | array of string | `[]`         | Deprecated in v0.33.0. Startup-only command allowlist override. Not enforced for child processes. |
 | `signal_mode`         | string          | `"isolated"` | One of: `"isolated"`, `"allow_same_sandbox"`, `"allow_all"`. |
 | `process_info_mode`   | string          | `"isolated"` | One of: `"isolated"`, `"allow_same_sandbox"`, `"allow_all"`. |
 | `ipc_mode`            | string          | `"shared_memory_only"` | One of: `"shared_memory_only"`, `"full"`. Use `"full"` for multiprocessing (enables POSIX semaphores). macOS only. |
@@ -101,7 +101,7 @@ Provides subtractive and additive composition on top of inherited groups and fil
 | `add_allow_write`    | array of string | Additional write-only path grants. |
 | `add_allow_readwrite`| array of string | Additional read+write path grants. |
 | `add_deny_access`    | array of string | Additional deny paths. |
-| `add_deny_commands`  | array of string | Command names (basename only) to block. Blocks execution of the named binaries regardless of where they are installed. Checked before the sandbox enforces filesystem rules. |
+| `add_deny_commands`  | array of string | Deprecated in v0.33.0. Startup-only command denylist extension. Not enforced for child processes; prefer `add_deny_access` and narrower grants instead. |
 | `override_deny`      | array of string | Paths to exempt from deny groups. Each path must also be granted via `filesystem` or `add_allow_*`. Does not implicitly grant access; only removes the deny rule. |
 
 ### network
@@ -349,7 +349,7 @@ With `capability_elevation` enabled, nono runs in supervised mode where every fi
 
 ### Blocking container access (Docker, Podman, kubectl)
 
-Use `add_deny_access` together with `add_deny_commands` for defense-in-depth when you want to prevent an agent from reaching the Docker daemon or similar container runtimes:
+Use `add_deny_access` to prevent an agent from reaching the Docker daemon or similar container runtimes. `add_deny_commands` is deprecated startup-only gating and should not be relied on as enforcement:
 
 ```json
 {
@@ -365,7 +365,7 @@ Use `add_deny_access` together with `add_deny_commands` for defense-in-depth whe
 }
 ```
 
-On macOS, `add_deny_access` on a socket path also emits a Seatbelt `network-outbound` deny — Seatbelt treats `connect(2)` as a network operation so a file deny alone won't block it. `add_deny_commands` blocks the CLI tools as defense-in-depth, catching cases where an agent reaches the daemon through a forwarded or alternate socket path. Both are visible in `nono policy show` under **Policy patches**.
+On macOS, `add_deny_access` on a socket path also emits a Seatbelt `network-outbound` deny — Seatbelt treats `connect(2)` as a network operation so a file deny alone won't block it. Prefer path- and network-based controls; `add_deny_commands` remains as deprecated startup-only compatibility behavior and is visible in `nono policy show` under **Policy patches**.
 
 ### Profile with group exclusion
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -810,11 +810,11 @@ pub struct SandboxArgs {
     pub env_credential_map: Vec<String>,
 
     // ── Commands ─────────────────────────────────────────────────────────
-    /// Allow a normally-blocked dangerous command (use with caution)
+    /// Deprecated startup-only command allowlist override (not child-process enforced)
     #[arg(long, value_name = "CMD", help_heading = "COMMANDS")]
     pub allow_command: Vec<String>,
 
-    /// Block an additional command beyond the default blocklist
+    /// Deprecated startup-only command denylist extension (not child-process enforced)
     #[arg(long, value_name = "CMD", help_heading = "COMMANDS")]
     pub block_command: Vec<String>,
 
@@ -971,11 +971,11 @@ pub struct WrapSandboxArgs {
     pub env_credential_map: Vec<String>,
 
     // ── Commands ─────────────────────────────────────────────────────────
-    /// Allow a normally-blocked dangerous command (use with caution)
+    /// Deprecated startup-only command allowlist override (not child-process enforced)
     #[arg(long, value_name = "CMD", help_heading = "COMMANDS")]
     pub allow_command: Vec<String>,
 
-    /// Block an additional command beyond the default blocklist
+    /// Deprecated startup-only command denylist extension (not child-process enforced)
     #[arg(long, value_name = "CMD", help_heading = "COMMANDS")]
     pub block_command: Vec<String>,
 

--- a/crates/nono-cli/src/command_blocking_deprecation.rs
+++ b/crates/nono-cli/src/command_blocking_deprecation.rs
@@ -1,0 +1,181 @@
+use crate::cli::{Cli, Commands};
+use crate::output;
+use crate::profile::Profile;
+use nono::manifest::CapabilityManifest;
+use std::path::Path;
+
+const DEPRECATION_SUMMARY: &str =
+    "deprecated in v0.33.0: startup-only command gating, not kernel-enforced. \
+     Child processes can bypass it. Prefer resource-based controls such as \
+     add_deny_access, narrower filesystem grants, unlink_protection, and network policy.";
+
+fn format_commands(commands: &[String]) -> String {
+    commands.join(", ")
+}
+
+fn warning_for_surface(surface: &str, commands: &[String]) -> String {
+    format!(
+        "{surface} is {DEPRECATION_SUMMARY} Configured commands: {}.",
+        format_commands(commands)
+    )
+}
+
+pub(crate) fn blocked_command_reason() -> String {
+    "Command blocking is deprecated in v0.33.0 and only checks the directly-invoked \
+     startup command. Child processes can bypass it. Prefer resource-based controls \
+     such as add_deny_access, narrower filesystem grants, unlink_protection, and \
+     network policy."
+        .to_string()
+}
+
+pub(crate) fn collect_cli_warnings(cli: &Cli) -> Vec<String> {
+    match &cli.command {
+        Commands::Run(args) => {
+            collect_sandbox_arg_warnings(&args.sandbox.allow_command, &args.sandbox.block_command)
+        }
+        Commands::Shell(args) => {
+            collect_sandbox_arg_warnings(&args.sandbox.allow_command, &args.sandbox.block_command)
+        }
+        Commands::Wrap(args) => {
+            collect_sandbox_arg_warnings(&args.sandbox.allow_command, &args.sandbox.block_command)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn collect_sandbox_arg_warnings(
+    allowed_commands: &[String],
+    blocked_commands: &[String],
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if !allowed_commands.is_empty() {
+        warnings.push(warning_for_surface(
+            "CLI flag `--allow-command`",
+            allowed_commands,
+        ));
+    }
+    if !blocked_commands.is_empty() {
+        warnings.push(warning_for_surface(
+            "CLI flag `--block-command`",
+            blocked_commands,
+        ));
+    }
+
+    warnings
+}
+
+pub(crate) fn collect_profile_warnings(profile: &Profile) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let profile_name = format!("profile `{}`", profile.meta.name);
+
+    if !profile.security.allowed_commands.is_empty() {
+        warnings.push(warning_for_surface(
+            &format!("{profile_name} field `security.allowed_commands`"),
+            &profile.security.allowed_commands,
+        ));
+    }
+    if !profile.policy.add_deny_commands.is_empty() {
+        warnings.push(warning_for_surface(
+            &format!("{profile_name} field `policy.add_deny_commands`"),
+            &profile.policy.add_deny_commands,
+        ));
+    }
+
+    warnings
+}
+
+pub(crate) fn collect_manifest_warnings(
+    manifest: &CapabilityManifest,
+    manifest_path: &Path,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if let Some(process) = manifest.process.as_ref() {
+        if !process.allowed_commands.is_empty() {
+            warnings.push(warning_for_surface(
+                &format!(
+                    "capability manifest `{}` field `process.allowed_commands`",
+                    manifest_path.display()
+                ),
+                &process.allowed_commands,
+            ));
+        }
+        if !process.blocked_commands.is_empty() {
+            warnings.push(warning_for_surface(
+                &format!(
+                    "capability manifest `{}` field `process.blocked_commands`",
+                    manifest_path.display()
+                ),
+                &process.blocked_commands,
+            ));
+        }
+    }
+
+    warnings
+}
+
+pub(crate) fn print_warnings(warnings: &[String], silent: bool) {
+    if silent {
+        return;
+    }
+
+    for warning in warnings {
+        output::print_warning(warning);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_arg_warnings_include_allow_and_block_flags() {
+        let warnings = collect_sandbox_arg_warnings(
+            &["rm".to_string(), "chmod".to_string()],
+            &["docker".to_string()],
+        );
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("`--allow-command`"));
+        assert!(warnings[0].contains("rm, chmod"));
+        assert!(warnings[1].contains("`--block-command`"));
+        assert!(warnings[1].contains("docker"));
+    }
+
+    #[test]
+    fn profile_warnings_include_allowed_and_denied_command_fields() {
+        let profile: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "deprecated-commands" },
+                "security": { "allowed_commands": ["rm"] },
+                "policy": { "add_deny_commands": ["docker"] }
+            }"#,
+        )
+        .expect("profile should deserialize");
+
+        let warnings = collect_profile_warnings(&profile);
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("security.allowed_commands"));
+        assert!(warnings[1].contains("policy.add_deny_commands"));
+    }
+
+    #[test]
+    fn manifest_warnings_include_process_command_fields() {
+        let manifest = CapabilityManifest::from_json(
+            r#"{
+                "version": "0.1.0",
+                "process": {
+                    "allowed_commands": ["rm"],
+                    "blocked_commands": ["docker"]
+                }
+            }"#,
+        )
+        .expect("manifest should deserialize");
+
+        let warnings = collect_manifest_warnings(&manifest, Path::new("/tmp/caps.json"));
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("process.allowed_commands"));
+        assert!(warnings[1].contains("process.blocked_commands"));
+    }
+}

--- a/crates/nono-cli/src/command_blocking_deprecation.rs
+++ b/crates/nono-cli/src/command_blocking_deprecation.rs
@@ -8,24 +8,25 @@ const DEPRECATION_SUMMARY: &str =
     "deprecated in v0.33.0: startup-only command gating, not kernel-enforced. \
      Child processes can bypass it. Prefer resource-based controls such as \
      add_deny_access, narrower filesystem grants, unlink_protection, and network policy.";
+pub(crate) const BLOCKED_COMMAND_REASON: &str =
+    "Command blocking is deprecated in v0.33.0 and only checks the directly-invoked \
+     startup command. Child processes can bypass it. Prefer resource-based controls \
+     such as add_deny_access, narrower filesystem grants, unlink_protection, and \
+     network policy.";
 
 fn format_commands(commands: &[String]) -> String {
     commands.join(", ")
 }
 
 fn warning_for_surface(surface: &str, commands: &[String]) -> String {
-    format!(
-        "{surface} is {DEPRECATION_SUMMARY} Configured commands: {}.",
-        format_commands(commands)
-    )
-}
-
-pub(crate) fn blocked_command_reason() -> String {
-    "Command blocking is deprecated in v0.33.0 and only checks the directly-invoked \
-     startup command. Child processes can bypass it. Prefer resource-based controls \
-     such as add_deny_access, narrower filesystem grants, unlink_protection, and \
-     network policy."
-        .to_string()
+    if commands.is_empty() {
+        format!("{surface} is {DEPRECATION_SUMMARY}")
+    } else {
+        format!(
+            "{surface} is {DEPRECATION_SUMMARY} Configured commands: {}.",
+            format_commands(commands)
+        )
+    }
 }
 
 pub(crate) fn collect_cli_warnings(cli: &Cli) -> Vec<String> {
@@ -141,6 +142,14 @@ mod tests {
         assert!(warnings[0].contains("rm, chmod"));
         assert!(warnings[1].contains("`--block-command`"));
         assert!(warnings[1].contains("docker"));
+    }
+
+    #[test]
+    fn warning_for_surface_omits_empty_command_list_suffix() {
+        let warning = warning_for_surface("CLI flag `--block-command`", &[]);
+
+        assert!(warning.contains("CLI flag `--block-command`"));
+        assert!(!warning.contains("Configured commands:"));
     }
 
     #[test]

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -1,7 +1,7 @@
 use crate::launch_runtime::{select_threading_context, LaunchPlan};
 use crate::proxy_runtime::start_proxy_runtime;
 use crate::supervised_runtime::{execute_supervised_runtime, SupervisedRuntimeContext};
-use crate::{config, exec_strategy, output, sandbox_state};
+use crate::{command_blocking_deprecation, config, exec_strategy, output, sandbox_state};
 use nono::{CapabilitySet, NonoError, Result, Sandbox};
 use std::path::Path;
 use std::time::Duration;
@@ -108,9 +108,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     {
         return Err(NonoError::BlockedCommand {
             command: blocked,
-            reason: "This command is blocked by default due to destructive potential. \
-                     Use --allow-command to override if you understand the risks."
-                .to_string(),
+            reason: command_blocking_deprecation::blocked_command_reason(),
         });
     }
 

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -108,7 +108,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     {
         return Err(NonoError::BlockedCommand {
             command: blocked,
-            reason: command_blocking_deprecation::blocked_command_reason(),
+            reason: command_blocking_deprecation::BLOCKED_COMMAND_REASON.to_string(),
         });
     }
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -7,6 +7,7 @@ mod audit_commands;
 mod capability_ext;
 mod cli;
 mod cli_bootstrap;
+mod command_blocking_deprecation;
 mod command_runtime;
 mod config;
 mod credential_runtime;
@@ -61,6 +62,9 @@ use cli_bootstrap::{
     collect_legacy_network_warnings, init_theme, init_tracing, normalize_legacy_flag_env_vars,
     print_legacy_network_warnings,
 };
+use command_blocking_deprecation::{
+    collect_cli_warnings, print_warnings as print_deprecation_warnings,
+};
 use nono::Result;
 use tracing::error;
 
@@ -78,6 +82,8 @@ fn main() {
     init_tracing(&cli);
     init_theme(&cli);
     print_legacy_network_warnings(&legacy_network_warnings, cli.silent);
+    let command_blocking_warnings = collect_cli_warnings(&cli);
+    print_deprecation_warnings(&command_blocking_warnings, cli.silent);
 
     if let Err(e) = run_cli(cli) {
         error!("{}", e);

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -479,7 +479,10 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
 
     if !profile.security.allowed_commands.is_empty() {
         println!();
-        println!("  {}", theme::fg("Allowed commands:", t.subtext).bold());
+        println!(
+            "  {}",
+            theme::fg("Allowed commands (deprecated, startup-only):", t.subtext).bold()
+        );
         for cmd in &profile.security.allowed_commands {
             println!("    {}", theme::fg(cmd, t.text));
         }
@@ -559,7 +562,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         if !pp.add_deny_commands.is_empty() {
             println!(
                 "    {}: {}",
-                theme::fg("add_deny_commands", t.yellow),
+                theme::fg("add_deny_commands (deprecated, startup-only)", t.yellow),
                 pp.add_deny_commands.join(", ")
             );
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -75,9 +75,8 @@ pub struct PolicyPatchConfig {
     /// Additional deny.access paths to apply.
     #[serde(default)]
     pub add_deny_access: Vec<String>,
-    /// Additional commands to block, extending deny.commands from groups.
-    /// Useful for blocking specific binaries (e.g. "docker", "kubectl") without
-    /// requiring changes to policy.json.
+    /// Deprecated startup-only command denylist extension.
+    /// Parsed for compatibility in v0.33.0, but not enforced for child processes.
     #[serde(default)]
     pub add_deny_commands: Vec<String>,
     /// Paths to exempt from deny groups.
@@ -856,8 +855,8 @@ pub struct SecurityConfig {
     /// Policy group names to resolve (from policy.json)
     #[serde(default)]
     pub groups: Vec<String>,
-    /// Commands to allow even when blocked by default policy (e.g. `["rm"]`).
-    /// Applied before CLI `--allow-command` overrides.
+    /// Deprecated startup-only command allowlist override.
+    /// Parsed for compatibility in v0.33.0, but not enforced for child processes.
     #[serde(default)]
     pub allowed_commands: Vec<String>,
     /// Signal isolation mode. Controls whether the sandboxed process can signal

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1,5 +1,6 @@
 use crate::capability_ext::{self, CapabilitySetExt};
 use crate::cli::SandboxArgs;
+use crate::command_blocking_deprecation;
 #[cfg(target_os = "linux")]
 use crate::config;
 use crate::credential_runtime::load_env_credentials;
@@ -531,6 +532,9 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         })?;
         let mut manifest = nono::manifest::CapabilityManifest::from_json(&json)?;
         manifest.validate()?;
+        let manifest_warnings =
+            command_blocking_deprecation::collect_manifest_warnings(&manifest, config_path);
+        command_blocking_deprecation::print_warnings(&manifest_warnings, silent);
 
         if let Some(ref mut fs) = manifest.filesystem {
             for grant in &mut fs.grants {
@@ -620,6 +624,11 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allow_gpu: profile_allow_gpu,
         override_deny_paths,
     } = prepared_profile;
+
+    if let Some(profile) = loaded_profile.as_ref() {
+        let profile_warnings = command_blocking_deprecation::collect_profile_warnings(profile);
+        command_blocking_deprecation::print_warnings(&profile_warnings, silent);
+    }
 
     #[cfg(target_os = "linux")]
     if args.profile.as_deref() == Some("claude-code") {

--- a/crates/nono/schema/capability-manifest.schema.json
+++ b/crates/nono/schema/capability-manifest.schema.json
@@ -280,12 +280,14 @@
         "allowed_commands": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Commands to allow even when blocked by policy."
+          "description": "Deprecated in v0.33.0. Startup-only command allowlist override. Not enforced for child processes.",
+          "deprecated": true
         },
         "blocked_commands": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Commands to block from execution."
+          "description": "Deprecated in v0.33.0. Startup-only command denylist extension. Not enforced for child processes.",
+          "deprecated": true
         },
         "signal_mode": {
           "$ref": "#/$defs/SignalMode",

--- a/docs/cli/development/testing.mdx
+++ b/docs/cli/development/testing.mdx
@@ -111,7 +111,7 @@ Tests network blocking functionality.
 
 ### 6. Dangerous Commands (`test_commands.sh`)
 
-Verifies that potentially destructive commands are blocked by default.
+Verifies the current startup-only command-blocking compatibility behavior.
 
 | Category | Commands Blocked |
 |----------|------------------|
@@ -124,6 +124,7 @@ Verifies that potentially destructive commands are blocked by default.
 Also tests:
 - `--allow-command` flag to permit specific blocked commands
 - `--block-command` flag to block additional commands
+- documented child-process bypass behavior while the feature is deprecated in `v0.33.x`
 
 ### 7. Edge Cases (`test_edge_cases.sh`)
 

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -297,7 +297,7 @@ Groups are referenced by name in the `security.groups` field. See [Profiles & Gr
   "extends": "default",
   "meta": {
     "name": "permissive-agent",
-    "description": "Agent without dangerous command blocking"
+    "description": "Agent without deprecated startup-only command gating"
   },
   "workdir": { "access": "readwrite" },
   "policy": {

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -103,7 +103,7 @@ The `policy` section provides fine-grained, additive and subtractive composition
 | `add_allow_write` | Additional write-only directories to allow |
 | `add_allow_readwrite` | Additional read+write directories to allow |
 | `add_deny_access` | Additional deny rules to apply (block read and write content). On macOS, Unix socket paths also emit a `network-outbound` deny so that `connect(2)` to the socket is blocked. |
-| `add_deny_commands` | Command names (basename only) to block execution of. Complements `add_deny_access` for defense-in-depth against tools like `docker`, `kubectl`, etc. |
+| `add_deny_commands` | Deprecated in v0.33.0. Startup-only command denylist extension. Not enforced for child processes; prefer `add_deny_access` and narrower grants. |
 | `override_deny` | Paths to exempt from deny groups (must also have a matching grant) |
 
 #### Adding a Deny Rule to an Inherited Profile
@@ -129,7 +129,7 @@ nono run --profile claude-deny-git -- claude
 
 #### Blocking Container Access (Docker, Podman, kubectl)
 
-Use `add_deny_access` and `add_deny_commands` together for defense-in-depth:
+Use `add_deny_access` as the enforcement mechanism. `add_deny_commands` remains deprecated startup-only compatibility behavior:
 
 ```json
 {
@@ -142,7 +142,7 @@ Use `add_deny_access` and `add_deny_commands` together for defense-in-depth:
 }
 ```
 
-On macOS, `add_deny_access` on a socket path also emits a `network-outbound` deny — Seatbelt classifies `connect(2)` as a network operation, so a file deny alone won't block it. `add_deny_commands` blocks the CLI tools directly as defense-in-depth.
+On macOS, `add_deny_access` on a socket path also emits a `network-outbound` deny — Seatbelt classifies `connect(2)` as a network operation, so a file deny alone won't block it. Prefer path- and network-based controls; `add_deny_commands` is not enforced for child processes.
 
 #### Adding Write-Only Access
 
@@ -166,7 +166,7 @@ Grant write-only access to a directory without granting read:
 
 #### Removing Groups from an Inherited Profile
 
-Remove the dangerous command blocking group to allow `rm`, `chmod`, etc.:
+Remove the deprecated startup-only command-gating group to allow `rm`, `chmod`, etc.:
 
 ```json
 {
@@ -527,7 +527,7 @@ Platform-specific groups use `_macos` or `_linux` suffixes by convention.
 
 ### default
 
-The base profile that all other profiles extend. Provides system path access, deny groups for sensitive content, and dangerous command blocking. Does not grant working directory access or any user-specific paths.
+The base profile that all other profiles extend. Provides system path access, deny groups for sensitive content, and deprecated startup-only command gating. Does not grant working directory access or any user-specific paths.
 
 **Groups:** `deny_credentials`, `deny_keychains_macos`, `deny_keychains_linux`, `deny_browser_data_macos`, `deny_browser_data_linux`, `deny_macos_private`, `deny_shell_history`, `deny_shell_configs`, `system_read_macos`, `system_read_linux`, `system_write_macos`, `system_write_linux`, `user_tools`, `homebrew`, `dangerous_commands`, `dangerous_commands_macos`, `dangerous_commands_linux`
 

--- a/docs/cli/internals/wsl2-feature-matrix.mdx
+++ b/docs/cli/internals/wsl2-feature-matrix.mdx
@@ -127,9 +127,9 @@ Legend: **Full** = identical to native Linux | **Blocked (default)** = fails sec
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Default dangerous command blocklist (46 commands) | Full | Policy-driven |
-| `--allow-command` | Full | |
-| `--block-command` | Full | |
+| Default dangerous command blocklist (46 commands) | Deprecated | Startup-only check, not child-process enforced |
+| `--allow-command` | Deprecated | Startup-only compatibility behavior |
+| `--block-command` | Deprecated | Startup-only compatibility behavior |
 
 ## Trust & Signing
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -475,7 +475,9 @@ nono shell --allow-cwd --shell /bin/zsh
 
 #### `--allow-command`
 
-Allow a normally-blocked dangerous command. By default, destructive commands like `rm`, `dd`, `chmod` are blocked. Use this flag to override for a specific command.
+Deprecated in `v0.33.0`. Allows a normally-blocked startup command, but only for
+the directly-invoked executable. Child processes can bypass this check, so it
+should not be treated as a sandbox security boundary.
 
 ```bash
 # Allow rm (blocked by default)
@@ -486,14 +488,16 @@ nono run --allow-cwd --allow-command rm --allow-command mv -- my-script.sh
 ```
 
 <Note>
-  Even with `--allow-command`, the kernel sandbox still restricts file operations to granted paths. A command can only affect files within directories you explicitly allowed.
+  `--allow-command` and the default command blocklist are startup-only checks.
+  They do not prevent child processes, interpreters, language runtimes, shell
+  built-ins, renamed binaries, or equivalent APIs from performing the same
+  operation. For hard protection, rely on kernel-enforced path and network
+  controls such as `deny.access`, `deny.unlink`, narrower filesystem grants,
+  and network policy.
 </Note>
 
-<Note>
-  Command blocking is a best-effort surface-level control. It matches against the executable name being invoked directly. It does not prevent a process from performing the equivalent operation through language-level APIs (e.g., `os.remove()` in Python), shell built-ins, or renamed binaries. For hard protection against destructive filesystem operations, rely on kernel-enforced deny groups (`deny.access`, `deny.unlink`) and path-based sandboxing, which apply regardless of how the operation is invoked.
-</Note>
-
-Commands can also be allowed permanently via the `allowed_commands` field in a profile's security config:
+Commands can also be allowed temporarily via the deprecated `allowed_commands`
+field in a profile's security config:
 
 ```json
 {
@@ -509,7 +513,8 @@ nono run --profile my-profile -- rm /tmp/old-file.txt
 
 #### `--block-command`
 
-Block an additional command beyond the default blocklist.
+Deprecated in `v0.33.0`. Adds a startup-only command denylist entry for the
+directly-invoked executable. Child processes can bypass this check.
 
 ```bash
 # Block a custom tool in addition to defaults

--- a/tests/integration/test_commands.sh
+++ b/tests/integration/test_commands.sh
@@ -101,6 +101,11 @@ expect_failure "ls blocked with --block-command ls" \
 expect_failure "explicitly blocked command overrides default allow" \
     "$NONO_BIN" run --allow "$TMPDIR" --block-command echo -- echo "should fail"
 
+# Documented limitation while command blocking is deprecated in v0.33.x:
+# the startup-only check does not apply to child processes.
+expect_success "documented limitation: child shell bypasses blocked command check" \
+    "$NONO_BIN" run --allow "$TMPDIR" --block-command uname -- sh -c "uname >/dev/null"
+
 # =============================================================================
 # Package Managers
 # =============================================================================


### PR DESCRIPTION
Deprecate the startup-only command blocking feature and add compatibility warnings. This change clarifies that command blocking is not a robust security boundary as it is only checked against the directly invoked startup command and not enforced for child processes.

- Mark `allowed_commands` and `add_deny_commands` in profiles and manifests as deprecated.
- Update CLI flag descriptions (`--allow-command`, `--block-command`) to reflect deprecation and startup-only nature.
- Introduce runtime warnings for users utilizing deprecated command blocking fields and CLI flags.
- Update all relevant documentation (README, schema, profile guides, CLI flags) to explain the deprecation and recommend resource-based controls like `add_deny_access`, `unlink_protection`, and narrower filesystem/network grants.
- Add a new integration test explicitly demonstrating the child-process bypass for blocked commands.
- Implement a new module (`command_blocking_deprecation`) to manage and display warnings.