### PR TITLE
docs: add github to credential route configuration

### DIFF
--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -290,6 +290,9 @@ The built-in `network-policy.json` defines default credential routes:
 | anthropic | https://api.anthropic.com | x-api-key | {} |
 | gemini | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
 | google-ai | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
+| github | https://api.github.com | Authorization | token {} |
+
+All services in this table can be used directly with `--credential <service>` (e.g. `--credential github`, `--credential anthropic`) without any custom credential definition in your profile.
 
 **Note:** OpenAI's upstream includes `/v1` because the OpenAI SDK expects the base URL to include the version prefix. Anthropic's SDK adds `/v1/messages` automatically, so its upstream is the root URL.
 


### PR DESCRIPTION
- Add `github` to the Credential Route Configuration table
- Add note that all built-in services are usable directly with `--credential <service>`