### PR TITLE
chore(cli): make path and policy messages informational

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -9,7 +9,7 @@ use crate::profile::{expand_vars, Profile};
 use crate::protected_paths::{self, ProtectedRoots};
 use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
 use std::path::{Path, PathBuf};
-use tracing::{debug, warn};
+use tracing::{debug, info};
 
 /// Try to create a directory capability, warning and skipping on PathNotFound.
 /// Propagates all other errors.
@@ -17,7 +17,7 @@ fn try_new_dir(path: &Path, access: AccessMode, label: &str) -> Result<Option<Fs
     match FsCapability::new_dir(path, access) {
         Ok(cap) => Ok(Some(cap)),
         Err(NonoError::PathNotFound(_)) => {
-            warn!("{}: {}", label, path.display());
+            info!("{}: {}", label, path.display());
             Ok(None)
         }
         Err(e) => Err(e),
@@ -122,7 +122,7 @@ fn handle_missing_file_capability(
     _access: AccessMode,
     label: &str,
 ) -> Result<Option<FsCapability>> {
-    warn!("{}: {}", label, path.display());
+    info!("{}: {}", label, path.display());
     Ok(None)
 }
 

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -9,7 +9,7 @@ use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError,
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 // ============================================================================
 // JSON schema types
@@ -970,10 +970,10 @@ pub fn apply_deny_overrides(
         }
 
         // Warn about the security relaxation
-        crate::output::print_warning(&format!(
+        info!(
             "override_deny relaxing deny rule for '{}'",
             canonical.display()
-        ));
+        );
 
         // On macOS: emit Seatbelt allow rules to punch through deny.
         // Only emit rules matching the effective access mode from the union

--- a/tests/integration/test_edge_cases.sh
+++ b/tests/integration/test_edge_cases.sh
@@ -127,7 +127,8 @@ expect_output_contains "NONO_CAP_FILE is set" "NONO_CAP_FILE=" \
 echo ""
 echo "--- Non-existent Paths ---"
 
-expect_output_contains "grant non-existent directory is skipped with warning" "Skipping non-existent path" \
+expect_output_contains "grant non-existent directory is skipped with warning" \
+    "some requested sandbox grants were skipped because the path does not exist" \
     "$NONO_BIN" run --allow /nonexistent/path/that/does/not/exist/anywhere -- echo "should run"
 
 if is_macos; then

--- a/tests/integration/test_override_deny.sh
+++ b/tests/integration/test_override_deny.sh
@@ -236,11 +236,16 @@ echo ""
 echo "--- Warning output ---"
 
 if [[ -d "$DOCKER_DIR" ]]; then
-    expect_output_contains "override_deny shows styled warning" \
-        "warning:" \
+    expect_output_not_contains "override_deny hides advisory by default" \
+        "override_deny relaxing deny rule" \
         "$NONO_BIN" run --profile "$PROFILES_DIR/docker-override.json" --dry-run -- echo ok
+
+    expect_output_contains "override_deny shows advisory with -v" \
+        "override_deny relaxing deny rule" \
+        "$NONO_BIN" run -v --profile "$PROFILES_DIR/docker-override.json" --dry-run -- echo ok
 else
-    skip_test "override_deny shows styled warning" "~/.docker not found"
+    skip_test "override_deny hides advisory by default" "~/.docker not found"
+    skip_test "override_deny shows advisory with -v" "~/.docker not found"
 fi
 
 # =============================================================================

--- a/tests/integration/test_profiles.sh
+++ b/tests/integration/test_profiles.sh
@@ -58,8 +58,16 @@ else
         "$NONO_BIN" run -v --profile codex --dry-run -- echo "test"
 fi
 
-expect_output_contains "opencode profile lists OpenTUI data dir in dry-run" ".local/share/opentui" \
-    "$NONO_BIN" run --profile opencode --dry-run -- echo "test"
+if [[ -d "$HOME/.local/share/opentui" ]]; then
+    expect_output_contains "opencode profile lists OpenTUI data dir in dry-run" ".local/share/opentui" \
+        "$NONO_BIN" run --profile opencode --dry-run -- echo "test"
+else
+    expect_output_not_contains "opencode profile hides missing OpenTUI dir by default" ".local/share/opentui" \
+        "$NONO_BIN" run --profile opencode --dry-run -- echo "test"
+    expect_output_contains "opencode profile shows missing OpenTUI dir warning with -v" \
+        "Profile path '\$HOME/.local/share/opentui' does not exist, skipping" \
+        "$NONO_BIN" run -v --profile opencode --dry-run -- echo "test"
+fi
 
 expect_output_contains "dry-run output shows Capabilities section" "Capabilities:" \
     "$NONO_BIN" run --profile claude-code --dry-run -- echo "test"

--- a/tests/integration/test_profiles.sh
+++ b/tests/integration/test_profiles.sh
@@ -47,8 +47,16 @@ expect_failure "nonexistent profile exits non-zero" \
 expect_output_contains "claude-code profile lists .claude in dry-run" ".claude" \
     "$NONO_BIN" run --profile claude-code --dry-run -- echo "test"
 
-expect_output_contains "codex profile lists .codex in dry-run" ".codex" \
-    "$NONO_BIN" run --profile codex --dry-run -- echo "test"
+if [[ -d "$HOME/.codex" ]]; then
+    expect_output_contains "codex profile lists .codex in dry-run" ".codex" \
+        "$NONO_BIN" run --profile codex --dry-run -- echo "test"
+else
+    expect_output_not_contains "codex profile hides missing .codex by default" ".codex" \
+        "$NONO_BIN" run --profile codex --dry-run -- echo "test"
+    expect_output_contains "codex profile shows missing .codex warning with -v" \
+        "Profile path '\$HOME/.codex' does not exist, skipping" \
+        "$NONO_BIN" run -v --profile codex --dry-run -- echo "test"
+fi
 
 expect_output_contains "opencode profile lists OpenTUI data dir in dry-run" ".local/share/opentui" \
     "$NONO_BIN" run --profile opencode --dry-run -- echo "test"

--- a/tests/integration/test_silent_output.sh
+++ b/tests/integration/test_silent_output.sh
@@ -43,10 +43,14 @@ expect_output_empty() {
     return 1
 }
 
-expect_output_contains \
-    "claude-code dry-run surfaces missing profile warnings without --silent" \
-    "Profile file '\$HOME/Library/Keychains/login.keychain-db' does not exist, skipping" \
+expect_output_empty \
+    "claude-code dry-run hides missing profile warnings by default" \
     "$NONO_BIN" run --profile claude-code --allow-cwd --dry-run -- echo ok
+
+expect_output_contains \
+    "claude-code dry-run shows missing profile warnings with -v" \
+    "Profile file '\$HOME/Library/Keychains/login.keychain-db' does not exist, skipping" \
+    "$NONO_BIN" run -v --profile claude-code --allow-cwd --dry-run -- echo ok
 
 expect_output_empty \
     "silent dry-run suppresses tracing warnings and CLI status output" \


### PR DESCRIPTION
Messages about missing optional paths during capability setup and the relaxation of deny rules via `override_deny` are now logged at the `info` level instead of `warn` to save hitting the TUI.

This change means these messages are no longer displayed by default, reducing console output noise for events that are often informational. Users can still see these details by running the CLI with the verbose flag (`-v`).