### PR TITLE
refactor(proxy-tls): remove rustls-pemfile and use pki_types for pem parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,6 @@ dependencies = [
  "keyring",
  "nono",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1913,7 +1912,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1958,7 +1957,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2007,9 +2006,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2273,15 +2272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,9 +2310,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/nono-proxy/Cargo.toml
+++ b/crates/nono-proxy/Cargo.toml
@@ -35,7 +35,6 @@ globset.workspace = true
 hyper-rustls = { version = "0.27", features = ["http1", "ring", "webpki-tokio"] }
 tokio-rustls = "0.26"
 rustls = { version = "0.23", features = ["ring"] }
-rustls-pemfile = "2"
 webpki-roots = "1"
 
 [dev-dependencies]

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -12,6 +12,7 @@
 
 use crate::config::{CompiledEndpointRules, RouteConfig};
 use crate::error::{ProxyError, Result};
+use rustls::pki_types::pem::PemObject;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::debug;
@@ -235,7 +236,7 @@ fn build_tls_connector(
         let ca_path = std::path::Path::new(ca_path);
         let ca_pem = read_pem_file(ca_path, "CA certificate")?;
 
-        let certs: Vec<_> = rustls_pemfile::certs(&mut ca_pem.as_slice())
+        let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_slice_iter(ca_pem.as_ref())
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| {
                 ProxyError::Config(format!(
@@ -280,7 +281,7 @@ fn build_tls_connector(
             let key_pem = read_pem_file(key_path, "client key")?;
 
             let cert_chain: Vec<rustls::pki_types::CertificateDer> =
-                rustls_pemfile::certs(&mut cert_pem.as_slice())
+                rustls::pki_types::CertificateDer::pem_slice_iter(cert_pem.as_ref())
                     .collect::<std::result::Result<Vec<_>, _>>()
                     .map_err(|e| {
                         ProxyError::Config(format!(
@@ -297,19 +298,17 @@ fn build_tls_connector(
                 )));
             }
 
-            let private_key = rustls_pemfile::private_key(&mut key_pem.as_slice())
-                .map_err(|e| {
-                    ProxyError::Config(format!(
+            let private_key = rustls::pki_types::PrivateKeyDer::from_pem_slice(key_pem.as_ref())
+                .map_err(|e| match e {
+                    rustls::pki_types::pem::Error::NoItemsFound => ProxyError::Config(format!(
+                        "client key file '{}' contains no valid PEM private key",
+                        key_path.display()
+                    )),
+                    _ => ProxyError::Config(format!(
                         "failed to parse client key '{}': {}",
                         key_path.display(),
                         e
-                    ))
-                })?
-                .ok_or_else(|| {
-                    ProxyError::Config(format!(
-                        "client key file '{}' contains no valid PEM private key",
-                        key_path.display()
-                    ))
+                    )),
                 })?;
 
             builder


### PR DESCRIPTION
This also resolves the ci failures

- Remove the `rustls-pemfile` crate, as its functionality for parsing PEM-encoded certificates and private keys has been integrated directly into `rustls::pki_types`.
- Update `rand` from 0.9.2 to 0.9.4.
- Update `rustls-webpki` from 0.103.10 to 0.103.12.