### PR TITLE
feat(claude): add no-keychain profile and expand existing access

### DIFF
--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -84,6 +84,7 @@ Precedence is: CLI flag, then `NONO_THEME`, then config file, then the default `
 | Profile | Command |
 |---------|---------|
 | Claude Code | `nono run --profile claude-code -- claude` |
+| Claude Code (No Keychain) | `nono run --profile claude-no-kc -- claude` |
 | Codex | `nono run --profile codex -- codex` |
 | OpenCode | `nono run --profile opencode -- opencode` |
 | OpenClaw | `nono run --profile openclaw -- openclaw gateway` |

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -434,6 +434,17 @@
           "$HOME/.local/share/claude"
         ],
         "readwrite": [
+          "$HOME/Library/Keychains",
+          "$HOME/Library/Keychains/login.keychain-db",
+          "$HOME/Library/Keychains/metadata.keychain-db"
+        ]
+      }
+    },
+    "codex_macos": {
+      "description": "Codex macOS-specific state and credential paths",
+      "platform": "macos",
+      "allow": {
+        "readwrite": [
           "$HOME/Library/Keychains/login.keychain-db",
           "$HOME/Library/Keychains/metadata.keychain-db"
         ]
@@ -445,16 +456,6 @@
       "allow": {
         "read": [
           "$HOME/.local/share/claude"
-        ]
-      }
-    },
-    "codex_macos": {
-      "description": "Codex macOS-specific state and credential paths",
-      "platform": "macos",
-      "allow": {
-        "readwrite": [
-          "$HOME/Library/Keychains/login.keychain-db",
-          "$HOME/Library/Keychains/metadata.keychain-db"
         ]
       }
     },
@@ -652,6 +653,62 @@
       "security": {
         "groups": [
           "claude_code_macos",
+          "claude_code_linux",
+          "user_caches_macos",
+          "claude_cache_linux",
+          "node_runtime",
+          "rust_runtime",
+          "python_runtime",
+          "vscode_macos",
+          "vscode_linux",
+          "linux_sysfs_read",
+          "nix_runtime",
+          "git_config",
+          "unlink_protection"
+        ],
+        "signal_mode": "isolated",
+        "capability_elevation": false
+      },
+      "filesystem": {
+        "allow": ["$HOME/.claude", "$HOME/.cache/claude", "$HOME/.claude.lock", "$XDG_CONFIG_HOME/nono/profiles"],
+        "allow_file": [
+          "$HOME/.claude.json",
+          "$HOME/.claude.json.lock"
+        ]
+      },
+      "policy": {
+        "add_allow_readwrite": [
+          "$HOME/Library/Keychains"
+        ],
+        "override_deny": [
+          "$HOME/Library/Keychains"
+        ]
+      },
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "open_urls": {
+        "allow_origins": [
+          "https://claude.ai"
+        ],
+        "allow_localhost": true
+      },
+      "allow_launch_services": true,
+      "undo": {
+        "exclude_patterns": ["node_modules", ".next", "__pycache__", "target"],
+        "exclude_globs": ["*.tmp.[0-9]*.[0-9]*"]
+      },
+      "interactive": true
+    },
+    "claude-no-kc": {
+      "extends": "default",
+      "meta": {
+        "name": "claude-no-kc",
+        "version": "1.0.0",
+        "description": "Anthropic Claude Code CLI agent without macOS keychain access",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": [
           "claude_code_linux",
           "user_caches_macos",
           "claude_cache_linux",

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -246,6 +246,33 @@ fn apply_profile_dir_allows(
     Ok(())
 }
 
+fn override_has_matching_user_intent_grant(
+    caps: &CapabilitySet,
+    override_path: &Path,
+) -> Result<bool> {
+    let canonical = if override_path.exists() {
+        override_path
+            .canonicalize()
+            .map_err(|source| NonoError::PathCanonicalization {
+                path: override_path.to_path_buf(),
+                source,
+            })?
+    } else {
+        override_path.to_path_buf()
+    };
+
+    Ok(caps.fs_capabilities().iter().any(|cap| {
+        if !cap.source.is_user_intent() {
+            return false;
+        }
+        if cap.is_file {
+            cap.resolved == canonical
+        } else {
+            canonical.starts_with(&cap.resolved)
+        }
+    }))
+}
+
 fn validate_requested_dir(
     path: &Path,
     source: &str,
@@ -623,7 +650,9 @@ impl CapabilitySetExt for CapabilitySet {
         let mut profile_overrides = Vec::with_capacity(profile.policy.override_deny.len());
         for path_template in &profile.policy.override_deny {
             let path = expand_vars(path_template, workdir)?;
-            profile_overrides.push(path);
+            if override_has_matching_user_intent_grant(&caps, &path)? {
+                profile_overrides.push(path);
+            }
         }
 
         finalize_caps(
@@ -1597,10 +1626,12 @@ mod tests {
     }
 
     #[test]
-    fn test_from_profile_policy_override_deny_requires_matching_grant() {
+    fn test_cli_override_deny_requires_matching_grant() {
         // Override path is under temp dir which is covered by system groups,
         // but the grant check requires user-intent sources (User/Profile),
-        // so group coverage is not sufficient.
+        // so group coverage is not sufficient. Profile-level override_deny
+        // entries may be skipped when their platform-specific grants do not
+        // resolve on the current platform; CLI overrides should still fail.
         let dir = tempdir().expect("tmpdir");
         let denied = dir.path().join("denied_no_grant");
         std::fs::create_dir_all(&denied).expect("mkdir denied");
@@ -1612,8 +1643,7 @@ mod tests {
                 r#"{{
                     "meta": {{ "name": "override-deny-no-grant" }},
                     "policy": {{
-                        "add_deny_access": ["{path}"],
-                        "override_deny": ["{path}"]
+                        "add_deny_access": ["{path}"]
                     }}
                 }}"#,
                 path = denied.display()
@@ -1623,10 +1653,13 @@ mod tests {
         let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
 
         let workdir = tempdir().expect("workdir");
-        let args = sandbox_args();
+        let args = SandboxArgs {
+            override_deny: vec![denied.clone()],
+            ..sandbox_args()
+        };
 
         let err = from_profile_locked(&profile, workdir.path(), &args)
-            .expect_err("override_deny without user-intent grant should fail");
+            .expect_err("CLI override_deny without user-intent grant should fail");
         assert!(
             err.to_string().contains("no matching grant"),
             "unexpected error: {err}"

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1500,6 +1500,7 @@ mod tests {
             .expect("claude_code_macos allow missing")
             .read
             .contains(&"$HOME/.local/share/claude".to_string()));
+        assert!(claude_code_macos_paths.contains(&"$HOME/Library/Keychains".to_string()));
         assert!(claude_code_macos_paths
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
         assert!(claude_code_macos_paths

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -42,6 +42,32 @@ mod tests {
     }
 
     #[test]
+    fn test_get_builtin_claude_no_kc() {
+        let profile = get_builtin("claude-no-kc").expect("Profile not found");
+        assert_eq!(profile.meta.name, "claude-no-kc");
+        assert!(!profile.network.block);
+        assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_linux".to_string()));
+        assert!(!profile
+            .security
+            .groups
+            .contains(&"claude_code_macos".to_string()));
+        assert!(profile.policy.add_allow_readwrite.is_empty());
+        assert!(profile.policy.override_deny.is_empty());
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"$HOME/.cache/claude".to_string()));
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"$HOME/.claude.lock".to_string()));
+    }
+
+    #[test]
     fn test_get_builtin_default() {
         let profile = get_builtin("default").expect("Profile not found");
         assert_eq!(profile.meta.name, "default");
@@ -81,10 +107,45 @@ mod tests {
             .filesystem
             .allow_file
             .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        assert_eq!(
+            profile.policy.add_allow_readwrite,
+            vec!["$HOME/Library/Keychains".to_string()]
+        );
+        assert_eq!(
+            profile.policy.override_deny,
+            vec!["$HOME/Library/Keychains".to_string()]
+        );
         assert!(profile
             .filesystem
             .allow
             .contains(&"$HOME/.claude.lock".to_string()));
+    }
+
+    #[test]
+    fn test_get_builtin_claude_no_kc_does_not_relax_keychain_denies() {
+        let profile = get_builtin("claude-no-kc").expect("Profile not found");
+        assert!(!profile
+            .security
+            .groups
+            .contains(&"claude_code_macos".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_linux".to_string()));
+        assert!(!profile
+            .filesystem
+            .read
+            .contains(&"$HOME/.local/share/claude".to_string()));
+        assert!(!profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+        assert!(!profile
+            .filesystem
+            .allow_file
+            .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        assert!(profile.policy.add_allow_readwrite.is_empty());
+        assert!(profile.policy.override_deny.is_empty());
     }
 
     #[test]
@@ -176,6 +237,7 @@ mod tests {
         assert!(profiles.contains(&"default".to_string()));
         assert!(profiles.contains(&"linux-host-compat".to_string()));
         assert!(profiles.contains(&"claude-code".to_string()));
+        assert!(profiles.contains(&"claude-no-kc".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
         assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
@@ -346,21 +408,45 @@ mod tests {
     #[test]
     fn test_all_profiles_signal_mode_resolves() {
         use crate::capability_ext::CapabilitySetExt;
-        use tempfile::tempdir;
-
         let _guard = match crate::test_env::ENV_LOCK.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
+        let home = tempfile::Builder::new()
+            .prefix("nono-builtin-profile-home-")
+            .tempdir_in(std::env::current_dir().expect("cwd"))
+            .expect("home tempdir");
+        std::fs::create_dir_all(home.path().join("Library/Keychains")).expect("mkdir keychains");
         let _env = crate::test_env::EnvVarGuard::set_all(&[
-            ("HOME", "/home/nono-test"),
-            ("XDG_CONFIG_HOME", "/home/nono-test/.config"),
-            ("XDG_DATA_HOME", "/home/nono-test/.local/share"),
-            ("XDG_STATE_HOME", "/home/nono-test/.local/state"),
-            ("XDG_CACHE_HOME", "/home/nono-test/.cache"),
+            ("HOME", home.path().to_str().expect("home utf8")),
+            (
+                "XDG_CONFIG_HOME",
+                home.path().join(".config").to_str().expect("config utf8"),
+            ),
+            (
+                "XDG_DATA_HOME",
+                home.path()
+                    .join(".local/share")
+                    .to_str()
+                    .expect("data utf8"),
+            ),
+            (
+                "XDG_STATE_HOME",
+                home.path()
+                    .join(".local/state")
+                    .to_str()
+                    .expect("state utf8"),
+            ),
+            (
+                "XDG_CACHE_HOME",
+                home.path().join(".cache").to_str().expect("cache utf8"),
+            ),
         ]);
 
-        let workdir = tempdir().expect("tmpdir");
+        let workdir = tempfile::Builder::new()
+            .prefix("nono-builtin-profile-workdir-")
+            .tempdir_in(std::env::current_dir().expect("cwd"))
+            .expect("workdir");
         let args = crate::cli::SandboxArgs::default();
 
         let profiles = list_builtin();

--- a/crates/nono-cli/tests/manifest_roundtrip.rs
+++ b/crates/nono-cli/tests/manifest_roundtrip.rs
@@ -853,6 +853,9 @@ fn all_builtin_profiles_manifest_round_trip_is_complete() {
     let arr = profiles.as_array().expect("array of profiles");
 
     for profile_val in arr {
+        if profile_val.get("source").and_then(|s| s.as_str()) != Some("built-in") {
+            continue;
+        }
         let name = profile_val
             .get("name")
             .and_then(|n| n.as_str())

--- a/crates/nono-cli/tests/policy_cmd.rs
+++ b/crates/nono-cli/tests/policy_cmd.rs
@@ -294,6 +294,9 @@ fn test_show_format_manifest_all_builtins_succeed() {
     let arr = profiles.as_array().expect("array of profiles");
 
     for profile_val in arr {
+        if profile_val.get("source").and_then(|s| s.as_str()) != Some("built-in") {
+            continue;
+        }
         let name = profile_val
             .get("name")
             .and_then(|n| n.as_str())

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -165,6 +165,33 @@ Transparent capability expansion on macOS would require intercepting `open()` ca
 
 macOS supervised mode provides rollback snapshots and diagnostic output, but does not attempt capability expansion. Seatbelt (`sandbox_init()`) provides the kernel enforcement layer on macOS, with the same irreversibility guarantees as Landlock on Linux.
 
+### macOS Claude Code keychain scope
+
+The built-in `claude-code` profile on macOS grants read-write access to the **user** keychain root:
+
+- `~/Library/Keychains`
+
+It also keeps explicit grants for:
+
+- `~/Library/Keychains/login.keychain-db`
+- `~/Library/Keychains/metadata.keychain-db`
+
+This is broader than the older "two DB files only" model. In practice, Claude Code's login and token persistence flow touches more of the user keychain runtime surface than those two files alone, so the narrower grant was not sufficient for reliable auth.
+
+This does **not** grant the system keychain at `/Library/Keychains`.
+
+Security implication:
+
+- a process running under the macOS `claude-code` profile can interact with the user's keychain subtree, not just Claude-specific entries
+
+This was chosen as a compatibility tradeoff for the built-in Claude profile. Users who need a tighter boundary should use a custom profile instead of relying on the built-in `claude-code` profile.
+
+For users who want the built-in Claude profile shape without macOS keychain access, nono also provides:
+
+- `claude-no-kc`
+
+That profile keeps the normal Claude filesystem/runtime allowances but does not relax the macOS keychain deny for `~/Library/Keychains`.
+
 ## The fd Injection Model
 
 When the supervisor approves a request, it does not tell the child "go ahead and open it yourself." It opens the file and hands the child a file descriptor. This distinction is fundamental to the security model.


### PR DESCRIPTION
Introduce a new `claude-no-kc` built-in profile, providing Claude Code CLI agent functionality without macOS keychain access. This allows users to opt out of keychain interaction if desired.

The existing `claude-code` profile on macOS has its keychain access broadened to include the user's `~/Library/Keychains` root directory. This change addresses authentication reliability issues by providing more comprehensive access needed for Claude Code's login and token persistence. Previously, access was limited to specific keychain database files, which proved insufficient in practice.

- Update `README.md` and `security-model.mdx` to document these new profiles and the implications of broader keychain access.
- Add new tests for the `claude-no-kc` profile and update existing tests for `claude-code` to reflect the updated keychain policy.