### PR TITLE
fix(policy): add entry for ~.local/share/claude/versions

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -430,6 +430,9 @@
       "description": "Claude Code macOS-specific state and credential paths",
       "platform": "macos",
       "allow": {
+        "read": [
+          "$HOME/.local/share/claude"
+        ],
         "readwrite": [
           "$HOME/Library/Keychains/login.keychain-db",
           "$HOME/Library/Keychains/metadata.keychain-db"

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1494,6 +1494,12 @@ mod tests {
             .as_ref()
             .expect("claude_code_macos allow missing")
             .readwrite;
+        assert!(claude_code_macos
+            .allow
+            .as_ref()
+            .expect("claude_code_macos allow missing")
+            .read
+            .contains(&"$HOME/.local/share/claude".to_string()));
         assert!(claude_code_macos_paths
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
         assert!(claude_code_macos_paths


### PR DESCRIPTION
An issue was occuring where claude-code would complain:

Claude symlink points to missing or invalid binary: /Users/<user>/.local/share/claude/versions/2.1.114

Resolves: #711