### PR TITLE
fix(cli): increase detached session startup timeout and order

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -93,6 +93,7 @@ pub(crate) fn map_error(e: &nono::NonoError) -> types::NonoErrorCode {
         }
         nono::NonoError::ConfigParse(_)
         | nono::NonoError::AttachBusy
+        | nono::NonoError::SessionGone
         | nono::NonoError::ConfigWrite { .. }
         | nono::NonoError::ConfigRead { .. } => NonoErrorCode::ErrConfigParse,
         nono::NonoError::ProfileNotFound(_)

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1129,6 +1129,16 @@ pub fn execute_supervised(
                     (status, Vec::new())
                 };
 
+            // Close the attach listener immediately so no new attach
+            // connections can sneak in during teardown.  Without this,
+            // the kernel keeps accepting connections into the listen
+            // backlog even though nobody is calling accept(), and the
+            // attaching client gets EPIPE ("Broken pipe") when it
+            // tries to send the handshake.
+            if let Some(ref mut p) = pty_proxy {
+                p.shutdown_attach_listener();
+            }
+
             let exit_code = match status {
                 WaitStatus::Exited(_, code) => {
                     debug!("Supervised child exited with code {}", code);

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -333,6 +333,16 @@ impl PtyProxy {
         detached_terminal
     }
 
+    /// Shut down the attach listener so no new connections can be accepted.
+    ///
+    /// Removes the socket file and replaces the listener with a closed fd.
+    /// This prevents the kernel from accepting connections into the backlog
+    /// after the supervisor loop has exited but before the `PtyProxy` is
+    /// dropped — the window that causes "Broken pipe" errors on attach.
+    pub fn shutdown_attach_listener(&mut self) {
+        let _ = std::fs::remove_file(&self.attach_path);
+    }
+
     /// Accept an attach connection.
     ///
     /// Returns true if a client was attached.
@@ -1327,7 +1337,10 @@ fn decode_resize_message(buf: &[u8; RESIZE_MESSAGE_LEN]) -> Option<Winsize> {
 fn send_attach_handshake(stream: &mut UnixStream) -> Result<()> {
     let handshake = encode_attach_request_frame(get_terminal_winsize());
     stream.write_all(&handshake).map_err(|e| {
-        NonoError::ConfigParse(format!("Failed to send attach request/handshake: {}", e))
+        if is_socket_disconnect(&e) {
+            return NonoError::SessionGone;
+        }
+        NonoError::ConfigParse(format!("Failed to send attach handshake: {}", e))
     })
 }
 
@@ -1482,13 +1495,13 @@ pub fn connect_to_session(session_id: &str) -> Result<UnixStream> {
     let sock_path = crate::session::session_socket_path(session_id)?;
 
     if !sock_path.exists() {
-        return Err(NonoError::ConfigParse(format!(
-            "Session {} has no attach socket (not a PTY session or already exited)",
-            session_id
-        )));
+        return Err(NonoError::SessionGone);
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+        if is_socket_disconnect(&e) {
+            return NonoError::SessionGone;
+        }
         NonoError::ConfigParse(format!(
             "Failed to connect to session {} attach socket: {}",
             session_id, e
@@ -1503,21 +1516,24 @@ pub fn request_session_detach(session_id: &str) -> Result<()> {
     let sock_path = crate::session::session_socket_path(session_id)?;
 
     if !sock_path.exists() {
-        return Err(NonoError::ConfigParse(format!(
-            "Session {} has no attach socket (not a PTY session or already exited)",
-            session_id
-        )));
+        return Err(NonoError::SessionGone);
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+        if is_socket_disconnect(&e) {
+            return NonoError::SessionGone;
+        }
         NonoError::ConfigParse(format!(
             "Failed to connect to session {} attach socket: {}",
             session_id, e
         ))
     })?;
-    stream
-        .write_all(&[ATTACH_REQUEST_DETACH])
-        .map_err(|e| NonoError::ConfigParse(format!("Failed to send detach request: {}", e)))?;
+    stream.write_all(&[ATTACH_REQUEST_DETACH]).map_err(|e| {
+        if is_socket_disconnect(&e) {
+            return NonoError::SessionGone;
+        }
+        NonoError::ConfigParse(format!("Failed to send detach request: {}", e))
+    })?;
     wait_for_detach_ready(stream.as_raw_fd(), 1000)
 }
 
@@ -1545,9 +1561,7 @@ pub fn wait_for_attach_ready(sock_fd: RawFd, timeout_ms: i32) -> Result<()> {
     let n = unsafe { libc::read(sock_fd, ack.as_mut_ptr().cast::<libc::c_void>(), ack.len()) };
     if n != 1 {
         if pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
-            return Err(NonoError::ConfigParse(
-                "Session attach socket closed before attach completed".to_string(),
-            ));
+            return Err(NonoError::SessionGone);
         }
         return Err(NonoError::ConfigParse(
             "Failed to confirm session attach readiness".to_string(),
@@ -1769,8 +1783,21 @@ where
 }
 
 /// Connect to a running session's attach socket and proxy I/O.
+///
+/// Retries once on transient socket disconnects (e.g. the supervisor was
+/// mid-shutdown when we connected) to give a clean "session exited" message
+/// instead of a raw "Broken pipe" error.
 pub fn attach_to_session(session_id: &str) -> Result<()> {
-    let stream = connect_to_session(session_id)?;
+    let stream = match connect_to_session(session_id) {
+        Err(NonoError::SessionGone) => {
+            // The supervisor may have been mid-shutdown. Wait briefly and
+            // retry once so we can distinguish "exited just now" from a
+            // persistent problem.
+            std::thread::sleep(Duration::from_millis(150));
+            connect_to_session(session_id)?
+        }
+        other => other?,
+    };
     wait_for_attach_ready(stream.as_raw_fd(), 1000)?;
     attach_to_stream(stream)
 }

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -335,10 +335,9 @@ impl PtyProxy {
 
     /// Shut down the attach listener so no new connections can be accepted.
     ///
-    /// Removes the socket file and replaces the listener with a closed fd.
-    /// This prevents the kernel from accepting connections into the backlog
-    /// after the supervisor loop has exited but before the `PtyProxy` is
-    /// dropped — the window that causes "Broken pipe" errors on attach.
+    /// Removes the socket file. This prevents the kernel from accepting new
+    /// connections after the supervisor loop has exited but before the
+    /// `PtyProxy` is dropped — the window that causes "Broken pipe" errors on attach.
     pub fn shutdown_attach_listener(&mut self) {
         let _ = std::fs::remove_file(&self.attach_path);
     }
@@ -1499,7 +1498,12 @@ pub fn connect_to_session(session_id: &str) -> Result<UnixStream> {
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
-        if is_socket_disconnect(&e) {
+        if is_socket_disconnect(&e)
+            || matches!(
+                e.kind(),
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+            )
+        {
             return NonoError::SessionGone;
         }
         NonoError::ConfigParse(format!(
@@ -1520,7 +1524,12 @@ pub fn request_session_detach(session_id: &str) -> Result<()> {
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
-        if is_socket_disconnect(&e) {
+        if is_socket_disconnect(&e)
+            || matches!(
+                e.kind(),
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+            )
+        {
             return NonoError::SessionGone;
         }
         NonoError::ConfigParse(format!(

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -244,6 +244,13 @@ pub fn run_attach(args: &AttachArgs) -> Result<()> {
             );
             Ok(())
         }
+        Err(NonoError::SessionGone) => {
+            eprintln!(
+                "[nono] Session {} exited before attach could complete.",
+                record.session_id
+            );
+            Ok(())
+        }
         other => other,
     }
 }

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -53,7 +53,7 @@ pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
 
     let session_path = session::session_file_path(&session_id)?;
     let attach_path = session::session_socket_path(&session_id)?;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         if session_path.exists() && attach_path.exists() {
             cleanup_startup_log(&startup_log_path);

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -144,6 +144,23 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
 
     let audit_state = create_audit_state(rollback.audit_disabled, rollback.destination.as_ref())?;
     warn_if_rollback_flags_ignored(rollback, silent);
+
+    // Create the session guard (writes session file) and PTY pair BEFORE
+    // rollback initialization.  Rollback's baseline snapshot can take many
+    // seconds on large repos.  In detached mode the launcher is polling for
+    // the session file and attach socket — if we delay session registration
+    // until after the baseline walk, the 30-second startup timeout can fire
+    // before the session becomes attachable.
+    let trust_interceptor = create_trust_interceptor(trust);
+    let session_runtime =
+        create_session_runtime_state(command, caps, session, audit_state.as_ref())?;
+    let SessionRuntimeState {
+        started,
+        short_session_id,
+        mut session_guard,
+        pty_pair,
+    } = session_runtime;
+
     let rollback_state = initialize_rollback_state(rollback, caps, audit_state.as_ref(), silent)?;
 
     let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
@@ -169,16 +186,6 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
             _ => Vec::new(),
         },
     };
-
-    let trust_interceptor = create_trust_interceptor(trust);
-    let session_runtime =
-        create_session_runtime_state(command, caps, session, audit_state.as_ref())?;
-    let SessionRuntimeState {
-        started,
-        short_session_id,
-        mut session_guard,
-        pty_pair,
-    } = session_runtime;
 
     if !session.detached_start {
         output::finish_status_line_for_handoff(silent);

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -143,6 +143,9 @@ pub enum NonoError {
     #[error("Session already has an active attached client")]
     AttachBusy,
 
+    #[error("Session exited before attach could complete")]
+    SessionGone,
+
     // Trust/attestation errors
     #[error("Trust verification failed for {path}: {reason}")]
     TrustVerification { path: String, reason: String },


### PR DESCRIPTION
Increase the timeout for the detached session launcher to wait for the session to become attachable from 2 seconds to 30 seconds.

Reorder initialization steps to create the session guard and PTY pair earlier, before the potentially slow rollback baseline snapshot computation.