### PR TITLE
fix(sandbox): allow Unix domain socket connections in restricted network modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,9 +2320,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -551,19 +551,25 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // symlinks, matching the mDNSResponder dual-path pattern above.
             for cap in caps.fs_capabilities() {
                 let (filter, resolved_str) = if cap.is_file {
-                    ("path", cap.resolved.to_str().ok_or_else(|| {
-                        NonoError::SandboxInit(format!(
-                            "path contains non-UTF-8 bytes: {}",
-                            cap.resolved.display()
-                        ))
-                    })?)
+                    (
+                        "path",
+                        cap.resolved.to_str().ok_or_else(|| {
+                            NonoError::SandboxInit(format!(
+                                "path contains non-UTF-8 bytes: {}",
+                                cap.resolved.display()
+                            ))
+                        })?,
+                    )
                 } else {
-                    ("subpath", cap.resolved.to_str().ok_or_else(|| {
-                        NonoError::SandboxInit(format!(
-                            "path contains non-UTF-8 bytes: {}",
-                            cap.resolved.display()
-                        ))
-                    })?)
+                    (
+                        "subpath",
+                        cap.resolved.to_str().ok_or_else(|| {
+                            NonoError::SandboxInit(format!(
+                                "path contains non-UTF-8 bytes: {}",
+                                cap.resolved.display()
+                            ))
+                        })?,
+                    )
                 };
                 let escaped = escape_path(resolved_str)?;
                 profile.push_str(&format!(
@@ -606,19 +612,25 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // Same Unix socket logic as Blocked mode above. See: #687
             for cap in caps.fs_capabilities() {
                 let (filter, resolved_str) = if cap.is_file {
-                    ("path", cap.resolved.to_str().ok_or_else(|| {
-                        NonoError::SandboxInit(format!(
-                            "path contains non-UTF-8 bytes: {}",
-                            cap.resolved.display()
-                        ))
-                    })?)
+                    (
+                        "path",
+                        cap.resolved.to_str().ok_or_else(|| {
+                            NonoError::SandboxInit(format!(
+                                "path contains non-UTF-8 bytes: {}",
+                                cap.resolved.display()
+                            ))
+                        })?,
+                    )
                 } else {
-                    ("subpath", cap.resolved.to_str().ok_or_else(|| {
-                        NonoError::SandboxInit(format!(
-                            "path contains non-UTF-8 bytes: {}",
-                            cap.resolved.display()
-                        ))
-                    })?)
+                    (
+                        "subpath",
+                        cap.resolved.to_str().ok_or_else(|| {
+                            NonoError::SandboxInit(format!(
+                                "path contains non-UTF-8 bytes: {}",
+                                cap.resolved.display()
+                            ))
+                        })?,
+                    )
                 };
                 let escaped = escape_path(resolved_str)?;
                 profile.push_str(&format!(
@@ -1312,7 +1324,10 @@ mod tests {
 
         let profile = generate_profile(&caps).unwrap();
 
-        assert!(profile.contains("(allow network-outbound)\n"), "AllowAll must still emit blanket rule");
+        assert!(
+            profile.contains("(allow network-outbound)\n"),
+            "AllowAll must still emit blanket rule"
+        );
         assert!(
             !profile.contains("(allow network-outbound (path \"/private/tmp/test.sock\"))"),
             "AllowAll must not emit per-path socket rules"

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -539,6 +539,47 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         NetworkMode::Blocked => {
             profile.push_str("(deny network*)\n");
             profile.push_str(MDNS_RULES);
+            // On macOS, connect(2) to a Unix domain socket is classified by Seatbelt
+            // as network-outbound. Emit per-path rules for all explicitly granted
+            // filesystem capabilities so that Unix sockets (IPC, notification daemons,
+            // etc.) remain reachable in restricted modes. See: #687
+            //
+            // Files   -> (allow network-outbound (path "..."))   literal socket path
+            // Dirs    -> (allow network-outbound (subpath "...")) sockets anywhere inside
+            //
+            // Both resolved and original paths are emitted to handle /tmp -> /private/tmp
+            // symlinks, matching the mDNSResponder dual-path pattern above.
+            for cap in caps.fs_capabilities() {
+                let (filter, resolved_str) = if cap.is_file {
+                    ("path", cap.resolved.to_str().ok_or_else(|| {
+                        NonoError::SandboxInit(format!(
+                            "path contains non-UTF-8 bytes: {}",
+                            cap.resolved.display()
+                        ))
+                    })?)
+                } else {
+                    ("subpath", cap.resolved.to_str().ok_or_else(|| {
+                        NonoError::SandboxInit(format!(
+                            "path contains non-UTF-8 bytes: {}",
+                            cap.resolved.display()
+                        ))
+                    })?)
+                };
+                let escaped = escape_path(resolved_str)?;
+                profile.push_str(&format!(
+                    "(allow network-outbound ({} \"{}\"))\n",
+                    filter, escaped
+                ));
+                if cap.original != cap.resolved {
+                    if let Some(orig_str) = cap.original.to_str() {
+                        let escaped_orig = escape_path(orig_str)?;
+                        profile.push_str(&format!(
+                            "(allow network-outbound ({} \"{}\"))\n",
+                            filter, escaped_orig
+                        ));
+                    }
+                }
+            }
             if !localhost_ports.is_empty() {
                 // Allow system-socket for TCP (required for connect/bind)
                 profile.push_str(
@@ -562,6 +603,38 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // Block all network, then allow only localhost TCP to the proxy port.
             profile.push_str("(deny network*)\n");
             profile.push_str(MDNS_RULES);
+            // Same Unix socket logic as Blocked mode above. See: #687
+            for cap in caps.fs_capabilities() {
+                let (filter, resolved_str) = if cap.is_file {
+                    ("path", cap.resolved.to_str().ok_or_else(|| {
+                        NonoError::SandboxInit(format!(
+                            "path contains non-UTF-8 bytes: {}",
+                            cap.resolved.display()
+                        ))
+                    })?)
+                } else {
+                    ("subpath", cap.resolved.to_str().ok_or_else(|| {
+                        NonoError::SandboxInit(format!(
+                            "path contains non-UTF-8 bytes: {}",
+                            cap.resolved.display()
+                        ))
+                    })?)
+                };
+                let escaped = escape_path(resolved_str)?;
+                profile.push_str(&format!(
+                    "(allow network-outbound ({} \"{}\"))\n",
+                    filter, escaped
+                ));
+                if cap.original != cap.resolved {
+                    if let Some(orig_str) = cap.original.to_str() {
+                        let escaped_orig = escape_path(orig_str)?;
+                        profile.push_str(&format!(
+                            "(allow network-outbound ({} \"{}\"))\n",
+                            filter, escaped_orig
+                        ));
+                    }
+                }
+            }
             profile.push_str(&format!(
                 "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
                 port
@@ -1134,6 +1207,116 @@ mod tests {
         assert!(profile.contains("(allow network-inbound)"));
         assert!(profile.contains("(allow network-bind)"));
         assert!(!profile.contains("(deny network*)"));
+    }
+
+    /// Regression test for #687: Unix domain socket paths explicitly granted via
+    /// --allow-file must remain reachable in ProxyOnly and Blocked modes.
+    /// On macOS, connect(2) to a Unix socket is classified as network-outbound by
+    /// Seatbelt, so (deny network*) blocks it unless a per-path rule is emitted.
+    #[test]
+    fn test_generate_profile_unix_socket_allowed_in_proxy_only_mode() {
+        let mut caps = CapabilitySet::new().proxy_only(54321);
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/tmp/test.sock"),
+            resolved: PathBuf::from("/private/tmp/test.sock"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        // Must deny all network and then allow the proxy port
+        assert!(profile.contains("(deny network*)"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:54321\"))"));
+        // Must allow outbound to the Unix socket path (both original and resolved)
+        assert!(
+            profile.contains("(allow network-outbound (path \"/private/tmp/test.sock\"))"),
+            "must allow network-outbound to resolved socket path"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (path \"/tmp/test.sock\"))"),
+            "must allow network-outbound to original (symlink) socket path"
+        );
+    }
+
+    #[test]
+    fn test_generate_profile_unix_socket_allowed_in_blocked_mode() {
+        let mut caps = CapabilitySet::new().block_network();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/var/run/app.sock"),
+            resolved: PathBuf::from("/private/var/run/app.sock"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(deny network*)"));
+        assert!(
+            profile.contains("(allow network-outbound (path \"/private/var/run/app.sock\"))"),
+            "must allow network-outbound to resolved socket path in blocked mode"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (path \"/var/run/app.sock\"))"),
+            "must allow network-outbound to original socket path in blocked mode"
+        );
+        // Must NOT open up general TCP outbound
+        assert!(!profile.contains("(allow network-outbound)\n"));
+    }
+
+    #[test]
+    fn test_generate_profile_unix_socket_subpath_for_directories() {
+        // Directory capabilities should emit (subpath "...") network-outbound rules
+        // so that Unix sockets anywhere inside the directory remain reachable.
+        // e.g. --allow /var/run/ should allow connecting to /var/run/app.sock.
+        let mut caps = CapabilitySet::new().proxy_only(54321);
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/tmp/mydir"),
+            resolved: PathBuf::from("/private/tmp/mydir"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(
+            profile.contains("(allow network-outbound (subpath \"/private/tmp/mydir\"))"),
+            "directory caps must emit subpath network-outbound rules"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (subpath \"/tmp/mydir\"))"),
+            "directory caps must emit subpath rule for original (symlink) path too"
+        );
+        // Must NOT use the literal-path form for directories
+        assert!(
+            !profile.contains("(allow network-outbound (path \"/private/tmp/mydir\"))"),
+            "directories must not use (path ...) — that is for literal file sockets"
+        );
+    }
+
+    #[test]
+    fn test_generate_profile_unix_socket_rules_not_emitted_in_allow_all() {
+        // AllowAll already permits all network-outbound — no per-path socket rules
+        // should be emitted (they would be redundant noise).
+        let mut caps = CapabilitySet::new(); // default = AllowAll
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/tmp/test.sock"),
+            resolved: PathBuf::from("/private/tmp/test.sock"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(allow network-outbound)\n"), "AllowAll must still emit blanket rule");
+        assert!(
+            !profile.contains("(allow network-outbound (path \"/private/tmp/test.sock\"))"),
+            "AllowAll must not emit per-path socket rules"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Unix domain socket connections (e.g. IPC sockets, notification daemons) were blocked in `ProxyOnly` and `Blocked` network modes even when the socket path was explicitly granted via `--allow-file`
- On macOS, `connect(2)` to a Unix socket is classified by Seatbelt as `network-outbound`, so `(deny network*)` blocked it regardless of filesystem grants
- Fix emits `(allow network-outbound (path "..."))` rules for each explicitly granted file-type capability in both restricted modes, right after the mDNSResponder rules

Fixes #687

## Test plan

- [x] Reproduced the bug: `nono run --allow-file $SOCK --allow-domain api.github.com -- python3 -c "socket.connect(SOCK)"` failed with `PermissionError: [Errno 1] Operation not permitted`
- [x] Verified the fix: same command succeeds with the patched binary
- [x] 3 new unit tests added to `sandbox::macos::tests` covering ProxyOnly mode, Blocked mode, and the directory-exclusion invariant
- [x] All 45 unit tests pass (`cargo test -p nono --lib sandbox::macos`)
- [x] All 20 integration test suites pass (`bash tests/run_integration_tests.sh`)