### PR TITLE
fix(proxy): set ANTHROPIC_API_KEY phantom token for anthropic credential

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -140,7 +140,7 @@
         "sigstore",
         "documentation"
       ],
-      "credentials": ["github"]
+      "credentials": ["anthropic", "github"]
     },
     "minimal": {
       "groups": [
@@ -170,7 +170,7 @@
       "upstream": "https://api.anthropic.com",
       "inject_header": "x-api-key",
       "credential_format": "{}",
-      "credential_key": "ANTHROPIC_API_KEY",
+      "credential_key": "env://ANTHROPIC_API_KEY",
       "env_var": "ANTHROPIC_API_KEY"
     },
     "gemini": {

--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -169,7 +169,9 @@
     "anthropic": {
       "upstream": "https://api.anthropic.com",
       "inject_header": "x-api-key",
-      "credential_format": "{}"
+      "credential_format": "{}",
+      "credential_key": "ANTHROPIC_API_KEY",
+      "env_var": "ANTHROPIC_API_KEY"
     },
     "gemini": {
       "upstream": "https://generativelanguage.googleapis.com",

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -886,6 +886,88 @@ mod tests {
     }
 
     #[test]
+    fn test_anthropic_credential_phantom_token_regression() {
+        // Regression test for issue #624: the built-in anthropic credential
+        // entry had no env_var or credential_key, so ANTHROPIC_API_KEY was
+        // never set to the phantom token. Only ANTHROPIC_BASE_URL was injected,
+        // leaving the sandbox to send the host's real key directly.
+        //
+        // Pre-fix state: route in loaded_routes but no env_var / credential_key
+        // => ANTHROPIC_API_KEY must NOT appear (demonstrates the bug).
+        let (shutdown_tx, _) = tokio::sync::watch::channel(false);
+        let handle_no_env_var = ProxyHandle {
+            port: 12345,
+            token: Zeroizing::new("phantom".to_string()),
+            audit_log: audit::new_audit_log(),
+            shutdown_tx: shutdown_tx.clone(),
+            loaded_routes: ["anthropic".to_string()].into_iter().collect(),
+            no_proxy_hosts: Vec::new(),
+        };
+        let config_no_env_var = ProxyConfig {
+            routes: vec![crate::config::RouteConfig {
+                prefix: "anthropic".to_string(),
+                upstream: "https://api.anthropic.com".to_string(),
+                credential_key: None,
+                inject_mode: crate::config::InjectMode::Header,
+                inject_header: "x-api-key".to_string(),
+                credential_format: "{}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+            }],
+            ..Default::default()
+        };
+        let vars_no_env_var = handle_no_env_var.credential_env_vars(&config_no_env_var);
+        assert!(
+            vars_no_env_var.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"),
+            "pre-fix: ANTHROPIC_API_KEY must not be set when neither env_var nor credential_key is defined (bug reproduced)"
+        );
+
+        // Post-fix state: route has env_var = "ANTHROPIC_API_KEY"
+        // => ANTHROPIC_API_KEY must be set to the phantom token.
+        let (shutdown_tx2, _) = tokio::sync::watch::channel(false);
+        let handle_fixed = ProxyHandle {
+            port: 12345,
+            token: Zeroizing::new("phantom".to_string()),
+            audit_log: audit::new_audit_log(),
+            shutdown_tx: shutdown_tx2,
+            loaded_routes: ["anthropic".to_string()].into_iter().collect(),
+            no_proxy_hosts: Vec::new(),
+        };
+        let config_fixed = ProxyConfig {
+            routes: vec![crate::config::RouteConfig {
+                prefix: "anthropic".to_string(),
+                upstream: "https://api.anthropic.com".to_string(),
+                credential_key: Some("ANTHROPIC_API_KEY".to_string()),
+                inject_mode: crate::config::InjectMode::Header,
+                inject_header: "x-api-key".to_string(),
+                credential_format: "{}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: Some("ANTHROPIC_API_KEY".to_string()),
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+            }],
+            ..Default::default()
+        };
+        let vars_fixed = handle_fixed.credential_env_vars(&config_fixed);
+        let api_key_var = vars_fixed.iter().find(|(k, _)| k == "ANTHROPIC_API_KEY");
+        assert!(
+            api_key_var.is_some(),
+            "post-fix: ANTHROPIC_API_KEY must be set to the phantom token"
+        );
+        assert_eq!(api_key_var.unwrap().1, "phantom");
+    }
+
+    #[test]
     fn test_no_proxy_excludes_credential_upstreams() {
         let (shutdown_tx, _) = tokio::sync::watch::channel(false);
         let handle = ProxyHandle {

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -150,8 +150,13 @@ impl ProxyHandle {
             if let Some(ref env_var) = route.env_var {
                 vars.push((env_var.clone(), self.token.to_string()));
             } else if let Some(ref cred_key) = route.credential_key {
-                let api_key_name = cred_key.to_uppercase();
-                vars.push((api_key_name, self.token.to_string()));
+                // Skip URI-format keys (e.g. env://, op://, apple-password://) —
+                // uppercasing a URI produces a nonsensical env var name. These
+                // routes must declare an explicit env_var to get phantom token injection.
+                if !cred_key.contains("://") {
+                    let api_key_name = cred_key.to_uppercase();
+                    vars.push((api_key_name, self.token.to_string()));
+                }
             }
         }
         vars


### PR DESCRIPTION
## Summary

- `network-policy.json`: adds `credential_key: env://ANTHROPIC_API_KEY` and `env_var: ANTHROPIC_API_KEY` to the `anthropic` credential entry — without these, `credential_env_vars()` never sets `ANTHROPIC_API_KEY` to the phantom token, so the sandbox keeps the host's real key and bypasses the proxy's credential swap
- `network-policy.json`: adds `"anthropic"` to the `claude-code` profile's credentials list so the credential is available when activated
- `server.rs`: hardens the `credential_key.to_uppercase()` fallback to skip URI-format refs (containing `://`) — uppercasing `env://` or `op://` produces nonsensical env var names; such routes must declare an explicit `env_var` instead
- `server.rs`: regression test that reproduces the pre-fix state (no phantom token injected) and confirms the post-fix state (phantom token set correctly)

## Activation note

The proxy (and phantom token injection) activates when credentials are explicitly requested — either via `--credential anthropic` on the CLI or by setting `credentials: ["anthropic"]` in the `network` section of a profile. The `claude-code` base profile does not auto-activate credentials, consistent with how `codex` treats OpenAI credentials. Whether the `claude-code` profile should auto-activate `anthropic` is a separate design question.

## Test plan

- [x] All 141 nono-proxy tests pass (`cargo test -p nono-proxy`)
- [x] Session with `--profile claude-code --credential anthropic`: `ANTHROPIC_API_KEY` in sandbox env equals the phantom token, not the host key (`ANTHROPIC_API_KEY=real-host-key-sentinel` → replaced with 64-char hex phantom token)
- [x] `ANTHROPIC_BASE_URL` points to the local proxy (`http://127.0.0.1:<port>/anthropic`)
- [ ] Claude Code in the sandbox reaches `api.anthropic.com` successfully via the proxy (requires live session with real key — not yet tested)