### PR TITLE
fix(learn): validate profile name and re-prompt on invalid input

### DIFF
--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -70,31 +70,36 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
         })?;
 
     eprintln!();
+    eprintln!(
+        "{}",
+        "Profile name must be alphanumeric with hyphens only (e.g. my-profile), no leading or trailing hyphens.".dimmed()
+    );
     eprint!("Save as profile? Enter a name (or press Enter to skip): ");
 
-    let mut input = String::new();
-    std::io::stdin()
-        .read_line(&mut input)
-        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
+    let profile_name = loop {
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
 
-    let input = input.trim();
+        let input = input.trim().to_string();
 
-    if input.is_empty() {
-        return Ok(());
-    }
+        if input.is_empty() {
+            return Ok(());
+        }
 
-    let profile_name = input;
+        if profile::is_valid_profile_name(&input) {
+            break input;
+        }
 
-    if !profile_name
-        .chars()
-        .all(|character| character.is_ascii_alphanumeric() || character == '-' || character == '_')
-    {
         eprintln!(
             "{}",
-            "Invalid profile name. Use only letters, numbers, hyphens, and underscores.".red()
+            "Invalid profile name. Use only letters and numbers separated by hyphens, with no leading or trailing hyphens.".red()
         );
-        return Ok(());
-    }
+        eprint!("Enter a name (or press Enter to skip): ");
+    };
+
+    let profile_name = profile_name.as_str();
 
     let profile_json = result.to_profile(profile_name, cmd_name)?;
 


### PR DESCRIPTION
## Summary

Fixes #661

- Display naming requirements before the save prompt so users know the rules upfront
- Replace the one-shot rejection with a validate-and-re-prompt loop using `profile::is_valid_profile_name`
- The old inline check incorrectly allowed underscores (e.g. `my_profile`), which pass the learn-time check but fail at run time — now both use the same validator

## Test plan

- [x] `cargo build` passes
- [x] All 20 integration test suites pass (`bash tests/run_integration_tests.sh`)
- [x] Manual: entering an invalid name (e.g. `bad_name`, `--bad`, `bad-`) re-prompts with an error message
- [x] Manual: pressing Enter skips saving as expected
- [x] Manual: a valid name (e.g. `my-profile`) saves successfully