### PR TITLE
fix(profile): add commands to manage profile drafts and check package status

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -120,9 +120,9 @@ pub(crate) fn map_error(e: &nono::NonoError) -> types::NonoErrorCode {
         | nono::NonoError::BlocklistBlocked { .. }
         | nono::NonoError::InstructionFileDenied { .. }
         | nono::NonoError::PackageVerification { .. } => NonoErrorCode::ErrTrustVerification,
-        nono::NonoError::PackageInstall(_) | nono::NonoError::RegistryError(_) => {
-            NonoErrorCode::ErrConfigParse
-        }
+        nono::NonoError::PackageInstall(_)
+        | nono::NonoError::RegistryError(_)
+        | nono::NonoError::ActionRequired(_) => NonoErrorCode::ErrConfigParse,
         nono::NonoError::NetworkFilterUnsupported { .. } => NonoErrorCode::ErrUnsupportedPlatform,
         // CLI-only user-cancellation marker. Library callers shouldn't
         // see it through the FFI in normal use, but if they do, surface

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -494,6 +494,8 @@ IN-BAND DETACH:
   nono profile show claude-code                # Show a fully resolved profile
   nono profile diff default claude-code        # Compare two profiles
   nono profile validate ~/my-profile.json      # Validate a user profile file
+  nono profile validate --draft my-profile     # Validate a profile draft
+  nono profile promote my-profile              # Review and apply a profile draft
   nono profile groups                          # List all policy groups
   nono profile groups deny_credentials         # Show details for a specific group
   nono profile schema                          # Print JSON Schema for editor validation
@@ -734,6 +736,8 @@ pub enum ProfileCommands {
     Diff(ProfileDiffArgs),
     /// Validate a profile JSON file
     Validate(ProfileValidateArgs),
+    /// Review and apply a profile draft from ~/.config/nono/profile-drafts
+    Promote(ProfilePromoteArgs),
     /// List policy groups or show details for a specific group
     Groups(ProfileGroupsArgs),
     /// Output the JSON Schema for profile files
@@ -816,9 +820,13 @@ pub struct ProfileDiffArgs {
 }
 
 #[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
 pub struct ProfileValidateArgs {
     /// Profile JSON file to validate
     pub file: PathBuf,
+    /// Treat the argument as a draft name under ~/.config/nono/profile-drafts
+    #[arg(long)]
+    pub draft: bool,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -829,6 +837,25 @@ pub struct ProfileValidateArgs {
     /// warnings passes as usual.
     #[arg(long)]
     pub strict: bool,
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
+}
+
+#[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
+pub struct ProfilePromoteArgs {
+    /// Draft profile name
+    pub name: String,
+    /// Show the proposed diff without applying it
+    #[arg(long)]
+    pub diff: bool,
+    /// Apply without interactive confirmation
+    #[arg(long)]
+    pub yes: bool,
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -32,6 +32,7 @@ mod open_url_runtime;
 mod output;
 mod package;
 mod package_cmd;
+mod package_status;
 mod policy;
 mod profile;
 mod profile_cmd;
@@ -106,6 +107,10 @@ fn main() {
     print_deprecation_warnings(&command_blocking_warnings, cli.silent);
 
     if let Err(e) = run_cli(cli) {
+        if let nono::NonoError::ActionRequired(message) = &e {
+            eprintln!("{message}");
+            std::process::exit(1);
+        }
         // User-initiated stops (declined prompt, non-TTY without
         // NONO_AUTO_MIGRATE) are surfaced as `NonoError::Cancelled`.
         // Their stderr message has already been printed at the call

--- a/crates/nono-cli/src/package.rs
+++ b/crates/nono-cli/src/package.rs
@@ -174,6 +174,27 @@ pub struct PackageSearchResponse {
     pub packages: Vec<PackageSearchResult>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageStatusResponse {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub latest: Option<String>,
+    #[serde(default)]
+    pub installed_status: Option<String>,
+    #[serde(default)]
+    pub yank_reason: Option<String>,
+    #[serde(default)]
+    pub advisory: Option<PackageAdvisory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageAdvisory {
+    #[serde(default)]
+    pub severity: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
 /// One pack that ships a given profile name (the `install_as` of a
 /// profile artifact in its manifest). Returned by
 /// `GET /api/v1/profiles/<name>/providers`. Used by the migration

--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -1,0 +1,218 @@
+//! Runtime checks for security-sensitive official pack status.
+
+use crate::package::{self, PackageRef, PackageStatusResponse};
+use crate::profile;
+use crate::registry_client::{resolve_registry_url, RegistryClient};
+use nono::{NonoError, Result};
+
+#[derive(Clone, Copy, Debug)]
+struct OfficialPackStatusTarget {
+    namespace: &'static str,
+    name: &'static str,
+    profiles: &'static [&'static str],
+}
+
+const CLAUDE_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
+    namespace: "always-further",
+    name: "claude",
+    profiles: &["claude", "claude-code"],
+};
+
+const CODEX_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
+    namespace: "always-further",
+    name: "codex",
+    profiles: &["codex"],
+};
+
+const OFFICIAL_PACK_STATUS_TARGETS: &[OfficialPackStatusTarget] = &[CLAUDE_PACK, CODEX_PACK];
+
+impl OfficialPackStatusTarget {
+    fn key(self) -> String {
+        format!("{}/{}", self.namespace, self.name)
+    }
+
+    fn package_ref(self) -> PackageRef {
+        PackageRef {
+            namespace: self.namespace.to_string(),
+            name: self.name.to_string(),
+            version: None,
+        }
+    }
+}
+
+pub(crate) fn enforce_for_active_profile(profile_name: Option<&str>, silent: bool) -> Result<()> {
+    let Some(profile_name) = profile_name else {
+        return Ok(());
+    };
+
+    for target in OFFICIAL_PACK_STATUS_TARGETS {
+        if depends_on_official_pack_profile(*target, profile_name) {
+            enforce_official_pack_status(*target, silent)?;
+        }
+    }
+    Ok(())
+}
+
+fn enforce_official_pack_status(target: OfficialPackStatusTarget, silent: bool) -> Result<()> {
+    let lockfile = package::read_lockfile()?;
+    let key = target.key();
+    let Some(locked) = lockfile.packages.get(&key) else {
+        return Ok(());
+    };
+
+    let package_ref = target.package_ref();
+    let registry_url = if lockfile.registry.trim().is_empty() {
+        resolve_registry_url(None)
+    } else {
+        resolve_registry_url(Some(lockfile.registry.as_str()))
+    };
+    let client = RegistryClient::new(registry_url);
+    let status = match client.fetch_package_status(&package_ref, Some(locked.version.as_str())) {
+        Ok(status) => status,
+        Err(error) => {
+            tracing::debug!(
+                "could not check official pack status for {key}@{}: {error}",
+                locked.version
+            );
+            return Ok(());
+        }
+    };
+
+    match status.installed_status.as_deref() {
+        Some("yanked") => Err(NonoError::ActionRequired(yanked_message(
+            &key,
+            locked.version.as_str(),
+            &status,
+        ))),
+        Some("current") | None => Ok(()),
+        Some(other) => {
+            if !silent {
+                eprintln!(
+                    "  [nono] official pack {}@{} status: {}",
+                    key, locked.version, other
+                );
+                if let Some(latest) = status.latest.as_deref() {
+                    eprintln!("  [nono] update with: nono pull {key}@{latest} --force");
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn yanked_message(key: &str, installed: &str, status: &PackageStatusResponse) -> String {
+    let mut message = format!("official pack {key}@{installed} has been yanked by the registry");
+    if let Some(reason) = status.yank_reason.as_deref() {
+        message.push_str(&format!(" (reason: {reason})"));
+    }
+    if let Some(advisory) = status.advisory.as_ref() {
+        let severity = advisory.severity.as_deref().unwrap_or("unknown");
+        let summary = advisory.summary.as_deref().unwrap_or("no summary provided");
+        message.push_str(&format!("\nadvisory: {severity} - {summary}"));
+    }
+    if let Some(latest) = status.latest.as_deref() {
+        message.push_str(&format!(
+            "\nupdate before launching this profile: nono pull {key}@{latest} --force"
+        ));
+    } else {
+        message.push_str(
+            "\nno replacement version was returned by the registry; inspect package versions before launching this profile",
+        );
+    }
+    message
+}
+
+fn depends_on_official_pack_profile(target: OfficialPackStatusTarget, name_or_path: &str) -> bool {
+    if is_official_package_ref(target, name_or_path) {
+        return true;
+    }
+    if is_official_profile_name(target, name_or_path) && !profile::is_user_override(name_or_path) {
+        return true;
+    }
+    depends_on_official_pack_profile_inner(target, name_or_path, &mut Vec::new())
+}
+
+fn depends_on_official_pack_profile_inner(
+    target: OfficialPackStatusTarget,
+    name_or_path: &str,
+    visited: &mut Vec<String>,
+) -> bool {
+    if is_official_profile_name(target, name_or_path) {
+        return true;
+    }
+    if visited.iter().any(|visited| visited == name_or_path) {
+        return false;
+    }
+    visited.push(name_or_path.to_string());
+
+    let Some(bases) = profile::load_profile_extends(name_or_path) else {
+        return false;
+    };
+    bases
+        .iter()
+        .any(|base| depends_on_official_pack_profile_inner(target, base, visited))
+}
+
+fn is_official_profile_name(target: OfficialPackStatusTarget, name: &str) -> bool {
+    target.profiles.contains(&name)
+}
+
+fn is_official_package_ref(target: OfficialPackStatusTarget, value: &str) -> bool {
+    let key = target.key();
+    value == key || value.starts_with(&format!("{key}@"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yanked_message_pins_latest_when_available() {
+        let status = PackageStatusResponse {
+            schema_version: 1,
+            latest: Some("1.2.3".to_string()),
+            installed_status: Some("yanked".to_string()),
+            yank_reason: Some("security".to_string()),
+            advisory: Some(package::PackageAdvisory {
+                severity: Some("high".to_string()),
+                summary: Some("profile policy fix".to_string()),
+            }),
+        };
+
+        let message = yanked_message("always-further/claude", "1.2.2", &status);
+        assert!(message.contains("nono pull always-further/claude@1.2.3 --force"));
+        assert!(message.contains("security"));
+        assert!(message.contains("high - profile policy fix"));
+    }
+
+    #[test]
+    fn official_profile_names_include_claude_and_codex() {
+        assert!(is_official_profile_name(CLAUDE_PACK, "claude"));
+        assert!(is_official_profile_name(CLAUDE_PACK, "claude-code"));
+        assert!(is_official_profile_name(CODEX_PACK, "codex"));
+        assert!(!is_official_profile_name(CLAUDE_PACK, "codex"));
+        assert!(!is_official_profile_name(CODEX_PACK, "claude"));
+    }
+
+    #[test]
+    fn canonical_package_refs_target_official_packs() {
+        assert!(is_official_package_ref(
+            CLAUDE_PACK,
+            "always-further/claude"
+        ));
+        assert!(is_official_package_ref(
+            CLAUDE_PACK,
+            "always-further/claude@1.2.3"
+        ));
+        assert!(is_official_package_ref(CODEX_PACK, "always-further/codex"));
+        assert!(is_official_package_ref(
+            CODEX_PACK,
+            "always-further/codex@1.2.3"
+        ));
+        assert!(!is_official_package_ref(CLAUDE_PACK, "someone/claude"));
+        assert!(!is_official_package_ref(
+            CODEX_PACK,
+            "always-further/codex-extra"
+        ));
+    }
+}

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1902,13 +1902,16 @@ fn merge_implicit_default_groups(profile: &mut Profile) -> Result<()> {
 /// Used during inheritance resolution to load base profiles without
 /// triggering infinite recursion.
 fn parse_profile_file(path: &Path) -> Result<Profile> {
-    let content = fs::read_to_string(path).map_err(|e| NonoError::ProfileRead {
+    let content = fs::read(path).map_err(|e| NonoError::ProfileRead {
         path: path.to_path_buf(),
         source: e,
     })?;
+    parse_profile_bytes(&content)
+}
 
+pub(crate) fn parse_profile_bytes(content: &[u8]) -> Result<Profile> {
     let profile: Profile =
-        serde_json::from_str(&content).map_err(|e| NonoError::ProfileParse(e.to_string()))?;
+        serde_json::from_slice(content).map_err(|e| NonoError::ProfileParse(e.to_string()))?;
 
     // Validate custom credentials for security issues
     validate_profile_custom_credentials(&profile)?;
@@ -2276,12 +2279,25 @@ pub(crate) fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &
 
 /// Get the path to a user profile
 pub(crate) fn get_user_profile_path(name: &str) -> Result<PathBuf> {
-    let config_dir = resolve_user_config_dir()?;
+    Ok(user_profile_dir()?.join(format!("{}.json", name)))
+}
 
-    Ok(config_dir
+pub(crate) fn user_profile_dir() -> Result<PathBuf> {
+    Ok(resolve_user_config_dir()?.join("nono").join("profiles"))
+}
+
+pub(crate) fn user_profile_draft_dir() -> Result<PathBuf> {
+    Ok(resolve_user_config_dir()?
         .join("nono")
-        .join("profiles")
-        .join(format!("{}.json", name)))
+        .join("profile-drafts"))
+}
+
+pub(crate) fn get_user_profile_draft_path(name: &str) -> Result<PathBuf> {
+    Ok(user_profile_draft_dir()?.join(format!("{}.json", name)))
+}
+
+pub(crate) fn get_user_profile_draft_base_path(name: &str) -> Result<PathBuf> {
+    Ok(user_profile_draft_dir()?.join(format!("{}.base", name)))
 }
 
 /// Resolve the user config directory with secure validation.

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -6,7 +6,8 @@
 
 use crate::cli::{
     ProfileCmdArgs, ProfileCommands, ProfileDiffArgs, ProfileGroupsArgs, ProfileGuideArgs,
-    ProfileInitArgs, ProfileListArgs, ProfileSchemaArgs, ProfileShowArgs, ProfileValidateArgs,
+    ProfileInitArgs, ProfileListArgs, ProfilePromoteArgs, ProfileSchemaArgs, ProfileShowArgs,
+    ProfileValidateArgs,
 };
 use crate::config::embedded;
 use crate::policy::{self, AllowOps, DenyOps, Group};
@@ -14,9 +15,13 @@ use crate::profile::{self, Profile, WorkdirAccess};
 use crate::theme;
 use colored::Colorize;
 use nono::{NonoError, Result};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
 
 /// Serialize a value to pretty-printed JSON, propagating serialization errors.
 fn to_json(val: &serde_json::Value) -> Result<String> {
@@ -38,6 +43,7 @@ pub fn run_profile(args: ProfileCmdArgs) -> Result<()> {
         ProfileCommands::Show(args) => cmd_show(args),
         ProfileCommands::Diff(args) => cmd_diff(args),
         ProfileCommands::Validate(args) => cmd_validate(args),
+        ProfileCommands::Promote(args) => cmd_promote(args),
         ProfileCommands::Groups(args) => cmd_groups(args),
         ProfileCommands::Schema(args) => cmd_schema(args),
         ProfileCommands::Guide(args) => cmd_guide(args),
@@ -2167,6 +2173,19 @@ fn resolve_validate_target(input: &std::path::Path) -> std::path::PathBuf {
     input.to_path_buf()
 }
 
+fn resolve_validate_draft_target(input: &std::path::Path) -> Result<std::path::PathBuf> {
+    let name = input.to_str().ok_or_else(|| {
+        NonoError::ProfileParse(format!("invalid draft profile name '{}'", input.display()))
+    })?;
+    if !profile::is_valid_profile_name(name) {
+        return Err(NonoError::ProfileParse(format!(
+            "invalid draft profile name '{}'",
+            name
+        )));
+    }
+    profile::get_user_profile_draft_path(name)
+}
+
 pub(crate) fn cmd_validate(args: ProfileValidateArgs) -> Result<()> {
     let pol = policy::load_embedded_policy()?;
     let mut errors: Vec<String> = Vec::new();
@@ -2177,7 +2196,11 @@ pub(crate) fn cmd_validate(args: ProfileValidateArgs) -> Result<()> {
     // `args.file = PathBuf::from("claude-docs")`. If that doesn't exist as
     // a file, treat it as a profile name and look it up the same way
     // `--profile` does.
-    let target_path = resolve_validate_target(&args.file);
+    let target_path = if args.draft {
+        resolve_validate_draft_target(&args.file)?
+    } else {
+        resolve_validate_target(&args.file)
+    };
 
     // Step 1: Load profile (parse JSON + resolve inheritance).
     //
@@ -2324,6 +2347,308 @@ pub(crate) fn cmd_validate(args: ProfileValidateArgs) -> Result<()> {
         emit_deprecation_summary(deprecation_count);
         Err(NonoError::ProfileParse("validation failed".into()))
     }
+}
+
+// ---------------------------------------------------------------------------
+// nono profile promote
+// ---------------------------------------------------------------------------
+
+pub(crate) fn cmd_promote(args: ProfilePromoteArgs) -> Result<()> {
+    if args.diff && args.yes {
+        return Err(NonoError::ProfileParse(
+            "`--diff` cannot be combined with `--yes`".to_string(),
+        ));
+    }
+    if !profile::is_valid_profile_name(&args.name) {
+        return Err(NonoError::ProfileParse(format!(
+            "invalid draft profile name '{}'",
+            args.name
+        )));
+    }
+
+    let draft_path = profile::get_user_profile_draft_path(&args.name)?;
+    let base_path = profile::get_user_profile_draft_base_path(&args.name)?;
+    let target_path = profile::get_user_profile_path(&args.name)?;
+
+    let draft_bytes = read_regular_file(&draft_path, "profile draft")?;
+    let raw_profile = profile::parse_profile_bytes(&draft_bytes)?;
+    if raw_profile.meta.name != args.name {
+        return Err(NonoError::ProfileParse(format!(
+            "draft meta.name '{}' does not match draft name '{}'",
+            raw_profile.meta.name, args.name
+        )));
+    }
+    let resolved_profile = profile::resolve_and_finalize_profile(raw_profile)?;
+    validate_promote_profile(&resolved_profile)?;
+
+    let target_exists = regular_file_exists(&target_path, "target profile")?;
+    let current_bytes = if target_exists {
+        Some(read_regular_file(&target_path, "target profile")?)
+    } else {
+        None
+    };
+
+    if current_bytes.is_none() {
+        if let Some(source) = reserved_profile_source(&args.name)? {
+            return Err(NonoError::ProfileParse(format!(
+                "refusing to promote '{}' because it would shadow a {source} profile. \
+                 Draft a derived profile such as '{}-local' with \"extends\": \"{}\" instead.",
+                args.name, args.name, args.name
+            )));
+        }
+    }
+
+    if let Some(current) = current_bytes.as_deref() {
+        verify_base_hash(&base_path, current)?;
+    }
+
+    print_promote_diff(&args.name, current_bytes.as_deref(), &draft_bytes);
+    if args.diff {
+        return Ok(());
+    }
+
+    if !args.yes && !crate::profile_save_runtime::confirm("Promote this draft? [y/N] ", false)? {
+        eprintln!("{} promotion skipped", prefix());
+        return Ok(());
+    }
+
+    atomic_write_file(&target_path, &draft_bytes)?;
+    let _ = fs::remove_file(&draft_path);
+    let _ = fs::remove_file(&base_path);
+
+    eprintln!(
+        "{} Promoted draft to {}",
+        prefix(),
+        target_path.display().to_string().bold()
+    );
+    Ok(())
+}
+
+fn validate_promote_profile(profile: &Profile) -> Result<()> {
+    let pol = policy::load_embedded_policy()?;
+    let mut errors = Vec::new();
+
+    for group_name in &profile.groups.include {
+        if !pol.groups.contains_key(group_name) {
+            errors.push(format!("group '{}' not found in policy.json", group_name));
+        }
+    }
+
+    for excluded in &profile.groups.exclude {
+        match pol.groups.get(excluded) {
+            Some(group) if group.required => {
+                errors.push(format!("cannot exclude required group '{}'", excluded));
+            }
+            Some(_) | None => {}
+        }
+    }
+
+    for (label, paths) in [
+        ("filesystem.allow", &profile.filesystem.allow),
+        ("filesystem.read", &profile.filesystem.read),
+        ("filesystem.write", &profile.filesystem.write),
+        ("filesystem.allow_file", &profile.filesystem.allow_file),
+        ("filesystem.read_file", &profile.filesystem.read_file),
+        ("filesystem.write_file", &profile.filesystem.write_file),
+    ] {
+        if paths.iter().any(|path| path.trim().is_empty()) {
+            errors.push(format!("empty path in {label}"));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(NonoError::ProfileParse(format!(
+            "draft profile failed validation: {}",
+            errors.join("; ")
+        )))
+    }
+}
+
+fn reserved_profile_source(name: &str) -> Result<Option<&'static str>> {
+    let pol = policy::load_embedded_policy()?;
+    if pol.profiles.contains_key(name) {
+        return Ok(Some("built-in"));
+    }
+    if profile::find_pack_store_profile(name).is_some() {
+        return Ok(Some("installed pack"));
+    }
+    Ok(None)
+}
+
+fn verify_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<()> {
+    let base_bytes = read_regular_file(base_path, "profile draft base hash")?;
+    let provided = std::str::from_utf8(&base_bytes)
+        .map_err(|e| NonoError::ProfileParse(format!("base hash is not UTF-8: {e}")))?
+        .trim();
+    if provided.len() != 64 || !provided.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(NonoError::ProfileParse(format!(
+            "invalid base hash in {}",
+            base_path.display()
+        )));
+    }
+
+    let current = sha256_hex(current_bytes);
+    if !provided.eq_ignore_ascii_case(&current) {
+        return Err(NonoError::ProfileParse(
+            "draft base hash does not match current profile. The profile changed after the draft was written; regenerate or review the draft before promoting."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        options.custom_flags(nix::libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(path).map_err(|e| NonoError::ProfileRead {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let metadata = file.metadata().map_err(|e| NonoError::ProfileRead {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(NonoError::ProfileParse(format!(
+            "{label} is not a regular file: {}",
+            path.display()
+        )));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|e| NonoError::ProfileRead {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    Ok(bytes)
+}
+
+fn regular_file_exists(path: &Path, label: &str) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(NonoError::ProfileParse(format!(
+                    "{label} must not be a symlink: {}",
+                    path.display()
+                )));
+            }
+            if !metadata.file_type().is_file() {
+                return Err(NonoError::ProfileParse(format!(
+                    "{label} is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(NonoError::ProfileRead {
+            path: path.to_path_buf(),
+            source: error,
+        }),
+    }
+}
+
+fn atomic_write_file(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        NonoError::ProfileParse(format!("invalid profile path {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|e| NonoError::ProfileRead {
+        path: parent.to_path_buf(),
+        source: e,
+    })?;
+
+    let file_name = path.file_name().ok_or_else(|| {
+        NonoError::ProfileParse(format!("invalid profile path {}", path.display()))
+    })?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+        .map_err(|e| NonoError::ProfileRead {
+            path: tmp_path.clone(),
+            source: e,
+        })?;
+    if let Err(error) = file.write_all(contents) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(NonoError::ProfileRead {
+            path: tmp_path,
+            source: error,
+        });
+    }
+    if let Err(error) = file.sync_all() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(NonoError::ProfileRead {
+            path: tmp_path,
+            source: error,
+        });
+    }
+    drop(file);
+
+    if let Err(error) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(NonoError::ProfileRead {
+            path: path.to_path_buf(),
+            source: error,
+        });
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn print_promote_diff(name: &str, current: Option<&[u8]>, draft: &[u8]) {
+    use similar::{ChangeTag, TextDiff};
+
+    let old_text = current
+        .map(String::from_utf8_lossy)
+        .unwrap_or_else(|| "".into());
+    let new_text = String::from_utf8_lossy(draft);
+    let t = theme::current();
+
+    println!(
+        "{}: promote draft '{}'",
+        prefix(),
+        theme::fg(name, t.text).bold()
+    );
+    println!();
+    println!("  {}", theme::fg("Diff:", t.subtext).bold());
+    println!("--- profiles/{name}.json");
+    println!("+++ profile-drafts/{name}.json");
+
+    let diff = TextDiff::from_lines(&old_text, &new_text);
+    let mut changed = false;
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Delete => {
+                changed = true;
+                print!("{}", format!("-{change}").red());
+            }
+            ChangeTag::Insert => {
+                changed = true;
+                print!("{}", format!("+{change}").green());
+            }
+            ChangeTag::Equal => print!(" {change}"),
+        }
+    }
+    if !changed {
+        println!("  {}", theme::fg("(no differences)", t.subtext));
+    }
+    println!();
 }
 
 /// Print the deprecation summary line to stderr when any legacy keys were
@@ -3139,8 +3464,10 @@ mod tests {
 
         let args = ProfileValidateArgs {
             file: path,
+            draft: false,
             json: false,
             strict: false,
+            help: None,
         };
         let result = cmd_validate(args);
         assert!(result.is_ok(), "valid profile should pass validation");
@@ -3161,8 +3488,10 @@ mod tests {
 
         let args = ProfileValidateArgs {
             file: path,
+            draft: false,
             json: false,
             strict: false,
+            help: None,
         };
         let result = cmd_validate(args);
         assert!(result.is_err(), "invalid group should fail validation");
@@ -3183,13 +3512,143 @@ mod tests {
 
         let args = ProfileValidateArgs {
             file: path,
+            draft: false,
             json: false,
             strict: false,
+            help: None,
         };
         let result = cmd_validate(args);
         assert!(
             result.is_err(),
             "excluding required group should fail validation"
+        );
+    }
+
+    #[test]
+    fn promote_creates_new_profile_from_draft_and_removes_draft() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let draft_dir = profile::user_profile_draft_dir().expect("draft dir");
+        std::fs::create_dir_all(&draft_dir).expect("create drafts");
+        let draft_path = profile::get_user_profile_draft_path("agent-local").expect("draft path");
+        std::fs::write(
+            &draft_path,
+            r#"{
+  "meta": { "name": "agent-local" },
+  "filesystem": { "read": ["/tmp"] }
+}
+"#,
+        )
+        .expect("write draft");
+
+        let result = cmd_promote(ProfilePromoteArgs {
+            name: "agent-local".to_string(),
+            diff: false,
+            yes: true,
+            help: None,
+        });
+        assert!(result.is_ok(), "promote should succeed: {result:?}");
+        let target = profile::get_user_profile_path("agent-local").expect("target path");
+        assert!(target.exists(), "target profile should exist");
+        assert!(
+            !draft_path.exists(),
+            "draft should be removed after promote"
+        );
+    }
+
+    #[test]
+    fn promote_existing_profile_requires_matching_base_hash() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let profiles_dir = profile::user_profile_dir().expect("profile dir");
+        let draft_dir = profile::user_profile_draft_dir().expect("draft dir");
+        std::fs::create_dir_all(&profiles_dir).expect("create profiles");
+        std::fs::create_dir_all(&draft_dir).expect("create drafts");
+
+        let target = profile::get_user_profile_path("agent-local").expect("target path");
+        let old = b"{\n  \"meta\": { \"name\": \"agent-local\" },\n  \"filesystem\": { \"read\": [\"/tmp\"] }\n}\n";
+        std::fs::write(&target, old).expect("write target");
+        let draft = profile::get_user_profile_draft_path("agent-local").expect("draft path");
+        std::fs::write(
+            &draft,
+            "{\n  \"meta\": { \"name\": \"agent-local\" },\n  \"filesystem\": { \"read\": [\"/var/tmp\"] }\n}\n",
+        )
+        .expect("write draft");
+
+        let missing_base = cmd_promote(ProfilePromoteArgs {
+            name: "agent-local".to_string(),
+            diff: false,
+            yes: true,
+            help: None,
+        });
+        assert!(
+            missing_base.is_err(),
+            "existing profile promote must require .base"
+        );
+
+        let base = profile::get_user_profile_draft_base_path("agent-local").expect("base path");
+        std::fs::write(&base, sha256_hex(old)).expect("write base");
+        let result = cmd_promote(ProfilePromoteArgs {
+            name: "agent-local".to_string(),
+            diff: false,
+            yes: true,
+            help: None,
+        });
+        assert!(result.is_ok(), "promote should succeed: {result:?}");
+        let promoted = std::fs::read_to_string(&target).expect("read promoted");
+        assert!(promoted.contains("/var/tmp"));
+    }
+
+    #[test]
+    fn promote_refuses_to_shadow_builtin_profile() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let draft_dir = profile::user_profile_draft_dir().expect("draft dir");
+        std::fs::create_dir_all(&draft_dir).expect("create drafts");
+        let draft_path = profile::get_user_profile_draft_path("default").expect("draft path");
+        std::fs::write(
+            &draft_path,
+            r#"{
+  "meta": { "name": "default" },
+  "filesystem": { "read": ["/tmp"] }
+}
+"#,
+        )
+        .expect("write draft");
+
+        let result = cmd_promote(ProfilePromoteArgs {
+            name: "default".to_string(),
+            diff: false,
+            yes: true,
+            help: None,
+        });
+        assert!(
+            result.is_err(),
+            "promote should refuse to shadow built-in profiles"
         );
     }
 }

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -266,18 +266,18 @@ fn prepare_profile_with_options(
     workdir: &Path,
     options: PrepareProfileOptions,
 ) -> crate::Result<PreparedProfile> {
-    // Ensure the user-profile dir exists before the sandbox is built.
-    // It's a nono-managed location that profiles routinely reference
-    // in `filesystem.allow` (so a sandboxed agent can write extension
-    // profiles there following hook guidance), but Landlock can't
-    // mkdir a path that's only granted by name — the parent needs
-    // write permission. Pre-creating here means the leaf grant is
-    // sufficient. Best-effort: a permission error here just means the
-    // sandbox will deny writes the same as before.
+    // Ensure nono-managed profile dirs exist before the sandbox is built.
+    // Landlock can't mkdir a path that's only granted by name — the
+    // parent needs write permission. Pre-creating here means the leaf
+    // grants in pack profiles are sufficient.
     if let Ok(config_dir) = profile::resolve_user_config_dir() {
         let profiles_dir = config_dir.join("nono").join("profiles");
         if !profiles_dir.exists() {
             let _ = std::fs::create_dir_all(&profiles_dir);
+        }
+        let drafts_dir = config_dir.join("nono").join("profile-drafts");
+        if !drafts_dir.exists() {
+            let _ = std::fs::create_dir_all(&drafts_dir);
         }
     }
 
@@ -286,6 +286,10 @@ fn prepare_profile_with_options(
         // `load_profile` itself so it fires from every call site (run,
         // wrap, shell, profile show, why, learn) without duplication.
         let profile = profile::load_profile(profile_name)?;
+        crate::package_status::enforce_for_active_profile(
+            Some(profile_name),
+            options.hook_output_silent,
+        )?;
         verify_profile_packs(&profile.packs)?;
 
         if !profile.packs.is_empty() && !options.hook_output_silent {

--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -1,6 +1,8 @@
 //! Registry client for package hosting.
 
-use crate::package::{PackageRef, PackageSearchResponse, PackageSearchResult, PullResponse};
+use crate::package::{
+    PackageRef, PackageSearchResponse, PackageSearchResult, PackageStatusResponse, PullResponse,
+};
 use nono::{NonoError, Result};
 use serde::de::DeserializeOwned;
 use sha2::Digest;
@@ -65,6 +67,24 @@ impl RegistryClient {
         let response: PackageSearchResponse =
             self.get_json(&format!("/api/v1/packages?q={query}"))?;
         Ok(response.packages)
+    }
+
+    pub fn fetch_package_status(
+        &self,
+        package_ref: &PackageRef,
+        installed: Option<&str>,
+    ) -> Result<PackageStatusResponse> {
+        let mut path = format!(
+            "/api/v1/packages/{}/{}/status",
+            package_ref.namespace, package_ref.name
+        );
+        if let Some(installed) = installed {
+            let encoded: String =
+                url::form_urlencoded::byte_serialize(installed.as_bytes()).collect();
+            path.push_str("?installed=");
+            path.push_str(&encoded);
+        }
+        self.get_json(&path)
     }
 
     /// Look up which packs (if any) ship a profile with the given

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -165,6 +165,11 @@ pub enum NonoError {
     #[error("Package install error: {0}")]
     PackageInstall(String),
 
+    /// User-facing stop where nono needs the user to take an explicit
+    /// corrective action before continuing.
+    #[error("{0}")]
+    ActionRequired(String),
+
     #[error("Package verification failed for {package}: {reason}")]
     PackageVerification { package: String, reason: String },
 


### PR DESCRIPTION
feat(cli): add profile draft promotion and package status

- `nono profile validate` now supports a `--draft` flag to validate profile drafts located in `~/.config/nono/profile-drafts`.
- A new `nono profile promote <name>` command is introduced to review and apply a profile draft as a user profile.
- Promotion includes:
    - Interactive confirmation (unless `--yes` is used).
    - A clear diff of the proposed changes.
    - Verification against a base hash of the current profile to prevent applying stale drafts.
    - Safeguards to prevent shadowing built-in or installed pack profiles.
    - Atomic file operations for safe updates.
- Introduce `NonoError::ActionRequired` to explicitly stop execution when user intervention is required, such as for critical package advisories.
- Enable the registry client to fetch `PackageStatusResponse`, which will be used by the profile runtime for package status enforcement.
- Map `NonoError::ActionRequired` to `NonoErrorCode::ErrConfigParse` in the C bindings.