### PR TITLE
refactor(test): improve test helpers and network test organization

### DIFF
--- a/tests/integration/test_network.sh
+++ b/tests/integration/test_network.sh
@@ -75,9 +75,6 @@ if command_exists curl; then
     expect_success "curl works by default" \
         "$NONO_BIN" run --allow "$TMPDIR" -- curl -s --max-time 10 https://example.com >/dev/null
 
-    expect_failure "proxy mode blocks direct curl bypass with --noproxy" \
-        "$NONO_BIN" run --allow "$TMPDIR" --allow-domain api.openai.com -- curl -s --noproxy '*' --max-time 10 https://example.com >/dev/null
-
     # Keep this assertion on a profile that still bundles a network_profile.
     # claude-code used to carry a profile-level proxy allowlist, but the current
     # built-in profile no longer sets network.network_profile in policy.json, so

--- a/tests/integration/test_network_proxy.sh
+++ b/tests/integration/test_network_proxy.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Network Proxy Tests
+# Verifies proxy-routed allow_domain behavior across Linux and macOS.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+echo ""
+echo -e "${BLUE}=== Network Proxy Tests ===${NC}"
+
+verify_nono_binary
+if ! require_working_sandbox "network proxy suite"; then
+    print_summary
+    exit 0
+fi
+
+TMPDIR=$(setup_test_dir)
+trap 'cleanup_test_dir "$TMPDIR"' EXIT
+
+PROFILE="$TMPDIR/proxy-allow-domain.json"
+cat > "$PROFILE" <<'JSON'
+{
+  "meta": { "name": "proxy-allow-domain", "version": "1.0.0" },
+  "workdir": { "access": "readwrite" },
+  "network": {
+    "allow_domain": [
+      "github.com",
+      "*.hashicorp.com"
+    ]
+  }
+}
+JSON
+
+echo ""
+echo "Test directory: $TMPDIR"
+echo ""
+
+if ! command_exists curl; then
+    skip_test "network proxy allow_domain tests" "curl not installed"
+    print_summary
+    exit 0
+fi
+
+# =============================================================================
+# allow_domain proxy routing
+# =============================================================================
+
+echo "--- allow_domain proxy routing ---"
+
+expect_success_output_equals "exact allow_domain host routes through proxy" "200" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    curl -sS --max-time 10 --connect-timeout 3 \
+        -o /dev/null -w '%{http_code}' https://github.com/
+
+expect_success_output_equals "wildcard allow_domain host routes through proxy" "200" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    curl -sS --max-time 10 --connect-timeout 3 \
+        -o /dev/null -w '%{http_code}' https://releases.hashicorp.com/
+
+# =============================================================================
+# NO_PROXY handling
+# =============================================================================
+
+echo ""
+echo "--- NO_PROXY handling ---"
+
+expect_success_output_equals "proxy mode NO_PROXY only contains loopback" \
+    $'localhost,127.0.0.1\nlocalhost,127.0.0.1' \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    sh -c 'printf "%s\n%s" "$NO_PROXY" "$no_proxy"'
+
+expect_success_output_not_contains "exact allow_domain host is not in NO_PROXY" "github.com" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    sh -c 'printf "%s\n%s" "$NO_PROXY" "$no_proxy"'
+
+expect_success_output_not_contains "wildcard allow_domain host is not in NO_PROXY" "*.hashicorp.com" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    sh -c 'printf "%s\n%s" "$NO_PROXY" "$no_proxy"'
+
+expect_success_output_not_contains "wildcard concrete host is not in NO_PROXY" "releases.hashicorp.com" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    sh -c 'printf "%s\n%s" "$NO_PROXY" "$no_proxy"'
+
+# =============================================================================
+# Bypass and deny behavior
+# =============================================================================
+
+echo ""
+echo "--- bypass and deny behavior ---"
+
+expect_failure "direct curl bypass is blocked for exact allow_domain host" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    curl -sS --noproxy '*' --max-time 5 --connect-timeout 3 https://github.com/
+
+expect_failure "host outside allow_domain is denied by proxy" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" -- \
+    curl -sS --max-time 5 --connect-timeout 3 https://example.com/
+
+# =============================================================================
+# allow-net override
+# =============================================================================
+
+echo ""
+echo "--- allow-net override ---"
+
+expect_success_output_not_contains "allow-net clears nono proxy token" "NONO_PROXY_TOKEN=" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" --allow-net -- env
+
+expect_success_output_not_contains "allow-net clears nono HTTPS proxy" "HTTPS_PROXY=http://nono:" \
+    "$NONO_BIN" run -s --allow-cwd --profile "$PROFILE" --allow-net -- env
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+print_summary

--- a/tests/lib/test_helpers.sh
+++ b/tests/lib/test_helpers.sh
@@ -165,6 +165,108 @@ expect_output_not_contains() {
     fi
 }
 
+# Check command succeeds and output exactly matches a string after trimming CR.
+# Usage: expect_success_output_equals "test name" "expected output" command args...
+expect_success_output_equals() {
+    local name="$1"
+    local expected_str="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    set +e
+    local output
+    output=$("$@" </dev/null 2>&1)
+    local exit_code=$?
+    set -e
+
+    local normalized
+    normalized=$(printf '%s' "$output" | tr -d '\r')
+
+    if [[ "$exit_code" -eq 0 && "$normalized" == "$expected_str" ]]; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected exit code 0 and output: '$expected_str'"
+    echo "       Exit code: $exit_code"
+    if [[ -n "$output" ]]; then
+        local stripped
+        stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+        echo "       Actual output: ${stripped:0:2000}"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+# Check command succeeds and output contains a fixed string.
+# Usage: expect_success_output_contains "test name" "expected string" command args...
+expect_success_output_contains() {
+    local name="$1"
+    local expected_str="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    set +e
+    local output
+    output=$("$@" </dev/null 2>&1)
+    local exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] && printf '%s' "$output" | grep -Fq -- "$expected_str"; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected exit code 0 and output containing: '$expected_str'"
+    echo "       Exit code: $exit_code"
+    if [[ -n "$output" ]]; then
+        local stripped
+        stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+        echo "       Actual output: ${stripped:0:2000}"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+# Check command succeeds and output does not contain a fixed string.
+# Usage: expect_success_output_not_contains "test name" "unexpected string" command args...
+expect_success_output_not_contains() {
+    local name="$1"
+    local unexpected_str="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    set +e
+    local output
+    output=$("$@" </dev/null 2>&1)
+    local exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] && ! printf '%s' "$output" | grep -Fq -- "$unexpected_str"; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected exit code 0 and output without: '$unexpected_str'"
+    echo "       Exit code: $exit_code"
+    if [[ -n "$output" ]]; then
+        local stripped
+        stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+        echo "       Actual output: ${stripped:0:2000}"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
 # Skip a test with a message
 skip_test() {
     local name="$1"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -137,6 +137,7 @@ SUITES=(
     "test_system_paths.sh:System Paths"
     "test_binary_exec.sh:Binary Execution"
     "test_network.sh:Network"
+    "test_network_proxy.sh:Network Proxy"
     "test_commands.sh:Dangerous Commands"
     "test_edge_cases.sh:Edge Cases"
     "test_policy_queries.sh:Policy Queries"
@@ -183,17 +184,22 @@ launch_suite() {
     local output_file="$2"
 
     local exit_file="${output_file%.out}.exit"
+    local rc
 
     if command -v timeout >/dev/null 2>&1; then
+        set +e
         timeout "$SUITE_TIMEOUT" bash "$SCRIPT_DIR/integration/$script" > "$output_file" 2>&1
         rc=$?
+        set -e
         if [[ "$rc" -eq 124 ]]; then
             echo "" >> "$output_file"
             echo "SUITE TIMED OUT after ${SUITE_TIMEOUT}s" >> "$output_file"
         fi
         echo "$rc" > "$exit_file"
     else
+        set +e
         bash "$SCRIPT_DIR/integration/$script" > "$output_file" 2>&1; rc=$?
+        set -e
         echo "$rc" > "$exit_file"
     fi
 }


### PR DESCRIPTION
As part of #763 related to #760 start increase of proxy / networking smoke tests 

- Add new `expect_success_output_equals`, `expect_success_output_contains`, and `expect_success_output_not_contains` helper functions for better output assertions in tests.
- Move network proxy-related tests from `test_network.sh` to a new dedicated integration suite, `test_network_proxy.sh`.
- Add `test_network_proxy.sh` to the list of integration test suites to be run.
- Enhance the `launch_suite` function to reliably capture the exit code of test scripts, even when `set -e` is active.