### PR TITLE
fix(sandbox): redirect ~/.claude.json to ~/.claude/ via symlink on all unix platforms

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1,7 +1,7 @@
 use crate::capability_ext::{self, CapabilitySetExt};
 use crate::cli::SandboxArgs;
 use crate::command_blocking_deprecation;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use crate::config;
 use crate::credential_runtime::load_env_credentials;
 use crate::profile;
@@ -12,7 +12,7 @@ use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
 use std::collections::HashMap;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
@@ -636,7 +636,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         command_blocking_deprecation::print_warnings(&profile_warnings, silent);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     if args.profile.as_deref() == Some("claude-code") {
         let home = config::validated_home()?;
         let home_path = std::path::Path::new(&home);
@@ -661,6 +661,46 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
 
         precreate(&home_path.join(".claude.json.lock"), false);
         precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
+
+        // Claude Code writes ~/.claude.json atomically via temp files named
+        // ~/.claude.json.tmp.<pid>.<timestamp>.  Landlock/Seatbelt cannot
+        // grant permission for these dynamically-named files in ~/, so token
+        // refreshes silently fail and the user is logged out.
+        //
+        // Fix: redirect ~/.claude.json to ~/.claude/claude.json via a
+        // symlink.  Claude Code resolves symlinks before computing the temp
+        // file path, so temp files land in ~/.claude/ (already readwrite)
+        // instead of ~/ (not writable inside the sandbox).
+        let claude_json = home_path.join(".claude.json");
+        let claude_dir = home_path.join(".claude");
+        let redirect_target = claude_dir.join("claude.json");
+
+        if let Err(e) = std::fs::create_dir_all(&claude_dir) {
+            warn!("Failed to create ~/.claude: {}", e);
+        } else if !claude_json.is_symlink() {
+            if claude_json.exists() {
+                // Regular file present — move it into ~/.claude/ then symlink.
+                if let Err(e) = std::fs::rename(&claude_json, &redirect_target) {
+                    warn!(
+                        "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
+                        e
+                    );
+                } else if let Err(e) =
+                    std::os::unix::fs::symlink(&redirect_target, &claude_json)
+                {
+                    warn!("Failed to create ~/.claude.json symlink: {}", e);
+                }
+            } else {
+                // File doesn't exist yet — pre-create the target so the
+                // sandbox can attach a path rule to it, then symlink.
+                precreate(&redirect_target, false);
+                if let Err(e) = std::os::unix::fs::symlink(&redirect_target, &claude_json) {
+                    if e.kind() != std::io::ErrorKind::AlreadyExists {
+                        warn!("Failed to create ~/.claude.json symlink: {}", e);
+                    }
+                }
+            }
+        }
     }
 
     let (mut caps, needs_unlink_overrides) = if let Some(ref profile) = loaded_profile {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -685,9 +685,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                         "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
                         e
                     );
-                } else if let Err(e) =
-                    std::os::unix::fs::symlink(&redirect_target, &claude_json)
-                {
+                } else if let Err(e) = std::os::unix::fs::symlink(&redirect_target, &claude_json) {
                     warn!("Failed to create ~/.claude.json symlink: {}", e);
                 }
             } else {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -685,14 +685,16 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                         "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
                         e
                     );
-                } else if let Err(e) = std::os::unix::fs::symlink(&redirect_target, &claude_json) {
+                } else if let Err(e) =
+                    std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
+                {
                     warn!("Failed to create ~/.claude.json symlink: {}", e);
                 }
             } else {
                 // File doesn't exist yet — pre-create the target so the
                 // sandbox can attach a path rule to it, then symlink.
                 precreate(&redirect_target, false);
-                if let Err(e) = std::os::unix::fs::symlink(&redirect_target, &claude_json) {
+                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json) {
                     if e.kind() != std::io::ErrorKind::AlreadyExists {
                         warn!("Failed to create ~/.claude.json symlink: {}", e);
                     }


### PR DESCRIPTION
## Problem

Fixes #220

Claude Code writes `~/.claude.json` atomically by creating a temp file at `~/.claude.json.tmp.<pid>.<timestamp>` in the same directory (`~/`), then renaming it. Landlock (Linux) and Seatbelt (macOS) cannot grant permission for these dynamically-named files in `~/`, so token writes silently fail and users are logged out mid-session.

This is the root cause of the workaround reported in #220 where users had to run `claude /login` outside the sandbox, then restart inside — the login itself worked but the token write failed silently, so the next session had no credentials.

## Fix

Before applying the sandbox, redirect `~/.claude.json` to `~/.claude/claude.json` via a symlink. Claude Code resolves symlinks before computing the temp file path, so temp files land in `~/.claude/` (already `readwrite` in the profile) instead of `~/` (not writable inside the sandbox).

Three cases handled:
- `~/.claude.json` is a regular file → move to `~/.claude/claude.json`, create symlink
- `~/.claude.json` doesn't exist yet → pre-create target, create symlink
- `~/.claude.json` is already a symlink → no-op

Also expands the precreate block from `#[cfg(target_os = "linux")]` to `#[cfg(unix)]` — the same atomic-write problem exists on macOS (confirmed by multiple users in #220), so the fix needs to run on both platforms.

## Testing

Tested on macOS with Seatbelt:

- Confirmed `~/` temp writes are blocked inside sandbox (`EPERM`)
- Confirmed `~/.claude/` temp writes succeed after symlink redirect
- Ran full `claude /login` flow inside the nono sandbox — browser opened, OAuth completed, token written successfully with no workaround needed
- Confirmed authenticated API calls work inside the sandbox after login (`claude --print` returns a real response)
- All 20 integration test suites pass