### PR TITLE
fix(proxy): downgrade blocked-CONNECT log from warn to debug

### DIFF
--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -448,7 +448,7 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                         .rsplit_once(':')
                         .map(|(h, p)| (h, p.parse::<u16>().unwrap_or(443)))
                         .unwrap_or((&host_port, 443));
-                    warn!(
+                    debug!(
                         "Blocked CONNECT to route upstream {} — use reverse proxy path instead",
                         authority
                     );


### PR DESCRIPTION
## Summary

- Fixes #655
- The proxy intentionally blocks CONNECT tunnels to route upstreams (e.g. `api.anthropic.com`) so that L7 filtering and credential injection remain enforced. This is correct behaviour.
- However, the `warn!` log emitted on each block was appearing on the user's terminal at the default log level, interleaving with stdout and corrupting TUI/interactive output.
- Demote to `debug!` — the 403 response is the appropriate signal to the client; no operator action is required on this event.

## Notes on reproduction

The issue was originally filed against **0.32.0** on Linux 6.1 (Landlock V2 / seccomp fallback). On the current 0.35.0 codebase on macOS:

- **Bug 1** (CONNECT 403 for `allow_domain` hosts such as `httpbin.org`) does **not** reproduce — CONNECT to an `allow_domain` host flows correctly through `handle_connect()` → `filter.check_host()` → allowed. This part was likely fixed in an earlier release.
- **Bug 2** (WARN polluting terminal when a client falls back to the reverse proxy path) **does** reproduce. With the original `warn!`, nono's default log level (`warn`) surfaces the message on every blocked CONNECT, including the expected case where a client (Node.js undici, curl) retries via the reverse proxy and ultimately succeeds.

## Test plan

- [x] `cargo test -p nono-proxy` — all 161 tests pass
- [x] `cargo test` — full suite passes
- [x] Manual smoke test with reproduction profile (`network_profile: claude-code`, `allow_domain: ["httpbin.org"]`):
  - `curl -sS https://httpbin.org/get` inside sandbox → succeeds, no WARN emitted
  - `curl -sS https://api.anthropic.com/v1/models` inside sandbox → 403 as expected, no WARN on terminal (previously showed WARN)