### PR TITLE
feat(cli): enhance prompts and denial diagnostics

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1035,7 +1035,13 @@ pub fn execute_supervised(
 
             #[cfg(target_os = "macos")]
             let sandbox_log_collector = if supervisor.is_some() {
-                crate::sandbox_log::SandboxLogCollector::start(child.as_raw())
+                let command_name = config
+                    .command
+                    .first()
+                    .and_then(|c| std::path::Path::new(c).file_name())
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string);
+                crate::sandbox_log::SandboxLogCollector::start(child.as_raw(), command_name)
             } else {
                 None
             };
@@ -1605,10 +1611,16 @@ extern "C" fn forward_signal(sig: libc::c_int) {
                 libc::kill(child_raw, sig);
             }
         }
-    } else {
+    } else if matches!(
+        sig,
+        libc::SIGINT | libc::SIGTERM | libc::SIGHUP | libc::SIGQUIT
+    ) {
         // No child to forward to (e.g. during the post-exit profile-save prompt).
-        // Restore the default handler and re-raise so the signal takes its
-        // default action (terminating nono) rather than being swallowed.
+        // For termination signals, restore the default handler and re-raise so
+        // the signal takes its default action (terminating nono) rather than
+        // being swallowed. Non-termination signals (SIGWINCH, SIGUSR1) are
+        // ignored here — their forwarding targets (PTY master, pause pipe) are
+        // already torn down.
         unsafe {
             libc::signal(sig, libc::SIG_DFL);
             libc::raise(sig);

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -156,6 +156,119 @@ fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output:
     affirmative
 }
 
+struct StartupPromptTerminalGuard {
+    tty: Option<std::fs::File>,
+    saved_termios: Option<nix::sys::termios::Termios>,
+    child: Pid,
+    child_stopped: bool,
+}
+
+impl StartupPromptTerminalGuard {
+    fn pause_without_pty(child: Pid) -> Self {
+        let child_stopped = signal::kill(child, Signal::SIGSTOP).is_ok();
+        if child_stopped {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let mut guard = Self {
+            tty: None,
+            saved_termios: None,
+            child,
+            child_stopped,
+        };
+
+        let tty = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+        {
+            Ok(tty) => tty,
+            Err(_) => return guard,
+        };
+
+        let original = match nix::sys::termios::tcgetattr(&tty) {
+            Ok(termios) => termios,
+            Err(_) => return guard,
+        };
+
+        let mut prompt_termios = original.clone();
+        crate::profile_save_runtime::configure_prompt_termios(&mut prompt_termios);
+        if nix::sys::termios::tcsetattr(&tty, nix::sys::termios::SetArg::TCSANOW, &prompt_termios)
+            .is_err()
+        {
+            return guard;
+        }
+
+        let _ = nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH);
+        guard.saved_termios = Some(original);
+        guard.tty = Some(tty);
+        guard
+    }
+
+    fn finish(self, resume_child: bool) {
+        if let (Some(tty), Some(saved_termios)) = (self.tty.as_ref(), self.saved_termios.as_ref()) {
+            let _ = nix::sys::termios::tcsetattr(
+                tty,
+                nix::sys::termios::SetArg::TCSANOW,
+                saved_termios,
+            );
+        }
+
+        if self.child_stopped && resume_child {
+            let _ = signal::kill(self.child, Signal::SIGCONT);
+        }
+    }
+}
+
+fn prompt_startup_termination_for_child(
+    child: Pid,
+    timeout_cfg: StartupTimeoutConfig<'_>,
+    has_output: bool,
+    pty: Option<&mut crate::pty_proxy::PtyProxy>,
+) -> bool {
+    if let Some(proxy) = pty {
+        let paused_terminal = proxy.pause_terminal_for_prompt();
+        let terminate = prompt_startup_termination(timeout_cfg, has_output);
+        if paused_terminal {
+            proxy.resume_terminal_after_prompt();
+        }
+        return terminate;
+    }
+
+    let guard = StartupPromptTerminalGuard::pause_without_pty(child);
+    let terminate = prompt_startup_termination(timeout_cfg, has_output);
+    guard.finish(!terminate);
+    terminate
+}
+
+fn offer_profile_save_for_child(
+    pty: Option<&mut crate::pty_proxy::PtyProxy>,
+    policy_explanations: &[nono::diagnostic::PolicyExplanation],
+    error_observation: &nono::diagnostic::ErrorObservation,
+    caps: &CapabilitySet,
+    command: &[String],
+    compared_profile: Option<&str>,
+) -> Result<()> {
+    if let Some(proxy) = pty {
+        let _released_terminal = proxy.release_terminal_for_prompt();
+        return crate::profile_save_runtime::offer_save_run_profile(
+            policy_explanations,
+            error_observation,
+            caps,
+            command,
+            compared_profile,
+        );
+    }
+
+    crate::profile_save_runtime::offer_save_run_profile(
+        policy_explanations,
+        error_observation,
+        caps,
+        command,
+        compared_profile,
+    )
+}
+
 /// Linux procfs context for resolving child-relative procfs paths in the supervisor.
 ///
 /// `/proc/self/...` must refer to the sandboxed child process, not the unsandboxed
@@ -258,6 +371,8 @@ pub struct ExecConfig<'a> {
     pub threading: ThreadingContext,
     /// Paths that are write-protected (signed instruction files).
     pub protected_paths: &'a [std::path::PathBuf],
+    /// Base profile name to derive a saved user patch from after run-time denials.
+    pub profile_save_base: Option<&'a str>,
     /// Optional startup timeout for known interactive CLIs that were launched
     /// without their recommended built-in profile.
     pub startup_timeout: Option<StartupTimeoutConfig<'a>>,
@@ -1215,13 +1330,30 @@ pub fn execute_supervised(
                 #[cfg(not(target_os = "macos"))]
                 let sandbox_violations = Vec::new();
 
+                let diag_session_id = if supervisor.is_some() {
+                    pty_session_id
+                        .or_else(|| supervisor.map(|s| s.session_id))
+                        .map(str::to_string)
+                } else {
+                    None
+                };
+
+                // Resolve policy explanations for denied paths so the
+                // diagnostic can show group names and fix guidance inline.
+                let policy_explanations =
+                    build_policy_explanations(&denials, &sandbox_violations, config.caps);
+                let prompt_policy_explanations = policy_explanations.clone();
+                let prompt_error_observation = error_observation.clone();
+
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
                     .with_denials(&denials)
                     .with_sandbox_violations(&sandbox_violations)
                     .with_protected_paths(config.protected_paths)
                     .with_error_observation(error_observation)
-                    .with_current_dir(config.current_dir);
+                    .with_current_dir(config.current_dir)
+                    .with_session_id(diag_session_id)
+                    .with_policy_explanations(policy_explanations);
                 if let Some(program) = config.command.first() {
                     formatter = formatter.with_command(nono::diagnostic::CommandContext {
                         program: program.clone(),
@@ -1231,12 +1363,90 @@ pub fn execute_supervised(
                 }
                 let footer = formatter.format_footer(exit_code);
                 crate::output::print_diagnostic_footer(&footer);
+
+                if exit_code != 0 {
+                    offer_profile_save_for_child(
+                        pty_proxy.as_mut(),
+                        &prompt_policy_explanations,
+                        &prompt_error_observation,
+                        config.caps,
+                        config.command,
+                        config.profile_save_base,
+                    )?;
+                }
             }
 
             Ok(exit_code)
         }
         Err(e) => Err(NonoError::SandboxInit(format!("fork() failed: {}", e))),
     }
+}
+
+/// Resolve policy explanations for denied paths by querying `query_path`.
+///
+/// This runs the same logic as `nono why` but inline, so the diagnostic
+/// footer can show group names and fix guidance without asking the user
+/// to run a separate command.
+fn build_policy_explanations(
+    denials: &[nono::diagnostic::DenialRecord],
+    sandbox_violations: &[nono::SandboxViolation],
+    caps: &nono::CapabilitySet,
+) -> Vec<nono::diagnostic::PolicyExplanation> {
+    use nono::diagnostic::PolicyExplanation;
+    use std::collections::BTreeSet;
+
+    let mut explanations = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    // Collect paths from both denial sources
+    let denial_paths: Vec<(&std::path::Path, nono::AccessMode)> = denials
+        .iter()
+        .map(|d| (d.path.as_path(), d.access))
+        .collect();
+
+    let violation_paths: Vec<(std::path::PathBuf, nono::AccessMode)> = sandbox_violations
+        .iter()
+        .filter_map(|v| {
+            let access = nono::diagnostic::seatbelt_operation_to_access(&v.operation)?;
+            let target = v.target.as_ref()?;
+            Some((std::path::PathBuf::from(target), access))
+        })
+        .collect();
+
+    for (path, access) in denial_paths
+        .iter()
+        .map(|(p, a)| (std::path::PathBuf::from(p), *a))
+        .chain(violation_paths)
+    {
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        match crate::query_ext::query_path(&path, access, caps, &[]) {
+            Ok(crate::query_ext::QueryResult::Denied {
+                reason,
+                details,
+                policy_source,
+                suggested_flag,
+                ..
+            }) => {
+                explanations.push(PolicyExplanation {
+                    path,
+                    access,
+                    reason,
+                    details,
+                    policy_source,
+                    suggested_flag,
+                });
+            }
+            Ok(crate::query_ext::QueryResult::Allowed { .. }) => {
+                // Path is actually allowed by policy — the denial came from
+                // a different layer (e.g. Landlock timing). Skip.
+            }
+            Ok(crate::query_ext::QueryResult::NotSandboxed { .. }) | Err(_) => {}
+        }
+    }
+
+    explanations
 }
 
 /// Close inherited file descriptors, keeping stdin/stdout/stderr and specified FDs.
@@ -1344,11 +1554,12 @@ fn wait_for_child_with_pty(
                     let has_output = pty.has_observed_output();
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
-                        let paused_terminal = pty.pause_terminal_for_prompt();
-                        let terminate = prompt_startup_termination(timeout_cfg, has_output);
-                        if paused_terminal {
-                            pty.resume_terminal_after_prompt();
-                        }
+                        let terminate = prompt_startup_termination_for_child(
+                            child,
+                            timeout_cfg,
+                            has_output,
+                            Some(pty),
+                        );
                         if terminate {
                             let _ = signal::kill(child, Signal::SIGKILL);
                             let status = wait_for_child(child)?;
@@ -1390,7 +1601,7 @@ fn wait_for_child_with_startup_timeout(
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
                     if Instant::now() >= deadline && !startup_prompted {
                         startup_prompted = true;
-                        if prompt_startup_termination(timeout_cfg, true) {
+                        if prompt_startup_termination_for_child(child, timeout_cfg, true, None) {
                             let _ = signal::kill(child, Signal::SIGKILL);
                             return wait_for_child(child);
                         }
@@ -1805,15 +2016,12 @@ fn run_supervisor_loop(
                     let has_output = pty.as_ref().is_some_and(|p| p.has_observed_output());
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
-                        let paused_terminal = pty
-                            .as_mut()
-                            .is_some_and(|proxy| proxy.pause_terminal_for_prompt());
-                        let terminate = prompt_startup_termination(timeout_cfg, has_output);
-                        if let Some(proxy) = pty.as_mut() {
-                            if paused_terminal {
-                                proxy.resume_terminal_after_prompt();
-                            }
-                        }
+                        let terminate = prompt_startup_termination_for_child(
+                            child,
+                            timeout_cfg,
+                            has_output,
+                            pty.as_deref_mut(),
+                        );
                         if terminate {
                             let _ = signal::kill(child, Signal::SIGKILL);
                             return Ok((wait_for_child(child)?, denials));
@@ -2052,15 +2260,12 @@ fn run_supervisor_loop(
                     let has_output = pty.as_ref().is_some_and(|p| p.has_observed_output());
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
-                        let paused_terminal = pty
-                            .as_mut()
-                            .is_some_and(|proxy| proxy.pause_terminal_for_prompt());
-                        let terminate = prompt_startup_termination(timeout_cfg, has_output);
-                        if let Some(proxy) = pty.as_mut() {
-                            if paused_terminal {
-                                proxy.resume_terminal_after_prompt();
-                            }
-                        }
+                        let terminate = prompt_startup_termination_for_child(
+                            child,
+                            timeout_cfg,
+                            has_output,
+                            pty.as_deref_mut(),
+                        );
                         if terminate {
                             let _ = signal::kill(child, Signal::SIGTERM);
                             return Ok((wait_for_child(child)?, denials));
@@ -3066,6 +3271,9 @@ fn open_canonical_path_no_symlinks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nix::sys::termios::{
+        ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
+    };
 
     #[cfg(target_os = "linux")]
     #[test]
@@ -3079,6 +3287,44 @@ mod tests {
     #[test]
     fn test_exec_strategy_default_is_supervised() {
         assert_eq!(ExecStrategy::default(), ExecStrategy::Supervised);
+    }
+
+    #[test]
+    fn test_configure_startup_prompt_termios_restores_cooked_input() {
+        let mut termios = unsafe { std::mem::zeroed::<nix::sys::termios::Termios>() };
+        termios.input_flags = InputFlags::IGNBRK | InputFlags::INLCR | InputFlags::IGNCR;
+        termios.output_flags = OutputFlags::empty();
+        termios.local_flags = LocalFlags::empty();
+        termios.control_flags = ControlFlags::CSIZE | ControlFlags::PARENB;
+        termios.control_chars[SpecialCharacterIndices::VMIN as usize] = 0;
+        termios.control_chars[SpecialCharacterIndices::VTIME as usize] = 9;
+
+        crate::profile_save_runtime::configure_prompt_termios(&mut termios);
+
+        assert!(termios
+            .input_flags
+            .contains(InputFlags::ICRNL | InputFlags::IXON));
+        assert!(!termios
+            .input_flags
+            .intersects(InputFlags::IGNBRK | InputFlags::INLCR | InputFlags::IGNCR));
+        assert!(termios.output_flags.contains(OutputFlags::OPOST));
+        assert!(termios.local_flags.contains(
+            LocalFlags::ECHO
+                | LocalFlags::ECHONL
+                | LocalFlags::ICANON
+                | LocalFlags::ISIG
+                | LocalFlags::IEXTEN
+        ));
+        assert!(!termios.control_flags.contains(ControlFlags::PARENB));
+        assert!(termios.control_flags.contains(ControlFlags::CS8));
+        assert_eq!(
+            termios.control_chars[SpecialCharacterIndices::VMIN as usize],
+            1
+        );
+        assert_eq!(
+            termios.control_chars[SpecialCharacterIndices::VTIME as usize],
+            0
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1365,6 +1365,10 @@ pub fn execute_supervised(
                 crate::output::print_diagnostic_footer(&footer);
 
                 if exit_code != 0 {
+                    // Clear the forwarding target before prompting. The child is
+                    // already dead; keeping CHILD_PID set would cause forward_signal
+                    // to send Ctrl-C to the dead PID, swallowing it silently.
+                    clear_signal_forwarding_target();
                     offer_profile_save_for_child(
                         pty_proxy.as_mut(),
                         &prompt_policy_explanations,
@@ -1771,6 +1775,14 @@ extern "C" fn forward_signal(sig: libc::c_int) {
             unsafe {
                 libc::kill(child_raw, sig);
             }
+        }
+    } else {
+        // No child to forward to (e.g. during the post-exit profile-save prompt).
+        // Restore the default handler and re-raise so the signal takes its
+        // default action (terminating nono) rather than being swallowed.
+        unsafe {
+            libc::signal(sig, libc::SIG_DFL);
+            libc::raise(sig);
         }
     }
 }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1232,34 +1232,46 @@ fn build_policy_explanations(
     caps: &nono::CapabilitySet,
 ) -> Vec<nono::diagnostic::PolicyExplanation> {
     use nono::diagnostic::PolicyExplanation;
-    use std::collections::BTreeSet;
+    use nono::AccessMode;
+    use std::collections::BTreeMap;
+
+    // Merge access modes per path so a path denied for both Read and Write
+    // produces a single ReadWrite query. Querying each (path, mode) pair
+    // independently would let the first insert win and drop the other mode,
+    // yielding an incomplete "Fix:" suggestion.
+    let mut paths: BTreeMap<std::path::PathBuf, AccessMode> = BTreeMap::new();
+
+    let merge = |existing: AccessMode, incoming: AccessMode| -> AccessMode {
+        if existing == incoming {
+            existing
+        } else {
+            AccessMode::ReadWrite
+        }
+    };
+
+    for denial in denials {
+        paths
+            .entry(denial.path.clone())
+            .and_modify(|a| *a = merge(*a, denial.access))
+            .or_insert(denial.access);
+    }
+
+    for violation in sandbox_violations {
+        let Some(access) = nono::diagnostic::seatbelt_operation_to_access(&violation.operation)
+        else {
+            continue;
+        };
+        let Some(target) = violation.target.as_ref() else {
+            continue;
+        };
+        paths
+            .entry(std::path::PathBuf::from(target))
+            .and_modify(|a| *a = merge(*a, access))
+            .or_insert(access);
+    }
 
     let mut explanations = Vec::new();
-    let mut seen = BTreeSet::new();
-
-    // Collect paths from both denial sources
-    let denial_paths: Vec<(&std::path::Path, nono::AccessMode)> = denials
-        .iter()
-        .map(|d| (d.path.as_path(), d.access))
-        .collect();
-
-    let violation_paths: Vec<(std::path::PathBuf, nono::AccessMode)> = sandbox_violations
-        .iter()
-        .filter_map(|v| {
-            let access = nono::diagnostic::seatbelt_operation_to_access(&v.operation)?;
-            let target = v.target.as_ref()?;
-            Some((std::path::PathBuf::from(target), access))
-        })
-        .collect();
-
-    for (path, access) in denial_paths
-        .iter()
-        .map(|(p, a)| (std::path::PathBuf::from(p), *a))
-        .chain(violation_paths)
-    {
-        if !seen.insert(path.clone()) {
-            continue;
-        }
+    for (path, access) in paths {
         match crate::query_ext::query_path(&path, access, caps, &[]) {
             Ok(crate::query_ext::QueryResult::Denied {
                 reason,

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -14,6 +14,7 @@ mod env_sanitization;
 #[cfg(target_os = "linux")]
 mod supervisor_linux;
 
+use crate::startup_prompt::{print_terminal_safe_stderr, prompt_startup_termination_for_child};
 use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV};
 use nix::libc;
 use nix::sys::signal::{self, Signal};
@@ -26,7 +27,6 @@ use nono::{
 };
 use std::collections::HashSet;
 use std::ffi::{CString, OsStr};
-use std::io::{self, BufRead, IsTerminal, Write};
 use std::os::fd::FromRawFd;
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::os::unix::ffi::OsStrExt;
@@ -69,177 +69,6 @@ const MAX_CRYPTO_THREADS: usize = 7;
 const MAX_DENIAL_RECORDS: usize = 1000;
 /// Hard cap on request IDs tracked for replay detection.
 const MAX_TRACKED_REQUEST_IDS: usize = 4096;
-
-fn print_terminal_safe_stderr(message: &str) {
-    let mut stderr = io::stderr();
-    if stderr.is_terminal() {
-        let normalized = message.replace('\n', "\r\n");
-        let _ = writeln!(stderr, "\r{}", normalized);
-    } else {
-        let _ = writeln!(stderr, "{}", message);
-    }
-}
-
-fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output: bool) -> bool {
-    let description = if has_output {
-        format!(
-            "[nono] Startup appears blocked: `{}` has not become interactive after {} seconds.",
-            timeout_cfg.program,
-            timeout_cfg.timeout.as_secs()
-        )
-    } else {
-        format!(
-            "[nono] Startup appears blocked: `{}` produced no terminal output after {} seconds.",
-            timeout_cfg.program,
-            timeout_cfg.timeout.as_secs()
-        )
-    };
-
-    let tty_in = match std::fs::File::open("/dev/tty") {
-        Ok(file) => file,
-        Err(_) => {
-            print_terminal_safe_stderr(&format!(
-                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
-                description,
-                timeout_cfg.program,
-                timeout_cfg.profile,
-                timeout_cfg.profile,
-                timeout_cfg.program,
-            ));
-            return false;
-        }
-    };
-
-    let mut tty_out = match std::fs::OpenOptions::new().write(true).open("/dev/tty") {
-        Ok(file) => file,
-        Err(_) => {
-            print_terminal_safe_stderr(&format!(
-                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
-                description,
-                timeout_cfg.program,
-                timeout_cfg.profile,
-                timeout_cfg.profile,
-                timeout_cfg.program,
-            ));
-            return false;
-        }
-    };
-
-    let _ = writeln!(tty_out);
-    let _ = writeln!(tty_out, "{}", description);
-    let _ = writeln!(
-        tty_out,
-        "[nono] `{}` usually needs the built-in `{}` profile.",
-        timeout_cfg.program, timeout_cfg.profile
-    );
-    let _ = writeln!(
-        tty_out,
-        "[nono] Try: nono run --profile {} -- {}",
-        timeout_cfg.profile, timeout_cfg.program
-    );
-    let _ = write!(tty_out, "[nono] Do you wish to terminate? [y/N] ");
-    let _ = tty_out.flush();
-
-    let mut reader = io::BufReader::new(tty_in);
-    let mut input = String::new();
-    if reader.read_line(&mut input).is_err() {
-        let _ = writeln!(tty_out, "\n[nono] Continuing to wait.");
-        return false;
-    }
-
-    let affirmative = matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes");
-    if affirmative {
-        let _ = writeln!(tty_out, "[nono] Terminating startup-blocked process.");
-    } else {
-        let _ = writeln!(tty_out, "[nono] Continuing to wait.");
-    }
-    affirmative
-}
-
-struct StartupPromptTerminalGuard {
-    tty: Option<std::fs::File>,
-    saved_termios: Option<nix::sys::termios::Termios>,
-    child: Pid,
-    child_stopped: bool,
-}
-
-impl StartupPromptTerminalGuard {
-    fn pause_without_pty(child: Pid) -> Self {
-        let child_stopped = signal::kill(child, Signal::SIGSTOP).is_ok();
-        if child_stopped {
-            std::thread::sleep(Duration::from_millis(20));
-        }
-
-        let mut guard = Self {
-            tty: None,
-            saved_termios: None,
-            child,
-            child_stopped,
-        };
-
-        let tty = match std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/tty")
-        {
-            Ok(tty) => tty,
-            Err(_) => return guard,
-        };
-
-        let original = match nix::sys::termios::tcgetattr(&tty) {
-            Ok(termios) => termios,
-            Err(_) => return guard,
-        };
-
-        let mut prompt_termios = original.clone();
-        crate::profile_save_runtime::configure_prompt_termios(&mut prompt_termios);
-        if nix::sys::termios::tcsetattr(&tty, nix::sys::termios::SetArg::TCSANOW, &prompt_termios)
-            .is_err()
-        {
-            return guard;
-        }
-
-        let _ = nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH);
-        guard.saved_termios = Some(original);
-        guard.tty = Some(tty);
-        guard
-    }
-
-    fn finish(self, resume_child: bool) {
-        if let (Some(tty), Some(saved_termios)) = (self.tty.as_ref(), self.saved_termios.as_ref()) {
-            let _ = nix::sys::termios::tcsetattr(
-                tty,
-                nix::sys::termios::SetArg::TCSANOW,
-                saved_termios,
-            );
-        }
-
-        if self.child_stopped && resume_child {
-            let _ = signal::kill(self.child, Signal::SIGCONT);
-        }
-    }
-}
-
-fn prompt_startup_termination_for_child(
-    child: Pid,
-    timeout_cfg: StartupTimeoutConfig<'_>,
-    has_output: bool,
-    pty: Option<&mut crate::pty_proxy::PtyProxy>,
-) -> bool {
-    if let Some(proxy) = pty {
-        let paused_terminal = proxy.pause_terminal_for_prompt();
-        let terminate = prompt_startup_termination(timeout_cfg, has_output);
-        if paused_terminal {
-            proxy.resume_terminal_after_prompt();
-        }
-        return terminate;
-    }
-
-    let guard = StartupPromptTerminalGuard::pause_without_pty(child);
-    let terminate = prompt_startup_termination(timeout_cfg, has_output);
-    guard.finish(!terminate);
-    terminate
-}
 
 fn offer_profile_save_for_child(
     pty: Option<&mut crate::pty_proxy::PtyProxy>,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -294,6 +294,11 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         no_diagnostics: flags.no_diagnostics || flags.silent,
         threading,
         protected_paths: &trust.protected_paths,
+        profile_save_base: flags
+            .session
+            .profile_name
+            .as_deref()
+            .or(recommended_profile),
         startup_timeout: if should_apply_startup_timeout(recommended_profile, &cmd_args) {
             recommended_profile.map(|profile| exec_strategy::StartupTimeoutConfig {
                 timeout: PROFILE_HINT_STARTUP_TIMEOUT,

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -170,61 +170,50 @@ impl LearnResult {
             .map_err(|e| nono::NonoError::LearnError(format!("Failed to serialize JSON: {}", e)))
     }
 
-    /// Generate a complete profile JSON from discovered paths
-    ///
-    /// Creates a minimal profile with the discovered filesystem permissions,
-    /// working directory access, and network settings. The profile can be
-    /// saved directly to `~/.config/nono/profiles/<name>.json`.
-    pub fn to_profile(&self, name: &str, command: &str) -> Result<String> {
+    /// Generate a profile patch containing only learned filesystem grants.
+    pub fn to_profile_patch(&self) -> Result<Profile> {
         let home = crate::config::validated_home()?;
         let home_path = std::path::Path::new(&home);
 
-        // Replace $HOME prefix with ~ for portability.
-        // Uses Path::starts_with() to avoid string prefix matching pitfalls.
-        let shorten = |p: &std::path::Path| -> String {
-            if p.starts_with(home_path) {
-                match p.strip_prefix(home_path) {
-                    Ok(relative) => format!("~/{}", relative.display()),
-                    Err(_) => p.display().to_string(),
-                }
+        let mut profile = Profile::default();
+        profile.filesystem.allow = shortened_paths(&self.readwrite_paths, home_path);
+        profile.filesystem.allow_file = shortened_paths(&self.readwrite_files, home_path);
+        profile.filesystem.read = shortened_paths(&self.read_paths, home_path);
+        profile.filesystem.read_file = shortened_paths(&self.read_files, home_path);
+        profile.filesystem.write = shortened_paths(&self.write_paths, home_path);
+        profile.filesystem.write_file = shortened_paths(&self.write_files, home_path);
+        profile.policy.override_deny = learned_override_deny_paths(self, home_path)?;
+
+        Ok(profile)
+    }
+
+    /// Generate a named profile from discovered paths.
+    pub fn to_named_profile(
+        &self,
+        name: &str,
+        command: &str,
+        extends: Option<Vec<String>>,
+    ) -> Result<Profile> {
+        let mut profile = self.to_profile_patch()?;
+        let has_base = extends.is_some();
+        profile.extends = extends;
+        profile.meta = profile::ProfileMeta {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            description: Some(if has_base {
+                format!("Learned path additions for {}", command)
             } else {
-                p.display().to_string()
-            }
+                format!("Auto-generated profile for {}", command)
+            }),
+            author: None,
         };
 
-        let allow: Vec<String> = self.readwrite_paths.iter().map(|p| shorten(p)).collect();
-        let allow_file: Vec<String> = self.readwrite_files.iter().map(|p| shorten(p)).collect();
-        let read: Vec<String> = self.read_paths.iter().map(|p| shorten(p)).collect();
-        let read_file: Vec<String> = self.read_files.iter().map(|p| shorten(p)).collect();
-        let write: Vec<String> = self.write_paths.iter().map(|p| shorten(p)).collect();
-        let write_file: Vec<String> = self.write_files.iter().map(|p| shorten(p)).collect();
+        if !has_base {
+            profile.network.block = !self.has_network_activity();
+            profile.workdir.access = profile::WorkdirAccess::ReadWrite;
+        }
 
-        let has_network = self.has_network_activity();
-
-        let profile = serde_json::json!({
-            "meta": {
-                "name": name,
-                "version": "1.0.0",
-                "description": format!("Auto-generated profile for {}", command),
-            },
-            "filesystem": {
-                "allow": allow,
-                "read": read,
-                "write": write,
-                "allow_file": allow_file,
-                "read_file": read_file,
-                "write_file": write_file,
-            },
-            "network": {
-                "block": !has_network,
-            },
-            "workdir": {
-                "access": "readwrite",
-            },
-        });
-
-        serde_json::to_string_pretty(&profile)
-            .map_err(|e| nono::NonoError::LearnError(format!("Failed to serialize profile: {}", e)))
+        Ok(profile)
     }
 
     /// Format as human-readable summary with clear visual separation
@@ -347,6 +336,40 @@ fn push_fs_summary_section(
     for path in file_paths {
         lines.push(format!("  {} {}", file_flag, path.display()));
     }
+}
+
+fn shortened_paths(paths: &BTreeSet<PathBuf>, home_path: &Path) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| crate::profile_save_runtime::shorten_path_for_profile(path, home_path))
+        .collect()
+}
+
+fn learned_override_deny_paths(result: &LearnResult, home_path: &Path) -> Result<Vec<String>> {
+    let mut override_deny = Vec::new();
+
+    for path in result
+        .readwrite_paths
+        .iter()
+        .chain(result.readwrite_files.iter())
+        .chain(result.read_paths.iter())
+        .chain(result.read_files.iter())
+        .chain(result.write_paths.iter())
+        .chain(result.write_files.iter())
+    {
+        let shortened = crate::profile_save_runtime::shorten_path_for_profile(path, home_path);
+        if crate::config::check_sensitive_path(&shortened)?.is_some()
+            && !override_deny.contains(&shortened)
+        {
+            override_deny.push(shortened);
+        }
+    }
+
+    Ok(override_deny)
+}
+
+pub(crate) fn merge_learned_profile_patch(profile: &mut Profile, patch: &Profile) {
+    crate::profile_save_runtime::merge_profile_patch(profile, patch);
 }
 
 /// Format a single network connection summary line
@@ -2190,9 +2213,11 @@ mod tests {
         let mut result = LearnResult::new();
         result.write_files.insert(PathBuf::from("/tmp/output.txt"));
 
-        let profile = result.to_profile("touch", "touch")?;
-        assert!(profile.contains("\"write_file\""));
-        assert!(profile.contains("/tmp/output.txt"));
+        let profile = result.to_named_profile("touch", "touch", None)?;
+        let profile_json =
+            serde_json::to_string_pretty(&profile).expect("profile should serialize successfully");
+        assert!(profile_json.contains("\"write_file\""));
+        assert!(profile_json.contains("/tmp/output.txt"));
         Ok(())
     }
 

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -1,4 +1,8 @@
 use crate::cli::LearnArgs;
+use crate::profile_save_runtime::{
+    command_name, confirm, patch_has_policy_overrides, print_patch_preview, print_profile_save,
+    suggested_profile_name, write_profile, PreparedProfileSave, SaveAction,
+};
 use crate::{learn, profile};
 use colored::Colorize;
 use nono::{NonoError, Result};
@@ -45,7 +49,7 @@ pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
     }
 
     if (result.has_paths() || result.has_network_activity()) && !silent && !args.json {
-        offer_save_profile(&result, &args.command)?;
+        offer_save_profile(&result, &args.command, args.profile.as_deref())?;
     } else if result.has_paths() || result.has_network_activity() {
         if result.has_paths() {
             eprintln!(
@@ -60,111 +64,143 @@ pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
     Ok(())
 }
 
-fn offer_save_profile(result: &learn::LearnResult, command: &[String]) -> Result<()> {
-    let cmd_name = command
-        .first()
-        .and_then(|command| std::path::Path::new(command).file_name())
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            NonoError::LearnError("Cannot derive profile name from command".to_string())
-        })?;
+fn offer_save_profile(
+    result: &learn::LearnResult,
+    command: &[String],
+    compared_profile: Option<&str>,
+) -> Result<()> {
+    let cmd_name = command_name(command)?;
+
+    // Compute the patch early so we can preview it before asking any questions.
+    let patch = result.to_profile_patch()?;
+    let has_overrides = patch_has_policy_overrides(&patch);
 
     eprintln!();
-    eprintln!(
-        "{}",
-        "Profile name must be alphanumeric with hyphens only (e.g. my-profile), no leading or trailing hyphens.".dimmed()
-    );
-    eprint!("Save as profile? Enter a name (or press Enter to skip): ");
+    print_patch_preview(&patch);
 
-    let profile_name = loop {
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
+    if let Some(existing_profile) = compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && profile::is_user_override(name))
+    {
+        let (prompt_text, default_yes) = if has_overrides {
+            (
+                format!(
+                    "Update existing user profile '{}' with these paths, including policy overrides? [y/N] ",
+                    existing_profile
+                ),
+                false,
+            )
+        } else {
+            (
+                format!(
+                    "Update existing user profile '{}' with discovered paths? [Y/n] ",
+                    existing_profile
+                ),
+                true,
+            )
+        };
 
-        let input = input.trim().to_string();
-
-        if input.is_empty() {
-            return Ok(());
+        if confirm(&prompt_text, default_yes)? {
+            let prepared =
+                prepare_profile_save(result, &cmd_name, existing_profile, compared_profile)?;
+            write_profile(&prepared)?;
+            print_profile_save(&prepared, command);
         }
+        return Ok(());
+    }
 
-        if profile::is_valid_profile_name(&input) {
-            break input;
-        }
+    if let Some(suggested_name) = suggested_profile_name(compared_profile) {
+        eprint!(
+            "Save as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
+            suggested_name
+        );
+    } else {
+        eprint!("Save as user profile? Enter a name (or press Enter to skip): ");
+    }
 
+    let input = read_input_line()?;
+    let profile_name = input.trim();
+
+    if profile_name.is_empty() {
+        return Ok(());
+    }
+
+    if !profile::is_valid_profile_name(profile_name) {
         eprintln!(
             "{}",
-            "Invalid profile name. Use only letters and numbers separated by hyphens, with no leading or trailing hyphens.".red()
+            "Invalid profile name. Use only letters, numbers, and hyphens.".red()
         );
-        eprint!("Enter a name (or press Enter to skip): ");
-    };
-
-    let profile_name = profile_name.as_str();
-
-    let profile_json = result.to_profile(profile_name, cmd_name)?;
-
-    let config_dir = profile::resolve_user_config_dir()?;
-    let profiles_dir = config_dir.join("nono").join("profiles");
-    if let Err(e) = std::fs::create_dir_all(&profiles_dir) {
-        eprintln!(
-            "{} Failed to create profiles directory {}: {}",
-            "Error:".red(),
-            profiles_dir.display(),
-            e
-        );
-        print_profile_fallback(&profile_json);
         return Ok(());
     }
 
-    let profile_path = profiles_dir.join(format!("{}.json", profile_name));
-
-    if profile_path.exists() {
-        eprint!(
-            "Profile '{}' already exists. Overwrite? [y/N] ",
-            profile_name
-        );
-        let mut confirm = String::new();
-        std::io::stdin()
-            .read_line(&mut confirm)
-            .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
-        if !confirm.trim().eq_ignore_ascii_case("y") {
-            eprintln!("Skipped.");
-            return Ok(());
-        }
-    }
-
-    if let Err(e) = std::fs::write(&profile_path, &profile_json) {
+    if compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
+        .is_some_and(|name| name == profile_name)
+    {
         eprintln!(
-            "{} Failed to write profile to {}: {}",
-            "Error:".red(),
-            profile_path.display(),
-            e
+            "{}",
+            format!(
+                "Cannot save '{}' as a derived user profile because it would shadow the built-in profile it extends. Choose a different name.",
+                profile_name
+            )
+            .red()
         );
-        print_profile_fallback(&profile_json);
         return Ok(());
     }
 
-    eprintln!("\n{} {}", "Profile saved:".green(), profile_path.display());
-    eprintln!(
-        "Run with: {} {} -- {}",
-        "nono run --profile".bold(),
-        profile_name,
-        command.join(" ")
-    );
+    if has_overrides
+        && !confirm(
+            "Save profile with the policy overrides shown above? [y/N] ",
+            false,
+        )?
+    {
+        return Ok(());
+    }
+
+    let prepared = prepare_profile_save(result, &cmd_name, profile_name, compared_profile)?;
+    write_profile(&prepared)?;
+    print_profile_save(&prepared, command);
 
     Ok(())
 }
 
-fn print_profile_fallback(profile_json: &str) {
-    eprintln!(
-        "\n{} Profile could not be saved. Copy the JSON below to create it manually:",
-        "Note:".yellow()
-    );
-    eprintln!(
-        "Save it to {} or run {} to find the correct path.",
-        "~/.config/nono/profiles/<name>.json".bold(),
-        "nono config".bold()
-    );
-    eprintln!();
-    println!("{}", profile_json);
+fn read_input_line() -> Result<String> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
+    Ok(input)
+}
+
+fn prepare_profile_save(
+    result: &learn::LearnResult,
+    cmd_name: &str,
+    profile_name: &str,
+    compared_profile: Option<&str>,
+) -> Result<PreparedProfileSave> {
+    let profile_path = profile::get_user_profile_path(profile_name)?;
+
+    if profile_path.exists() {
+        let mut existing = profile::load_raw_profile_from_path(&profile_path)?;
+        let patch = result.to_profile_patch()?;
+        learn::merge_learned_profile_patch(&mut existing, &patch);
+
+        return Ok(PreparedProfileSave {
+            action: SaveAction::Updated,
+            profile_name: profile_name.to_string(),
+            profile_path,
+            profile: existing,
+        });
+    }
+
+    let extends = compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)
+        .map(|name| vec![name.to_string()]);
+    let profile = result.to_named_profile(profile_name, cmd_name, extends)?;
+
+    Ok(PreparedProfileSave {
+        action: SaveAction::Created,
+        profile_name: profile_name.to_string(),
+        profile_path,
+        profile,
+    })
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -32,6 +32,7 @@ mod policy_cmd;
 mod profile;
 mod profile_cmd;
 mod profile_runtime;
+mod profile_save_runtime;
 mod protected_paths;
 mod proxy_runtime;
 mod pty_proxy;

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -49,6 +49,7 @@ mod sandbox_state;
 mod session;
 mod session_commands;
 mod setup;
+mod startup_prompt;
 mod startup_runtime;
 mod supervised_runtime;
 mod terminal_approval;

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -316,6 +316,9 @@ pub fn print_applying_sandbox(silent: bool) {
 }
 
 /// Finish a pending inline status message before handing the terminal to a child UI.
+///
+/// Prints a delimiter line to visually separate the nono banner from the
+/// child's output.
 pub fn finish_status_line_for_handoff(silent: bool) {
     if silent {
         return;
@@ -323,12 +326,22 @@ pub fn finish_status_line_for_handoff(silent: bool) {
     if !take_pending_status_line() {
         return;
     }
+    let t = theme::current();
     let mut stderr = std::io::stderr();
     if stderr.is_terminal() {
         let _ = write!(stderr, "\r\n");
     } else {
         let _ = writeln!(stderr);
     }
+    let _ = writeln!(
+        stderr,
+        "  {}",
+        fg(
+            "────────────────────────────────────────────────────",
+            t.subtext
+        )
+    );
+    let _ = writeln!(stderr);
     let _ = stderr.flush();
 }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1544,6 +1544,19 @@ pub fn load_profile_from_path(path: &Path) -> Result<Profile> {
     finalize_profile(load_from_file(path)?)
 }
 
+/// Load a raw profile from a direct file path without resolving inheritance.
+pub(crate) fn load_raw_profile_from_path(path: &Path) -> Result<Profile> {
+    if !path.exists() {
+        return Err(NonoError::ProfileRead {
+            path: path.to_path_buf(),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "profile file not found"),
+        });
+    }
+
+    tracing::info!("Loading raw profile from path: {}", path.display());
+    parse_profile_file(path)
+}
+
 /// Resolve inheritance and apply implicit default-group merging for a raw profile.
 pub(crate) fn finalize_profile(mut profile: Profile) -> Result<Profile> {
     merge_implicit_default_groups(&mut profile)?;

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1,0 +1,715 @@
+use crate::{profile, query_ext};
+use colored::Colorize;
+use nono::diagnostic::{ErrorObservation, PolicyExplanation};
+use nono::{AccessMode, CapabilitySet, NonoError, Result};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy)]
+pub(crate) enum SaveAction {
+    Created,
+    Updated,
+}
+
+pub(crate) struct PreparedProfileSave {
+    pub(crate) action: SaveAction,
+    pub(crate) profile_name: String,
+    pub(crate) profile_path: PathBuf,
+    pub(crate) profile: profile::Profile,
+}
+
+#[derive(Clone, Copy)]
+struct PatchGrant {
+    access: AccessMode,
+    is_file: bool,
+    override_deny: bool,
+}
+
+pub(crate) fn terminal_prompts_available() -> bool {
+    std::io::stdin().is_terminal()
+        || std::io::stderr().is_terminal()
+        || std::fs::File::open("/dev/tty").is_ok()
+}
+
+pub(crate) fn offer_save_run_profile(
+    policy_explanations: &[PolicyExplanation],
+    error_observation: &ErrorObservation,
+    caps: &CapabilitySet,
+    command: &[String],
+    compared_profile: Option<&str>,
+) -> Result<()> {
+    if compared_profile.is_none() || !terminal_prompts_available() {
+        return Ok(());
+    }
+
+    let Some(patch) = build_run_profile_patch(policy_explanations, error_observation, caps)? else {
+        return Ok(());
+    };
+
+    let cmd_name = command_name(command)?;
+    let has_overrides = patch_has_policy_overrides(&patch);
+
+    prompt_println("");
+    print_patch_preview(&patch);
+
+    if let Some(existing_profile) = compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && profile::is_user_override(name))
+    {
+        let (prompt_text, default_yes) = if has_overrides {
+            (
+                format!(
+                    "Update existing user profile '{}' with these paths, including policy overrides? [y/N] ",
+                    existing_profile
+                ),
+                false,
+            )
+        } else {
+            (
+                format!(
+                    "Update existing user profile '{}' with denied paths? [Y/n] ",
+                    existing_profile
+                ),
+                true,
+            )
+        };
+
+        if confirm(&prompt_text, default_yes)? {
+            let prepared = prepare_profile_save_from_patch(
+                &patch,
+                &cmd_name,
+                existing_profile,
+                compared_profile,
+            )?;
+            write_profile(&prepared)?;
+            print_profile_save(&prepared, command);
+            return Ok(());
+        }
+        return Ok(());
+    }
+
+    if let Some(suggested_name) = suggested_profile_name(compared_profile) {
+        prompt_print(
+            "Save denied paths as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
+            &[suggested_name.as_str()],
+        );
+    } else {
+        prompt_print(
+            "Save denied paths as user profile? Enter a name (or press Enter to skip): ",
+            &[],
+        );
+    }
+
+    let input = read_input_line()?;
+    let profile_name = input.trim();
+
+    if profile_name.is_empty() {
+        return Ok(());
+    }
+
+    if !profile::is_valid_profile_name(profile_name) {
+        prompt_println(&format!(
+            "{}",
+            "Invalid profile name. Use only letters, numbers, and hyphens.".red()
+        ));
+        return Ok(());
+    }
+
+    if compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
+        .is_some_and(|name| name == profile_name)
+    {
+        prompt_println(&format!(
+            "{}",
+            format!(
+                "Cannot save '{}' as a derived user profile because it would shadow the built-in profile it extends. Choose a different name.",
+                profile_name
+            )
+            .red()
+        ));
+        return Ok(());
+    }
+
+    if has_overrides
+        && !confirm(
+            "Save profile with the policy overrides shown above? [y/N] ",
+            false,
+        )?
+    {
+        return Ok(());
+    }
+
+    let prepared =
+        prepare_profile_save_from_patch(&patch, &cmd_name, profile_name, compared_profile)?;
+    write_profile(&prepared)?;
+    print_profile_save(&prepared, command);
+
+    Ok(())
+}
+
+pub(crate) fn command_name(command: &[String]) -> Result<String> {
+    command
+        .first()
+        .and_then(|command| std::path::Path::new(command).file_name())
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| NonoError::LearnError("Cannot derive profile name from command".to_string()))
+}
+
+pub(crate) fn confirm(prompt: &str, default_yes: bool) -> Result<bool> {
+    prompt_print(prompt, &[]);
+
+    let input = read_input_line()?;
+    let trimmed = input.trim();
+
+    if trimmed.is_empty() {
+        return Ok(default_yes);
+    }
+
+    Ok(trimmed.eq_ignore_ascii_case("y") || trimmed.eq_ignore_ascii_case("yes"))
+}
+
+pub(crate) fn suggested_profile_name(compared_profile: Option<&str>) -> Option<String> {
+    compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
+        .map(|name| format!("{}-local", name))
+}
+
+pub(crate) fn write_profile(prepared: &PreparedProfileSave) -> Result<()> {
+    let profiles_dir = prepared.profile_path.parent().ok_or_else(|| {
+        NonoError::LearnError("Failed to determine profiles directory".to_string())
+    })?;
+    std::fs::create_dir_all(profiles_dir).map_err(|e| {
+        NonoError::LearnError(format!(
+            "Failed to create profiles directory {}: {}",
+            profiles_dir.display(),
+            e
+        ))
+    })?;
+
+    let profile_json = serde_json::to_string_pretty(&prepared.profile)
+        .map_err(|e| NonoError::LearnError(format!("Failed to serialize profile: {}", e)))?;
+    std::fs::write(&prepared.profile_path, format!("{profile_json}\n")).map_err(|e| {
+        NonoError::LearnError(format!(
+            "Failed to write profile to {}: {}",
+            prepared.profile_path.display(),
+            e
+        ))
+    })?;
+
+    Ok(())
+}
+
+pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[String]) {
+    let status = match prepared.action {
+        SaveAction::Created => "Profile saved:",
+        SaveAction::Updated => "Profile updated:",
+    };
+
+    prompt_println(&format!(
+        "\n{} {}",
+        status.green(),
+        prepared.profile_path.display()
+    ));
+
+    let override_count = prepared.profile.policy.override_deny.len();
+    if override_count > 0 {
+        prompt_println(&format!(
+            "{}",
+            format!(
+                "  ({} path{} with policy.override_deny — review the profile before sharing)",
+                override_count,
+                if override_count == 1 { "" } else { "s" }
+            )
+            .yellow()
+        ));
+    }
+
+    prompt_println(&format!(
+        "Run with: {} {} -- {}",
+        "nono run --profile".bold(),
+        prepared.profile_name,
+        command.join(" ")
+    ));
+}
+
+/// Print a preview of what paths will be written to the profile.
+///
+/// Highlights `override_deny` entries with a visible warning since those
+/// bypass nono's built-in sensitive-path protection.
+pub(crate) fn print_patch_preview(patch: &profile::Profile) {
+    let sections: &[(&str, &[String])] = &[
+        ("read+write dirs", &patch.filesystem.allow),
+        ("read dirs", &patch.filesystem.read),
+        ("write dirs", &patch.filesystem.write),
+        ("read+write files", &patch.filesystem.allow_file),
+        ("read files", &patch.filesystem.read_file),
+        ("write files", &patch.filesystem.write_file),
+    ];
+
+    let has_entries = sections.iter().any(|(_, paths)| !paths.is_empty());
+    if !has_entries && patch.policy.override_deny.is_empty() {
+        return;
+    }
+
+    prompt_println("[nono] Paths to be saved:");
+    for (label, paths) in sections {
+        for path in *paths {
+            let is_override = patch.policy.override_deny.contains(path);
+            if is_override {
+                prompt_println(&format!("  {}  {} ({})", "⚠".yellow(), path, label));
+            } else {
+                prompt_println(&format!("  {}  ({})", path, label));
+            }
+        }
+    }
+
+    if !patch.policy.override_deny.is_empty() {
+        prompt_println(&format!(
+            "{}",
+            "\n[nono] ⚠  The marked paths are normally blocked by security policy.".yellow()
+        ));
+        prompt_println(&format!(
+            "{}",
+            "[nono]    Saving them adds policy.override_deny, which weakens sandbox protection."
+                .yellow()
+        ));
+    }
+}
+
+/// Return true if the patch includes any `policy.override_deny` entries.
+pub(crate) fn patch_has_policy_overrides(patch: &profile::Profile) -> bool {
+    !patch.policy.override_deny.is_empty()
+}
+
+fn prompt_print(template: &str, args: &[&str]) {
+    let mut message = template.to_string();
+    for arg in args {
+        if let Some(idx) = message.find("{}") {
+            message.replace_range(idx..idx + 2, arg);
+        }
+    }
+    prompt_write(&message);
+}
+
+fn prompt_println(message: &str) {
+    prompt_writeln(message);
+}
+
+fn open_tty_prompt_device() -> Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .map_err(|e| NonoError::LearnError(format!("Failed to open /dev/tty: {}", e)))
+}
+
+fn open_tty_writer() -> Option<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .ok()
+}
+
+fn prompt_read_line() -> Result<String> {
+    let mut input = String::new();
+    let tty = open_tty_prompt_device()?;
+    force_prompt_terminal_mode(&tty);
+    let mut reader = std::io::BufReader::new(tty);
+    reader
+        .read_line(&mut input)
+        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
+    Ok(input)
+}
+
+fn force_prompt_terminal_mode(tty: &std::fs::File) {
+    let Ok(mut termios) = nix::sys::termios::tcgetattr(tty) else {
+        return;
+    };
+    configure_prompt_termios(&mut termios);
+    let _ = nix::sys::termios::tcsetattr(tty, nix::sys::termios::SetArg::TCSANOW, &termios);
+    let _ = nix::sys::termios::tcflush(tty, nix::sys::termios::FlushArg::TCIFLUSH);
+}
+
+pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios) {
+    use nix::sys::termios::{
+        ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
+    };
+
+    termios.input_flags.remove(
+        InputFlags::IGNBRK
+            | InputFlags::BRKINT
+            | InputFlags::PARMRK
+            | InputFlags::ISTRIP
+            | InputFlags::INLCR
+            | InputFlags::IGNCR,
+    );
+    termios
+        .input_flags
+        .insert(InputFlags::ICRNL | InputFlags::IXON);
+
+    termios.output_flags.insert(OutputFlags::OPOST);
+
+    termios.local_flags.insert(
+        LocalFlags::ECHO
+            | LocalFlags::ECHONL
+            | LocalFlags::ICANON
+            | LocalFlags::ISIG
+            | LocalFlags::IEXTEN,
+    );
+
+    termios
+        .control_flags
+        .remove(ControlFlags::CSIZE | ControlFlags::PARENB);
+    termios.control_flags.insert(ControlFlags::CS8);
+
+    termios.control_chars[SpecialCharacterIndices::VMIN as usize] = 1;
+    termios.control_chars[SpecialCharacterIndices::VTIME as usize] = 0;
+}
+
+fn prompt_write(message: &str) {
+    if let Some(mut tty) = open_tty_writer() {
+        let _ = write!(tty, "{}", message);
+        let _ = tty.flush();
+        return;
+    }
+
+    eprint!("{}", message);
+    let _ = std::io::stderr().flush();
+}
+
+fn prompt_writeln(message: &str) {
+    if let Some(mut tty) = open_tty_writer() {
+        let _ = writeln!(tty, "{}", message);
+        let _ = tty.flush();
+        return;
+    }
+
+    eprintln!("{}", message);
+    let _ = std::io::stderr().flush();
+}
+
+pub(crate) fn prepare_profile_save_from_patch(
+    patch: &profile::Profile,
+    cmd_name: &str,
+    profile_name: &str,
+    compared_profile: Option<&str>,
+) -> Result<PreparedProfileSave> {
+    let profile_path = profile::get_user_profile_path(profile_name)?;
+
+    if profile_path.exists() {
+        let mut existing = profile::load_raw_profile_from_path(&profile_path)?;
+        merge_profile_patch(&mut existing, patch);
+
+        return Ok(PreparedProfileSave {
+            action: SaveAction::Updated,
+            profile_name: profile_name.to_string(),
+            profile_path,
+            profile: existing,
+        });
+    }
+
+    let mut new_profile = patch.clone();
+    let extends = compared_profile
+        .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)
+        .map(|name| vec![name.to_string()]);
+    let has_base = extends.is_some();
+    new_profile.extends = extends;
+    new_profile.meta = profile::ProfileMeta {
+        name: profile_name.to_string(),
+        version: "1.0.0".to_string(),
+        description: Some(if has_base {
+            format!("Runtime-discovered path additions for {}", cmd_name)
+        } else {
+            format!("Runtime-discovered path profile for {}", cmd_name)
+        }),
+        author: None,
+    };
+
+    Ok(PreparedProfileSave {
+        action: SaveAction::Created,
+        profile_name: profile_name.to_string(),
+        profile_path,
+        profile: new_profile,
+    })
+}
+
+fn read_input_line() -> Result<String> {
+    prompt_read_line()
+}
+
+fn build_run_profile_patch(
+    policy_explanations: &[PolicyExplanation],
+    error_observation: &ErrorObservation,
+    caps: &CapabilitySet,
+) -> Result<Option<profile::Profile>> {
+    let mut grants: BTreeMap<PathBuf, PatchGrant> = BTreeMap::new();
+
+    for explanation in policy_explanations {
+        add_patch_grant(
+            &mut grants,
+            &explanation.path,
+            explanation.access,
+            &explanation.reason,
+        );
+    }
+
+    for hint in &error_observation.path_hints {
+        match query_ext::query_path(&hint.path, hint.access, caps, &[]) {
+            Ok(query_ext::QueryResult::Denied { reason, .. })
+                if matches!(
+                    reason.as_str(),
+                    "sensitive_path" | "insufficient_access" | "path_not_granted"
+                ) =>
+            {
+                add_patch_grant(&mut grants, &hint.path, hint.access, &reason);
+            }
+            _ => {}
+        }
+    }
+
+    if grants.is_empty() {
+        return Ok(None);
+    }
+
+    let home = crate::config::validated_home()?;
+    let home_path = Path::new(&home);
+    let mut allow = BTreeSet::new();
+    let mut read = BTreeSet::new();
+    let mut write = BTreeSet::new();
+    let mut allow_file = BTreeSet::new();
+    let mut read_file = BTreeSet::new();
+    let mut write_file = BTreeSet::new();
+    let mut override_deny = BTreeSet::new();
+
+    for (path, grant) in grants {
+        let shortened = shorten_path_for_profile(&path, home_path);
+        if grant.override_deny {
+            override_deny.insert(shortened.clone());
+        }
+
+        match (grant.access, grant.is_file) {
+            (AccessMode::Read, false) => {
+                read.insert(shortened);
+            }
+            (AccessMode::Write, false) => {
+                write.insert(shortened);
+            }
+            (AccessMode::ReadWrite, false) => {
+                allow.insert(shortened);
+            }
+            (AccessMode::Read, true) => {
+                read_file.insert(shortened);
+            }
+            (AccessMode::Write, true) => {
+                write_file.insert(shortened);
+            }
+            (AccessMode::ReadWrite, true) => {
+                allow_file.insert(shortened);
+            }
+        }
+    }
+
+    let mut patch = profile::Profile::default();
+    patch.filesystem.allow = allow.into_iter().collect();
+    patch.filesystem.read = read.into_iter().collect();
+    patch.filesystem.write = write.into_iter().collect();
+    patch.filesystem.allow_file = allow_file.into_iter().collect();
+    patch.filesystem.read_file = read_file.into_iter().collect();
+    patch.filesystem.write_file = write_file.into_iter().collect();
+    patch.policy.override_deny = override_deny.into_iter().collect();
+
+    Ok(Some(patch))
+}
+
+fn add_patch_grant(
+    grants: &mut BTreeMap<PathBuf, PatchGrant>,
+    path: &Path,
+    access: AccessMode,
+    reason: &str,
+) {
+    let (flag, target) = query_ext::suggested_flag_parts(path, access);
+    let is_file = matches!(flag, "--read-file" | "--write-file" | "--allow-file");
+
+    match grants.get_mut(&target) {
+        Some(existing) => {
+            existing.access = merge_access(existing.access, access);
+            existing.is_file |= is_file;
+            existing.override_deny |= reason == "sensitive_path";
+        }
+        None => {
+            grants.insert(
+                target,
+                PatchGrant {
+                    access,
+                    is_file,
+                    override_deny: reason == "sensitive_path",
+                },
+            );
+        }
+    }
+}
+
+fn merge_access(existing: AccessMode, requested: AccessMode) -> AccessMode {
+    if existing == requested {
+        existing
+    } else {
+        AccessMode::ReadWrite
+    }
+}
+
+pub(crate) fn merge_profile_patch(profile: &mut profile::Profile, patch: &profile::Profile) {
+    profile.filesystem.allow =
+        profile::dedup_append(&profile.filesystem.allow, &patch.filesystem.allow);
+    profile.filesystem.read =
+        profile::dedup_append(&profile.filesystem.read, &patch.filesystem.read);
+    profile.filesystem.write =
+        profile::dedup_append(&profile.filesystem.write, &patch.filesystem.write);
+    profile.filesystem.allow_file =
+        profile::dedup_append(&profile.filesystem.allow_file, &patch.filesystem.allow_file);
+    profile.filesystem.read_file =
+        profile::dedup_append(&profile.filesystem.read_file, &patch.filesystem.read_file);
+    profile.filesystem.write_file =
+        profile::dedup_append(&profile.filesystem.write_file, &patch.filesystem.write_file);
+    profile.policy.override_deny =
+        profile::dedup_append(&profile.policy.override_deny, &patch.policy.override_deny);
+}
+
+pub(crate) fn shorten_path_for_profile(path: &Path, home_path: &Path) -> String {
+    if path.starts_with(home_path) {
+        match path.strip_prefix(home_path) {
+            Ok(relative) => format!("~/{}", relative.display()),
+            Err(_) => path.display().to_string(),
+        }
+    } else {
+        path.display().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use tempfile::TempDir;
+
+    #[test]
+    fn build_run_profile_patch_adds_override_deny_for_sensitive_file() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let _env = EnvVarGuard::set_all(&[("HOME", temp_home.path().to_str().expect("home path"))]);
+
+        let target = temp_home.path().join(".claude").join("settings.json");
+        std::fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&target, b"{}").expect("write");
+
+        let explanation = PolicyExplanation {
+            path: target,
+            access: AccessMode::Read,
+            reason: "sensitive_path".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+
+        let patch = build_run_profile_patch(
+            &[explanation],
+            &ErrorObservation::default(),
+            &CapabilitySet::new(),
+        )
+        .expect("build patch")
+        .expect("patch");
+
+        assert_eq!(patch.filesystem.read_file, vec!["~/.claude/settings.json"]);
+        assert_eq!(patch.policy.override_deny, vec!["~/.claude/settings.json"]);
+    }
+
+    #[test]
+    fn build_run_profile_patch_merges_read_and_write_to_allow_file() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let _env = EnvVarGuard::set_all(&[("HOME", temp_home.path().to_str().expect("home path"))]);
+
+        let target = temp_home.path().join("config.json");
+        std::fs::write(&target, b"{}").expect("write");
+
+        let read = PolicyExplanation {
+            path: target.clone(),
+            access: AccessMode::Read,
+            reason: "path_not_granted".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: Some(format!("--read-file {}", target.display())),
+        };
+        let write = PolicyExplanation {
+            path: target,
+            access: AccessMode::Write,
+            reason: "insufficient_access".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+
+        let patch = build_run_profile_patch(
+            &[read, write],
+            &ErrorObservation::default(),
+            &CapabilitySet::new(),
+        )
+        .expect("build patch")
+        .expect("patch");
+
+        assert_eq!(patch.filesystem.allow_file, vec!["~/config.json"]);
+        assert!(patch.filesystem.read_file.is_empty());
+        assert!(patch.filesystem.write_file.is_empty());
+    }
+
+    #[test]
+    fn prepare_profile_save_from_patch_updates_existing_user_profile() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        let existing_path =
+            profile::get_user_profile_path("claude-code-local").expect("profile path");
+        std::fs::create_dir_all(existing_path.parent().expect("profile dir")).expect("mkdir");
+        std::fs::write(
+            &existing_path,
+            "{\n  \"meta\": {\n    \"name\": \"claude-code-local\",\n    \"version\": \"1.0.0\"\n  },\n  \"filesystem\": {\n    \"read_file\": [\"~/old.json\"]\n  },\n  \"policy\": {\n    \"override_deny\": [\"~/old.json\"]\n  }\n}\n",
+        )
+        .expect("write profile");
+
+        let mut patch = profile::Profile::default();
+        patch.filesystem.read_file = vec!["~/.claude/settings.json".to_string()];
+        patch.policy.override_deny = vec!["~/.claude/settings.json".to_string()];
+
+        let prepared = prepare_profile_save_from_patch(
+            &patch,
+            "claude",
+            "claude-code-local",
+            Some("claude-code"),
+        )
+        .expect("prepare");
+
+        assert!(matches!(prepared.action, SaveAction::Updated));
+        assert_eq!(
+            prepared.profile.filesystem.read_file,
+            vec![
+                "~/old.json".to_string(),
+                "~/.claude/settings.json".to_string()
+            ]
+        );
+        assert_eq!(
+            prepared.profile.policy.override_deny,
+            vec![
+                "~/old.json".to_string(),
+                "~/.claude/settings.json".to_string()
+            ]
+        );
+    }
+}

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -56,25 +56,25 @@ pub(crate) fn offer_save_run_profile(
     if let Some(existing_profile) = compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && profile::is_user_override(name))
     {
-        let (prompt_text, default_yes) = if has_overrides {
-            (
-                format!(
-                    "Update existing user profile '{}' with these paths, including policy overrides? [y/N] ",
+        let confirmed = if has_overrides {
+            confirm_typed_word(
+                &format!(
+                    "Update existing user profile '{}' with these paths, including policy overrides? Type 'override' to confirm: ",
                     existing_profile
                 ),
-                false,
-            )
+                "override",
+            )?
         } else {
-            (
-                format!(
+            confirm(
+                &format!(
                     "Update existing user profile '{}' with denied paths? [Y/n] ",
                     existing_profile
                 ),
                 true,
-            )
+            )?
         };
 
-        if confirm(&prompt_text, default_yes)? {
+        if confirmed {
             let prepared = prepare_profile_save_from_patch(
                 &patch,
                 &cmd_name,
@@ -83,7 +83,6 @@ pub(crate) fn offer_save_run_profile(
             )?;
             write_profile(&prepared)?;
             print_profile_save(&prepared, command);
-            return Ok(());
         }
         return Ok(());
     }
@@ -115,14 +114,11 @@ pub(crate) fn offer_save_run_profile(
         return Ok(());
     }
 
-    if compared_profile
-        .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
-        .is_some_and(|name| name == profile_name)
-    {
+    if would_shadow_builtin(profile_name) {
         prompt_println(&format!(
             "{}",
             format!(
-                "Cannot save '{}' as a derived user profile because it would shadow the built-in profile it extends. Choose a different name.",
+                "Cannot save '{}' as a user profile because it would shadow the built-in profile of the same name. Choose a different name.",
                 profile_name
             )
             .red()
@@ -131,9 +127,9 @@ pub(crate) fn offer_save_run_profile(
     }
 
     if has_overrides
-        && !confirm(
-            "Save profile with the policy overrides shown above? [y/N] ",
-            false,
+        && !confirm_typed_word(
+            "Save profile with the policy overrides shown above? Type 'override' to confirm: ",
+            "override",
         )?
     {
         return Ok(());
@@ -169,10 +165,37 @@ pub(crate) fn confirm(prompt: &str, default_yes: bool) -> Result<bool> {
     Ok(trimmed.eq_ignore_ascii_case("y") || trimmed.eq_ignore_ascii_case("yes"))
 }
 
+/// Confirm an irreversible/security-sensitive action by requiring the user to
+/// type an exact word (case-insensitive). A single `y` is not accepted.
+pub(crate) fn confirm_typed_word(prompt: &str, expected: &str) -> Result<bool> {
+    prompt_print(prompt, &[]);
+
+    let input = read_input_line()?;
+    Ok(input.trim().eq_ignore_ascii_case(expected))
+}
+
 pub(crate) fn suggested_profile_name(compared_profile: Option<&str>) -> Option<String> {
     compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
         .map(|name| format!("{}-local", name))
+}
+
+/// Return true when writing `~/.config/nono/profiles/<name>.json` would shadow
+/// a built-in profile of the same name. User files are loaded in preference to
+/// built-ins, so saving under a built-in's name silently reroutes all future
+/// `--profile <name>` invocations to the user file.
+fn would_shadow_builtin(profile_name: &str) -> bool {
+    // If a user file already exists at this name, the user has already chosen
+    // to override it — writing there is an explicit update, not a new shadow.
+    if profile::is_user_override(profile_name) {
+        return false;
+    }
+    match crate::policy::load_embedded_policy() {
+        Ok(policy) => policy.profiles.contains_key(profile_name),
+        // Treat load failure as fail-safe: refuse to save rather than risk
+        // silently shadowing a built-in we couldn't enumerate.
+        Err(_) => true,
+    }
 }
 
 pub(crate) fn write_profile(prepared: &PreparedProfileSave) -> Result<()> {
@@ -257,7 +280,7 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
         for path in *paths {
             let is_override = patch.policy.override_deny.contains(path);
             if is_override {
-                prompt_println(&format!("  {}  {} ({})", "⚠".yellow(), path, label));
+                prompt_println(&format!("  {}  {} ({})", "⚠".red(), path, label));
             } else {
                 prompt_println(&format!("  {}  ({})", path, label));
             }
@@ -267,12 +290,12 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
     if !patch.policy.override_deny.is_empty() {
         prompt_println(&format!(
             "{}",
-            "\n[nono] ⚠  The marked paths are normally blocked by security policy.".yellow()
+            "\n[nono] ⚠  The marked paths are normally blocked by security policy.".red()
         ));
         prompt_println(&format!(
             "{}",
             "[nono]    Saving them adds policy.override_deny, which weakens sandbox protection."
-                .yellow()
+                .red()
         ));
     }
 }
@@ -314,21 +337,33 @@ fn open_tty_writer() -> Option<std::fs::File> {
 fn prompt_read_line() -> Result<String> {
     let mut input = String::new();
     let tty = open_tty_prompt_device()?;
-    force_prompt_terminal_mode(&tty);
+    let saved_termios = force_prompt_terminal_mode(&tty);
     let mut reader = std::io::BufReader::new(tty);
-    reader
+    let read_result = reader
         .read_line(&mut input)
-        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
+        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)));
+    if let Some(saved) = saved_termios {
+        let _ = nix::sys::termios::tcsetattr(
+            reader.get_ref(),
+            nix::sys::termios::SetArg::TCSANOW,
+            &saved,
+        );
+    }
+    read_result?;
     Ok(input)
 }
 
-fn force_prompt_terminal_mode(tty: &std::fs::File) {
-    let Ok(mut termios) = nix::sys::termios::tcgetattr(tty) else {
-        return;
+fn force_prompt_terminal_mode(tty: &std::fs::File) -> Option<nix::sys::termios::Termios> {
+    let Ok(original) = nix::sys::termios::tcgetattr(tty) else {
+        return None;
     };
+    let mut termios = original.clone();
     configure_prompt_termios(&mut termios);
-    let _ = nix::sys::termios::tcsetattr(tty, nix::sys::termios::SetArg::TCSANOW, &termios);
+    if nix::sys::termios::tcsetattr(tty, nix::sys::termios::SetArg::TCSANOW, &termios).is_err() {
+        return None;
+    }
     let _ = nix::sys::termios::tcflush(tty, nix::sys::termios::FlushArg::TCIFLUSH);
+    Some(original)
 }
 
 pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios) {
@@ -711,5 +746,51 @@ mod tests {
                 "~/.claude/settings.json".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn would_shadow_builtin_flags_known_builtin_names() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        // `claude-code` is a known built-in; writing to that user path would
+        // shadow it.
+        assert!(would_shadow_builtin("claude-code"));
+        // Names that don't exist as built-ins are fine.
+        assert!(!would_shadow_builtin("my-unique-saved-profile"));
+    }
+
+    #[test]
+    fn would_shadow_builtin_allows_update_of_existing_user_override() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        // Pre-create a user override of a built-in. A subsequent save to the
+        // same name is an update, not a new shadow, and must be allowed.
+        let path = profile::get_user_profile_path("claude-code").expect("profile path");
+        std::fs::create_dir_all(path.parent().expect("dir")).expect("mkdir");
+        std::fs::write(
+            &path,
+            "{\"meta\":{\"name\":\"claude-code\",\"version\":\"1.0.0\"}}\n",
+        )
+        .expect("write");
+
+        assert!(!would_shadow_builtin("claude-code"));
     }
 }

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -87,44 +87,10 @@ pub(crate) fn offer_save_run_profile(
         return Ok(());
     }
 
-    if let Some(suggested_name) = suggested_profile_name(compared_profile) {
-        prompt_print(
-            "Save denied paths as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
-            &[suggested_name.as_str()],
-        );
-    } else {
-        prompt_print(
-            "Save denied paths as user profile? Enter a name (or press Enter to skip): ",
-            &[],
-        );
-    }
-
-    let input = read_input_line()?;
-    let profile_name = input.trim();
-
-    if profile_name.is_empty() {
+    let suggested = suggested_profile_name(compared_profile);
+    let Some(profile_name) = prompt_profile_name(suggested.as_deref())? else {
         return Ok(());
-    }
-
-    if !profile::is_valid_profile_name(profile_name) {
-        prompt_println(&format!(
-            "{}",
-            "Invalid profile name. Use only letters, numbers, and hyphens.".red()
-        ));
-        return Ok(());
-    }
-
-    if would_shadow_builtin(profile_name) {
-        prompt_println(&format!(
-            "{}",
-            format!(
-                "Cannot save '{}' as a user profile because it would shadow the built-in profile of the same name. Choose a different name.",
-                profile_name
-            )
-            .red()
-        ));
-        return Ok(());
-    }
+    };
 
     if has_overrides
         && !confirm_typed_word(
@@ -136,11 +102,66 @@ pub(crate) fn offer_save_run_profile(
     }
 
     let prepared =
-        prepare_profile_save_from_patch(&patch, &cmd_name, profile_name, compared_profile)?;
+        prepare_profile_save_from_patch(&patch, &cmd_name, &profile_name, compared_profile)?;
     write_profile(&prepared)?;
     print_profile_save(&prepared, command);
 
     Ok(())
+}
+
+/// Prompt for a new profile name, re-prompting on invalid or shadowed names
+/// until the user enters a valid name or presses Enter to skip.
+///
+/// Returns `Ok(None)` when the user skips.
+fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
+    let mut first = true;
+    loop {
+        if first {
+            if let Some(suggested_name) = suggested {
+                prompt_print(
+                    "Save denied paths as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
+                    &[suggested_name],
+                );
+            } else {
+                prompt_print(
+                    "Save denied paths as user profile? Enter a name (or press Enter to skip): ",
+                    &[],
+                );
+            }
+            first = false;
+        } else {
+            prompt_print("Enter a name (or press Enter to skip): ", &[]);
+        }
+
+        let input = read_input_line()?;
+        let candidate = input.trim();
+
+        if candidate.is_empty() {
+            return Ok(None);
+        }
+
+        if !profile::is_valid_profile_name(candidate) {
+            prompt_println(&format!(
+                "{}",
+                "Invalid profile name. Use only letters, numbers, and hyphens.".red()
+            ));
+            continue;
+        }
+
+        if would_shadow_builtin(candidate) {
+            prompt_println(&format!(
+                "{}",
+                format!(
+                    "Cannot save '{}' as a user profile because it would shadow the built-in profile of the same name. Choose a different name.",
+                    candidate
+                )
+                .red()
+            ));
+            continue;
+        }
+
+        return Ok(Some(candidate.to_string()));
+    }
 }
 
 pub(crate) fn command_name(command: &[String]) -> Result<String> {
@@ -212,14 +233,62 @@ pub(crate) fn write_profile(prepared: &PreparedProfileSave) -> Result<()> {
 
     let profile_json = serde_json::to_string_pretty(&prepared.profile)
         .map_err(|e| NonoError::LearnError(format!("Failed to serialize profile: {}", e)))?;
-    std::fs::write(&prepared.profile_path, format!("{profile_json}\n")).map_err(|e| {
+    atomic_write(
+        &prepared.profile_path,
+        format!("{profile_json}\n").as_bytes(),
+    )
+}
+
+/// Write `contents` to `path` atomically: write to a sibling temp file, fsync,
+/// then rename. On crash or disk-full mid-write, the original file at `path`
+/// is left intact rather than truncated.
+fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
+    let dir = path.parent().ok_or_else(|| {
         NonoError::LearnError(format!(
-            "Failed to write profile to {}: {}",
-            prepared.profile_path.display(),
-            e
+            "Failed to determine parent directory of {}",
+            path.display()
         ))
     })?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| NonoError::LearnError(format!("Invalid profile path {}", path.display())))?;
 
+    // Use a sibling temp file so the final rename is same-filesystem and
+    // therefore atomic on POSIX.
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = dir.join(&tmp_name);
+
+    let write_err = |stage: &str, e: std::io::Error| {
+        NonoError::LearnError(format!(
+            "Failed to {} profile {}: {}",
+            stage,
+            path.display(),
+            e
+        ))
+    };
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+        .map_err(|e| write_err("open temp file for", e))?;
+    if let Err(e) = file.write_all(contents) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(write_err("write", e));
+    }
+    if let Err(e) = file.sync_all() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(write_err("sync", e));
+    }
+    drop(file);
+
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(write_err("rename into place", e));
+    }
     Ok(())
 }
 
@@ -337,33 +406,67 @@ fn open_tty_writer() -> Option<std::fs::File> {
 fn prompt_read_line() -> Result<String> {
     let mut input = String::new();
     let tty = open_tty_prompt_device()?;
-    let saved_termios = force_prompt_terminal_mode(&tty);
+    // Guard restores termios on any exit path (normal, error, panic unwind).
+    // Previously the restore ran only after `read_line` succeeded, so a panic
+    // during reading could leave the terminal in no-echo/canonical-disabled
+    // state.
+    let _guard = PromptTerminalGuard::new(&tty);
     let mut reader = std::io::BufReader::new(tty);
-    let read_result = reader
+    reader
         .read_line(&mut input)
-        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)));
-    if let Some(saved) = saved_termios {
-        let _ = nix::sys::termios::tcsetattr(
-            reader.get_ref(),
-            nix::sys::termios::SetArg::TCSANOW,
-            &saved,
-        );
-    }
-    read_result?;
+        .map_err(|e| NonoError::LearnError(format!("Failed to read input: {}", e)))?;
     Ok(input)
 }
 
-fn force_prompt_terminal_mode(tty: &std::fs::File) -> Option<nix::sys::termios::Termios> {
-    let Ok(original) = nix::sys::termios::tcgetattr(tty) else {
-        return None;
-    };
-    let mut termios = original.clone();
-    configure_prompt_termios(&mut termios);
-    if nix::sys::termios::tcsetattr(tty, nix::sys::termios::SetArg::TCSANOW, &termios).is_err() {
-        return None;
+/// RAII guard that switches the tty into prompt-friendly termios and restores
+/// the saved settings when dropped.
+///
+/// Owns a duplicated fd (via `try_clone`) so the caller can still move the
+/// original `File` into a `BufReader` while the guard retains a handle for
+/// the termios restore in `Drop`.
+struct PromptTerminalGuard {
+    tty: Option<std::fs::File>,
+    saved: Option<nix::sys::termios::Termios>,
+}
+
+impl PromptTerminalGuard {
+    fn new(tty: &std::fs::File) -> Self {
+        let Ok(owned) = tty.try_clone() else {
+            return Self {
+                tty: None,
+                saved: None,
+            };
+        };
+        let Ok(original) = nix::sys::termios::tcgetattr(&owned) else {
+            return Self {
+                tty: Some(owned),
+                saved: None,
+            };
+        };
+        let mut termios = original.clone();
+        configure_prompt_termios(&mut termios);
+        if nix::sys::termios::tcsetattr(&owned, nix::sys::termios::SetArg::TCSANOW, &termios)
+            .is_err()
+        {
+            return Self {
+                tty: Some(owned),
+                saved: None,
+            };
+        }
+        let _ = nix::sys::termios::tcflush(&owned, nix::sys::termios::FlushArg::TCIFLUSH);
+        Self {
+            tty: Some(owned),
+            saved: Some(original),
+        }
     }
-    let _ = nix::sys::termios::tcflush(tty, nix::sys::termios::FlushArg::TCIFLUSH);
-    Some(original)
+}
+
+impl Drop for PromptTerminalGuard {
+    fn drop(&mut self) {
+        if let (Some(tty), Some(saved)) = (self.tty.as_ref(), self.saved.as_ref()) {
+            let _ = nix::sys::termios::tcsetattr(tty, nix::sys::termios::SetArg::TCSANOW, saved);
+        }
+    }
 }
 
 pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios) {
@@ -792,5 +895,28 @@ mod tests {
         .expect("write");
 
         assert!(!would_shadow_builtin("claude-code"));
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_file_without_truncating_on_failure() {
+        let dir = TempDir::new().expect("temp dir");
+        let target = dir.path().join("profile.json");
+        std::fs::write(&target, b"original\n").expect("seed");
+
+        atomic_write(&target, b"updated\n").expect("atomic write");
+
+        let contents = std::fs::read(&target).expect("read");
+        assert_eq!(contents, b"updated\n");
+
+        // No stray temp siblings left behind on success.
+        let leftover = std::fs::read_dir(dir.path())
+            .expect("readdir")
+            .filter_map(|e| e.ok())
+            .any(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".profile.json.tmp.")
+            });
+        assert!(!leftover, "temp file should be renamed into place");
     }
 }

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -333,6 +333,29 @@ impl PtyProxy {
         detached_terminal
     }
 
+    /// Release the local terminal for a final supervisor-owned prompt.
+    ///
+    /// This leaves the attach screen, restores cooked terminal mode, and
+    /// drops the terminal client so later teardown does not redraw or clear it.
+    pub fn release_terminal_for_prompt(&mut self) -> bool {
+        let had_terminal_client = self
+            .client
+            .as_ref()
+            .is_some_and(AttachedClient::is_terminal);
+        if !had_terminal_client {
+            return false;
+        }
+
+        leave_attach_screen();
+        self.restore_terminal();
+        self.client = None;
+        self.resize_notifier = None;
+        self.pending_detach_match_len = 0;
+        self.pending_detach_escape.clear();
+        self.persist_attachment_state(crate::session::SessionAttachment::Detached);
+        true
+    }
+
     /// Shut down the attach listener so no new connections can be accepted.
     ///
     /// Removes the socket file. This prevents the kernel from accepting new

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -104,9 +104,8 @@ pub fn query_path(
             return Ok(QueryResult::Denied {
                 reason: "sensitive_path".to_string(),
                 details: Some(format!(
-                    "Path is blocked by security policy group '{}' ({}). It cannot be granted with path flags alone. If you need an exception, use a profile with policy.override_deny plus an explicit filesystem grant.",
-                    matched.group_name,
-                    matched.description
+                    "Blocked by policy group '{}': {} Use policy.override_deny to exempt specific paths when appropriate.",
+                    matched.group_name, matched.description
                 )),
                 policy_source: Some(format!("group:{}", matched.group_name)),
                 matching_capability: None,
@@ -184,8 +183,8 @@ pub fn query_path(
     Ok(QueryResult::Denied {
         reason: "path_not_granted".to_string(),
         details: Some(format!(
-            "Path is not covered by any capability. Add {} to grant the requested access.",
-            suggested_flag_for_path(&canonical, requested)
+            "Path is not covered by any capability: {}",
+            canonical.display()
         )),
         policy_source: None,
         matching_capability: None,
@@ -274,7 +273,7 @@ fn suggested_flag_for_path(path: &Path, requested: AccessMode) -> String {
     format!("{flag} {}", target.display())
 }
 
-fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'static str, PathBuf) {
+pub(crate) fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'static str, PathBuf) {
     let flag = if path.is_file() {
         match requested {
             AccessMode::Read => "--read-file",
@@ -292,7 +291,12 @@ fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'static str, Pa
     let target = if path.exists() || path.is_dir() || path.parent().is_none() {
         path.to_path_buf()
     } else if let Some(parent) = path.parent() {
-        parent.to_path_buf()
+        // Never suggest granting access to the root filesystem
+        if parent == Path::new("/") {
+            path.to_path_buf()
+        } else {
+            parent.to_path_buf()
+        }
     } else {
         path.to_path_buf()
     };

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -27,10 +27,46 @@ struct SharedViolations {
     violations: Vec<SandboxViolation>,
 }
 
+/// Attribution filter for matching Seatbelt log entries to our sandboxed child.
+///
+/// A log line is accepted if its PID matches `pid` OR its process name matches
+/// `process_name` (case-sensitive, exact). This lets the historical fallback
+/// catch forked copies of the command without matching unrelated sandboxed
+/// apps (Safari, Messages, etc.) that happen to deny filesystem ops at the
+/// same time.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Default)]
+struct ViolationFilter {
+    pid: Option<i32>,
+    process_name: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
+impl ViolationFilter {
+    fn matches_pid(&self, pid: i64) -> bool {
+        match self.pid {
+            Some(expected) => pid == i64::from(expected),
+            None => false,
+        }
+    }
+
+    fn matches_process_name(&self, name: &str) -> bool {
+        match self.process_name.as_deref() {
+            Some(expected) => name == expected,
+            None => false,
+        }
+    }
+
+    fn is_unfiltered(&self) -> bool {
+        self.pid.is_none() && self.process_name.is_none()
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub struct SandboxLogCollector {
     child: Child,
     child_pid: i32,
+    command_name: Option<String>,
     reader_thread: Option<JoinHandle<()>>,
     shared: Arc<Mutex<SharedViolations>>,
 }
@@ -38,7 +74,7 @@ pub struct SandboxLogCollector {
 #[cfg(target_os = "macos")]
 impl SandboxLogCollector {
     #[must_use]
-    pub fn start(child_pid: i32) -> Option<Self> {
+    pub fn start(child_pid: i32, command_name: Option<String>) -> Option<Self> {
         let mut child = match Command::new("/usr/bin/log")
             .args([
                 "stream",
@@ -72,6 +108,10 @@ impl SandboxLogCollector {
 
         let shared = Arc::new(Mutex::new(SharedViolations::default()));
         let thread_shared = Arc::clone(&shared);
+        let thread_filter = ViolationFilter {
+            pid: Some(child_pid),
+            process_name: command_name.clone(),
+        };
         let reader_thread = thread::Builder::new()
             .name("nono-sandbox-log".to_string())
             .spawn(move || {
@@ -81,7 +121,7 @@ impl SandboxLogCollector {
                         break;
                     };
 
-                    let Some(violation) = parse_violation_line(Some(child_pid), &line) else {
+                    let Some(violation) = parse_violation_line(&thread_filter, &line) else {
                         continue;
                     };
 
@@ -107,6 +147,7 @@ impl SandboxLogCollector {
         Some(Self {
             child,
             child_pid,
+            command_name,
             reader_thread: Some(reader_thread),
             shared,
         })
@@ -139,7 +180,11 @@ impl SandboxLogCollector {
         // the denial event. Fall back to a historical log query which is
         // deterministic — events are already committed by this point.
         if violations.is_empty() {
-            if let Some(historical) = collect_historical_violations(self.child_pid) {
+            let filter = ViolationFilter {
+                pid: Some(self.child_pid),
+                process_name: self.command_name.clone(),
+            };
+            if let Some(historical) = collect_historical_violations(&filter) {
                 violations = historical;
             }
         }
@@ -157,12 +202,13 @@ pub struct SandboxLogCollector;
 /// This is the fallback for short-lived commands where the real-time log stream
 /// couldn't deliver events before the child exited. `log show --last 10s` queries
 /// committed log entries, which is deterministic.
+///
+/// Attribution: entries are accepted only when the filter matches by PID or by
+/// process name. The broader match-any-PID approach previously used here could
+/// pick up denials from unrelated sandboxed apps (Safari, Messages, etc.) that
+/// happened to deny a filesystem op in the same window.
 #[cfg(target_os = "macos")]
-fn collect_historical_violations(_child_pid: i32) -> Option<Vec<SandboxViolation>> {
-    // Use the same predicate as the real-time stream. We match any PID
-    // because the child may have forked subprocesses (e.g. copilot forks
-    // git, which hits the denial under a different PID). The predicate
-    // parse_violation_line extracts via regex matching.
+fn collect_historical_violations(filter: &ViolationFilter) -> Option<Vec<SandboxViolation>> {
     let predicate = LOG_STREAM_PREDICATE;
 
     let output = Command::new("/usr/bin/log")
@@ -190,15 +236,13 @@ fn collect_historical_violations(_child_pid: i32) -> Option<Vec<SandboxViolation
     let mut violations = Vec::new();
 
     for line in text.lines() {
-        // Pass None to match any PID — the child may have forked
-        // subprocesses that triggered denials under a different PID.
-        let Some(violation) = parse_violation_line(None, line) else {
+        let Some(violation) = parse_violation_line(filter, line) else {
             continue;
         };
         // Only include filesystem operations in historical results.
-        // Non-filesystem violations (mach-lookup, signal, etc.) from the
-        // broad query cannot be reliably attributed to our sandbox — they
-        // may come from other sandboxed processes on the system.
+        // Non-filesystem violations (mach-lookup, signal, etc.) are dropped
+        // here because even with pid/name filtering they're noisier and less
+        // actionable than file denials.
         if !violation.operation.starts_with("file-") {
             continue;
         }
@@ -226,7 +270,7 @@ fn collect_historical_violations(_child_pid: i32) -> Option<Vec<SandboxViolation
 #[allow(dead_code)]
 impl SandboxLogCollector {
     #[must_use]
-    pub fn start(_child_pid: i32) -> Option<Self> {
+    pub fn start(_child_pid: i32, _command_name: Option<String>) -> Option<Self> {
         None
     }
 
@@ -237,15 +281,15 @@ impl SandboxLogCollector {
 }
 
 #[cfg(target_os = "macos")]
-fn parse_violation_line(child_pid: Option<i32>, line: &str) -> Option<SandboxViolation> {
+fn parse_violation_line(filter: &ViolationFilter, line: &str) -> Option<SandboxViolation> {
     let value: Value = serde_json::from_str(line).ok()?;
-    parse_violation_value(child_pid, &value)
+    parse_violation_value(filter, &value)
 }
 
 #[cfg(target_os = "macos")]
-fn parse_violation_value(child_pid: Option<i32>, value: &Value) -> Option<SandboxViolation> {
+fn parse_violation_value(filter: &ViolationFilter, value: &Value) -> Option<SandboxViolation> {
     if let Some(message) = value.get("eventMessage").and_then(Value::as_str) {
-        if let Some(violation) = parse_event_message(child_pid, message) {
+        if let Some(violation) = parse_event_message(filter, message) {
             return Some(violation);
         }
     }
@@ -257,7 +301,7 @@ fn parse_violation_value(child_pid: Option<i32>, value: &Value) -> Option<Sandbo
     });
     if let Some(violation) = metadata
         .as_ref()
-        .and_then(|metadata| parse_metadata_violation(child_pid, metadata))
+        .and_then(|metadata| parse_metadata_violation(filter, metadata))
     {
         return Some(violation);
     }
@@ -278,19 +322,22 @@ fn parse_violation_value(child_pid: Option<i32>, value: &Value) -> Option<Sandbo
 
     metadata
         .as_ref()
-        .and_then(|metadata| parse_metadata_violation(child_pid, metadata))
+        .and_then(|metadata| parse_metadata_violation(filter, metadata))
 }
 
 #[cfg(target_os = "macos")]
-fn parse_metadata_violation(child_pid: Option<i32>, metadata: &Value) -> Option<SandboxViolation> {
+fn parse_metadata_violation(
+    filter: &ViolationFilter,
+    metadata: &Value,
+) -> Option<SandboxViolation> {
     let pid = metadata
         .get("pid")
         .and_then(Value::as_i64)
         .or_else(|| metadata.get("processID").and_then(Value::as_i64))?;
-    if let Some(expected) = child_pid {
-        if pid != i64::from(expected) {
-            return None;
-        }
+    // Metadata entries only expose PID — so PID must match (or filter is off).
+    // A process-name-only filter will not match metadata-only entries.
+    if !filter.is_unfiltered() && !filter.matches_pid(pid) {
+        return None;
     }
 
     let operation = metadata
@@ -308,7 +355,7 @@ fn parse_metadata_violation(child_pid: Option<i32>, metadata: &Value) -> Option<
 }
 
 #[cfg(target_os = "macos")]
-fn parse_event_message(child_pid: Option<i32>, message: &str) -> Option<SandboxViolation> {
+fn parse_event_message(filter: &ViolationFilter, message: &str) -> Option<SandboxViolation> {
     // Format: "Sandbox: processname(PID) deny(N) operation target"
     // or:     "N duplicate reports for Sandbox: processname(PID) deny(N) operation target"
     let first_line = message.lines().next()?.trim();
@@ -317,19 +364,24 @@ fn parse_event_message(child_pid: Option<i32>, message: &str) -> Option<SandboxV
         .map(|(_, suffix)| suffix)
         .or_else(|| first_line.strip_prefix("Sandbox: "))?;
 
-    // When child_pid is Some, match only that PID.
-    // When None, match any PID (for historical queries where the child
-    // may have forked subprocesses with different PIDs).
-    if let Some(pid) = child_pid {
-        let pid_token = format!("({pid})");
-        if !sandbox_line.contains(&pid_token) {
-            return None;
-        }
+    // Split into "processname(PID)" | "deny(N)" | "operation [target]"
+    let (process_and_pid, after_deny) = sandbox_line.split_once(") deny(")?;
+    let (_, detail) = after_deny.split_once(") ")?;
+    // `process_and_pid` is now "processname(PID" — split out the name and PID.
+    let (process_name, pid_str) = process_and_pid.rsplit_once('(')?;
+    let pid: i64 = pid_str.parse().ok()?;
+
+    // Accept if filter is off, or if either PID or process name matches.
+    // Both must be checked: PID alone misses forked copies under the same
+    // executable name, process-name alone would catch unrelated system apps
+    // named generically (rare but possible).
+    if !filter.is_unfiltered()
+        && !filter.matches_pid(pid)
+        && !filter.matches_process_name(process_name)
+    {
+        return None;
     }
 
-    // Parse: "processname(PID) deny(N) operation [target]"
-    let (_, after_deny) = sandbox_line.split_once(") deny(")?;
-    let (_, detail) = after_deny.split_once(") ")?;
     let detail = detail.trim();
     let (operation, target) = match detail.split_once(' ') {
         Some((op, t)) => (op.to_string(), Some(t.trim().to_string())),
@@ -341,12 +393,33 @@ fn parse_event_message(child_pid: Option<i32>, message: &str) -> Option<SandboxV
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-    use super::{parse_event_message, parse_violation_line};
+    use super::{parse_event_message, parse_violation_line, ViolationFilter};
+
+    fn pid_filter(pid: i32) -> ViolationFilter {
+        ViolationFilter {
+            pid: Some(pid),
+            process_name: None,
+        }
+    }
+
+    fn name_filter(name: &str) -> ViolationFilter {
+        ViolationFilter {
+            pid: None,
+            process_name: Some(name.to_string()),
+        }
+    }
+
+    fn combined_filter(pid: i32, name: &str) -> ViolationFilter {
+        ViolationFilter {
+            pid: Some(pid),
+            process_name: Some(name.to_string()),
+        }
+    }
 
     #[test]
     fn parses_file_violation_line() {
         let msg = "Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa";
-        let violation = parse_event_message(Some(1234), msg).expect("violation");
+        let violation = parse_event_message(&pid_filter(1234), msg).expect("violation");
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
     }
@@ -354,7 +427,7 @@ mod tests {
     #[test]
     fn parses_mach_violation_line() {
         let msg = "Sandbox: codex(14485) deny(1) mach-lookup com.apple.logd";
-        let violation = parse_event_message(Some(14485), msg).expect("violation");
+        let violation = parse_event_message(&pid_filter(14485), msg).expect("violation");
         assert_eq!(violation.operation, "mach-lookup");
         assert_eq!(violation.target.as_deref(), Some("com.apple.logd"));
     }
@@ -362,21 +435,21 @@ mod tests {
     #[test]
     fn parses_ndjson_metadata_violation() {
         let line = r#"{"eventMessage":"Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa","subsystem":"com.apple.sandbox.reporting","category":"violation","MetaData":{"operation":"file-read-data","pid":1234,"target":"/Users/test/.ssh/id_rsa"}}"#;
-        let violation = parse_violation_line(Some(1234), line).expect("violation");
+        let violation = parse_violation_line(&pid_filter(1234), line).expect("violation");
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
     }
 
     #[test]
-    fn ignores_other_pids_when_filtered() {
+    fn ignores_other_pids_when_pid_filtered() {
         let msg = "Sandbox: cat(9999) deny(1) file-read-data /tmp/x";
-        assert!(parse_event_message(Some(1234), msg).is_none());
+        assert!(parse_event_message(&pid_filter(1234), msg).is_none());
     }
 
     #[test]
-    fn matches_any_pid_when_none() {
+    fn matches_any_pid_when_filter_unset() {
         let msg = "Sandbox: copilot(9999) deny(1) mach-lookup com.apple.securityd";
-        let violation = parse_event_message(None, msg).expect("violation");
+        let violation = parse_event_message(&ViolationFilter::default(), msg).expect("violation");
         assert_eq!(violation.operation, "mach-lookup");
         assert_eq!(violation.target.as_deref(), Some("com.apple.securityd"));
     }
@@ -385,8 +458,33 @@ mod tests {
     fn parses_duplicate_reports() {
         let msg =
             "3 duplicate reports for Sandbox: git(5678) deny(1) file-read-data /etc/gitconfig";
-        let violation = parse_event_message(None, msg).expect("violation");
+        let violation = parse_event_message(&ViolationFilter::default(), msg).expect("violation");
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/etc/gitconfig"));
+    }
+
+    #[test]
+    fn matches_process_name_when_pid_differs() {
+        // Scenario: `copilot` forks a helper also named `copilot` at a
+        // different PID. Accept it by name when PID doesn't match.
+        let msg = "Sandbox: copilot(9999) deny(1) file-read-data /Users/a/.cache";
+        let violation =
+            parse_event_message(&combined_filter(1234, "copilot"), msg).expect("violation");
+        assert_eq!(violation.operation, "file-read-data");
+    }
+
+    #[test]
+    fn rejects_foreign_process_when_filtered() {
+        // Scenario: Safari produces a file-read denial in the historical
+        // window. Neither PID nor process name matches; it must be dropped.
+        let msg = "Sandbox: Safari(777) deny(1) file-read-data /Users/a/.safari/cookies";
+        assert!(parse_event_message(&combined_filter(1234, "copilot"), msg).is_none());
+    }
+
+    #[test]
+    fn matches_by_name_only_filter() {
+        let msg = "Sandbox: copilot(5555) deny(1) file-read-data /tmp/x";
+        let violation = parse_event_message(&name_filter("copilot"), msg).expect("violation");
+        assert_eq!(violation.operation, "file-read-data");
     }
 }

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -30,6 +30,7 @@ struct SharedViolations {
 #[cfg(target_os = "macos")]
 pub struct SandboxLogCollector {
     child: Child,
+    child_pid: i32,
     reader_thread: Option<JoinHandle<()>>,
     shared: Arc<Mutex<SharedViolations>>,
 }
@@ -80,7 +81,7 @@ impl SandboxLogCollector {
                         break;
                     };
 
-                    let Some(violation) = parse_violation_line(child_pid, &line) else {
+                    let Some(violation) = parse_violation_line(Some(child_pid), &line) else {
                         continue;
                     };
 
@@ -105,6 +106,7 @@ impl SandboxLogCollector {
 
         Some(Self {
             child,
+            child_pid,
             reader_thread: Some(reader_thread),
             shared,
         })
@@ -112,6 +114,8 @@ impl SandboxLogCollector {
 
     #[must_use]
     pub fn finish(mut self) -> Vec<SandboxViolation> {
+        // Kill the real-time stream — it may or may not have captured
+        // events depending on timing.
         let _ = self.child.kill();
         let _ = self.child.wait();
 
@@ -119,7 +123,7 @@ impl SandboxLogCollector {
             let _ = reader_thread.join();
         }
 
-        match Arc::try_unwrap(self.shared) {
+        let mut violations: Vec<SandboxViolation> = match Arc::try_unwrap(self.shared) {
             Ok(shared) => match shared.into_inner() {
                 Ok(shared) => shared.violations,
                 Err(poisoned) => poisoned.into_inner().violations,
@@ -128,13 +132,95 @@ impl SandboxLogCollector {
                 Ok(shared) => shared.violations.clone(),
                 Err(poisoned) => poisoned.into_inner().violations.clone(),
             },
+        };
+
+        // The real-time stream is inherently racy for short-lived commands
+        // (e.g. `cat`). The child can exit before the log system delivers
+        // the denial event. Fall back to a historical log query which is
+        // deterministic — events are already committed by this point.
+        if violations.is_empty() {
+            if let Some(historical) = collect_historical_violations(self.child_pid) {
+                violations = historical;
+            }
         }
+
+        violations
     }
 }
 
 #[cfg(not(target_os = "macos"))]
 #[allow(dead_code)]
 pub struct SandboxLogCollector;
+
+/// Query the unified log for sandbox violations that occurred in the recent past.
+///
+/// This is the fallback for short-lived commands where the real-time log stream
+/// couldn't deliver events before the child exited. `log show --last 10s` queries
+/// committed log entries, which is deterministic.
+#[cfg(target_os = "macos")]
+fn collect_historical_violations(_child_pid: i32) -> Option<Vec<SandboxViolation>> {
+    // Use the same predicate as the real-time stream. We match any PID
+    // because the child may have forked subprocesses (e.g. copilot forks
+    // git, which hits the denial under a different PID). The predicate
+    // parse_violation_line extracts via regex matching.
+    let predicate = LOG_STREAM_PREDICATE;
+
+    let output = Command::new("/usr/bin/log")
+        .args([
+            "show",
+            "--style",
+            "ndjson",
+            "--last",
+            "10s",
+            "--predicate",
+            predicate,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        debug!("log show exited with {:?}", output.status.code());
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut seen = BTreeSet::<(String, String)>::new();
+    let mut violations = Vec::new();
+
+    for line in text.lines() {
+        // Pass None to match any PID — the child may have forked
+        // subprocesses that triggered denials under a different PID.
+        let Some(violation) = parse_violation_line(None, line) else {
+            continue;
+        };
+        // Only include filesystem operations in historical results.
+        // Non-filesystem violations (mach-lookup, signal, etc.) from the
+        // broad query cannot be reliably attributed to our sandbox — they
+        // may come from other sandboxed processes on the system.
+        if !violation.operation.starts_with("file-") {
+            continue;
+        }
+        let key = (
+            violation.operation.clone(),
+            violation.target.clone().unwrap_or_default(),
+        );
+        if !seen.insert(key) {
+            continue;
+        }
+        violations.push(violation);
+        if violations.len() >= MAX_VIOLATIONS {
+            break;
+        }
+    }
+
+    if violations.is_empty() {
+        None
+    } else {
+        Some(violations)
+    }
+}
 
 #[cfg(not(target_os = "macos"))]
 #[allow(dead_code)]
@@ -151,13 +237,13 @@ impl SandboxLogCollector {
 }
 
 #[cfg(target_os = "macos")]
-fn parse_violation_line(child_pid: i32, line: &str) -> Option<SandboxViolation> {
+fn parse_violation_line(child_pid: Option<i32>, line: &str) -> Option<SandboxViolation> {
     let value: Value = serde_json::from_str(line).ok()?;
     parse_violation_value(child_pid, &value)
 }
 
 #[cfg(target_os = "macos")]
-fn parse_violation_value(child_pid: i32, value: &Value) -> Option<SandboxViolation> {
+fn parse_violation_value(child_pid: Option<i32>, value: &Value) -> Option<SandboxViolation> {
     if let Some(message) = value.get("eventMessage").and_then(Value::as_str) {
         if let Some(violation) = parse_event_message(child_pid, message) {
             return Some(violation);
@@ -196,13 +282,15 @@ fn parse_violation_value(child_pid: i32, value: &Value) -> Option<SandboxViolati
 }
 
 #[cfg(target_os = "macos")]
-fn parse_metadata_violation(child_pid: i32, metadata: &Value) -> Option<SandboxViolation> {
+fn parse_metadata_violation(child_pid: Option<i32>, metadata: &Value) -> Option<SandboxViolation> {
     let pid = metadata
         .get("pid")
         .and_then(Value::as_i64)
         .or_else(|| metadata.get("processID").and_then(Value::as_i64))?;
-    if pid != i64::from(child_pid) {
-        return None;
+    if let Some(expected) = child_pid {
+        if pid != i64::from(expected) {
+            return None;
+        }
     }
 
     let operation = metadata
@@ -220,21 +308,31 @@ fn parse_metadata_violation(child_pid: i32, metadata: &Value) -> Option<SandboxV
 }
 
 #[cfg(target_os = "macos")]
-fn parse_event_message(child_pid: i32, message: &str) -> Option<SandboxViolation> {
+fn parse_event_message(child_pid: Option<i32>, message: &str) -> Option<SandboxViolation> {
+    // Format: "Sandbox: processname(PID) deny(N) operation target"
+    // or:     "N duplicate reports for Sandbox: processname(PID) deny(N) operation target"
     let first_line = message.lines().next()?.trim();
     let sandbox_line = first_line
         .split_once("Sandbox: ")
         .map(|(_, suffix)| suffix)
         .or_else(|| first_line.strip_prefix("Sandbox: "))?;
 
-    let pid_token = format!("({child_pid})");
-    let (_, remainder) = sandbox_line.split_once(&pid_token)?;
-    let remainder = remainder.trim_start();
-    let remainder = remainder.strip_prefix("deny(")?;
-    let (_, detail) = remainder.split_once(") ")?;
+    // When child_pid is Some, match only that PID.
+    // When None, match any PID (for historical queries where the child
+    // may have forked subprocesses with different PIDs).
+    if let Some(pid) = child_pid {
+        let pid_token = format!("({pid})");
+        if !sandbox_line.contains(&pid_token) {
+            return None;
+        }
+    }
+
+    // Parse: "processname(PID) deny(N) operation [target]"
+    let (_, after_deny) = sandbox_line.split_once(") deny(")?;
+    let (_, detail) = after_deny.split_once(") ")?;
     let detail = detail.trim();
     let (operation, target) = match detail.split_once(' ') {
-        Some((operation, target)) => (operation.to_string(), Some(target.trim().to_string())),
+        Some((op, t)) => (op.to_string(), Some(t.trim().to_string())),
         None => (detail.to_string(), None),
     };
 
@@ -248,7 +346,7 @@ mod tests {
     #[test]
     fn parses_file_violation_line() {
         let msg = "Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa";
-        let violation = parse_event_message(1234, msg).expect("violation");
+        let violation = parse_event_message(Some(1234), msg).expect("violation");
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
     }
@@ -256,7 +354,7 @@ mod tests {
     #[test]
     fn parses_mach_violation_line() {
         let msg = "Sandbox: codex(14485) deny(1) mach-lookup com.apple.logd";
-        let violation = parse_event_message(14485, msg).expect("violation");
+        let violation = parse_event_message(Some(14485), msg).expect("violation");
         assert_eq!(violation.operation, "mach-lookup");
         assert_eq!(violation.target.as_deref(), Some("com.apple.logd"));
     }
@@ -264,14 +362,31 @@ mod tests {
     #[test]
     fn parses_ndjson_metadata_violation() {
         let line = r#"{"eventMessage":"Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa","subsystem":"com.apple.sandbox.reporting","category":"violation","MetaData":{"operation":"file-read-data","pid":1234,"target":"/Users/test/.ssh/id_rsa"}}"#;
-        let violation = parse_violation_line(1234, line).expect("violation");
+        let violation = parse_violation_line(Some(1234), line).expect("violation");
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
     }
 
     #[test]
-    fn ignores_other_pids() {
+    fn ignores_other_pids_when_filtered() {
         let msg = "Sandbox: cat(9999) deny(1) file-read-data /tmp/x";
-        assert!(parse_event_message(1234, msg).is_none());
+        assert!(parse_event_message(Some(1234), msg).is_none());
+    }
+
+    #[test]
+    fn matches_any_pid_when_none() {
+        let msg = "Sandbox: copilot(9999) deny(1) mach-lookup com.apple.securityd";
+        let violation = parse_event_message(None, msg).expect("violation");
+        assert_eq!(violation.operation, "mach-lookup");
+        assert_eq!(violation.target.as_deref(), Some("com.apple.securityd"));
+    }
+
+    #[test]
+    fn parses_duplicate_reports() {
+        let msg =
+            "3 duplicate reports for Sandbox: git(5678) deny(1) file-read-data /etc/gitconfig";
+        let violation = parse_event_message(None, msg).expect("violation");
+        assert_eq!(violation.operation, "file-read-data");
+        assert_eq!(violation.target.as_deref(), Some("/etc/gitconfig"));
     }
 }

--- a/crates/nono-cli/src/startup_prompt.rs
+++ b/crates/nono-cli/src/startup_prompt.rs
@@ -99,6 +99,10 @@ struct StartupPromptTerminalGuard {
 
 impl StartupPromptTerminalGuard {
     fn pause_without_pty(child: Pid) -> Self {
+        // SIGSTOP freezes the direct child so its output doesn't interleave with
+        // the prompt. Descendants keep running, and the child's network peers
+        // may time out if the prompt is answered "no". Acceptable tradeoff:
+        // the prompt only fires after the startup timeout already elapsed.
         let child_stopped = signal::kill(child, Signal::SIGSTOP).is_ok();
         if child_stopped {
             std::thread::sleep(Duration::from_millis(20));

--- a/crates/nono-cli/src/startup_prompt.rs
+++ b/crates/nono-cli/src/startup_prompt.rs
@@ -1,0 +1,176 @@
+use crate::exec_strategy::StartupTimeoutConfig;
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::time::Duration;
+
+pub(crate) fn print_terminal_safe_stderr(message: &str) {
+    let mut stderr = io::stderr();
+    if stderr.is_terminal() {
+        let normalized = message.replace('\n', "\r\n");
+        let _ = writeln!(stderr, "\r{}", normalized);
+    } else {
+        let _ = writeln!(stderr, "{}", message);
+    }
+}
+
+fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output: bool) -> bool {
+    let description = if has_output {
+        format!(
+            "[nono] Startup appears blocked: `{}` has not become interactive after {} seconds.",
+            timeout_cfg.program,
+            timeout_cfg.timeout.as_secs()
+        )
+    } else {
+        format!(
+            "[nono] Startup appears blocked: `{}` produced no terminal output after {} seconds.",
+            timeout_cfg.program,
+            timeout_cfg.timeout.as_secs()
+        )
+    };
+
+    let tty_in = match std::fs::File::open("/dev/tty") {
+        Ok(file) => file,
+        Err(_) => {
+            print_terminal_safe_stderr(&format!(
+                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
+                description,
+                timeout_cfg.program,
+                timeout_cfg.profile,
+                timeout_cfg.profile,
+                timeout_cfg.program,
+            ));
+            return false;
+        }
+    };
+
+    let mut tty_out = match std::fs::OpenOptions::new().write(true).open("/dev/tty") {
+        Ok(file) => file,
+        Err(_) => {
+            print_terminal_safe_stderr(&format!(
+                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
+                description,
+                timeout_cfg.program,
+                timeout_cfg.profile,
+                timeout_cfg.profile,
+                timeout_cfg.program,
+            ));
+            return false;
+        }
+    };
+
+    let _ = writeln!(tty_out);
+    let _ = writeln!(tty_out, "{}", description);
+    let _ = writeln!(
+        tty_out,
+        "[nono] `{}` usually needs the built-in `{}` profile.",
+        timeout_cfg.program, timeout_cfg.profile
+    );
+    let _ = writeln!(
+        tty_out,
+        "[nono] Try: nono run --profile {} -- {}",
+        timeout_cfg.profile, timeout_cfg.program
+    );
+    let _ = write!(tty_out, "[nono] Do you wish to terminate? [y/N] ");
+    let _ = tty_out.flush();
+
+    let mut reader = io::BufReader::new(tty_in);
+    let mut input = String::new();
+    if reader.read_line(&mut input).is_err() {
+        let _ = writeln!(tty_out, "\n[nono] Continuing to wait.");
+        return false;
+    }
+
+    let affirmative = matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes");
+    if affirmative {
+        let _ = writeln!(tty_out, "[nono] Terminating startup-blocked process.");
+    } else {
+        let _ = writeln!(tty_out, "[nono] Continuing to wait.");
+    }
+    affirmative
+}
+
+struct StartupPromptTerminalGuard {
+    tty: Option<std::fs::File>,
+    saved_termios: Option<nix::sys::termios::Termios>,
+    child: Pid,
+    child_stopped: bool,
+}
+
+impl StartupPromptTerminalGuard {
+    fn pause_without_pty(child: Pid) -> Self {
+        let child_stopped = signal::kill(child, Signal::SIGSTOP).is_ok();
+        if child_stopped {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let mut guard = Self {
+            tty: None,
+            saved_termios: None,
+            child,
+            child_stopped,
+        };
+
+        let tty = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+        {
+            Ok(tty) => tty,
+            Err(_) => return guard,
+        };
+
+        let original = match nix::sys::termios::tcgetattr(&tty) {
+            Ok(termios) => termios,
+            Err(_) => return guard,
+        };
+
+        let mut prompt_termios = original.clone();
+        crate::profile_save_runtime::configure_prompt_termios(&mut prompt_termios);
+        if nix::sys::termios::tcsetattr(&tty, nix::sys::termios::SetArg::TCSANOW, &prompt_termios)
+            .is_err()
+        {
+            return guard;
+        }
+
+        let _ = nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH);
+        guard.saved_termios = Some(original);
+        guard.tty = Some(tty);
+        guard
+    }
+
+    fn finish(self, resume_child: bool) {
+        if let (Some(tty), Some(saved_termios)) = (self.tty.as_ref(), self.saved_termios.as_ref()) {
+            let _ = nix::sys::termios::tcsetattr(
+                tty,
+                nix::sys::termios::SetArg::TCSANOW,
+                saved_termios,
+            );
+        }
+
+        if self.child_stopped && resume_child {
+            let _ = signal::kill(self.child, Signal::SIGCONT);
+        }
+    }
+}
+
+pub(crate) fn prompt_startup_termination_for_child(
+    child: Pid,
+    timeout_cfg: StartupTimeoutConfig<'_>,
+    has_output: bool,
+    pty: Option<&mut crate::pty_proxy::PtyProxy>,
+) -> bool {
+    if let Some(proxy) = pty {
+        let paused_terminal = proxy.pause_terminal_for_prompt();
+        let terminate = prompt_startup_termination(timeout_cfg, has_output);
+        if paused_terminal {
+            proxy.resume_terminal_after_prompt();
+        }
+        return terminate;
+    }
+
+    let guard = StartupPromptTerminalGuard::pause_without_pty(child);
+    let terminate = prompt_startup_termination(timeout_cfg, has_output);
+    guard.finish(!terminate);
+    terminate
+}

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -56,6 +56,27 @@ pub struct SandboxViolation {
     pub target: Option<String>,
 }
 
+/// Policy explanation for a denied path, resolved from `nono why` logic.
+///
+/// This carries the enriched query result so the diagnostic can show
+/// group names, policy details, and suggested fixes inline rather than
+/// asking the user to run `nono why` separately.
+#[derive(Debug, Clone)]
+pub struct PolicyExplanation {
+    /// The denied path.
+    pub path: PathBuf,
+    /// Access mode that was denied.
+    pub access: AccessMode,
+    /// Why it was denied: "sensitive_path", "insufficient_access", or "path_not_granted".
+    pub reason: String,
+    /// Human-readable explanation (e.g. "blocked by group 'ssh' (SSH keys and config)").
+    pub details: Option<String>,
+    /// Policy source identifier (e.g. "group:ssh").
+    pub policy_source: Option<String>,
+    /// Suggested CLI flag to fix (e.g. "--read ~/.ssh/id_rsa").
+    pub suggested_flag: Option<String>,
+}
+
 /// Path-level hint extracted from a command's own error output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObservedPathHint {
@@ -249,6 +270,15 @@ fn detect_non_sandbox_failure_line(line: &str) -> Option<String> {
         return Some(trimmed.to_string());
     }
 
+    // Version requirement errors are never sandbox-related
+    if lower.contains("version must be at least")
+        || lower.contains("requires version")
+        || lower.contains("minimum version")
+        || lower.contains("upgrade your")
+    {
+        return Some(trimmed.to_string());
+    }
+
     None
 }
 
@@ -279,7 +309,7 @@ fn looks_like_missing_path(line: &str) -> bool {
 }
 
 fn render_diagnostic_block(body: &str) -> String {
-    let mut lines = vec!["nono diagnostic".to_string(), "───────────────".to_string()];
+    let mut lines = Vec::new();
 
     for line in body.lines() {
         if line == "[nono]" {
@@ -297,10 +327,7 @@ fn render_diagnostic_block(body: &str) -> String {
 }
 
 fn format_command_failed_line(exit_code: i32) -> String {
-    format!(
-        "[nono] The command failed. This may be due to sandbox restrictions. (exit code {})",
-        exit_code
-    )
+    format!("[nono] Command exited with code {}.", exit_code)
 }
 
 fn format_command_failed_not_sandbox_line(exit_code: i32) -> String {
@@ -484,6 +511,10 @@ pub struct DiagnosticFormatter<'a> {
     command: Option<CommandContext>,
     /// Directory the child process started in.
     current_dir: Option<&'a Path>,
+    /// Session ID for `nono grant` suggestions in supervised mode.
+    session_id: Option<String>,
+    /// Policy explanations for denied paths, resolved from `query_path`.
+    policy_explanations: Vec<PolicyExplanation>,
 }
 
 impl<'a> DiagnosticFormatter<'a> {
@@ -503,6 +534,8 @@ impl<'a> DiagnosticFormatter<'a> {
             non_sandbox_failure: None,
             command: None,
             current_dir: None,
+            session_id: None,
+            policy_explanations: Vec::new(),
         }
     }
 
@@ -569,6 +602,24 @@ impl<'a> DiagnosticFormatter<'a> {
     #[must_use]
     pub fn with_current_dir(mut self, current_dir: &'a Path) -> Self {
         self.current_dir = Some(current_dir);
+        self
+    }
+
+    /// Set the session ID for `nono grant` suggestions in supervised mode.
+    #[must_use]
+    pub fn with_session_id(mut self, session_id: Option<String>) -> Self {
+        self.session_id = session_id;
+        self
+    }
+
+    /// Add policy explanations for denied paths.
+    ///
+    /// These are resolved from `query_path` in the CLI layer and provide
+    /// group names, policy details, and suggested fixes so the diagnostic
+    /// can show them inline.
+    #[must_use]
+    pub fn with_policy_explanations(mut self, explanations: Vec<PolicyExplanation>) -> Self {
+        self.policy_explanations = explanations;
         self
     }
 
@@ -910,69 +961,50 @@ impl<'a> DiagnosticFormatter<'a> {
         }
         lines.push("[nono]".to_string());
 
-        if self.denials.is_empty()
-            && self.sandbox_violations.is_empty()
-            && !self.caps.extensions_enabled()
-        {
-            // No denials and no capability expansion (macOS supervised mode).
-            // Seatbelt blocks at the kernel level without notifying the supervisor,
-            // so we fall back to the standard policy summary with re-run suggestions.
-            let observed_hints = self.actionable_observed_path_hints();
-            if let Some(verdict) = primary_verdict.as_ref() {
-                self.format_primary_verdict_guidance(&mut lines, verdict);
-                lines.push("[nono]".to_string());
-            }
+        // Convert macOS Seatbelt violations (operation + target) into
+        // DenialRecords so the same rendering logic handles both platforms.
+        let (violation_denials, non_fs_violations) = violations_to_denials(self.sandbox_violations);
 
-            lines.push("[nono] Sandbox policy:".to_string());
-            self.format_allowed_paths_concise(&mut lines);
-            self.format_network_status(&mut lines);
-            self.format_protected_paths(&mut lines);
-            let additional_hints = if observed_hints.len() > 1 {
-                &observed_hints[1..]
+        // Merge supervisor denials (Linux seccomp) with violation-derived
+        // denials (macOS Seatbelt) into a single unified list.
+        let all_denials: Vec<DenialRecord> = self
+            .denials
+            .iter()
+            .cloned()
+            .chain(violation_denials)
+            .collect();
+
+        if all_denials.is_empty() {
+            // No denials from either source.
+            if !non_fs_violations.is_empty() {
+                // Non-filesystem violations (mach-lookup, signal, etc.) —
+                // show them with human-readable descriptions.
+                lines.push("[nono] Sandbox blocked system services:".to_string());
+                format_non_fs_violations(&mut lines, &non_fs_violations);
+                lines.push("[nono]".to_string());
+                format_non_fs_guidance(&mut lines, &non_fs_violations);
             } else {
-                &[]
-            };
-            self.format_observed_path_hints(&mut lines, additional_hints);
-            if observed_hints.is_empty() && primary_verdict.is_none() {
-                lines.push("[nono]".to_string());
-                self.format_grant_help(&mut lines);
-                lines.push("[nono]".to_string());
-                self.format_follow_up_guidance(&mut lines, None);
-            }
-            return lines.join("\n");
-        } else if self.denials.is_empty() && !self.sandbox_violations.is_empty() {
-            if let Some(verdict) = primary_verdict.as_ref() {
-                self.format_primary_verdict_guidance(&mut lines, verdict);
-                lines.push("[nono]".to_string());
-            }
-
-            lines.push("[nono] Sandbox denied the following operations:".to_string());
-            for violation in self.sandbox_violations {
-                match &violation.target {
-                    Some(target) => {
-                        lines.push(format!("[nono]   {}  {}", violation.operation, target));
-                    }
-                    None => {
-                        lines.push(format!("[nono]   {}", violation.operation));
-                    }
+                // Genuinely no denials observed.
+                if let Some(verdict) = primary_verdict.as_ref() {
+                    self.format_primary_verdict_guidance(&mut lines, verdict);
+                    lines.push("[nono]".to_string());
                 }
+                lines.push("[nono] No path denials were observed during this session.".to_string());
+                lines.push(
+                    "[nono] The failure may be unrelated to sandbox restrictions.".to_string(),
+                );
             }
             lines.push("[nono]".to_string());
-            self.format_follow_up_guidance(&mut lines, None);
-            return lines.join("\n");
-        } else if self.denials.is_empty() {
-            // No denials but expansion is active (Linux supervised mode).
-            // seccomp-notify would have caught any denial, so this is genuine.
-            lines.push("[nono] No access requests were denied during this session.".to_string());
-            lines.push("[nono] The failure may be unrelated to sandbox restrictions.".to_string());
+            self.format_grant_help(&mut lines);
             lines.push("[nono]".to_string());
             self.format_follow_up_guidance(&mut lines, None);
         } else {
-            let policy_blocked = self.aggregate_denials(DenialReason::PolicyBlocked);
-            let insufficient_access = self.aggregate_denials(DenialReason::InsufficientAccess);
-            let user_denied = self.aggregate_denials(DenialReason::UserDenied);
-            let rate_limited = self.aggregate_denials(DenialReason::RateLimited);
-            let backend_errors = self.aggregate_denials(DenialReason::BackendError);
+            let policy_blocked = aggregate_denials_from(&all_denials, DenialReason::PolicyBlocked);
+            let insufficient_access =
+                aggregate_denials_from(&all_denials, DenialReason::InsufficientAccess);
+            let user_denied = aggregate_denials_from(&all_denials, DenialReason::UserDenied);
+            let rate_limited = aggregate_denials_from(&all_denials, DenialReason::RateLimited);
+            let backend_errors = aggregate_denials_from(&all_denials, DenialReason::BackendError);
 
             let mut actionable = Vec::new();
             actionable.extend(insufficient_access.iter().cloned());
@@ -1082,29 +1114,21 @@ impl<'a> DiagnosticFormatter<'a> {
                     );
                 }
             }
+
+            // Show non-filesystem violations (mach-lookup, etc.) if any
+            if !non_fs_violations.is_empty() {
+                lines.push("[nono]".to_string());
+                lines.push("[nono] Also blocked (system services):".to_string());
+                format_non_fs_violations(&mut lines, &non_fs_violations);
+                lines.push("[nono]".to_string());
+                format_non_fs_guidance(&mut lines, &non_fs_violations);
+            }
+
+            // Note: `nono grant` suggestions are shown via desktop
+            // notifications during the session, not in the post-exit footer.
         }
 
         lines.join("\n")
-    }
-
-    fn aggregate_denials(&self, reason: DenialReason) -> Vec<DenialRecord> {
-        let mut aggregated = std::collections::BTreeMap::<PathBuf, AccessMode>::new();
-
-        for denial in self.denials.iter().filter(|d| d.reason == reason) {
-            aggregated
-                .entry(denial.path.clone())
-                .and_modify(|existing| *existing = merge_access_modes(*existing, denial.access))
-                .or_insert(denial.access);
-        }
-
-        aggregated
-            .into_iter()
-            .map(|(path, access)| DenialRecord {
-                path,
-                access,
-                reason: reason.clone(),
-            })
-            .collect()
     }
 
     fn closest_covering_capability(
@@ -1203,34 +1227,24 @@ impl<'a> DiagnosticFormatter<'a> {
     fn format_follow_up_guidance(
         &self,
         lines: &mut Vec<String>,
-        hint: Option<(&Path, AccessMode)>,
+        _hint: Option<(&Path, AccessMode)>,
     ) {
         lines.push("[nono] Next steps:".to_string());
         if let Some(command) = self.format_command_for_learn() {
-            lines.push(format!("[nono]   Learn: nono learn -- {}", command));
-        } else {
-            lines.push("[nono]   Learn: nono learn -- <your command>".to_string());
-        }
-
-        if let Some((path, access)) = hint {
             lines.push(format!(
-                "[nono]   Why: nono why --path {} --op {}",
-                path.display(),
-                why_op_str(access)
+                "[nono]   Discover paths: nono learn -- {}",
+                command
             ));
-            lines.push(
-                "[nono]   Re-use the same --profile/--allow flags from the failing run."
-                    .to_string(),
-            );
         } else {
-            lines.push(
-                "[nono]   Why: nono why --path <path> --op <read|write|readwrite>".to_string(),
-            );
+            lines.push("[nono]   Discover paths: nono learn -- <your command>".to_string());
         }
+        lines.push(
+            "[nono]   Query policy: nono why --path <path> --op <read|write|readwrite>".to_string(),
+        );
     }
 
     fn format_primary_observed_guidance(&self, lines: &mut Vec<String>, hint: &ObservedPathHint) {
-        lines.push("[nono] Likely sandbox denial:".to_string());
+        lines.push("[nono] Sandbox denial:".to_string());
         if self.observed_hint_points_to_read_only_cwd(hint) {
             lines.push(
                 "[nono]   The command appears to be writing inside the current working directory,"
@@ -1250,7 +1264,6 @@ impl<'a> DiagnosticFormatter<'a> {
             "[nono]   Try: {}",
             self.suggested_flag_for_hint(&hint.path, hint.access)
         ));
-        self.format_primary_follow_up(lines, hint.path.as_path(), hint.access);
     }
 
     fn format_primary_verdict_guidance(&self, lines: &mut Vec<String>, verdict: &ErrorVerdict) {
@@ -1291,98 +1304,90 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 
     fn format_primary_denial_guidance(&self, lines: &mut Vec<String>, denial: &DenialRecord) {
-        lines.push("[nono] Likely sandbox denial:".to_string());
+        lines.push("[nono] Sandbox denial:".to_string());
         lines.push(format!(
             "[nono]   {} ({})",
             denial.path.display(),
             access_str(denial.access),
         ));
 
-        match denial.reason {
-            DenialReason::PolicyBlocked => {
-                lines.push(
-                    "[nono]   This path is blocked by security policy; path flags alone will not allow it."
-                        .to_string(),
-                );
-                lines.push(format!(
-                    "[nono]   Why: nono why --path {} --op {}",
-                    denial.path.display(),
-                    why_op_str(denial.access)
-                ));
-                lines.push(
-                    "[nono]   Learn: use this for grantable paths; policy-blocked paths need a profile exception."
-                        .to_string(),
-                );
+        // Look up policy explanation for this path
+        let explanation = self
+            .policy_explanations
+            .iter()
+            .find(|e| e.path == denial.path);
+
+        if let Some(expl) = explanation {
+            // Show inline policy details instead of asking user to run `nono why`
+            if let Some(ref details) = expl.details {
+                lines.push(format!("[nono]   {}", details));
             }
-            DenialReason::InsufficientAccess => {
+            if expl.reason == "sensitive_path" {
+                // Policy-blocked path: needs profile exception
+                lines.push("[nono]".to_string());
                 lines.push(
-                    "[nono]   This path matched the sandbox, but the access mode was not granted."
+                    "[nono] To override, create a user profile with policy.override_deny:"
                         .to_string(),
                 );
-                if let Some(cap) = self.closest_covering_capability(&denial.path, denial.access) {
+                lines.push("[nono]   ~/.config/nono/profiles/<name>.json:".to_string());
+                lines.push("[nono]   {".to_string());
+                lines.push(format!(
+                    "[nono]     \"policy\": {{ \"override_deny\": [\"{}\"] }},",
+                    denial.path.display()
+                ));
+                lines.push(format!(
+                    "[nono]     \"filesystem\": {{ \"{}\": [\"{}\"] }}",
+                    access_str(denial.access),
+                    denial.path.display()
+                ));
+                lines.push("[nono]   }".to_string());
+            } else if let Some(ref flag) = expl.suggested_flag {
+                lines.push(format!("[nono]   Fix: {}", flag));
+            }
+        } else {
+            // No policy explanation available — fall back to generic guidance
+            match denial.reason {
+                DenialReason::PolicyBlocked => {
+                    lines.push("[nono]   Blocked by security policy.".to_string());
+                }
+                DenialReason::InsufficientAccess => {
+                    if let Some(cap) = self.closest_covering_capability(&denial.path, denial.access)
+                    {
+                        lines.push(format!(
+                            "[nono]   Closest grant: {} ({}, {})",
+                            cap.resolved.display(),
+                            access_str(cap.access),
+                            cap.source,
+                        ));
+                    }
                     lines.push(format!(
-                        "[nono]   Closest grant: {} ({}, {})",
-                        cap.resolved.display(),
-                        access_str(cap.access),
-                        cap.source,
+                        "[nono]   Fix: {}",
+                        suggested_flag_for_path(&denial.path, denial.access)
                     ));
                 }
-                lines.push(format!(
-                    "[nono]   Try: {}",
-                    suggested_flag_for_path(&denial.path, denial.access)
-                ));
-                self.format_primary_follow_up(lines, denial.path.as_path(), denial.access);
-            }
-            DenialReason::UserDenied => {
-                lines.push("[nono]   This access was declined at the prompt.".to_string());
-                lines.push(
-                    "[nono]   Re-run and approve the prompt, or pre-grant the path with the suggested flag."
-                        .to_string(),
-                );
-                lines.push(format!(
-                    "[nono]   Try: {}",
-                    suggested_flag_for_path(&denial.path, denial.access)
-                ));
-                self.format_primary_follow_up(lines, denial.path.as_path(), denial.access);
-            }
-            DenialReason::RateLimited => {
-                lines.push(
-                    "[nono]   This path was denied after too many approval requests.".to_string(),
-                );
-                lines.push(format!(
-                    "[nono]   Try: {}",
-                    suggested_flag_for_path(&denial.path, denial.access)
-                ));
-                self.format_primary_follow_up(lines, denial.path.as_path(), denial.access);
-            }
-            DenialReason::BackendError => {
-                lines.push(
-                    "[nono]   The approval backend failed before this access could be granted."
-                        .to_string(),
-                );
-                lines.push(format!(
-                    "[nono]   Try: {}",
-                    suggested_flag_for_path(&denial.path, denial.access)
-                ));
-                self.format_primary_follow_up(lines, denial.path.as_path(), denial.access);
+                DenialReason::UserDenied => {
+                    lines.push("[nono]   Access was declined at the prompt.".to_string());
+                    lines.push(format!(
+                        "[nono]   Fix: {}",
+                        suggested_flag_for_path(&denial.path, denial.access)
+                    ));
+                }
+                DenialReason::RateLimited => {
+                    lines.push("[nono]   Denied after too many approval requests.".to_string());
+                    lines.push(format!(
+                        "[nono]   Fix: {}",
+                        suggested_flag_for_path(&denial.path, denial.access)
+                    ));
+                }
+                DenialReason::BackendError => {
+                    lines.push("[nono]   Approval backend failed.".to_string());
+                    lines.push(format!(
+                        "[nono]   Fix: {}",
+                        suggested_flag_for_path(&denial.path, denial.access)
+                    ));
+                }
             }
         }
-    }
-
-    fn format_primary_follow_up(&self, lines: &mut Vec<String>, path: &Path, access: AccessMode) {
-        lines.push(format!(
-            "[nono]   Why: nono why --path {} --op {}",
-            path.display(),
-            why_op_str(access)
-        ));
-        if let Some(command) = self.format_command_for_learn() {
-            lines.push(format!("[nono]   Learn: nono learn -- {}", command));
-        } else {
-            lines.push("[nono]   Learn: nono learn -- <your command>".to_string());
-        }
-        lines.push(
-            "[nono]   Re-use the same --profile/--allow flags from the failing run.".to_string(),
-        );
     }
 
     fn format_grant_help(&self, lines: &mut Vec<String>) {
@@ -1590,19 +1595,137 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 }
 
+/// Human-readable descriptions for commonly denied macOS mach services.
+fn describe_mach_service(service: &str) -> Option<&'static str> {
+    Some(match service {
+        s if s.starts_with("com.apple.security") || s == "com.apple.secd" => {
+            "Keychain / Security framework"
+        }
+        "com.apple.logd" => "System logging",
+        "com.apple.system.notification_center" | "com.apple.distributed_notifications" => {
+            "Distributed notifications"
+        }
+        "com.apple.CoreServices.coreservicesd" | "com.apple.lsd.mapdb" => "Launch Services",
+        s if s.starts_with("com.apple.windowserver") => "Window Server / GUI",
+        s if s.starts_with("com.apple.cfprefsd") => "Preferences (NSUserDefaults)",
+        s if s.starts_with("com.apple.pasteboard") => "Pasteboard / clipboard",
+        s if s.starts_with("com.apple.coreservices") => "Core Services",
+        _ => return None,
+    })
+}
+
+/// Format non-filesystem violations with human-readable service descriptions.
+fn format_non_fs_violations(lines: &mut Vec<String>, violations: &[&SandboxViolation]) {
+    for v in violations {
+        let desc = v.target.as_deref().and_then(describe_mach_service);
+        match (&v.target, desc) {
+            (Some(target), Some(description)) => {
+                lines.push(format!(
+                    "[nono]   {} ({}) — {}",
+                    v.operation, target, description
+                ));
+            }
+            (Some(target), None) => {
+                lines.push(format!("[nono]   {} ({})", v.operation, target));
+            }
+            (None, _) => {
+                lines.push(format!("[nono]   {}", v.operation));
+            }
+        }
+    }
+}
+
+/// Generate actionable guidance for non-filesystem violations.
+fn format_non_fs_guidance(lines: &mut Vec<String>, violations: &[&SandboxViolation]) {
+    let has_keychain = violations.iter().any(|v| {
+        v.target
+            .as_deref()
+            .is_some_and(|t| t.contains("SecurityServer") || t.contains("securityd"))
+    });
+
+    if has_keychain {
+        lines.push("[nono] Keychain access requires granting the login keychain path:".to_string());
+        lines.push("[nono]   --read ~/Library/Keychains/login.keychain-db".to_string());
+    }
+}
+
+/// Aggregate denial records by reason, deduplicating by path and merging access modes.
+fn aggregate_denials_from(denials: &[DenialRecord], reason: DenialReason) -> Vec<DenialRecord> {
+    let mut aggregated = std::collections::BTreeMap::<PathBuf, AccessMode>::new();
+
+    for denial in denials.iter().filter(|d| d.reason == reason) {
+        aggregated
+            .entry(denial.path.clone())
+            .and_modify(|existing| *existing = merge_access_modes(*existing, denial.access))
+            .or_insert(denial.access);
+    }
+
+    aggregated
+        .into_iter()
+        .map(|(path, access)| DenialRecord {
+            path,
+            access,
+            reason: reason.clone(),
+        })
+        .collect()
+}
+
+/// Map a Seatbelt operation name to an `AccessMode`.
+///
+/// Returns `None` for non-filesystem operations (e.g. `mach-lookup`,
+/// `signal`, `process-exec`) that cannot be expressed as path grants.
+pub fn seatbelt_operation_to_access(operation: &str) -> Option<AccessMode> {
+    match operation {
+        "file-read-data" | "file-read-metadata" | "file-read-xattr" => Some(AccessMode::Read),
+        "file-write-data" | "file-write-create" | "file-write-unlink" | "file-write-flags"
+        | "file-write-mode" | "file-write-owner" | "file-write-times" | "file-write-xattr" => {
+            Some(AccessMode::Write)
+        }
+        _ => None,
+    }
+}
+
+/// Convert `SandboxViolation`s with filesystem targets into `DenialRecord`s.
+///
+/// Non-filesystem violations (mach-lookup, signal, etc.) are returned
+/// separately since they can't be expressed as path grants.
+fn violations_to_denials(
+    violations: &[SandboxViolation],
+) -> (Vec<DenialRecord>, Vec<&SandboxViolation>) {
+    let mut denials = Vec::new();
+    let mut non_fs = Vec::new();
+    // Deduplicate: multiple operations on the same path merge into one denial
+    let mut seen = std::collections::BTreeMap::<PathBuf, AccessMode>::new();
+
+    for v in violations {
+        if let (Some(access), Some(target)) =
+            (seatbelt_operation_to_access(&v.operation), &v.target)
+        {
+            let path = PathBuf::from(target);
+            seen.entry(path)
+                .and_modify(|existing| *existing = merge_access_modes(*existing, access))
+                .or_insert(access);
+        } else {
+            non_fs.push(v);
+        }
+    }
+
+    for (path, access) in seen {
+        denials.push(DenialRecord {
+            path,
+            access,
+            reason: DenialReason::PolicyBlocked,
+        });
+    }
+
+    (denials, non_fs)
+}
+
 fn access_str(access: AccessMode) -> &'static str {
     match access {
         AccessMode::Read => "read",
         AccessMode::Write => "write",
         AccessMode::ReadWrite => "read+write",
-    }
-}
-
-fn why_op_str(access: AccessMode) -> &'static str {
-    match access {
-        AccessMode::Read => "read",
-        AccessMode::Write => "write",
-        AccessMode::ReadWrite => "readwrite",
     }
 }
 
@@ -1767,8 +1890,7 @@ mod tests {
         let formatter = DiagnosticFormatter::new(&caps);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("The command failed."));
-        assert!(output.contains("(exit code 1)"));
+        assert!(output.contains("Command exited with code 1."));
     }
 
     #[test]
@@ -1777,7 +1899,7 @@ mod tests {
         let formatter = DiagnosticFormatter::new(&caps);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("may be due to"));
+        assert!(!output.contains("may be due to sandbox restrictions"));
         assert!(!output.contains("was caused by"));
     }
 
@@ -1787,7 +1909,7 @@ mod tests {
         let formatter = DiagnosticFormatter::new(&caps);
         let output = formatter.format_footer(1);
 
-        assert!(output.starts_with("nono diagnostic\n───────────────\n"));
+        assert!(!output.starts_with("nono diagnostic"));
         assert!(!output.contains("[nono]"));
     }
 
@@ -2117,36 +2239,11 @@ mod tests {
             non_sandbox_failure: None,
         });
         let output = formatter.format_footer(1);
-        let denial_idx = match output.find("Likely sandbox denial:") {
-            Some(idx) => idx,
-            None => panic!("missing primary denial block: {output}"),
-        };
-        let why_idx = match output.find(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )) {
-            Some(idx) => idx,
-            None => panic!("missing why follow-up: {output}"),
-        };
-        let learn_idx = match output.find("Learn: nono learn -- <your command>") {
-            Some(idx) => idx,
-            None => panic!("missing learn follow-up: {output}"),
-        };
-        let policy_idx = match output.find("Sandbox policy:") {
-            Some(idx) => idx,
-            None => panic!("missing sandbox policy section: {output}"),
-        };
 
-        assert!(output.contains("Likely sandbox denial:"));
+        assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&denied.display().to_string()));
         assert!(output.contains(&format!("Try: --read-file {}", denied.display())));
-        assert!(output.contains(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )));
-        assert!(denial_idx < policy_idx);
-        assert!(why_idx < policy_idx);
-        assert!(learn_idx < policy_idx);
+        assert!(output.contains("Sandbox policy:"));
     }
 
     #[test]
@@ -2171,12 +2268,8 @@ mod tests {
         assert!(output.contains(
             "The command succeeded, but stderr showed a likely sandbox-related access issue."
         ));
-        assert!(output.contains("Likely sandbox denial:"));
+        assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&denied.display().to_string()));
-        assert!(output.contains(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )));
     }
 
     #[test]
@@ -2279,7 +2372,6 @@ mod tests {
 
         assert!(output.contains(&format!("{} (write)", denied.display())));
         assert!(output.contains(&format!("--write {}", canonical_temp.display())));
-        assert!(output.contains(&format!("nono why --path {} --op write", denied.display())));
         assert!(!output.contains(&format!("--allow-file {}", denied.display())));
     }
 
@@ -2316,10 +2408,6 @@ mod tests {
         assert!(output.contains("current working directory is read-only"));
         assert!(output.contains(&format!("Try: --write {}", cwd.display())));
         assert!(!output.contains("Try: --allow-cwd"));
-        assert!(output.contains(&format!(
-            "Why: nono why --path {} --op write",
-            denied.display()
-        )));
     }
 
     #[test]
@@ -2369,15 +2457,15 @@ mod tests {
 
     #[test]
     fn test_supervised_no_denials_no_extensions() {
-        // macOS supervised mode: no capability expansion, Seatbelt blocks silently.
-        // Should fall back to policy summary + --allow suggestions.
         let caps = make_test_caps(); // extensions_enabled defaults to false
         let formatter = DiagnosticFormatter::new(&caps).with_mode(DiagnosticMode::Supervised);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("Sandbox policy:"));
+        assert!(output.contains("No path denials were observed during this session."));
+        assert!(output.contains("The failure may be unrelated to sandbox restrictions."));
+        assert!(output.contains("To grant additional access, re-run with:"));
         assert!(output.contains("--allow <path>"));
-        assert!(!output.contains("No access requests were denied"));
+        assert!(!output.contains("Sandbox policy:"));
     }
 
     #[test]
@@ -2408,35 +2496,12 @@ mod tests {
                 non_sandbox_failure: None,
             });
         let output = formatter.format_footer(1);
-        let denial_idx = match output.find("Likely sandbox denial:") {
-            Some(idx) => idx,
-            None => panic!("missing primary denial block: {output}"),
-        };
-        let why_idx = match output.find(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )) {
-            Some(idx) => idx,
-            None => panic!("missing why follow-up: {output}"),
-        };
-        let learn_idx = match output.find("Learn: nono learn -- <your command>") {
-            Some(idx) => idx,
-            None => panic!("missing learn follow-up: {output}"),
-        };
-        let policy_idx = match output.find("Sandbox policy:") {
-            Some(idx) => idx,
-            None => panic!("missing sandbox policy section: {output}"),
-        };
 
-        assert!(output.contains("Likely sandbox denial:"));
+        assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&format!("Try: --read-file {}", denied.display())));
-        assert!(output.contains(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )));
-        assert!(denial_idx < policy_idx);
-        assert!(why_idx < policy_idx);
-        assert!(learn_idx < policy_idx);
+        assert!(output.contains("No path denials were observed during this session."));
+        assert!(output.contains("Discover paths: nono learn -- <your command>"));
+        assert!(!output.contains("Sandbox policy:"));
     }
 
     #[test]
@@ -2463,12 +2528,9 @@ mod tests {
         assert!(output.contains(
             "The command succeeded, but stderr showed a likely sandbox-related access issue."
         ));
-        assert!(output.contains("Likely sandbox denial:"));
+        assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&denied.display().to_string()));
-        assert!(output.contains(&format!(
-            "Why: nono why --path {} --op read",
-            denied.display()
-        )));
+        assert!(output.contains("Discover paths: nono learn -- <your command>"));
     }
 
     #[test]
@@ -2485,22 +2547,13 @@ mod tests {
                 non_sandbox_failure: None,
             });
         let output = formatter.format_footer(1);
-        let missing_idx = match output.find("Missing path:") {
-            Some(idx) => idx,
-            None => panic!("missing path block missing: {output}"),
-        };
-        let policy_idx = match output.find("Sandbox policy:") {
-            Some(idx) => idx,
-            None => panic!("policy block missing: {output}"),
-        };
 
         assert!(
             output.contains("The command failed, but this does not look like a sandbox denial.")
         );
         assert!(output.contains(&missing.display().to_string()));
-        assert!(missing_idx < policy_idx);
-        assert!(!output.contains("To grant additional access, re-run with:"));
-        assert!(!output.contains("Why: nono why"));
+        assert!(output.contains("To grant additional access, re-run with:"));
+        assert!(output.contains("Query policy: nono why --path <path> --op <read|write|readwrite>"));
     }
 
     #[test]
@@ -2528,22 +2581,20 @@ mod tests {
         );
         assert!(output.contains("Application error:"));
         assert!(output.contains("EEXIST: file already exists"));
-        assert!(!output.contains("To grant additional access, re-run with:"));
-        assert!(!output.contains("Why: nono why"));
+        assert!(output.contains("To grant additional access, re-run with:"));
+        assert!(output.contains("Discover paths: nono learn -- <your command>"));
     }
 
     #[test]
     fn test_supervised_no_denials_extensions_active() {
-        // Linux supervised mode: seccomp-notify is active, empty denials means
-        // nothing was actually blocked.
         let mut caps = make_test_caps();
         caps.set_extensions_enabled(true);
         let formatter = DiagnosticFormatter::new(&caps).with_mode(DiagnosticMode::Supervised);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("No access requests were denied"));
+        assert!(output.contains("No path denials were observed during this session."));
         assert!(output.contains("may be unrelated"));
-        assert!(!output.contains("--allow <path>"));
+        assert!(output.contains("--allow <path>"));
     }
 
     #[test]
@@ -2564,10 +2615,11 @@ mod tests {
             .with_sandbox_violations(&violations);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("Sandbox denied the following operations:"));
-        assert!(output.contains("file-read-data  /Users/alice/.ssh/id_rsa"));
-        assert!(output.contains("mach-lookup  com.apple.logd"));
-        assert!(!output.contains("Sandbox policy:"));
+        assert!(output.contains("Sandbox denial:"));
+        assert!(output.contains("/Users/alice/.ssh/id_rsa (read)"));
+        assert!(output.contains("Also blocked (system services):"));
+        assert!(output.contains("mach-lookup (com.apple.logd)"));
+        assert!(output.contains("System logging"));
     }
 
     #[test]
@@ -2584,7 +2636,7 @@ mod tests {
         let output = formatter.format_footer(1);
 
         assert!(output.contains("/etc/shadow"));
-        assert!(output.contains("blocked by security policy"));
+        assert!(output.contains("Blocked by security policy"));
         assert!(!output.contains("--allow <path>"));
     }
 
@@ -2605,9 +2657,8 @@ mod tests {
         let output = formatter.format_footer(1);
 
         assert!(output.contains(&denied_path.display().to_string()));
-        assert!(output.contains("declined at the prompt"));
-        assert!(output.contains(&format!("--read-file {}", denied_path.display())));
-        assert!(output.contains("pre-grant the path"));
+        assert!(output.contains("Access was declined at the prompt."));
+        assert!(output.contains(&format!("Fix: --read-file {}", denied_path.display())));
     }
 
     #[test]
@@ -2633,7 +2684,8 @@ mod tests {
         assert!(output.contains("/etc/shadow"));
         assert!(output.contains("/home/user/data.txt"));
         assert!(output.contains("blocked by security policy"));
-        assert!(output.contains("granting the requested access mode"));
+        assert!(output.contains("access declined at the prompt"));
+        assert!(output.contains("Some paths are permanently restricted."));
     }
 
     #[test]
@@ -2656,9 +2708,8 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        // The path should appear once in the primary diagnosis and once in the `why` follow-up.
         let count = output.matches("/etc/shadow").count();
-        assert_eq!(count, 2, "Path should be deduplicated");
+        assert_eq!(count, 1, "Path should be deduplicated");
         assert!(!output.contains("Denied paths during this session:"));
     }
 
@@ -2675,7 +2726,7 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.starts_with("nono diagnostic\n───────────────\n"));
+        assert!(!output.starts_with("nono diagnostic"));
         assert!(!output.contains("[nono]"));
     }
 
@@ -2725,12 +2776,11 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("access mode was not granted"));
         assert!(output.contains(&format!(
             "Closest grant: {} (read, group:project_read)",
             dir_path.display()
         )));
-        assert!(output.contains(&format!("Try: --write-file {}", denied_path.display())));
+        assert!(output.contains(&format!("Fix: --write-file {}", denied_path.display())));
         assert!(!output.contains("Denied paths during this session:"));
     }
 
@@ -2762,7 +2812,6 @@ mod tests {
 
     #[test]
     fn test_protected_paths_shown_in_supervised_macos_fallback() {
-        // macOS supervised mode (no extensions) falls back to standard policy format
         let caps = make_test_caps(); // extensions_enabled defaults to false
         let protected = vec![PathBuf::from("/project/config.json")];
         let formatter = DiagnosticFormatter::new(&caps)
@@ -2770,8 +2819,7 @@ mod tests {
             .with_protected_paths(&protected);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("Write-protected"));
-        assert!(output.contains("config.json"));
+        assert!(!output.contains("Write-protected"));
     }
 
     // --- Exit code explanation tests ---
@@ -2879,9 +2927,7 @@ mod tests {
         let formatter = DiagnosticFormatter::new(&caps);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("The command failed."));
-        assert!(output.contains("(exit code 1)"));
-        assert!(output.contains("may be due to sandbox restrictions"));
+        assert!(output.contains("Command exited with code 1."));
     }
 
     #[test]
@@ -2934,8 +2980,6 @@ mod tests {
         let formatter = DiagnosticFormatter::new(&caps);
         let output = formatter.format_footer(42);
 
-        assert!(output.contains("The command failed."));
-        assert!(output.contains("(exit code 42)"));
-        assert!(output.contains("may be due to sandbox restrictions"));
+        assert!(output.contains("Command exited with code 42."));
     }
 }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -999,121 +999,11 @@ impl<'a> DiagnosticFormatter<'a> {
             lines.push("[nono]".to_string());
             self.format_follow_up_guidance(&mut lines, None);
         } else {
-            let policy_blocked = aggregate_denials_from(&all_denials, DenialReason::PolicyBlocked);
-            let insufficient_access =
-                aggregate_denials_from(&all_denials, DenialReason::InsufficientAccess);
-            let user_denied = aggregate_denials_from(&all_denials, DenialReason::UserDenied);
-            let rate_limited = aggregate_denials_from(&all_denials, DenialReason::RateLimited);
-            let backend_errors = aggregate_denials_from(&all_denials, DenialReason::BackendError);
-
-            let mut actionable = Vec::new();
-            actionable.extend(insufficient_access.iter().cloned());
-            actionable.extend(user_denied.iter().cloned());
-            actionable.extend(rate_limited.iter().cloned());
-            actionable.extend(backend_errors.iter().cloned());
-            let denial_count = policy_blocked.len()
-                + insufficient_access.len()
-                + user_denied.len()
-                + rate_limited.len()
-                + backend_errors.len();
-
-            if let Some(primary_denial) = actionable.first() {
-                self.format_primary_denial_guidance(&mut lines, primary_denial);
-            } else if let Some(primary_denial) = policy_blocked.first() {
-                self.format_primary_denial_guidance(&mut lines, primary_denial);
-            }
-
-            if denial_count > 1 {
-                lines.push("[nono]".to_string());
-
-                lines.push("[nono] Denied paths during this session:".to_string());
-
-                if !policy_blocked.is_empty() {
-                    for denial in &policy_blocked {
-                        lines.push(format!(
-                            "[nono]   {} ({}) - blocked by security policy",
-                            denial.path.display(),
-                            access_str(denial.access),
-                        ));
-                    }
-                }
-                if !insufficient_access.is_empty() {
-                    for denial in &insufficient_access {
-                        lines.push(format!(
-                            "[nono]   {} ({}) - path matched the sandbox, but the access mode was not granted",
-                            denial.path.display(),
-                            access_str(denial.access),
-                        ));
-                        if let Some(cap) =
-                            self.closest_covering_capability(&denial.path, denial.access)
-                        {
-                            lines.push(format!(
-                                "[nono]     closest grant: {} ({}, {})",
-                                cap.resolved.display(),
-                                access_str(cap.access),
-                                cap.source,
-                            ));
-                        }
-                    }
-                }
-                if !user_denied.is_empty() {
-                    for denial in &user_denied {
-                        lines.push(format!(
-                            "[nono]   {} ({}) - access declined at the prompt",
-                            denial.path.display(),
-                            access_str(denial.access),
-                        ));
-                    }
-                }
-                if !rate_limited.is_empty() {
-                    for denial in &rate_limited {
-                        lines.push(format!(
-                            "[nono]   {} ({}) - denied after too many approval requests",
-                            denial.path.display(),
-                            access_str(denial.access),
-                        ));
-                    }
-                }
-                if !backend_errors.is_empty() {
-                    for denial in &backend_errors {
-                        lines.push(format!(
-                            "[nono]   {} ({}) - denied because the approval backend failed",
-                            denial.path.display(),
-                            access_str(denial.access),
-                        ));
-                    }
-                }
-
-                lines.push("[nono]".to_string());
-            }
-
-            let has_policy_blocked = !policy_blocked.is_empty();
-            let has_user_denied = !user_denied.is_empty();
-            let has_insufficient_access = !insufficient_access.is_empty();
-
-            if denial_count > 1 {
-                if has_policy_blocked && actionable.is_empty() {
-                    lines.push(
-                        "[nono] Some paths are permanently restricted and cannot be granted with flags."
-                            .to_string(),
-                    );
-                } else if has_user_denied && !has_policy_blocked && !has_insufficient_access {
-                    lines.push(
-                        "[nono] Re-run the command and approve the prompt, or pre-grant the path with a flag below."
-                            .to_string(),
-                    );
-                } else if has_insufficient_access && !has_policy_blocked {
-                    lines.push(
-                        "[nono] Some paths were inside the sandbox, but the requested read/write mode was missing."
-                            .to_string(),
-                    );
-                } else if has_policy_blocked {
-                    lines.push(
-                        "[nono] Some paths are permanently restricted. Others can be fixed by granting the requested access mode."
-                            .to_string(),
-                    );
-                }
-            }
+            // Deduplicate by path, merging access modes. Classification into
+            // actionable vs. policy-blocked is done by the consolidated
+            // formatter using policy_explanations when available.
+            let deduped = dedupe_denials(&all_denials);
+            self.format_consolidated_denial_guidance(&mut lines, &deduped);
 
             // Show non-filesystem violations (mach-lookup, etc.) if any
             if !non_fs_violations.is_empty() {
@@ -1129,15 +1019,6 @@ impl<'a> DiagnosticFormatter<'a> {
         }
 
         lines.join("\n")
-    }
-
-    fn closest_covering_capability(
-        &self,
-        path: &Path,
-        requested: AccessMode,
-    ) -> Option<&crate::capability::FsCapability> {
-        self.closest_covering_capability_any(path)
-            .filter(|cap| !cap.access.contains(requested))
     }
 
     fn actionable_observed_path_hints(&self) -> Vec<ObservedPathHint> {
@@ -1303,91 +1184,123 @@ impl<'a> DiagnosticFormatter<'a> {
         );
     }
 
-    fn format_primary_denial_guidance(&self, lines: &mut Vec<String>, denial: &DenialRecord) {
-        lines.push("[nono] Sandbox denial:".to_string());
-        lines.push(format!(
-            "[nono]   {} ({})",
-            denial.path.display(),
-            access_str(denial.access),
-        ));
+    /// Render the consolidated denial block.
+    ///
+    /// Shows every denied path (truncated past `MAX_INLINE_LIST` entries) with
+    /// a `[permanently restricted]` marker for paths that are blocked by the
+    /// sensitive-path policy, and emits a single `Fix:` line combining the
+    /// `--read`/`--write`/`--allow` flags for all actionable denials.
+    ///
+    /// Classification: if a policy explanation with `reason == "sensitive_path"`
+    /// exists for a path, it is treated as policy-blocked and cannot be fixed
+    /// via flags. Everything else is actionable, including macOS Seatbelt
+    /// denials whose `DenialReason` defaults to `PolicyBlocked` (that reason
+    /// is over-broad on macOS — we trust the query_path result instead).
+    fn format_consolidated_denial_guidance(
+        &self,
+        lines: &mut Vec<String>,
+        denials: &[DenialRecord],
+    ) {
+        const MAX_INLINE_LIST: usize = 10;
 
-        // Look up policy explanation for this path
-        let explanation = self
-            .policy_explanations
-            .iter()
-            .find(|e| e.path == denial.path);
+        let total = denials.len();
+        let mut actionable: Vec<&DenialRecord> = Vec::new();
+        let mut policy_blocked: Vec<&DenialRecord> = Vec::new();
 
-        if let Some(expl) = explanation {
-            // Show inline policy details instead of asking user to run `nono why`
-            if let Some(ref details) = expl.details {
-                lines.push(format!("[nono]   {}", details));
-            }
-            if expl.reason == "sensitive_path" {
-                // Policy-blocked path: needs profile exception
-                lines.push("[nono]".to_string());
-                lines.push(
-                    "[nono] To override, create a user profile with policy.override_deny:"
-                        .to_string(),
-                );
-                lines.push("[nono]   ~/.config/nono/profiles/<name>.json:".to_string());
-                lines.push("[nono]   {".to_string());
-                lines.push(format!(
-                    "[nono]     \"policy\": {{ \"override_deny\": [\"{}\"] }},",
-                    denial.path.display()
-                ));
-                lines.push(format!(
-                    "[nono]     \"filesystem\": {{ \"{}\": [\"{}\"] }}",
-                    access_str(denial.access),
-                    denial.path.display()
-                ));
-                lines.push("[nono]   }".to_string());
-            } else if let Some(ref flag) = expl.suggested_flag {
-                lines.push(format!("[nono]   Fix: {}", flag));
-            }
-        } else {
-            // No policy explanation available — fall back to generic guidance
-            match denial.reason {
-                DenialReason::PolicyBlocked => {
-                    lines.push("[nono]   Blocked by security policy.".to_string());
-                }
-                DenialReason::InsufficientAccess => {
-                    if let Some(cap) = self.closest_covering_capability(&denial.path, denial.access)
-                    {
-                        lines.push(format!(
-                            "[nono]   Closest grant: {} ({}, {})",
-                            cap.resolved.display(),
-                            access_str(cap.access),
-                            cap.source,
-                        ));
-                    }
-                    lines.push(format!(
-                        "[nono]   Fix: {}",
-                        suggested_flag_for_path(&denial.path, denial.access)
-                    ));
-                }
-                DenialReason::UserDenied => {
-                    lines.push("[nono]   Access was declined at the prompt.".to_string());
-                    lines.push(format!(
-                        "[nono]   Fix: {}",
-                        suggested_flag_for_path(&denial.path, denial.access)
-                    ));
-                }
-                DenialReason::RateLimited => {
-                    lines.push("[nono]   Denied after too many approval requests.".to_string());
-                    lines.push(format!(
-                        "[nono]   Fix: {}",
-                        suggested_flag_for_path(&denial.path, denial.access)
-                    ));
-                }
-                DenialReason::BackendError => {
-                    lines.push("[nono]   Approval backend failed.".to_string());
-                    lines.push(format!(
-                        "[nono]   Fix: {}",
-                        suggested_flag_for_path(&denial.path, denial.access)
-                    ));
-                }
+        for denial in denials {
+            if self.is_denial_policy_blocked(denial) {
+                policy_blocked.push(denial);
+            } else {
+                actionable.push(denial);
             }
         }
+
+        let plural_s = if total == 1 { "" } else { "s" };
+        lines.push(format!(
+            "[nono] Sandbox denial: {} path{} blocked.",
+            total, plural_s
+        ));
+
+        for (idx, denial) in denials.iter().enumerate() {
+            if idx >= MAX_INLINE_LIST {
+                lines.push(format!("[nono]   … and {} more", total - idx));
+                break;
+            }
+            let suffix = if self.is_denial_policy_blocked(denial) {
+                "  [permanently restricted]"
+            } else {
+                ""
+            };
+            lines.push(format!(
+                "[nono]   {} ({}){}",
+                denial.path.display(),
+                access_str(denial.access),
+                suffix,
+            ));
+        }
+
+        if !actionable.is_empty() {
+            let flags: Vec<String> = actionable
+                .iter()
+                .map(|d| self.suggested_flag_for_denial(d))
+                .collect();
+            lines.push(format!("[nono] Fix: {}", flags.join(" ")));
+        }
+
+        if !policy_blocked.is_empty() {
+            let n = policy_blocked.len();
+            let (subject, verb) = if n == 1 {
+                ("1 path is", "")
+            } else {
+                ("paths are", "")
+            };
+            let count_prefix = if n == 1 {
+                String::from(subject)
+            } else {
+                format!("{} {}", n, subject)
+            };
+            lines.push("[nono]".to_string());
+            lines.push(format!(
+                "[nono] {}{} permanently restricted — override via a user profile with policy.override_deny.",
+                count_prefix, verb,
+            ));
+        }
+    }
+
+    /// Return true when the denial cannot be fixed by a path flag alone —
+    /// i.e. the path is blocked by the sensitive-path policy and requires a
+    /// profile with `policy.override_deny`.
+    fn is_denial_policy_blocked(&self, denial: &DenialRecord) -> bool {
+        if let Some(expl) = self
+            .policy_explanations
+            .iter()
+            .find(|e| e.path == denial.path)
+        {
+            return expl.reason == "sensitive_path";
+        }
+        // No explanation (e.g. Linux seccomp path without a matching lookup):
+        // trust the DenialRecord reason.
+        denial.reason == DenialReason::PolicyBlocked
+    }
+
+    /// Build the CLI flag suggestion for a single denial. Prefers the
+    /// explanation's `suggested_flag` (which knows about parent-directory
+    /// canonicalization) and falls back to a local computation otherwise.
+    fn suggested_flag_for_denial(&self, denial: &DenialRecord) -> String {
+        if let Some(flag) = self
+            .policy_explanations
+            .iter()
+            .find(|e| e.path == denial.path)
+            .and_then(|e| e.suggested_flag.clone())
+        {
+            // explanations' suggested_flag is of the form "--read /path".
+            // Strip any leading "Fix: " that callers may have prepended.
+            return flag
+                .strip_prefix("Fix: ")
+                .map(str::to_string)
+                .unwrap_or(flag);
+        }
+        suggested_flag_for_path(&denial.path, denial.access)
     }
 
     fn format_grant_help(&self, lines: &mut Vec<String>) {
@@ -1649,25 +1562,48 @@ fn format_non_fs_guidance(lines: &mut Vec<String>, violations: &[&SandboxViolati
     }
 }
 
-/// Aggregate denial records by reason, deduplicating by path and merging access modes.
-fn aggregate_denials_from(denials: &[DenialRecord], reason: DenialReason) -> Vec<DenialRecord> {
-    let mut aggregated = std::collections::BTreeMap::<PathBuf, AccessMode>::new();
+/// Deduplicate denials by path, merging access modes. When the same path
+/// appears with multiple reasons, the most restrictive reason wins
+/// (`PolicyBlocked` > `InsufficientAccess` > `UserDenied` > `RateLimited` >
+/// `BackendError`). Output is sorted by path for stable rendering.
+fn dedupe_denials(denials: &[DenialRecord]) -> Vec<DenialRecord> {
+    let mut by_path = std::collections::BTreeMap::<PathBuf, (AccessMode, DenialReason)>::new();
 
-    for denial in denials.iter().filter(|d| d.reason == reason) {
-        aggregated
+    for denial in denials {
+        by_path
             .entry(denial.path.clone())
-            .and_modify(|existing| *existing = merge_access_modes(*existing, denial.access))
-            .or_insert(denial.access);
+            .and_modify(|(access, reason)| {
+                *access = merge_access_modes(*access, denial.access);
+                *reason = stricter_reason(reason.clone(), denial.reason.clone());
+            })
+            .or_insert_with(|| (denial.access, denial.reason.clone()));
     }
 
-    aggregated
+    by_path
         .into_iter()
-        .map(|(path, access)| DenialRecord {
+        .map(|(path, (access, reason))| DenialRecord {
             path,
             access,
-            reason: reason.clone(),
+            reason,
         })
         .collect()
+}
+
+fn stricter_reason(a: DenialReason, b: DenialReason) -> DenialReason {
+    fn rank(r: &DenialReason) -> u8 {
+        match r {
+            DenialReason::PolicyBlocked => 5,
+            DenialReason::InsufficientAccess => 4,
+            DenialReason::UserDenied => 3,
+            DenialReason::RateLimited => 2,
+            DenialReason::BackendError => 1,
+        }
+    }
+    if rank(&a) >= rank(&b) {
+        a
+    } else {
+        b
+    }
 }
 
 /// Map a Seatbelt operation name to an `AccessMode`.
@@ -2635,8 +2571,11 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("/etc/shadow"));
-        assert!(output.contains("Blocked by security policy"));
+        assert!(output.contains("Sandbox denial: 1 path blocked."));
+        assert!(output.contains("/etc/shadow (read)  [permanently restricted]"));
+        assert!(output.contains("permanently restricted — override via a user profile"));
+        // Policy-blocked paths cannot be fixed with a path flag.
+        assert!(!output.contains("Fix: --read /etc/shadow"));
         assert!(!output.contains("--allow <path>"));
     }
 
@@ -2656,9 +2595,11 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
+        assert!(output.contains("Sandbox denial: 1 path blocked."));
         assert!(output.contains(&denied_path.display().to_string()));
-        assert!(output.contains("Access was declined at the prompt."));
         assert!(output.contains(&format!("Fix: --read-file {}", denied_path.display())));
+        // User-denied paths are actionable, not policy-blocked.
+        assert!(!output.contains("[permanently restricted]"));
     }
 
     #[test]
@@ -2681,11 +2622,19 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("/etc/shadow"));
-        assert!(output.contains("/home/user/data.txt"));
-        assert!(output.contains("blocked by security policy"));
-        assert!(output.contains("access declined at the prompt"));
-        assert!(output.contains("Some paths are permanently restricted."));
+        assert!(output.contains("Sandbox denial: 2 paths blocked."));
+        // Policy-blocked path gets the marker.
+        assert!(output.contains("/etc/shadow (read)  [permanently restricted]"));
+        // Actionable path is listed without the marker.
+        assert!(output.contains("/home/user/data.txt (read)"));
+        assert!(!output.contains("/home/user/data.txt (read)  [permanently restricted]"));
+        // Consolidated Fix line covers only the actionable path. The suggested
+        // target falls back to the nearest existing parent directory since the
+        // path itself doesn't exist in the test environment.
+        assert!(output.contains("Fix: --read "));
+        assert!(!output.contains("Fix: --read /etc/shadow"));
+        // The permanent-restriction note appears once for the policy-blocked path.
+        assert!(output.contains("1 path is permanently restricted"));
     }
 
     #[test]
@@ -2711,6 +2660,76 @@ mod tests {
         let count = output.matches("/etc/shadow").count();
         assert_eq!(count, 1, "Path should be deduplicated");
         assert!(!output.contains("Denied paths during this session:"));
+    }
+
+    #[test]
+    fn test_supervised_consolidated_fix_combines_all_actionable() {
+        let caps = make_test_caps();
+        let dir = tempdir().expect("tempdir should be created");
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        std::fs::write(&a, "a").expect("write a");
+        std::fs::write(&b, "b").expect("write b");
+        let denials = vec![
+            DenialRecord {
+                path: a.clone(),
+                access: AccessMode::Read,
+                reason: DenialReason::UserDenied,
+            },
+            DenialRecord {
+                path: b.clone(),
+                access: AccessMode::Write,
+                reason: DenialReason::InsufficientAccess,
+            },
+        ];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials);
+        let output = formatter.format_footer(1);
+
+        // Single Fix line covers both paths.
+        let fix_lines: Vec<&str> = output
+            .lines()
+            .filter(|line| line.contains("Fix: "))
+            .collect();
+        assert_eq!(
+            fix_lines.len(),
+            1,
+            "expected one consolidated Fix line: {output}"
+        );
+        assert!(fix_lines[0].contains(&format!("--read-file {}", a.display())));
+        assert!(fix_lines[0].contains(&format!("--write-file {}", b.display())));
+        assert!(!output.contains("[permanently restricted]"));
+    }
+
+    #[test]
+    fn test_supervised_consolidated_list_truncates_beyond_cap() {
+        // Zero-pad the index so paths sort in numeric order.
+        let caps = make_test_caps();
+        let denials: Vec<DenialRecord> = (0..15)
+            .map(|i| DenialRecord {
+                path: PathBuf::from(format!("/tmp/denied-{i:02}")),
+                access: AccessMode::Read,
+                reason: DenialReason::UserDenied,
+            })
+            .collect();
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains("Sandbox denial: 15 paths blocked."));
+        // First 10 paths listed, remaining 5 collapsed.
+        assert!(output.contains("/tmp/denied-00 "));
+        assert!(output.contains("/tmp/denied-09 "));
+        assert!(!output.contains("/tmp/denied-10 "));
+        assert!(output.contains("… and 5 more"));
+        // Fix line still covers all 15 paths.
+        assert_eq!(
+            output.lines().filter(|l| l.contains("Fix: ")).count(),
+            1,
+            "expected one consolidated Fix line"
+        );
     }
 
     #[test]
@@ -2743,8 +2762,13 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains("/tmp/flood"));
-        assert!(output.contains("too many approval requests"));
+        assert!(output.contains("Sandbox denial: 1 path blocked."));
+        assert!(output.contains("/tmp/flood (read)"));
+        // Rate-limited denials are still actionable via a path flag. The
+        // suggested target falls back to the nearest existing parent since
+        // /tmp/flood itself doesn't exist.
+        assert!(output.contains("Fix: --read "));
+        assert!(!output.contains("[permanently restricted]"));
     }
 
     #[test]
@@ -2776,10 +2800,9 @@ mod tests {
             .with_denials(&denials);
         let output = formatter.format_footer(1);
 
-        assert!(output.contains(&format!(
-            "Closest grant: {} (read, group:project_read)",
-            dir_path.display()
-        )));
+        // The "Closest grant" hint moved out of the consolidated footer;
+        // users can recover it with `nono why` if they want the detail.
+        assert!(!output.contains("Closest grant:"));
         assert!(output.contains(&format!("Fix: --write-file {}", denied_path.display())));
         assert!(!output.contains("Denied paths during this session:"));
     }


### PR DESCRIPTION
Improve user interaction for profile saving, refine sandbox log attribution on macOS, and make sandbox denial diagnostics more actionable and concise.

-   **Profile Management & Prompts:**
Require users to type 'override' for policy override confirmations, enhancing
security for irreversible actions. New user profiles are now prevented
from shadowing built-in profiles of the same name. Terminal settings
are restored after interactive prompts to prevent unexpected state
issues. Policy override warnings are also now highlighted in red.

-   **Sandbox Log Attribution (macOS):**
Sandbox log entries are now filtered by both PID and process name,
significantly improving attribution accuracy and reducing false positives
from unrelated sandboxed applications. Non-filesystem violations
are also dropped from historical log queries to reduce noise.

-   **Consolidated Denial Diagnostics:**
The output for sandbox denials has been refactored for clarity. Denied
paths are consolidated and deduplicated, merging access modes. Paths that
are permanently restricted by security policy are explicitly marked with
`[permanently restricted]`. A single "Fix:" line is generated, combining
all actionable `--read`, `--write`, or `--allow` flags. Long lists of
denied paths are truncated (max 10 entries plus a summary), and
guidance for policy-blocked paths now clearly suggests profile overrides.
The verbose "Closest grant" detail has been removed from the default
output for conciseness.