### PR TITLE
feat(reverse-proxy): add http upstream support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,9 +2311,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -23,7 +23,7 @@ use crate::route::RouteStore;
 use crate::token;
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 use tracing::{debug, warn};
@@ -189,7 +189,8 @@ pub async fn handle_reverse_proxy(
     );
     debug!("Forwarding to upstream: {} {}", method, upstream_url);
 
-    let (upstream_host, upstream_port, upstream_path_full) = parse_upstream_url(&upstream_url)?;
+    let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
+        parse_upstream_url(&upstream_url)?;
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
     if !check.result.is_allowed() {
         let reason = check.result.reason();
@@ -211,30 +212,6 @@ pub async fn handle_reverse_proxy(
     let body = match read_request_body(stream, content_length, buffered_body).await? {
         Some(body) => body,
         None => return Ok(()),
-    };
-
-    let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
-    let mut tls_stream = match connect_upstream_tls(
-        &upstream_host,
-        upstream_port,
-        &check.resolved_addrs,
-        connector,
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("Upstream connection failed: {}", e);
-            send_error(stream, 502, "Bad Gateway").await?;
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::Reverse,
-                &service,
-                0,
-                &e.to_string(),
-            );
-            return Ok(());
-        }
     };
 
     let mut request = Zeroizing::new(format!(
@@ -264,13 +241,59 @@ pub async fn handle_reverse_proxy(
     }
     request.push_str("\r\n");
 
-    tls_stream.write_all(request.as_bytes()).await?;
-    if !body.is_empty() {
-        tls_stream.write_all(&body).await?;
-    }
-    tls_stream.flush().await?;
+    let status_code = match upstream_scheme {
+        UpstreamScheme::Https => {
+            let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
+            let mut tls_stream = match connect_upstream_tls(
+                &upstream_host,
+                upstream_port,
+                &check.resolved_addrs,
+                connector,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Upstream connection failed: {}", e);
+                    send_error(stream, 502, "Bad Gateway").await?;
+                    audit::log_denied(
+                        ctx.audit_log,
+                        audit::ProxyMode::Reverse,
+                        &service,
+                        0,
+                        &e.to_string(),
+                    );
+                    return Ok(());
+                }
+            };
 
-    let status_code = stream_response(&mut tls_stream, stream).await?;
+            write_upstream_request(&mut tls_stream, &request, &body).await?;
+            stream_response(&mut tls_stream, stream).await?
+        }
+        UpstreamScheme::Http => {
+            let mut upstream_stream =
+                match connect_upstream_tcp(&upstream_host, upstream_port, &check.resolved_addrs)
+                    .await
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!("Upstream connection failed: {}", e);
+                        send_error(stream, 502, "Bad Gateway").await?;
+                        audit::log_denied(
+                            ctx.audit_log,
+                            audit::ProxyMode::Reverse,
+                            &service,
+                            0,
+                            &e.to_string(),
+                        );
+                        return Ok(());
+                    }
+                };
+
+            write_upstream_request(&mut upstream_stream, &request, &body).await?;
+            stream_response(&mut upstream_stream, stream).await?
+        }
+    };
     audit::log_reverse_proxy(
         ctx.audit_log,
         &service,
@@ -325,7 +348,8 @@ async fn handle_oauth2_credential(
     );
     debug!("OAuth2 forwarding to upstream: {} {}", method, upstream_url);
 
-    let (upstream_host, upstream_port, upstream_path_full) = parse_upstream_url(&upstream_url)?;
+    let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
+        parse_upstream_url(&upstream_url)?;
 
     // DNS resolve + host check via the filter
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
@@ -354,31 +378,6 @@ async fn handle_oauth2_credential(
         None => return Ok(()),
     };
 
-    // Connect to upstream over TLS, honoring any per-route custom CA / mTLS.
-    let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
-    let mut tls_stream = match connect_upstream_tls(
-        &upstream_host,
-        upstream_port,
-        &check.resolved_addrs,
-        connector,
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("Upstream connection failed: {}", e);
-            send_error(stream, 502, "Bad Gateway").await?;
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::Reverse,
-                service,
-                0,
-                &e.to_string(),
-            );
-            return Ok(());
-        }
-    };
-
     // Build upstream request with Bearer token injection
     let mut request = Zeroizing::new(format!(
         "{} {} {}\r\nHost: {}\r\n",
@@ -401,16 +400,73 @@ async fn handle_oauth2_credential(
     }
     request.push_str("\r\n");
 
-    tls_stream.write_all(request.as_bytes()).await?;
-    if !body.is_empty() {
-        tls_stream.write_all(&body).await?;
-    }
-    tls_stream.flush().await?;
+    let status_code = match upstream_scheme {
+        UpstreamScheme::Https => {
+            let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
+            let mut tls_stream = match connect_upstream_tls(
+                &upstream_host,
+                upstream_port,
+                &check.resolved_addrs,
+                connector,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Upstream connection failed: {}", e);
+                    send_error(stream, 502, "Bad Gateway").await?;
+                    audit::log_denied(
+                        ctx.audit_log,
+                        audit::ProxyMode::Reverse,
+                        service,
+                        0,
+                        &e.to_string(),
+                    );
+                    return Ok(());
+                }
+            };
 
-    // Stream the response back
-    let status_code = stream_response(&mut tls_stream, stream).await?;
+            write_upstream_request(&mut tls_stream, &request, &body).await?;
+            stream_response(&mut tls_stream, stream).await?
+        }
+        UpstreamScheme::Http => {
+            let mut upstream_stream =
+                match connect_upstream_tcp(&upstream_host, upstream_port, &check.resolved_addrs)
+                    .await
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!("Upstream connection failed: {}", e);
+                        send_error(stream, 502, "Bad Gateway").await?;
+                        audit::log_denied(
+                            ctx.audit_log,
+                            audit::ProxyMode::Reverse,
+                            service,
+                            0,
+                            &e.to_string(),
+                        );
+                        return Ok(());
+                    }
+                };
+
+            write_upstream_request(&mut upstream_stream, &request, &body).await?;
+            stream_response(&mut upstream_stream, stream).await?
+        }
+    };
 
     audit::log_reverse_proxy(ctx.audit_log, service, method, upstream_path, status_code);
+    Ok(())
+}
+
+async fn write_upstream_request<S>(stream: &mut S, request: &str, body: &[u8]) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    stream.write_all(request.as_bytes()).await?;
+    if !body.is_empty() {
+        stream.write_all(body).await?;
+    }
+    stream.flush().await?;
     Ok(())
 }
 
@@ -445,10 +501,13 @@ async fn read_request_body(
 /// Stream the upstream TLS response back to the client.
 ///
 /// Returns the HTTP status code parsed from the first chunk.
-async fn stream_response(
-    tls_stream: &mut tokio_rustls::client::TlsStream<TcpStream>,
+async fn stream_response<S>(
+    tls_stream: &mut S,
     stream: &mut TcpStream,
-) -> Result<u16> {
+) -> Result<u16>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let mut response_buf = [0u8; 8192];
     let mut status_code: u16 = 502;
     let mut first_chunk = true;
@@ -601,24 +660,37 @@ fn extract_content_length(header_bytes: &[u8]) -> Option<usize> {
 }
 
 /// Parse an upstream URL into (host, port, path).
-fn parse_upstream_url(url_str: &str) -> Result<(String, u16, String)> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpstreamScheme {
+    Http,
+    Https,
+}
+
+fn parse_upstream_url(url_str: &str) -> Result<(UpstreamScheme, String, u16, String)> {
     let parsed = url::Url::parse(url_str)
         .map_err(|e| ProxyError::HttpParse(format!("invalid upstream URL '{}': {}", url_str, e)))?;
 
-    let scheme = parsed.scheme();
-    if scheme != "https" && scheme != "http" {
-        return Err(ProxyError::HttpParse(format!(
-            "unsupported URL scheme: {}",
-            url_str
-        )));
-    }
+    let scheme = match parsed.scheme() {
+        "https" => UpstreamScheme::Https,
+        "http" => UpstreamScheme::Http,
+        _ => {
+            return Err(ProxyError::HttpParse(format!(
+                "unsupported URL scheme: {}",
+                url_str
+            )));
+        }
+    };
 
     let host = parsed
         .host_str()
         .ok_or_else(|| ProxyError::HttpParse(format!("missing host in URL: {}", url_str)))?
         .to_string();
 
-    let default_port = if scheme == "https" { 443 } else { 80 };
+    let default_port = if matches!(scheme, UpstreamScheme::Https) {
+        443
+    } else {
+        80
+    };
     let port = parsed.port().unwrap_or(default_port);
 
     let path = parsed.path().to_string();
@@ -635,7 +707,7 @@ fn parse_upstream_url(url_str: &str) -> Result<(String, u16, String)> {
         path
     };
 
-    Ok((host, port, path_with_query))
+    Ok((scheme, host, port, path_with_query))
 }
 
 /// Connect to an upstream host over TLS using pre-resolved addresses.
@@ -691,6 +763,29 @@ async fn connect_upstream_tls(
             })?;
 
     Ok(tls_stream)
+}
+
+async fn connect_upstream_tcp(
+    host: &str,
+    port: u16,
+    resolved_addrs: &[SocketAddr],
+) -> Result<TcpStream> {
+    if resolved_addrs.is_empty() {
+        let addr = format!("{}:{}", host, port);
+        match tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, TcpStream::connect(&addr)).await {
+            Ok(Ok(s)) => Ok(s),
+            Ok(Err(e)) => Err(ProxyError::UpstreamConnect {
+                host: host.to_string(),
+                reason: e.to_string(),
+            }),
+            Err(_) => Err(ProxyError::UpstreamConnect {
+                host: host.to_string(),
+                reason: "connection timed out".to_string(),
+            }),
+        }
+    } else {
+        connect_to_resolved(resolved_addrs, host).await
+    }
 }
 
 /// Connect to one of the pre-resolved socket addresses with timeout.
@@ -1284,8 +1379,9 @@ mod tests {
 
     #[test]
     fn test_parse_upstream_url_https() {
-        let (host, port, path) =
+        let (scheme, host, port, path) =
             parse_upstream_url("https://api.openai.com/v1/chat/completions").unwrap();
+        assert_eq!(scheme, UpstreamScheme::Https);
         assert_eq!(host, "api.openai.com");
         assert_eq!(port, 443);
         assert_eq!(path, "/v1/chat/completions");
@@ -1293,7 +1389,8 @@ mod tests {
 
     #[test]
     fn test_parse_upstream_url_http_with_port() {
-        let (host, port, path) = parse_upstream_url("http://localhost:8080/api").unwrap();
+        let (scheme, host, port, path) = parse_upstream_url("http://localhost:8080/api").unwrap();
+        assert_eq!(scheme, UpstreamScheme::Http);
         assert_eq!(host, "localhost");
         assert_eq!(port, 8080);
         assert_eq!(path, "/api");
@@ -1301,7 +1398,8 @@ mod tests {
 
     #[test]
     fn test_parse_upstream_url_no_path() {
-        let (host, port, path) = parse_upstream_url("https://api.anthropic.com").unwrap();
+        let (scheme, host, port, path) = parse_upstream_url("https://api.anthropic.com").unwrap();
+        assert_eq!(scheme, UpstreamScheme::Https);
         assert_eq!(host, "api.anthropic.com");
         assert_eq!(port, 443);
         assert_eq!(path, "/");

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -705,7 +705,7 @@ fn validate_http_upstream_target(
         Ok(())
     } else {
         Err(format!(
-            "refusing insecure http upstream for non-local host '{}'; http is only allowed for loopback or unspecified local addresses",
+            "refusing insecure http upstream for non-local host '{}'; http is only allowed for loopback addresses",
             host
         ))
     }
@@ -713,15 +713,12 @@ fn validate_http_upstream_target(
 
 fn is_local_only_target(host: &str, resolved_addrs: &[SocketAddr]) -> bool {
     if !resolved_addrs.is_empty() {
-        return resolved_addrs.iter().all(|addr| {
-            let ip = addr.ip();
-            ip.is_loopback() || ip.is_unspecified()
-        });
+        return resolved_addrs.iter().all(|addr| addr.ip().is_loopback());
     }
 
     match host.parse::<std::net::IpAddr>() {
-        Ok(std::net::IpAddr::V4(ip)) => ip.is_loopback() || ip.is_unspecified(),
-        Ok(std::net::IpAddr::V6(ip)) => ip.is_loopback() || ip.is_unspecified(),
+        Ok(std::net::IpAddr::V4(ip)) => ip.is_loopback(),
+        Ok(std::net::IpAddr::V6(ip)) => ip.is_loopback(),
         Err(_) => false,
     }
 }
@@ -1503,6 +1500,18 @@ mod tests {
         assert!(
             validate_http_upstream_target(UpstreamScheme::Http, "localhost", &loopback).is_ok()
         );
+    }
+
+    #[test]
+    fn test_validate_http_upstream_target_rejects_unspecified_addresses() {
+        let unspecified = [SocketAddr::from(([0, 0, 0, 0], 8080))];
+        let err = validate_http_upstream_target(UpstreamScheme::Http, "0.0.0.0", &[])
+            .expect_err("unspecified http upstream should be rejected");
+        assert!(err.contains("loopback addresses"));
+
+        let err = validate_http_upstream_target(UpstreamScheme::Http, "localhost", &unspecified)
+            .expect_err("localhost resolving to unspecified should be rejected");
+        assert!(err.contains("loopback addresses"));
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -191,9 +191,11 @@ pub async fn handle_reverse_proxy(
 
     let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
         parse_upstream_url(&upstream_url)?;
-    if let Err(reason) = validate_http_upstream_target(upstream_scheme, &upstream_host) {
-        warn!("{}", reason);
-        send_error(stream, 502, "Bad Gateway").await?;
+    let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
+    if !check.result.is_allowed() {
+        let reason = check.result.reason();
+        warn!("Upstream host denied by filter: {}", reason);
+        send_error(stream, 403, "Forbidden").await?;
         audit::log_denied(
             ctx.audit_log,
             audit::ProxyMode::Reverse,
@@ -203,11 +205,11 @@ pub async fn handle_reverse_proxy(
         );
         return Ok(());
     }
-    let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
-    if !check.result.is_allowed() {
-        let reason = check.result.reason();
-        warn!("Upstream host denied by filter: {}", reason);
-        send_error(stream, 403, "Forbidden").await?;
+    if let Err(reason) =
+        validate_http_upstream_target(upstream_scheme, &upstream_host, &check.resolved_addrs)
+    {
+        warn!("{}", reason);
+        send_error(stream, 502, "Bad Gateway").await?;
         audit::log_denied(
             ctx.audit_log,
             audit::ProxyMode::Reverse,
@@ -363,9 +365,12 @@ async fn handle_oauth2_credential(
 
     let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
         parse_upstream_url(&upstream_url)?;
-    if let Err(reason) = validate_http_upstream_target(upstream_scheme, &upstream_host) {
-        warn!("{}", reason);
-        send_error(stream, 502, "Bad Gateway").await?;
+    // DNS resolve + host check via the filter
+    let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
+    if !check.result.is_allowed() {
+        let reason = check.result.reason();
+        warn!("Upstream host denied by filter: {}", reason);
+        send_error(stream, 403, "Forbidden").await?;
         audit::log_denied(
             ctx.audit_log,
             audit::ProxyMode::Reverse,
@@ -375,13 +380,11 @@ async fn handle_oauth2_credential(
         );
         return Ok(());
     }
-
-    // DNS resolve + host check via the filter
-    let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
-    if !check.result.is_allowed() {
-        let reason = check.result.reason();
-        warn!("Upstream host denied by filter: {}", reason);
-        send_error(stream, 403, "Forbidden").await?;
+    if let Err(reason) =
+        validate_http_upstream_target(upstream_scheme, &upstream_host, &check.resolved_addrs)
+    {
+        warn!("{}", reason);
+        send_error(stream, 502, "Bad Gateway").await?;
         audit::log_denied(
             ctx.audit_log,
             audit::ProxyMode::Reverse,
@@ -692,12 +695,16 @@ enum UpstreamScheme {
     Https,
 }
 
-fn validate_http_upstream_target(scheme: UpstreamScheme, host: &str) -> std::result::Result<(), String> {
+fn validate_http_upstream_target(
+    scheme: UpstreamScheme,
+    host: &str,
+    resolved_addrs: &[SocketAddr],
+) -> std::result::Result<(), String> {
     if matches!(scheme, UpstreamScheme::Https) {
         return Ok(());
     }
 
-    if is_local_only_host(host) {
+    if is_local_only_target(host, resolved_addrs) {
         Ok(())
     } else {
         Err(format!(
@@ -707,9 +714,12 @@ fn validate_http_upstream_target(scheme: UpstreamScheme, host: &str) -> std::res
     }
 }
 
-fn is_local_only_host(host: &str) -> bool {
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
+fn is_local_only_target(host: &str, resolved_addrs: &[SocketAddr]) -> bool {
+    if !resolved_addrs.is_empty() {
+        return resolved_addrs.iter().all(|addr| {
+            let ip = addr.ip();
+            ip.is_loopback() || ip.is_unspecified()
+        });
     }
 
     match host.parse::<std::net::IpAddr>() {
@@ -1483,16 +1493,25 @@ mod tests {
 
     #[test]
     fn test_validate_http_upstream_target_rejects_non_local_host() {
-        let err = validate_http_upstream_target(UpstreamScheme::Http, "api.example.com")
+        let err = validate_http_upstream_target(UpstreamScheme::Http, "api.example.com", &[])
             .expect_err("non-local http upstream should be rejected");
         assert!(err.contains("refusing insecure http upstream"));
     }
 
     #[test]
     fn test_validate_http_upstream_target_allows_loopback() {
-        assert!(validate_http_upstream_target(UpstreamScheme::Http, "127.0.0.1").is_ok());
-        assert!(validate_http_upstream_target(UpstreamScheme::Http, "::1").is_ok());
-        assert!(validate_http_upstream_target(UpstreamScheme::Http, "localhost").is_ok());
+        let loopback = [SocketAddr::from(([127, 0, 0, 1], 8080))];
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "127.0.0.1", &[]).is_ok());
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "::1", &[]).is_ok());
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "localhost", &loopback).is_ok());
+    }
+
+    #[test]
+    fn test_validate_http_upstream_target_rejects_localhost_resolving_non_loopback() {
+        let poisoned = [SocketAddr::from(([203, 0, 113, 10], 8080))];
+        let err = validate_http_upstream_target(UpstreamScheme::Http, "localhost", &poisoned)
+            .expect_err("localhost resolving off-host should be rejected");
+        assert!(err.contains("refusing insecure http upstream"));
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -191,6 +191,18 @@ pub async fn handle_reverse_proxy(
 
     let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
         parse_upstream_url(&upstream_url)?;
+    if let Err(reason) = validate_http_upstream_target(upstream_scheme, &upstream_host) {
+        warn!("{}", reason);
+        send_error(stream, 502, "Bad Gateway").await?;
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            &service,
+            0,
+            &reason,
+        );
+        return Ok(());
+    }
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
     if !check.result.is_allowed() {
         let reason = check.result.reason();
@@ -214,9 +226,10 @@ pub async fn handle_reverse_proxy(
         None => return Ok(()),
     };
 
+    let upstream_authority = format_host_header(upstream_scheme, &upstream_host, upstream_port);
     let mut request = Zeroizing::new(format!(
         "{} {} {}\r\nHost: {}\r\n",
-        method, upstream_path_full, version, upstream_host
+        method, upstream_path_full, version, upstream_authority
     ));
 
     if let Some(cred) = cred {
@@ -350,6 +363,18 @@ async fn handle_oauth2_credential(
 
     let (upstream_scheme, upstream_host, upstream_port, upstream_path_full) =
         parse_upstream_url(&upstream_url)?;
+    if let Err(reason) = validate_http_upstream_target(upstream_scheme, &upstream_host) {
+        warn!("{}", reason);
+        send_error(stream, 502, "Bad Gateway").await?;
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            service,
+            0,
+            &reason,
+        );
+        return Ok(());
+    }
 
     // DNS resolve + host check via the filter
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
@@ -379,9 +404,10 @@ async fn handle_oauth2_credential(
     };
 
     // Build upstream request with Bearer token injection
+    let upstream_authority = format_host_header(upstream_scheme, &upstream_host, upstream_port);
     let mut request = Zeroizing::new(format!(
         "{} {} {}\r\nHost: {}\r\n",
-        method, upstream_path_full, version, upstream_host
+        method, upstream_path_full, version, upstream_authority
     ));
 
     // Inject OAuth2 access token as Authorization: Bearer
@@ -664,6 +690,51 @@ fn extract_content_length(header_bytes: &[u8]) -> Option<usize> {
 enum UpstreamScheme {
     Http,
     Https,
+}
+
+fn validate_http_upstream_target(scheme: UpstreamScheme, host: &str) -> std::result::Result<(), String> {
+    if matches!(scheme, UpstreamScheme::Https) {
+        return Ok(());
+    }
+
+    if is_local_only_host(host) {
+        Ok(())
+    } else {
+        Err(format!(
+            "refusing insecure http upstream for non-local host '{}'; http is only allowed for loopback or unspecified local addresses",
+            host
+        ))
+    }
+}
+
+fn is_local_only_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(ip)) => ip.is_loopback() || ip.is_unspecified(),
+        Ok(std::net::IpAddr::V6(ip)) => ip.is_loopback() || ip.is_unspecified(),
+        Err(_) => false,
+    }
+}
+
+fn format_host_header(scheme: UpstreamScheme, host: &str, port: u16) -> String {
+    let default_port = match scheme {
+        UpstreamScheme::Http => 80,
+        UpstreamScheme::Https => 443,
+    };
+    let bracketed_host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{}]", host)
+    } else {
+        host.to_string()
+    };
+
+    if port == default_port {
+        bracketed_host
+    } else {
+        format!("{}:{}", bracketed_host, port)
+    }
 }
 
 fn parse_upstream_url(url_str: &str) -> Result<(UpstreamScheme, String, u16, String)> {
@@ -1408,6 +1479,44 @@ mod tests {
     #[test]
     fn test_parse_upstream_url_invalid_scheme() {
         assert!(parse_upstream_url("ftp://example.com").is_err());
+    }
+
+    #[test]
+    fn test_validate_http_upstream_target_rejects_non_local_host() {
+        let err = validate_http_upstream_target(UpstreamScheme::Http, "api.example.com")
+            .expect_err("non-local http upstream should be rejected");
+        assert!(err.contains("refusing insecure http upstream"));
+    }
+
+    #[test]
+    fn test_validate_http_upstream_target_allows_loopback() {
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "127.0.0.1").is_ok());
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "::1").is_ok());
+        assert!(validate_http_upstream_target(UpstreamScheme::Http, "localhost").is_ok());
+    }
+
+    #[test]
+    fn test_format_host_header_uses_port_for_non_default_http() {
+        assert_eq!(
+            format_host_header(UpstreamScheme::Http, "localhost", 8080),
+            "localhost:8080"
+        );
+    }
+
+    #[test]
+    fn test_format_host_header_omits_default_https_port() {
+        assert_eq!(
+            format_host_header(UpstreamScheme::Https, "api.openai.com", 443),
+            "api.openai.com"
+        );
+    }
+
+    #[test]
+    fn test_format_host_header_brackets_ipv6() {
+        assert_eq!(
+            format_host_header(UpstreamScheme::Http, "::1", 8080),
+            "[::1]:8080"
+        );
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -530,10 +530,7 @@ async fn read_request_body(
 /// Stream the upstream TLS response back to the client.
 ///
 /// Returns the HTTP status code parsed from the first chunk.
-async fn stream_response<S>(
-    tls_stream: &mut S,
-    stream: &mut TcpStream,
-) -> Result<u16>
+async fn stream_response<S>(tls_stream: &mut S, stream: &mut TcpStream) -> Result<u16>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -1503,7 +1500,9 @@ mod tests {
         let loopback = [SocketAddr::from(([127, 0, 0, 1], 8080))];
         assert!(validate_http_upstream_target(UpstreamScheme::Http, "127.0.0.1", &[]).is_ok());
         assert!(validate_http_upstream_target(UpstreamScheme::Http, "::1", &[]).is_ok());
-        assert!(validate_http_upstream_target(UpstreamScheme::Http, "localhost", &loopback).is_ok());
+        assert!(
+            validate_http_upstream_target(UpstreamScheme::Http, "localhost", &loopback).is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Previously, the reverse proxy only supported HTTPS upstreams, implicitly assuming all connections to upstream servers would be over TLS. This change introduces explicit support for connecting to upstream HTTP (plain TCP) servers based on the scheme specified in the upstream URL configuration.

- The `parse_upstream_url` function now returns an `UpstreamScheme` enum (Http or Https) alongside host, port, and path.
- Connection logic in `handle_reverse_proxy` and `handle_oauth2_credential` has been refactored to conditionally connect using `connect_upstream_tls` or a new `connect_upstream_tcp` function based on the detected scheme.
- Helper functions `write_upstream_request` and `stream_response` have been generalized to work with any `AsyncRead + AsyncWrite` stream type, allowing them to handle both TLS and plain TCP connections.

This change enhances the flexibility of the reverse proxy by allowing it to forward requests to both HTTPS and HTTP backend services