### PR TITLE
feat: add unsafe_macos_seatbelt_rules profile field

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -100,6 +100,11 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Extra arguments appended to the child command at launch. Supports variable expansion (e.g. $NONO_PACKAGES)."
+    },
+    "unsafe_macos_seatbelt_rules": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "macOS-only. Expert escape hatch: raw Seatbelt S-expression rules applied verbatim to the sandbox policy. Each entry must be a valid S-expression, e.g. \"(allow iokit-open)\". Rules are validated at load time and rejected if malformed. Ignored on Linux. Surfaced prominently in 'nono policy profile' output. If a rule pattern becomes common, prefer promoting it to a typed first-class capability instead."
     }
   },
   "$defs": {

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -130,6 +130,8 @@ pub struct ProfileDef {
     pub packs: Vec<String>,
     #[serde(default)]
     pub command_args: Vec<String>,
+    #[serde(default)]
+    pub unsafe_macos_seatbelt_rules: Vec<String>,
 }
 
 impl ProfileDef {
@@ -166,7 +168,7 @@ impl ProfileDef {
             skipdirs: Vec::new(),
             packs: self.packs.clone(),
             command_args: self.command_args.clone(),
-            unsafe_macos_seatbelt_rules: Vec::new(),
+            unsafe_macos_seatbelt_rules: self.unsafe_macos_seatbelt_rules.clone(),
         }
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -166,6 +166,7 @@ impl ProfileDef {
             skipdirs: Vec::new(),
             packs: self.packs.clone(),
             command_args: self.command_args.clone(),
+            unsafe_macos_seatbelt_rules: Vec::new(),
         }
     }
 }

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -690,7 +690,11 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         println!();
         println!(
             "  {}",
-            theme::fg("Raw Seatbelt rules (unsafe_macos_seatbelt_rules):", t.yellow).bold()
+            theme::fg(
+                "Raw Seatbelt rules (unsafe_macos_seatbelt_rules):",
+                t.yellow
+            )
+            .bold()
         );
         for rule in &profile.unsafe_macos_seatbelt_rules {
             println!("    {}", theme::fg(rule, t.text));
@@ -839,8 +843,7 @@ fn profile_to_json(
     }
 
     if !profile.unsafe_macos_seatbelt_rules.is_empty() {
-        val["unsafe_macos_seatbelt_rules"] =
-            serde_json::json!(profile.unsafe_macos_seatbelt_rules);
+        val["unsafe_macos_seatbelt_rules"] = serde_json::json!(profile.unsafe_macos_seatbelt_rules);
     }
 
     val

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -685,7 +685,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
     }
 
     // Raw Seatbelt rules — surfaced prominently so it is obvious a profile uses them.
-    #[cfg(target_os = "macos")]
+    // Shown on all platforms so cross-platform auditing is possible.
     if !profile.unsafe_macos_seatbelt_rules.is_empty() {
         println!();
         println!(

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -684,6 +684,19 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         }
     }
 
+    // Raw Seatbelt rules — surfaced prominently so it is obvious a profile uses them.
+    #[cfg(target_os = "macos")]
+    if !profile.unsafe_macos_seatbelt_rules.is_empty() {
+        println!();
+        println!(
+            "  {}",
+            theme::fg("Raw Seatbelt rules (unsafe_macos_seatbelt_rules):", t.yellow).bold()
+        );
+        for rule in &profile.unsafe_macos_seatbelt_rules {
+            println!("    {}", theme::fg(rule, t.text));
+        }
+    }
+
     Ok(())
 }
 
@@ -823,6 +836,11 @@ fn profile_to_json(
 
     if let Some(ag) = profile.allow_gpu {
         val["allow_gpu"] = serde_json::json!(ag);
+    }
+
+    if !profile.unsafe_macos_seatbelt_rules.is_empty() {
+        val["unsafe_macos_seatbelt_rules"] =
+            serde_json::json!(profile.unsafe_macos_seatbelt_rules);
     }
 
     val

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1239,6 +1239,19 @@ pub struct Profile {
     /// Supports variable expansion (e.g. `$NONO_PACKAGES`).
     #[serde(default)]
     pub command_args: Vec<String>,
+    /// Raw macOS-only Seatbelt S-expression rules applied verbatim to the sandbox policy.
+    ///
+    /// Expert escape hatch for capability gaps. Each entry must be a valid Seatbelt
+    /// S-expression such as `(allow iokit-open)`. Rules are validated at load time
+    /// and rejected if malformed. Ignored on Linux. Prominently surfaced in
+    /// `nono policy profile` output when present so it is obvious a profile uses
+    /// raw platform rules.
+    ///
+    /// This field is intentionally named `unsafe_*` — it bypasses nono's capability
+    /// model. If a rule pattern becomes common, prefer promoting it to a typed
+    /// first-class capability.
+    #[serde(default)]
+    pub unsafe_macos_seatbelt_rules: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -1284,6 +1297,8 @@ struct ProfileDeserialize {
     packs: Vec<String>,
     #[serde(default)]
     command_args: Vec<String>,
+    #[serde(default)]
+    unsafe_macos_seatbelt_rules: Vec<String>,
 }
 
 impl From<ProfileDeserialize> for Profile {
@@ -1308,6 +1323,7 @@ impl From<ProfileDeserialize> for Profile {
             skipdirs: raw.skipdirs,
             packs: raw.packs,
             command_args: raw.command_args,
+            unsafe_macos_seatbelt_rules: raw.unsafe_macos_seatbelt_rules,
         }
     }
 }
@@ -1856,6 +1872,10 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
         skipdirs: dedup_append(&base.skipdirs, &child.skipdirs),
         packs: dedup_append(&base.packs, &child.packs),
         command_args: dedup_append(&base.command_args, &child.command_args),
+        unsafe_macos_seatbelt_rules: dedup_append(
+            &base.unsafe_macos_seatbelt_rules,
+            &child.unsafe_macos_seatbelt_rules,
+        ),
     }
 }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3431,6 +3431,7 @@ mod tests {
             skipdirs: vec!["vendor".to_string()],
             packs: vec![],
             command_args: vec![],
+            unsafe_macos_seatbelt_rules: vec![],
         }
     }
 
@@ -3504,6 +3505,7 @@ mod tests {
             skipdirs: vec!["dist".to_string()],
             packs: vec![],
             command_args: vec![],
+            unsafe_macos_seatbelt_rules: vec![],
         }
     }
 

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1110,7 +1110,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     #[cfg(target_os = "macos")]
     if let Some(ref profile) = loaded_profile {
         if !profile.unsafe_macos_seatbelt_rules.is_empty() {
-            warn!(
+            info!(
                 "Profile uses {} raw Seatbelt rule(s) via unsafe_macos_seatbelt_rules — review carefully",
                 profile.unsafe_macos_seatbelt_rules.len()
             );

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1106,6 +1106,24 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         CapabilitySet::from_args(args)?
     };
 
+    // Apply raw Seatbelt rules from the profile (macOS only).
+    #[cfg(target_os = "macos")]
+    if let Some(ref profile) = loaded_profile {
+        if !profile.unsafe_macos_seatbelt_rules.is_empty() {
+            warn!(
+                "Profile uses {} raw Seatbelt rule(s) via unsafe_macos_seatbelt_rules — review carefully",
+                profile.unsafe_macos_seatbelt_rules.len()
+            );
+            for rule in &profile.unsafe_macos_seatbelt_rules {
+                caps.add_platform_rule(rule).map_err(|e| {
+                    NonoError::ConfigParse(format!(
+                        "unsafe_macos_seatbelt_rules: invalid rule {rule:?}: {e}"
+                    ))
+                })?;
+            }
+        }
+    }
+
     let allow_launch_services_active = maybe_enable_macos_launch_services(
         &mut caps,
         args.allow_launch_services,


### PR DESCRIPTION
Closes #678

## Summary

- Adds `unsafe_macos_seatbelt_rules: Vec<String>` to the profile schema — a macOS-only expert escape hatch for raw Seatbelt S-expressions
- Rules are applied via the existing `add_platform_rule` path in `sandbox_prepare`, gated with `#[cfg(target_os = "macos")]`
- Malformed S-expressions are rejected at sandbox setup time with a clear error message
- A `WARN` log is emitted whenever rules are active so it is always visible in logs
- `nono policy show` surfaces the rules under a yellow **"Raw Seatbelt rules (unsafe_macos_seatbelt_rules):"** header — both in human and `--json` output
- Merged via `dedup_append` in profile inheritance (child rules appended after base)
- JSON schema updated with field description and usage guidance

## Test plan

- [x] `cargo build` passes cleanly
- [x] `nono policy show <profile>` displays rules under the yellow header
- [x] Valid rule `(allow iokit-open)` runs successfully inside sandbox
- [x] Malformed rule `"not an s-expression"` produces a clear `ConfigParse` error at startup
- [x] All 20 integration test suites pass (`bash tests/run_integration_tests.sh`)