### PR TITLE
fix: unify path canonicalization with ancestor-walk fallback

### DIFF
--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -11,7 +11,7 @@
 
 use super::*;
 use crate::trust_intercept::TrustInterceptor;
-use nono::AccessMode;
+use nono::{try_canonicalize, AccessMode};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InitialCapability {
@@ -231,8 +231,7 @@ pub(super) fn handle_seccomp_notification(
             return Ok(());
         }
     };
-    let canonicalized =
-        std::fs::canonicalize(&resolved_path).unwrap_or_else(|_| resolved_path.clone());
+    let canonicalized = try_canonicalize(&resolved_path);
 
     // For the initial capability match, map a grandchild's /proc/<tgid> path back to the
     // direct child's /proc/<child_pid>, because initial_caps are built from the direct

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -5,7 +5,7 @@
 //! to be allowed in a nono profile.
 
 use crate::cli::LearnArgs;
-use nono::{AccessMode, NonoError, Result};
+use nono::{try_canonicalize, AccessMode, NonoError, Result};
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -1565,7 +1565,7 @@ fn process_accesses(
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn canonicalize_existing_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    try_canonicalize(path)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -44,12 +44,17 @@ pub fn validate_caps_against_protected_roots(
     protected_roots: &[PathBuf],
     allow_parent_of_protected: bool,
 ) -> Result<()> {
+    // Pre-canonicalize once so the per-capability loop doesn't repeat the work.
+    let resolved_roots: Vec<PathBuf> = protected_roots
+        .iter()
+        .map(|p| try_canonicalize(p))
+        .collect();
     for cap in caps.fs_capabilities() {
         validate_requested_path_against_protected_roots(
             &cap.resolved,
             cap.is_file,
             &cap.source.to_string(),
-            protected_roots,
+            &resolved_roots,
             allow_parent_of_protected,
         )?;
     }
@@ -77,8 +82,9 @@ pub fn validate_requested_path_against_protected_roots(
     let requested_path = try_canonicalize(path);
 
     for protected_root in protected_roots {
-        let inside_protected = requested_path.starts_with(protected_root);
-        let parent_of_protected = !is_file && protected_root.starts_with(&requested_path);
+        let resolved_root = try_canonicalize(protected_root);
+        let inside_protected = requested_path.starts_with(&resolved_root);
+        let parent_of_protected = !is_file && resolved_root.starts_with(&requested_path);
 
         // inside_protected is always a hard error on all platforms
         if inside_protected {
@@ -86,7 +92,7 @@ pub fn validate_requested_path_against_protected_roots(
                 "Refusing to grant '{}' (source: {}) because it overlaps protected nono state root '{}'.",
                 requested_path.display(),
                 source,
-                protected_root.display(),
+                resolved_root.display(),
             )));
         }
 
@@ -97,7 +103,7 @@ pub fn validate_requested_path_against_protected_roots(
                 "Refusing to grant '{}' (source: {}) because it overlaps protected nono state root '{}'.",
                 requested_path.display(),
                 source,
-                protected_root.display(),
+                resolved_root.display(),
             )));
         }
     }
@@ -126,14 +132,15 @@ pub fn overlapping_protected_root(
     let requested_path = try_canonicalize(path);
 
     for protected_root in protected_roots {
-        let inside_protected = requested_path.starts_with(protected_root);
+        let resolved_root = try_canonicalize(protected_root);
+        let inside_protected = requested_path.starts_with(&resolved_root);
         if inside_protected {
-            return Some(protected_root.clone());
+            return Some(resolved_root);
         }
 
-        let parent_of_protected = !is_file && protected_root.starts_with(&requested_path);
+        let parent_of_protected = !is_file && resolved_root.starts_with(&requested_path);
         if parent_of_protected && !cfg!(target_os = "macos") {
-            return Some(protected_root.clone());
+            return Some(resolved_root);
         }
     }
 

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -3,7 +3,7 @@
 //! These checks enforce a hard fail if initial sandbox capabilities overlap
 //! with internal CLI state roots (currently `~/.nono`).
 
-use nono::{CapabilitySet, NonoError, Result};
+use nono::{try_canonicalize, CapabilitySet, NonoError, Result};
 use std::path::{Path, PathBuf};
 
 /// Resolved internal state roots that must not be accessible by the sandboxed child.
@@ -20,7 +20,7 @@ impl ProtectedRoots {
     /// Today this protects the full `~/.nono` subtree.
     pub fn from_defaults() -> Result<Self> {
         let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
-        let state_root = resolve_path(&home.join(".nono"));
+        let state_root = try_canonicalize(&home.join(".nono"));
         Ok(Self {
             roots: vec![state_root],
         })
@@ -74,8 +74,8 @@ pub fn validate_requested_path_against_protected_roots(
     protected_roots: &[PathBuf],
     allow_parent_of_protected: bool,
 ) -> Result<()> {
-    let requested_path = resolve_path(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| resolve_path(p)).collect();
+    let requested_path = try_canonicalize(path);
+    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| try_canonicalize(p)).collect();
 
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
@@ -124,8 +124,8 @@ pub fn overlapping_protected_root(
     is_file: bool,
     protected_roots: &[PathBuf],
 ) -> Option<PathBuf> {
-    let requested_path = resolve_path(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| resolve_path(p)).collect();
+    let requested_path = try_canonicalize(path);
+    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| try_canonicalize(p)).collect();
 
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
@@ -159,7 +159,7 @@ pub(crate) fn emit_protected_root_deny_rules(
     }
 
     for root in protected_roots {
-        let resolved = resolve_path(root);
+        let resolved = try_canonicalize(root);
         emit_deny_rules_for_path(&resolved, caps)?;
 
         // Also emit for the canonical path if it differs (important on macOS
@@ -190,37 +190,6 @@ fn emit_deny_rules_for_path(_path: &Path, _caps: &mut CapabilitySet) -> Result<(
     Ok(())
 }
 
-/// Resolve path by canonicalizing the full path, or canonicalizing the longest
-/// existing ancestor and appending remaining components.
-fn resolve_path(path: &Path) -> PathBuf {
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-
-    let mut remaining = Vec::new();
-    let mut current = path.to_path_buf();
-    loop {
-        if let Ok(canonical) = current.canonicalize() {
-            let mut result = canonical;
-            for component in remaining.iter().rev() {
-                result = result.join(component);
-            }
-            return result;
-        }
-
-        match current.file_name() {
-            Some(name) => {
-                remaining.push(name.to_os_string());
-                if !current.pop() {
-                    break;
-                }
-            }
-            None => break,
-        }
-    }
-
-    path.to_path_buf()
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -75,7 +75,10 @@ pub fn validate_requested_path_against_protected_roots(
     allow_parent_of_protected: bool,
 ) -> Result<()> {
     let requested_path = try_canonicalize(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| try_canonicalize(p)).collect();
+    let resolved_roots: Vec<PathBuf> = protected_roots
+        .iter()
+        .map(|p| try_canonicalize(p))
+        .collect();
 
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
@@ -125,7 +128,10 @@ pub fn overlapping_protected_root(
     protected_roots: &[PathBuf],
 ) -> Option<PathBuf> {
     let requested_path = try_canonicalize(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| try_canonicalize(p)).collect();
+    let resolved_roots: Vec<PathBuf> = protected_roots
+        .iter()
+        .map(|p| try_canonicalize(p))
+        .collect();
 
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
@@ -189,7 +195,6 @@ fn emit_deny_rules_for_path(path: &Path, caps: &mut CapabilitySet) -> Result<()>
 fn emit_deny_rules_for_path(_path: &Path, _caps: &mut CapabilitySet) -> Result<()> {
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -75,12 +75,8 @@ pub fn validate_requested_path_against_protected_roots(
     allow_parent_of_protected: bool,
 ) -> Result<()> {
     let requested_path = try_canonicalize(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots
-        .iter()
-        .map(|p| try_canonicalize(p))
-        .collect();
 
-    for protected_root in &resolved_roots {
+    for protected_root in protected_roots {
         let inside_protected = requested_path.starts_with(protected_root);
         let parent_of_protected = !is_file && protected_root.starts_with(&requested_path);
 
@@ -128,12 +124,8 @@ pub fn overlapping_protected_root(
     protected_roots: &[PathBuf],
 ) -> Option<PathBuf> {
     let requested_path = try_canonicalize(path);
-    let resolved_roots: Vec<PathBuf> = protected_roots
-        .iter()
-        .map(|p| try_canonicalize(p))
-        .collect();
 
-    for protected_root in &resolved_roots {
+    for protected_root in protected_roots {
         let inside_protected = requested_path.starts_with(protected_root);
         if inside_protected {
             return Some(protected_root.clone());

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -5,7 +5,7 @@
 
 use crate::config;
 use colored::Colorize;
-use nono::{AccessMode, CapabilitySet, NonoError, Result};
+use nono::{try_canonicalize, AccessMode, CapabilitySet, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -65,32 +65,10 @@ pub fn query_path(
     caps: &CapabilitySet,
     overridden_paths: &[std::path::PathBuf],
 ) -> Result<QueryResult> {
-    // Canonicalize the path for proper comparison
-    let canonical = if path.exists() {
-        path.canonicalize()
-            .map_err(|e| NonoError::PathCanonicalization {
-                path: path.to_path_buf(),
-                source: e,
-            })?
-    } else {
-        // For non-existent paths, try to canonicalize the parent
-        if let Some(parent) = path.parent() {
-            if parent.exists() {
-                let parent_canonical =
-                    parent
-                        .canonicalize()
-                        .map_err(|e| NonoError::PathCanonicalization {
-                            path: parent.to_path_buf(),
-                            source: e,
-                        })?;
-                parent_canonical.join(path.file_name().unwrap_or_default())
-            } else {
-                path.to_path_buf()
-            }
-        } else {
-            path.to_path_buf()
-        }
-    };
+    // Canonicalize the path for proper comparison using ancestor-walk fallback
+    // so that macOS symlinks (/tmp → /private/tmp) are resolved correctly even
+    // when the leaf path doesn't exist yet.
+    let canonical = try_canonicalize(path);
 
     // Check if this path is covered by an override_deny exemption
     let is_overridden = overridden_paths

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -14,7 +14,7 @@ use crate::rollback_session::{
 use crate::theme;
 use colored::Colorize;
 use nono::undo::{MerkleTree, ObjectStore, SnapshotManager};
-use nono::{NonoError, Result};
+use nono::{try_canonicalize, NonoError, Result};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -29,8 +29,8 @@ type SessionChanges<'a> = (&'a SessionInfo, (usize, usize, usize));
 fn canonical_candidates(path: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::with_capacity(2);
 
-    // Primary: canonicalize if possible, otherwise use as-is
-    let primary = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    // Primary: canonicalize using ancestor-walk fallback
+    let primary = try_canonicalize(path);
     candidates.push(primary.clone());
 
     // macOS symlink aliases: try both directions

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -15,6 +15,7 @@
 //! - **Library code**: No process management, no CLI assumptions
 
 use crate::capability::{AccessMode, CapabilitySet, CapabilitySource};
+use crate::path::try_canonicalize;
 use std::path::{Path, PathBuf};
 
 /// Why a path access was denied during a supervised session.
@@ -1175,7 +1176,7 @@ impl<'a> DiagnosticFormatter<'a> {
         &self,
         path: &Path,
     ) -> Option<&crate::capability::FsCapability> {
-        let canonical = canonicalize_query_path(path);
+        let canonical = try_canonicalize(path);
         let mut best_covering: Option<&crate::capability::FsCapability> = None;
         let mut best_covering_score = 0usize;
 
@@ -1614,25 +1615,6 @@ fn merge_access_modes(existing: AccessMode, new: AccessMode) -> AccessMode {
     }
 }
 
-fn canonicalize_query_path(path: &Path) -> PathBuf {
-    if path.exists() {
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-    } else if let Some(parent) = path.parent() {
-        if parent.exists() {
-            match parent.canonicalize() {
-                Ok(parent_canonical) => match path.file_name() {
-                    Some(name) => parent_canonical.join(name),
-                    None => path.to_path_buf(),
-                },
-                Err(_) => path.to_path_buf(),
-            }
-        } else {
-            path.to_path_buf()
-        }
-    } else {
-        path.to_path_buf()
-    }
-}
 
 fn suggested_flag_for_path(path: &Path, requested: AccessMode) -> String {
     let (flag, target) = suggested_flag_parts(path, requested);

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1615,7 +1615,6 @@ fn merge_access_modes(existing: AccessMode, new: AccessMode) -> AccessMode {
     }
 }
 
-
 fn suggested_flag_for_path(path: &Path, requested: AccessMode) -> String {
     let (flag, target) = suggested_flag_parts(path, requested);
     format!("{flag} {}", target.display())

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -52,6 +52,7 @@ pub mod keystore;
 pub mod manifest;
 pub mod manifest_convert;
 pub mod net_filter;
+pub mod path;
 pub mod query;
 pub mod sandbox;
 pub mod state;
@@ -76,6 +77,7 @@ pub use keystore::{
     validate_env_uri, validate_file_uri, validate_keyring_uri, validate_op_uri, LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
+pub use path::try_canonicalize;
 #[cfg(target_os = "linux")]
 pub use sandbox::{detect_abi, is_wsl2, DetectedAbi};
 pub use sandbox::{Sandbox, SupportInfo};

--- a/crates/nono/src/path.rs
+++ b/crates/nono/src/path.rs
@@ -56,15 +56,15 @@ mod tests {
 
     #[test]
     fn existing_path_canonicalizes() {
-        let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().canonicalize().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
         assert_eq!(try_canonicalize(dir.path()), canonical);
     }
 
     #[test]
     fn nonexistent_leaf_uses_ancestor() {
-        let dir = tempfile::tempdir().unwrap();
-        let canonical_dir = dir.path().canonicalize().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical_dir = dir.path().canonicalize().expect("canonicalize");
         let nonexistent = dir.path().join("does_not_exist");
         let result = try_canonicalize(&nonexistent);
         assert_eq!(result, canonical_dir.join("does_not_exist"));
@@ -72,8 +72,8 @@ mod tests {
 
     #[test]
     fn nonexistent_nested_uses_deepest_ancestor() {
-        let dir = tempfile::tempdir().unwrap();
-        let canonical_dir = dir.path().canonicalize().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical_dir = dir.path().canonicalize().expect("canonicalize");
         let nonexistent = dir.path().join("a").join("b").join("c");
         let result = try_canonicalize(&nonexistent);
         assert_eq!(result, canonical_dir.join("a").join("b").join("c"));
@@ -81,16 +81,16 @@ mod tests {
 
     #[test]
     fn existing_symlink_resolves_through() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
         let real_file = dir.path().join("real.txt");
-        fs::write(&real_file, "hello").unwrap();
+        fs::write(&real_file, "hello").expect("write file");
         let link = dir.path().join("link.txt");
         #[cfg(unix)]
-        std::os::unix::fs::symlink(&real_file, &link).unwrap();
+        std::os::unix::fs::symlink(&real_file, &link).expect("symlink");
         #[cfg(unix)]
         {
             let result = try_canonicalize(&link);
-            assert_eq!(result, real_file.canonicalize().unwrap());
+            assert_eq!(result, real_file.canonicalize().expect("canonicalize"));
         }
     }
 }

--- a/crates/nono/src/path.rs
+++ b/crates/nono/src/path.rs
@@ -16,7 +16,14 @@ pub fn try_canonicalize(path: &Path) -> PathBuf {
     if let Ok(canonical) = path.canonicalize() {
         return canonical;
     }
+    try_canonicalize_ancestor_walk(path)
+}
 
+/// Ancestor-walk canonicalization, skipping the initial `canonicalize()` attempt.
+///
+/// Use this when `std::fs::canonicalize` has already been tried and failed,
+/// to avoid a redundant syscall.
+pub(crate) fn try_canonicalize_ancestor_walk(path: &Path) -> PathBuf {
     let mut remaining = Vec::new();
     let mut current = path.to_path_buf();
     loop {

--- a/crates/nono/src/path.rs
+++ b/crates/nono/src/path.rs
@@ -1,0 +1,89 @@
+//! Path utilities shared across nono library and CLI.
+
+use std::path::{Path, PathBuf};
+
+/// Canonicalize a path using an ancestor-walk fallback.
+///
+/// Unlike `std::fs::canonicalize`, this never returns an error for
+/// non-existent paths. When the full path cannot be canonicalized (e.g. a
+/// path component doesn't exist yet), it walks up to find the longest
+/// existing ancestor, canonicalizes that, and re-appends the remaining
+/// components.
+///
+/// This correctly handles macOS symlinks such as `/tmp` → `/private/tmp`
+/// even when the leaf path does not exist yet.
+pub fn try_canonicalize(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    let mut remaining = Vec::new();
+    let mut current = path.to_path_buf();
+    loop {
+        if let Ok(canonical) = current.canonicalize() {
+            let mut result = canonical;
+            for component in remaining.iter().rev() {
+                result = result.join(component);
+            }
+            return result;
+        }
+
+        match current.file_name() {
+            Some(name) => {
+                remaining.push(name.to_os_string());
+                if !current.pop() {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+
+    path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn existing_path_canonicalizes() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        assert_eq!(try_canonicalize(dir.path()), canonical);
+    }
+
+    #[test]
+    fn nonexistent_leaf_uses_ancestor() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical_dir = dir.path().canonicalize().unwrap();
+        let nonexistent = dir.path().join("does_not_exist");
+        let result = try_canonicalize(&nonexistent);
+        assert_eq!(result, canonical_dir.join("does_not_exist"));
+    }
+
+    #[test]
+    fn nonexistent_nested_uses_deepest_ancestor() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical_dir = dir.path().canonicalize().unwrap();
+        let nonexistent = dir.path().join("a").join("b").join("c");
+        let result = try_canonicalize(&nonexistent);
+        assert_eq!(result, canonical_dir.join("a").join("b").join("c"));
+    }
+
+    #[test]
+    fn existing_symlink_resolves_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_file = dir.path().join("real.txt");
+        fs::write(&real_file, "hello").unwrap();
+        let link = dir.path().join("link.txt");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_file, &link).unwrap();
+        #[cfg(unix)]
+        {
+            let result = try_canonicalize(&link);
+            assert_eq!(result, real_file.canonicalize().unwrap());
+        }
+    }
+}

--- a/crates/nono/src/query.rs
+++ b/crates/nono/src/query.rs
@@ -4,6 +4,7 @@
 //! by a given capability set, without actually applying the sandbox.
 
 use crate::capability::{AccessMode, CapabilitySet};
+use crate::path::try_canonicalize;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -70,22 +71,29 @@ impl QueryContext {
     #[must_use]
     pub fn query_path(&self, path: &Path, requested: AccessMode) -> QueryResult {
         // Try to canonicalize for the most accurate comparison.
-        // Falls back to raw path if the target doesn't exist yet.
-        let canonical = std::fs::canonicalize(path).ok();
-        let query_path = canonical.as_deref().unwrap_or(path);
+        // Falls back to ancestor-walk if the target doesn't exist yet so that
+        // macOS symlinks (/tmp → /private/tmp) are resolved correctly.
+        let full_canonical = std::fs::canonicalize(path).ok();
+        let query_path_buf;
+        let query_path: &Path = if let Some(ref c) = full_canonical {
+            c.as_path()
+        } else {
+            query_path_buf = try_canonicalize(path);
+            query_path_buf.as_path()
+        };
 
         for cap in self.caps.fs_capabilities() {
             let covers = if cap.is_file {
                 // File capability: exact match against resolved, or if not
                 // canonicalized, also check against original
                 query_path == cap.resolved
-                    || (canonical.is_none() && path == cap.original.as_path())
+                    || (full_canonical.is_none() && path == cap.original.as_path())
             } else {
                 // Directory capability: path must be under the directory.
                 // Check resolved first (canonical path), then original
                 // (symlink path) for non-existent paths.
                 query_path.starts_with(&cap.resolved)
-                    || (canonical.is_none() && path.starts_with(&cap.original))
+                    || (full_canonical.is_none() && path.starts_with(&cap.original))
             };
 
             if covers {

--- a/crates/nono/src/query.rs
+++ b/crates/nono/src/query.rs
@@ -4,7 +4,7 @@
 //! by a given capability set, without actually applying the sandbox.
 
 use crate::capability::{AccessMode, CapabilitySet};
-use crate::path::try_canonicalize;
+use crate::path::try_canonicalize_ancestor_walk;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -78,7 +78,9 @@ impl QueryContext {
         let query_path: &Path = if let Some(ref c) = full_canonical {
             c.as_path()
         } else {
-            query_path_buf = try_canonicalize(path);
+            // canonicalize already failed above; skip the redundant retry
+            // and go straight to the ancestor-walk fallback.
+            query_path_buf = try_canonicalize_ancestor_walk(path);
             query_path_buf.as_path()
         };
 


### PR DESCRIPTION
## Summary

- Extracts a shared `try_canonicalize(path: &Path) -> PathBuf` utility into `nono::path`, using the correct ancestor-walk strategy that was already implemented (but duplicated) in `protected_paths.rs`
- Replaces 7 inconsistent call sites that used weaker fallbacks (raw path or parent-only) with the shared utility
- Removes the duplicate `resolve_path` private function from `protected_paths.rs`

**Why it matters:** On macOS, `/tmp`, `/var`, and `/etc` are symlinks to `/private/tmp` etc. The weak fallbacks left these unresolved for non-existent paths, causing silent security comparison failures when capability paths (stored as `/private/tmp/...`) were compared against query paths that stayed as `/tmp/...`.

## Sites updated

| File | Old approach | New |
|---|---|---|
| `nono/src/query.rs` | `.ok()` → raw path | `try_canonicalize` |
| `nono-cli/src/query_ext.rs` | parent-only (1 level) | `try_canonicalize` |
| `nono-cli/src/exec_strategy/supervisor_linux.rs` | `.unwrap_or_else` → raw path | `try_canonicalize` |
| `nono-cli/src/learn.rs` | `.unwrap_or` → raw path | `try_canonicalize` |
| `nono-cli/src/rollback_commands.rs` | `.unwrap_or_else` → raw path | `try_canonicalize` |
| `nono-cli/src/protected_paths.rs` | private `resolve_path` (ancestor-walk) | shared `try_canonicalize` |

## Test plan

- [x] `cargo test -p nono` passes (576 tests)
- [x] `cargo build` clean with no warnings
- [x] New unit tests in `nono::path` cover: existing path, non-existent leaf, non-existent nested path, symlink resolution

Closes #257