### PR TITLE
fix(sandbox): support claude-code profile extensions and simplify config

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -666,11 +666,10 @@
         "capability_elevation": false
       },
       "filesystem": {
-        "allow": ["$HOME/.claude", "$HOME/.cache/claude"],
+        "allow": ["$HOME/.claude", "$HOME/.cache/claude", "$HOME/.claude.lock"],
         "allow_file": [
           "$HOME/.claude.json",
-          "$HOME/.claude.json.lock",
-          "$HOME/.claude.lock"
+          "$HOME/.claude.json.lock"
         ]
       },
       "network": { "block": false },

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1413,7 +1413,7 @@ mod tests {
             .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
         assert!(profile
             .filesystem
-            .allow_file
+            .allow
             .contains(&"$HOME/.claude.lock".to_string()));
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -37,7 +37,7 @@ mod tests {
             .contains(&"$HOME/.cache/claude".to_string()));
         assert!(profile
             .filesystem
-            .allow_file
+            .allow
             .contains(&"$HOME/.claude.lock".to_string()));
     }
 
@@ -83,7 +83,7 @@ mod tests {
             .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
         assert!(profile
             .filesystem
-            .allow_file
+            .allow
             .contains(&"$HOME/.claude.lock".to_string()));
     }
 

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1057,10 +1057,21 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         // inside ~/.claude/ (which the sandbox already grants readwrite).
         // This replaces the old symlink-based redirect for ~/.claude.json
         // and also ensures token refresh temp files land in a writable dir.
-        if std::env::var_os("CLAUDE_CONFIG_DIR").is_none() {
-            #[allow(clippy::disallowed_methods)] // Single-threaded before fork.
-            std::env::set_var("CLAUDE_CONFIG_DIR", home_path.join(".claude"));
-        }
+        let claude_config_dir = match std::env::var_os("CLAUDE_CONFIG_DIR") {
+            Some(dir) => PathBuf::from(dir),
+            None => {
+                let dir = home_path.join(".claude");
+                #[allow(clippy::disallowed_methods)] // Single-threaded before fork.
+                std::env::set_var("CLAUDE_CONFIG_DIR", &dir);
+                dir
+            }
+        };
+
+        // Claude Code creates $CLAUDE_CONFIG_DIR.lock/ for token refresh
+        // locking, then removes it afterwards. The sandbox blocks mkdir in
+        // the parent directory, so pre-create it each time.
+        let lock_dir = claude_config_dir.with_extension("lock");
+        precreate(&lock_dir, true);
 
         precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
     }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1053,27 +1053,48 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             }
         };
 
-        // Set CLAUDE_CONFIG_DIR so Claude Code writes config and lock files
-        // inside ~/.claude/ (which the sandbox already grants readwrite).
-        // This replaces the old symlink-based redirect for ~/.claude.json
-        // and also ensures token refresh temp files land in a writable dir.
-        let claude_config_dir = match std::env::var_os("CLAUDE_CONFIG_DIR") {
-            Some(dir) => PathBuf::from(dir),
-            None => {
-                let dir = home_path.join(".claude");
-                #[allow(clippy::disallowed_methods)] // Single-threaded before fork.
-                std::env::set_var("CLAUDE_CONFIG_DIR", &dir);
-                dir
-            }
-        };
-
-        // Claude Code creates $CLAUDE_CONFIG_DIR.lock/ for token refresh
-        // locking, then removes it afterwards. The sandbox blocks mkdir in
-        // the parent directory, so pre-create it each time.
-        let lock_dir = claude_config_dir.with_extension("lock");
-        precreate(&lock_dir, true);
-
+        precreate(&home_path.join(".claude.json.lock"), false);
         precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
+
+        // Claude Code writes ~/.claude.json atomically via temp files named
+        // ~/.claude.json.tmp.<pid>.<timestamp>.  Landlock/Seatbelt cannot
+        // grant permission for these dynamically-named files in ~/, so token
+        // refreshes silently fail and the user is logged out.
+        //
+        // Fix: redirect ~/.claude.json to ~/.claude/claude.json via a
+        // symlink.  Claude Code resolves symlinks before computing the temp
+        // file path, so temp files land in ~/.claude/ (already readwrite)
+        // instead of ~/ (not writable inside the sandbox).
+        let claude_json = home_path.join(".claude.json");
+        let claude_dir = home_path.join(".claude");
+        let redirect_target = claude_dir.join("claude.json");
+
+        if let Err(e) = std::fs::create_dir_all(&claude_dir) {
+            warn!("Failed to create ~/.claude: {}", e);
+        } else if !claude_json.is_symlink() {
+            if claude_json.exists() {
+                // Regular file present — move it into ~/.claude/ then symlink.
+                if let Err(e) = std::fs::rename(&claude_json, &redirect_target) {
+                    warn!(
+                        "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
+                        e
+                    );
+                } else if let Err(e) =
+                    std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
+                {
+                    warn!("Failed to create ~/.claude.json symlink: {}", e);
+                }
+            } else {
+                // File doesn't exist yet — pre-create the target so the
+                // sandbox can attach a path rule to it, then symlink.
+                precreate(&redirect_target, false);
+                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json) {
+                    if e.kind() != std::io::ErrorKind::AlreadyExists {
+                        warn!("Failed to create ~/.claude.json symlink: {}", e);
+                    }
+                }
+            }
+        }
     }
 
     let (mut caps, needs_unlink_overrides) = if let Some(ref profile) = loaded_profile {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -25,14 +25,21 @@ use tracing::{info, warn};
 
 /// Returns `true` if `profile_name` is `"claude-code"` or transitively extends it.
 fn is_claude_code_profile(profile_name: &str) -> bool {
-    if profile_name == "claude-code" {
-        return true;
+    fn check(name: &str, visited: &mut Vec<String>) -> bool {
+        if name == "claude-code" {
+            return true;
+        }
+        if visited.iter().any(|v| v == name) {
+            return false; // cycle — bail out
+        }
+        visited.push(name.to_string());
+        let bases = match profile::load_profile_extends(name) {
+            Some(bases) => bases,
+            None => return false,
+        };
+        bases.iter().any(|base| check(base, visited))
     }
-    let bases = match profile::load_profile_extends(profile_name) {
-        Some(bases) => bases,
-        None => return false,
-    };
-    bases.iter().any(|base| is_claude_code_profile(base))
+    check(profile_name, &mut Vec::new())
 }
 
 fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -23,6 +23,18 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tracing::{info, warn};
 
+/// Returns `true` if `profile_name` is `"claude-code"` or transitively extends it.
+fn is_claude_code_profile(profile_name: &str) -> bool {
+    if profile_name == "claude-code" {
+        return true;
+    }
+    let bases = match profile::load_profile_extends(profile_name) {
+        Some(bases) => bases,
+        None => return false,
+    };
+    bases.iter().any(|base| is_claude_code_profile(base))
+}
+
 fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {
     let mut missing = Vec::new();
 
@@ -302,7 +314,7 @@ pub(crate) fn should_auto_enable_claude_launch_services(
     cmd_args: &[std::ffi::OsString],
 ) -> bool {
     if args.allow_launch_services
-        || args.profile.as_deref() != Some("claude-code")
+        || !args.profile.as_deref().is_some_and(is_claude_code_profile)
         || !command_is_claude(program)
         || claude_session_has_non_browser_auth(cmd_args)
     {
@@ -1012,7 +1024,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     }
 
     #[cfg(unix)]
-    if args.profile.as_deref() == Some("claude-code") {
+    if args.profile.as_deref().is_some_and(is_claude_code_profile) {
         let home = config::validated_home()?;
         let home_path = std::path::Path::new(&home);
 
@@ -1034,48 +1046,16 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             }
         };
 
-        precreate(&home_path.join(".claude.json.lock"), false);
-        precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
-
-        // Claude Code writes ~/.claude.json atomically via temp files named
-        // ~/.claude.json.tmp.<pid>.<timestamp>.  Landlock/Seatbelt cannot
-        // grant permission for these dynamically-named files in ~/, so token
-        // refreshes silently fail and the user is logged out.
-        //
-        // Fix: redirect ~/.claude.json to ~/.claude/claude.json via a
-        // symlink.  Claude Code resolves symlinks before computing the temp
-        // file path, so temp files land in ~/.claude/ (already readwrite)
-        // instead of ~/ (not writable inside the sandbox).
-        let claude_json = home_path.join(".claude.json");
-        let claude_dir = home_path.join(".claude");
-        let redirect_target = claude_dir.join("claude.json");
-
-        if let Err(e) = std::fs::create_dir_all(&claude_dir) {
-            warn!("Failed to create ~/.claude: {}", e);
-        } else if !claude_json.is_symlink() {
-            if claude_json.exists() {
-                // Regular file present — move it into ~/.claude/ then symlink.
-                if let Err(e) = std::fs::rename(&claude_json, &redirect_target) {
-                    warn!(
-                        "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
-                        e
-                    );
-                } else if let Err(e) =
-                    std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
-                {
-                    warn!("Failed to create ~/.claude.json symlink: {}", e);
-                }
-            } else {
-                // File doesn't exist yet — pre-create the target so the
-                // sandbox can attach a path rule to it, then symlink.
-                precreate(&redirect_target, false);
-                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json) {
-                    if e.kind() != std::io::ErrorKind::AlreadyExists {
-                        warn!("Failed to create ~/.claude.json symlink: {}", e);
-                    }
-                }
-            }
+        // Set CLAUDE_CONFIG_DIR so Claude Code writes config and lock files
+        // inside ~/.claude/ (which the sandbox already grants readwrite).
+        // This replaces the old symlink-based redirect for ~/.claude.json
+        // and also ensures token refresh temp files land in a writable dir.
+        if std::env::var_os("CLAUDE_CONFIG_DIR").is_none() {
+            #[allow(clippy::disallowed_methods)] // Single-threaded before fork.
+            std::env::set_var("CLAUDE_CONFIG_DIR", home_path.join(".claude"));
         }
+
+        precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
     }
 
     let (mut caps, needs_unlink_overrides) = if let Some(ref profile) = loaded_profile {

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -96,6 +96,41 @@ nono run --profile claude-code -- claude
 Custom profiles with the same name override the built-in. Remove or rename the file to revert to the built-in profile.
 </Note>
 
+## Multiple Claude Profiles (`CLAUDE_CONFIG_DIR`)
+
+If you use multiple Claude Code configurations via the `CLAUDE_CONFIG_DIR` environment variable, nono handles this automatically for the built-in `claude-code` profile and any profile that extends it:
+
+- When `CLAUDE_CONFIG_DIR` is **not set**, nono sets it to `~/.claude` before launching Claude Code. This ensures config files, credentials, and token refresh temp files all land inside `~/.claude/`, which the sandbox already grants read/write access.
+- When `CLAUDE_CONFIG_DIR` **is set**, nono respects your value and does not override it.
+
+If you set a custom `CLAUDE_CONFIG_DIR`, you need to grant the sandbox access to both the config directory and its sibling `.lock` directory. Claude Code creates `$CLAUDE_CONFIG_DIR.lock/` during token refresh and removes it afterwards — the sandbox must allow creating it:
+
+```bash
+export CLAUDE_CONFIG_DIR=~/.claude-work
+mkdir -p ~/.claude-work ~/.claude-work.lock
+
+nono run --profile claude-code \
+  --allow ~/.claude-work \
+  --allow ~/.claude-work.lock \
+  -- claude
+```
+
+Alternatively, create a custom profile that includes the paths:
+
+```json
+{
+  "meta": { "name": "claude-work" },
+  "extends": "claude-code",
+  "filesystem": {
+    "allow": ["$HOME/.claude-work", "$HOME/.claude-work.lock"]
+  }
+}
+```
+
+<Note>
+For the default `~/.claude` config directory, no extra flags or directories are needed — the built-in profile already grants access to both `~/.claude` and `~/.claude.lock`.
+</Note>
+
 ## Security Tips
 
 ### Use Secrets Management

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -98,16 +98,10 @@ Custom profiles with the same name override the built-in. Remove or rename the f
 
 ## Multiple Claude Profiles (`CLAUDE_CONFIG_DIR`)
 
-If you use multiple Claude Code configurations via the `CLAUDE_CONFIG_DIR` environment variable, nono handles this automatically for the built-in `claude-code` profile and any profile that extends it:
-
-- When `CLAUDE_CONFIG_DIR` is **not set**, nono sets it to `~/.claude` before launching Claude Code. This ensures config files, credentials, and token refresh temp files all land inside `~/.claude/`, which the sandbox already grants read/write access.
-- When `CLAUDE_CONFIG_DIR` **is set**, nono respects your value and does not override it.
-
-If you set a custom `CLAUDE_CONFIG_DIR`, you need to grant the sandbox access to both the config directory and its sibling `.lock` directory. Claude Code creates `$CLAUDE_CONFIG_DIR.lock/` during token refresh and removes it afterwards — the sandbox must allow creating it:
+If you use multiple Claude Code configurations via the `CLAUDE_CONFIG_DIR` environment variable, you need to grant the sandbox access to the custom config directory and its sibling `.lock` directory. Claude Code creates `$CLAUDE_CONFIG_DIR.lock/` during OAuth token refresh coordination:
 
 ```bash
 export CLAUDE_CONFIG_DIR=~/.claude-work
-mkdir -p ~/.claude-work ~/.claude-work.lock
 
 nono run --profile claude-code \
   --allow ~/.claude-work \
@@ -126,6 +120,10 @@ Alternatively, create a custom profile that includes the paths:
   }
 }
 ```
+
+<Note>
+Do not set `CLAUDE_CONFIG_DIR` to its default value (`~/.claude`) explicitly — Claude Code treats "explicitly set" differently from "unset", which changes keychain service names and config file lookup paths. Only set it when you genuinely need a non-default location.
+</Note>
 
 <Note>
 For the default `~/.claude` config directory, no extra flags or directories are needed — the built-in profile already grants access to both `~/.claude` and `~/.claude.lock`.


### PR DESCRIPTION
Issue discovered and reported by @ctrlok 

 @ctrlok you can use this in yours, or we can merge this, I have added co-author as I don't want to deny you the opportunity to contribute. 

- Introduce `is_claude_code_profile` to correctly identify profiles that are "claude-code" or transitively extend it.
- Update `should_auto_enable_claude_launch_services` and `prepare_sandbox` to use this new profile check.
- Replace the symlink-based redirection for `~/.claude.json` with setting the `CLAUDE_CONFIG_DIR` environment variable to `~/.claude`.
- This ensures Claude Code writes all its config and temporary files (used for atomic writes during token refresh) into a directory (`~/.claude/`) that the sandbox already grants read/write permissions to.
- This resolves silently failing token refreshes due to temporary files being created in a non-writable home directory.