### PR TITLE
feat(learn): print profile JSON as fallback when save fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,9 +2320,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -100,13 +100,16 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
 
     let config_dir = profile::resolve_user_config_dir()?;
     let profiles_dir = config_dir.join("nono").join("profiles");
-    std::fs::create_dir_all(&profiles_dir).map_err(|e| {
-        NonoError::LearnError(format!(
-            "Failed to create profiles directory {}: {}",
+    if let Err(e) = std::fs::create_dir_all(&profiles_dir) {
+        eprintln!(
+            "{} Failed to create profiles directory {}: {}",
+            "Error:".red(),
             profiles_dir.display(),
             e
-        ))
-    })?;
+        );
+        print_profile_fallback(&profile_json);
+        return Ok(());
+    }
 
     let profile_path = profiles_dir.join(format!("{}.json", profile_name));
 
@@ -125,13 +128,16 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
         }
     }
 
-    std::fs::write(&profile_path, profile_json).map_err(|e| {
-        NonoError::LearnError(format!(
-            "Failed to write profile to {}: {}",
+    if let Err(e) = std::fs::write(&profile_path, &profile_json) {
+        eprintln!(
+            "{} Failed to write profile to {}: {}",
+            "Error:".red(),
             profile_path.display(),
             e
-        ))
-    })?;
+        );
+        print_profile_fallback(&profile_json);
+        return Ok(());
+    }
 
     eprintln!("\n{} {}", "Profile saved:".green(), profile_path.display());
     eprintln!(
@@ -142,4 +148,18 @@ fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result
     );
 
     Ok(())
+}
+
+fn print_profile_fallback(profile_json: &str) {
+    eprintln!(
+        "\n{} Profile could not be saved. Copy the JSON below to create it manually:",
+        "Note:".yellow()
+    );
+    eprintln!(
+        "Save it to {} or run {} to find the correct path.",
+        "~/.config/nono/profiles/<name>.json".bold(),
+        "nono config".bold()
+    );
+    eprintln!();
+    println!("{}", profile_json);
 }


### PR DESCRIPTION
## Summary

- When `nono learn` cannot save a profile due to a non-retryable error (e.g. full disk, permissions issue on the profiles directory), the generated profile JSON is now printed to stdout
- The user sees a clear error message plus instructions to save the file manually to `~/.config/nono/profiles/<name>.json`
- Prevents the result of a long tracing session from being silently lost

Closes #671 (suggestion 3, following on from #681 which handled suggestions 1 and 2)

## Test plan

- [x] `cargo build` passes
- [x] All 20 integration test suites pass (`bash tests/run_integration_tests.sh`)