### PR TITLE
fix(cli): re-validate deny overlaps after all grants

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -1635,6 +1635,12 @@ mod tests {
         let denied = workdir.join(".ssh");
         std::fs::create_dir_all(&denied).expect("mkdir denied child");
 
+        // Exclude `system_write_linux` (default group) — it grants write to
+        // `/tmp`, which the test's tempdir lives under. Without the exclusion
+        // the *initial* validate_deny_overlaps inside from_profile fires on
+        // that group's `/tmp` allow vs our deny under `/tmp/.../.ssh`, before
+        // we ever get to exercise the post-CWD validation that is the actual
+        // subject of this regression.
         let profile_path = dir.path().join("post-cwd-deny.json");
         std::fs::write(
             &profile_path,
@@ -1642,6 +1648,7 @@ mod tests {
                 r#"{{
                     "meta": {{ "name": "post-cwd-deny" }},
                     "policy": {{
+                        "exclude_groups": ["system_write_linux"],
                         "add_deny_access": ["{}"]
                     }}
                 }}"#,

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -446,27 +446,34 @@ pub(crate) fn retains_missing_exact_file_grants() -> bool {
     cfg!(target_os = "macos")
 }
 
-/// Extension trait for CapabilitySet to add CLI-specific construction methods.
+/// Result of building a CapabilitySet from CLI args or a profile.
 ///
-/// Both methods return `(CapabilitySet, bool)` where the bool indicates whether
-/// `policy::apply_unlink_overrides()` must be called after all writable paths
-/// are finalized (including CWD). The caller is responsible for calling it.
+/// `needs_unlink_overrides` defers `policy::apply_unlink_overrides()` until the
+/// caller has added every writable path (including CWD).
+///
+/// `deny_paths` carries the resolved policy-deny set (groups + profile
+/// `add_deny_access`) so the caller can re-run `validate_deny_overlaps` after
+/// it adds further allow paths (e.g. `--allow-cwd`). Without this, a deny
+/// configured by the profile can silently be neutralised on Linux when a later
+/// allow path covers it — which Landlock cannot enforce.
+#[derive(Debug)]
+pub struct PreparedCaps {
+    pub caps: CapabilitySet,
+    pub needs_unlink_overrides: bool,
+    pub deny_paths: Vec<PathBuf>,
+}
+
+/// Extension trait for CapabilitySet to add CLI-specific construction methods.
 pub trait CapabilitySetExt {
     /// Create a capability set from CLI sandbox arguments.
-    /// Returns `(caps, needs_unlink_overrides)`.
-    fn from_args(args: &SandboxArgs) -> Result<(CapabilitySet, bool)>;
+    fn from_args(args: &SandboxArgs) -> Result<PreparedCaps>;
 
     /// Create a capability set from a profile with CLI overrides.
-    /// Returns `(caps, needs_unlink_overrides)`.
-    fn from_profile(
-        profile: &Profile,
-        workdir: &Path,
-        args: &SandboxArgs,
-    ) -> Result<(CapabilitySet, bool)>;
+    fn from_profile(profile: &Profile, workdir: &Path, args: &SandboxArgs) -> Result<PreparedCaps>;
 }
 
 impl CapabilitySetExt for CapabilitySet {
-    fn from_args(args: &SandboxArgs) -> Result<(CapabilitySet, bool)> {
+    fn from_args(args: &SandboxArgs) -> Result<PreparedCaps> {
         let mut caps = CapabilitySet::new();
         let protected_roots = ProtectedRoots::from_defaults()?;
 
@@ -561,14 +568,14 @@ impl CapabilitySetExt for CapabilitySet {
 
         finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
 
-        Ok((caps, resolved.needs_unlink_overrides))
+        Ok(PreparedCaps {
+            caps,
+            needs_unlink_overrides: resolved.needs_unlink_overrides,
+            deny_paths: resolved.deny_paths,
+        })
     }
 
-    fn from_profile(
-        profile: &Profile,
-        workdir: &Path,
-        args: &SandboxArgs,
-    ) -> Result<(CapabilitySet, bool)> {
+    fn from_profile(profile: &Profile, workdir: &Path, args: &SandboxArgs) -> Result<PreparedCaps> {
         let mut caps = CapabilitySet::new();
         let protected_roots = ProtectedRoots::from_defaults()?;
         let allow_parent_of_protected = profile.allow_parent_of_protected.unwrap_or(false);
@@ -953,7 +960,11 @@ impl CapabilitySetExt for CapabilitySet {
             &profile_overrides,
         )?;
 
-        Ok((caps, resolved.needs_unlink_overrides))
+        Ok(PreparedCaps {
+            caps,
+            needs_unlink_overrides: resolved.needs_unlink_overrides,
+            deny_paths: resolved.deny_paths,
+        })
     }
 }
 
@@ -1117,7 +1128,16 @@ mod tests {
     }
 
     fn from_args_locked(args: &SandboxArgs) -> Result<(CapabilitySet, bool)> {
-        with_env_lock(|| CapabilitySet::from_args(args))
+        with_env_lock(|| {
+            CapabilitySet::from_args(args).map(|prepared| {
+                let PreparedCaps {
+                    caps,
+                    needs_unlink_overrides,
+                    ..
+                } = prepared;
+                (caps, needs_unlink_overrides)
+            })
+        })
     }
 
     fn from_profile_locked(
@@ -1125,7 +1145,16 @@ mod tests {
         workdir: &Path,
         args: &SandboxArgs,
     ) -> Result<(CapabilitySet, bool)> {
-        with_env_lock(|| CapabilitySet::from_profile(profile, workdir, args))
+        with_env_lock(|| {
+            CapabilitySet::from_profile(profile, workdir, args).map(|prepared| {
+                let PreparedCaps {
+                    caps,
+                    needs_unlink_overrides,
+                    ..
+                } = prepared;
+                (caps, needs_unlink_overrides)
+            })
+        })
     }
 
     fn sandbox_args() -> SandboxArgs {
@@ -1196,7 +1225,8 @@ mod tests {
     fn test_from_args_uses_default_profile_groups_for_runtime_policy() {
         with_env_lock(|| {
             let args = sandbox_args();
-            let (caps, _) = CapabilitySet::from_args(&args).expect("build caps from args");
+            let PreparedCaps { caps, .. } =
+                CapabilitySet::from_args(&args).expect("build caps from args");
 
             let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
             let default_groups = default_profile_groups().expect("get default profile groups");
@@ -1240,7 +1270,7 @@ mod tests {
 
         let result = CapabilitySet::from_args(&args);
 
-        let (caps, _) = result.expect(
+        let PreparedCaps { caps, .. } = result.expect(
             "from_args should succeed when HOME is nested under TMPDIR and the user grants a sibling path",
         );
         let allowed_canonical = allowed.canonicalize().expect("canonicalize allowed dir");
@@ -1587,6 +1617,68 @@ mod tests {
         assert_eq!(read_cap.access, AccessMode::Read);
         assert_eq!(write_cap.access, AccessMode::Write);
         assert_eq!(rw_cap.access, AccessMode::ReadWrite);
+    }
+
+    /// Regression test for the `--allow-cwd` deny-bypass bug.
+    ///
+    /// A profile that denies `$WORKDIR/.ssh` must not be silently neutralised
+    /// when the caller adds the workdir as an allow path *after* `from_profile`
+    /// returns (which is what `--allow-cwd` does in `prepare_sandbox`). The
+    /// fix exposes `PreparedCaps::deny_paths` so the caller can re-run
+    /// `validate_deny_overlaps` against the full set of grants and fail closed
+    /// on Linux.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_prepared_caps_deny_paths_catch_post_profile_cwd_overlap() {
+        let dir = tempdir().expect("tmpdir");
+        let workdir = dir.path().join("project");
+        let denied = workdir.join(".ssh");
+        std::fs::create_dir_all(&denied).expect("mkdir denied child");
+
+        let profile_path = dir.path().join("post-cwd-deny.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "post-cwd-deny" }},
+                    "policy": {{
+                        "add_deny_access": ["{}"]
+                    }}
+                }}"#,
+                denied.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        with_env_lock(|| {
+            // from_profile succeeds because CWD is not yet present in caps.
+            let prepared = CapabilitySet::from_profile(&profile, &workdir, &sandbox_args())
+                .expect("profile builds (no CWD allow yet)");
+
+            assert!(
+                prepared.deny_paths.iter().any(|p| p == &denied),
+                "PreparedCaps::deny_paths must include profile add_deny_access entries; \
+                 got {:?}",
+                prepared.deny_paths,
+            );
+
+            // Simulate the --allow-cwd grant added by prepare_sandbox.
+            let mut caps = prepared.caps;
+            let cwd_canonical = workdir.canonicalize().expect("canonicalize workdir");
+            let cap = nono::FsCapability::new_dir(cwd_canonical, AccessMode::ReadWrite)
+                .expect("build cwd cap");
+            caps.add_fs(cap);
+
+            // Re-validating against the same deny set must now reject the
+            // configuration: Landlock cannot enforce a deny under an allow.
+            let err = crate::policy::validate_deny_overlaps(&prepared.deny_paths, &caps)
+                .expect_err("post-CWD validation must fail on linux");
+            assert!(
+                err.to_string().contains("Landlock deny-overlap"),
+                "unexpected error: {err}"
+            );
+        });
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1076,6 +1076,7 @@ pub fn apply_unlink_overrides(caps: &mut CapabilitySet) {
 }
 
 /// Resolve deny.access paths for a group list without mutating caller capabilities.
+#[cfg(test)]
 pub fn resolve_deny_paths_for_groups(
     policy: &Policy,
     group_names: &[String],

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -316,8 +316,9 @@ mod tests {
             let profile = get_builtin(name)
                 .unwrap_or_else(|| panic!("built-in profile '{}' should load", name));
 
-            let (caps, _) = nono::CapabilitySet::from_profile(&profile, workdir.path(), &args)
+            let prepared = nono::CapabilitySet::from_profile(&profile, workdir.path(), &args)
                 .unwrap_or_else(|e| panic!("profile '{}' should build caps: {}", name, e));
+            let caps = prepared.caps;
 
             // Whether the profile uses Isolated or AllowSameSandbox, the
             // Seatbelt generator must emit same-sandbox signal rules.

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -505,11 +505,12 @@ pub(crate) fn resolve_detached_cwd_prompt_response(
         ..
     } = prepare_profile_for_preflight(args, &workdir)?;
 
-    let (caps, _) = if let Some(ref profile) = loaded_profile {
+    let prepared = if let Some(ref profile) = loaded_profile {
         CapabilitySet::from_profile(profile, &workdir, args)?
     } else {
         CapabilitySet::from_args(args)?
     };
+    let caps = prepared.caps;
 
     let Some(request) =
         pending_cwd_access_request(&caps, &workdir, profile_workdir_access.as_ref())?
@@ -1115,11 +1116,17 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         }
     }
 
-    let (mut caps, needs_unlink_overrides) = if let Some(ref profile) = loaded_profile {
+    let prepared = if let Some(ref profile) = loaded_profile {
         CapabilitySet::from_profile(profile, &workdir, args)?
     } else {
         CapabilitySet::from_args(args)?
     };
+    let mut caps = prepared.caps;
+    let needs_unlink_overrides = prepared.needs_unlink_overrides;
+    // Resolved policy denies (groups + profile add_deny_access). Used to
+    // re-run validate_deny_overlaps after CWD/pack grants are added below,
+    // because Landlock cannot enforce a deny that lives under a later allow.
+    let prepared_deny_paths = prepared.deny_paths;
 
     // Apply raw Seatbelt rules from the profile (macOS only).
     #[cfg(target_os = "macos")]
@@ -1224,17 +1231,13 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         caps.deduplicate();
     }
 
-    let active_groups = if let Some(profile) = loaded_profile
-        .as_ref()
-        .filter(|profile| !profile.security.groups.is_empty())
-    {
-        profile.security.groups.clone()
-    } else {
-        capability_ext::default_profile_groups()?
-    };
-    let loaded_policy = policy::load_embedded_policy()?;
-    let deny_paths = policy::resolve_deny_paths_for_groups(&loaded_policy, &active_groups)?;
-    policy::validate_deny_overlaps(&deny_paths, &caps)?;
+    // Re-validate against the full deny set (groups + profile add_deny_access)
+    // now that CWD, pack dirs, and any GPU/launch-services grants have been
+    // added on top of the caps produced by from_profile/from_args. The initial
+    // validation inside finalize_caps did not see those later grants, so a
+    // profile deny that lands under e.g. --allow-cwd would otherwise be a
+    // silent no-op on Linux (Landlock cannot deny under an allow).
+    policy::validate_deny_overlaps(&prepared_deny_paths, &caps)?;
     let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
     let allow_parent_of_protected = profile_allow_parent_of_protected;
     protected_paths::validate_caps_against_protected_roots(

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -60,9 +60,9 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             }
         }
 
-        let (mut caps, needs_unlink) =
-            CapabilitySet::from_profile(&profile, &workdir, &sandbox_args)?;
-        if needs_unlink {
+        let prepared = CapabilitySet::from_profile(&profile, &workdir, &sandbox_args)?;
+        let mut caps = prepared.caps;
+        if prepared.needs_unlink_overrides {
             policy::apply_unlink_overrides(&mut caps);
         }
         (caps, override_paths)
@@ -79,8 +79,9 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             ..SandboxArgs::default()
         };
 
-        let (mut caps, needs_unlink) = CapabilitySet::from_args(&sandbox_args)?;
-        if needs_unlink {
+        let prepared = CapabilitySet::from_args(&sandbox_args)?;
+        let mut caps = prepared.caps;
+        if prepared.needs_unlink_overrides {
             policy::apply_unlink_overrides(&mut caps);
         }
         (caps, vec![])

--- a/crates/nono-cli/tests/deny_overlap_run.rs
+++ b/crates/nono-cli/tests/deny_overlap_run.rs
@@ -1,0 +1,119 @@
+//! Regression test for the `--allow-cwd` deny-bypass on Linux.
+//!
+//! A profile that denies a path under the workdir must not be silently
+//! neutralised when the user passes `--allow-cwd`. Before the fix,
+//! `nono run --allow-cwd --profile <p> -- cat .ssh/id_rsa` would print the
+//! contents of `.ssh/id_rsa` despite the profile's `add_deny_access` rule,
+//! because Landlock cannot enforce a deny under an allow and the validator
+//! did not see the CWD allow added after `from_profile` returned.
+//!
+//! After the fix, `prepare_sandbox` re-runs `validate_deny_overlaps` against
+//! the full deny set (groups + profile `add_deny_access`) once CWD has been
+//! merged in, so the binary fails closed instead of leaking the file.
+//!
+//! Linux-only: macOS Seatbelt enforces deny-within-allow natively and
+//! `validate_deny_overlaps` is a no-op there.
+
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn nono_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nono"))
+}
+
+fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let temp_root = std::env::current_dir()
+        .expect("cwd")
+        .join("target")
+        .join("test-artifacts");
+    fs::create_dir_all(&temp_root).expect("create temp root");
+    let tmp = tempfile::Builder::new()
+        .prefix("nono-deny-overlap-run-it-")
+        .tempdir_in(&temp_root)
+        .expect("tempdir");
+    let home = tmp.path().join("home");
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir_all(home.join(".config")).expect("create config dir");
+    fs::create_dir_all(&workspace).expect("create workspace dir");
+    (tmp, home, workspace)
+}
+
+fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
+    nono_bin()
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        // Disable the detached-launch path and any interactive prompts —
+        // `--allow-cwd` already pre-confirms CWD sharing, but be defensive.
+        .env_remove("NONO_DETACHED_LAUNCH")
+        .current_dir(cwd)
+        .output()
+        .expect("failed to run nono")
+}
+
+#[test]
+fn run_allow_cwd_with_profile_deny_under_workdir_fails_closed() {
+    let (_tmp, home, workspace) = setup_isolated_home();
+
+    // Stand up a fake .ssh/id_rsa under the workspace. The profile denies it,
+    // so even though `--allow-cwd` opens up the workspace, the run must abort
+    // before the inner `cat` can read the file.
+    let ssh_dir = workspace.join(".ssh");
+    fs::create_dir_all(&ssh_dir).expect("create .ssh");
+    let secret_path = ssh_dir.join("id_rsa");
+    let secret = "-----BEGIN OPENSSH PRIVATE KEY-----\nfake-test-secret\n";
+    fs::write(&secret_path, secret).expect("write fake secret");
+
+    // Minimal profile: no `extends` so we don't depend on a registry pack
+    // being installed under the test HOME. `add_deny_access` is what we are
+    // exercising; the implicit default groups merged in by the loader do
+    // not allow $WORKDIR, so the only allow that covers `.ssh` is the one
+    // injected by `--allow-cwd`.
+    let profile_path = home.join("deny-overlap-repro.json");
+    let profile_json = format!(
+        r#"{{
+            "meta": {{ "name": "deny-overlap-repro" }},
+            "policy": {{
+                "add_deny_access": ["{workspace}/.ssh"]
+            }}
+        }}"#,
+        workspace = workspace.display()
+    );
+    fs::write(&profile_path, profile_json).expect("write profile");
+
+    let profile_arg = profile_path.to_string_lossy().into_owned();
+    let secret_arg = secret_path.to_string_lossy().into_owned();
+    let output = run_nono(
+        &[
+            "run",
+            "--allow-cwd",
+            "--profile",
+            &profile_arg,
+            "--",
+            "/bin/cat",
+            &secret_arg,
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "nono run must fail closed when a profile deny overlaps --allow-cwd; \
+         instead it exited successfully.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("Landlock deny-overlap"),
+        "expected 'Landlock deny-overlap' refusal in stderr, got:\n{stderr}",
+    );
+    assert!(
+        !stdout.contains("fake-test-secret"),
+        "secret content leaked to stdout despite profile deny:\n{stdout}",
+    );
+}

--- a/crates/nono-cli/tests/deny_overlap_run.rs
+++ b/crates/nono-cli/tests/deny_overlap_run.rs
@@ -76,6 +76,7 @@ fn run_allow_cwd_with_profile_deny_under_workdir_fails_closed() {
     let profile_json = format!(
         r#"{{
             "meta": {{ "name": "deny-overlap-repro" }},
+            "workdir": {{ "access": "readwrite" }},
             "policy": {{
                 "add_deny_access": ["{workspace}/.ssh"]
             }}


### PR DESCRIPTION
On Linux, Landlock cannot enforce a deny rule that is covered by an allow rule. Previously, when building capabilities, deny rules (from profile `add_deny_access` or groups) were validated against the capability set *before* all allow grants were finalized.

This created a silent bypass bug where, for example, a profile could deny access to `$WORKDIR/.ssh`, but if `--allow-cwd` was later applied in `prepare_sandbox` (effectively granting read/write to `$WORKDIR`), the `.ssh` deny would be neutralised without warning.

This commit refactors `CapabilitySetExt::from_args` and `from_profile` to return a `PreparedCaps` struct. This struct includes the resolved `deny_paths` from the profile and active groups.

`prepare_sandbox` now uses these `prepared_deny_paths` to re-run `policy::validate_deny_overlaps` *after* all potential overlapping allow grants (such as `--allow-cwd`, pack directories, or GPU/launch services grants) have been added to the capability set. This ensures that deny rules are always effectively checked against the final set of grants, failing closed if an overlap is detected.

This also moves the primary calculation of `deny_paths` into the capability builders, rather than recalculating it separately in `prepare_sandbox`.

Thank you to @bbinet for raising this