### PR TITLE
feat(policy): remove openclaw built-in profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -645,32 +645,6 @@
       "workdir": { "access": "none" },
       "interactive": false
     },
-    "openclaw": {
-      "extends": "default",
-      "meta": {
-        "name": "openclaw",
-        "version": "1.0.0",
-        "description": "OpenClaw messaging gateway",
-        "author": "nono-project"
-      },
-      "security": {
-        "groups": ["node_runtime"],
-        "signal_mode": "isolated"
-      },
-      "filesystem": {
-        "allow": [
-          "$HOME/.openclaw",
-          "$HOME/.config/openclaw",
-          "$TMPDIR/openclaw-$UID"
-        ]
-      },
-      "network": { "block": false },
-      "workdir": { "access": "read" },
-      "undo": {
-        "exclude_patterns": ["node_modules", ".next"]
-      },
-      "interactive": false
-    },
     "opencode": {
       "extends": "default",
       "meta": {

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -125,7 +125,6 @@ fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
         "claude" => Some("claude-code"),
         "codex" => Some("codex"),
         "opencode" => Some("opencode"),
-        "openclaw" => Some("openclaw"),
         "swival" => Some("swival"),
         _ => None,
     }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -125,6 +125,7 @@ fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
         "claude" => Some("claude-code"),
         "codex" => Some("codex"),
         "opencode" => Some("opencode"),
+        "openclaw" => Some("openclaw"),
         "swival" => Some("swival"),
         _ => None,
     }
@@ -405,6 +406,10 @@ mod tests {
         assert_eq!(
             recommended_builtin_profile(Path::new("/usr/local/bin/codex")),
             Some("codex")
+        );
+        assert_eq!(
+            recommended_builtin_profile(Path::new("/usr/local/bin/openclaw")),
+            Some("openclaw")
         );
     }
 

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -67,6 +67,13 @@ const OFFICIAL_PACKS: &[OfficialPack] = &[
         description: Some("OpenAI Codex CLI sandbox profile + plugin"),
         installs_summary: Some("sandbox profile + Codex plugin (hooks, skill)"),
     },
+    OfficialPack {
+        profile_name: "openclaw",
+        namespace: "always-further",
+        pack_name: "openclaw",
+        description: Some("OpenClaw sandbox profile"),
+        installs_summary: Some("sandbox profile"),
+    },
 ];
 
 struct OfficialPack {
@@ -327,6 +334,7 @@ mod tests {
         assert!(official_pack_for("claude").is_some());
         assert!(official_pack_for("claude-code").is_some());
         assert!(official_pack_for("codex").is_some());
+        assert!(official_pack_for("openclaw").is_some());
         assert!(official_pack_for("definitely-not-real").is_none());
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -39,14 +39,11 @@ mod tests {
     }
 
     #[test]
-    fn test_get_builtin_openclaw() {
-        let profile = get_builtin("openclaw").expect("Profile not found");
-        assert_eq!(profile.meta.name, "openclaw");
-        assert!(!profile.network.block); // network allowed
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.openclaw".to_string()));
+    fn test_openclaw_no_longer_inbuilt() {
+        // Removed in v0.44.0: openclaw ships via the registry pack
+        // `always-further/openclaw` and is resolved through the user-profile
+        // symlink, not the embedded policy.json.
+        assert!(get_builtin("openclaw").is_none());
     }
 
     #[test]
@@ -96,15 +93,16 @@ mod tests {
         let profiles = list_builtin();
         assert!(profiles.contains(&"default".to_string()));
         assert!(profiles.contains(&"linux-host-compat".to_string()));
-        assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
         assert!(profiles.contains(&"swival".to_string()));
         // Profiles that ship via registry packs instead of as built-ins:
-        //   claude-code → always-further/claude (removed v0.43.0)
-        //   codex       → always-further/codex  (removed v0.43.0)
+        //   claude-code → always-further/claude   (removed v0.43.0)
+        //   codex       → always-further/codex    (removed v0.43.0)
+        //   openclaw    → always-further/openclaw (removed v0.44.0)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"claude-no-kc".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"openclaw".to_string()));
     }
 
     #[test]
@@ -133,13 +131,13 @@ mod tests {
     fn test_profile_exclusion_mechanism() {
         // Verify that built-in profiles resolve exclusions through the shared
         // group-exclusion path. Current embedded profiles do not exclude any.
-        let profile = get_builtin("openclaw").expect("Profile not found");
+        let profile = get_builtin("opencode").expect("Profile not found");
         let default = get_builtin("default").expect("default profile");
         // All default groups should be present since embedded exclusions are empty.
         for group in &default.security.groups {
             assert!(
                 profile.security.groups.contains(group),
-                "openclaw should contain default profile group '{}'",
+                "opencode should contain default profile group '{}'",
                 group
             );
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1,8 +1,8 @@
 //! Profile system for pre-configured capability sets
 //!
 //! Profiles provide named configurations for common applications like
-//! claude-code, openclaw, and opencode. They can be built-in (compiled
-//! into the binary) or user-defined (in ~/.config/nono/profiles/).
+//! opencode and swival. They can be built-in (compiled into the binary),
+//! installed via registry packs, or user-defined (in ~/.config/nono/profiles/).
 
 pub(crate) mod builtin;
 
@@ -2679,12 +2679,14 @@ mod tests {
     #[test]
     fn test_list_profiles() {
         let profiles = list_profiles();
-        assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
-        // claude-code and codex were removed from the inbuilt profiles in
-        // v0.43.0; they ship via registry packs.
+        // Profiles removed from built-ins; now ship via registry packs:
+        //   claude-code → always-further/claude   (removed v0.43.0)
+        //   codex       → always-further/codex    (removed v0.43.0)
+        //   openclaw    → always-further/openclaw (removed v0.44.0)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"openclaw".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes the `openclaw` profile from the embedded `policy.json` — it now ships via the `always-further/openclaw` registry pack (nono-packs#2)
- Removes `"openclaw"` from the `recommended_builtin_profile` auto-detection table in `execution_runtime.rs`
- Updates tests in `builtin.rs` and `profile/mod.rs` to assert openclaw is no longer a built-in, following the same pattern used for claude-code/codex in v0.43.0

Closes #791

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p nono-cli` — all tests pass
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy` — no errors