### PR TITLE
refactor(string-truncation): extract generic string truncation utility

### DIFF
--- a/crates/nono-cli/src/command_display.rs
+++ b/crates/nono-cli/src/command_display.rs
@@ -60,10 +60,11 @@ pub(crate) fn format_command_line(command: &[String]) -> String {
 /// do — there is no shorter way to signal truncation. Callers should pass
 /// `max_len >= 3`.
 pub(crate) fn truncate_chars(s: &str, max_len: usize) -> String {
-    // Fast path: byte length is always >= char count, so when bytes fit, we
-    // know the char count fits too and no truncation (or char counting) is
-    // needed.
-    if s.len() <= max_len {
+    // Fast path: byte length >= char count always, so if bytes fit, chars fit
+    // too. When bytes exceed max_len we still need to check char count —
+    // a short string of multi-byte chars may have fewer chars than max_len
+    // and must not be truncated.
+    if s.len() <= max_len || s.chars().count() <= max_len {
         return s.to_string();
     }
     let keep = max_len.saturating_sub(3);
@@ -185,24 +186,43 @@ mod tests {
 
     #[test]
     fn truncate_chars_handles_multibyte_utf8_at_byte_boundary() {
-        // Mirrors the panic shape that bit `truncate_str` in
-        // `rollback_commands::print_side_by_side_diff`: `col_width` defaults
-        // to `(120 - 3) / 2 = 58`, so byte slicing at index 55 panics when a
-        // 4-byte UTF-8 sequence straddles that boundary.
+        // Regression: `print_side_by_side_diff` calls `truncate_chars` on
+        // diff lines with `col_width = (120-3)/2 = 58`. Byte-slicing at
+        // index `max_len - 3 = 54` panics when a 4-byte UTF-8 sequence
+        // straddles that boundary.
         //
-        // 53 ASCII bytes + 😀 (bytes 53..57) → byte 55 is mid-character.
+        // Build a 58-char / 61-byte line where byte 54 is inside an emoji:
+        //   53 ASCII bytes + 😀 (bytes 53..57) + "tail" → 58 chars, 61 bytes.
+        //   Byte 54 is a continuation byte (0x9F) inside the emoji.
         let prefix: String = "x".repeat(53);
         let line = format!("{prefix}\u{1F600}tail");
-        assert!(line.len() > 58);
-        assert!(!line.is_char_boundary(55));
+        assert_eq!(line.chars().count(), 58);
+        assert_eq!(line.len(), 61);
+        assert!(!line.is_char_boundary(54)); // byte 54 is mid-emoji
 
-        let result = truncate_chars(&line, 58);
+        // max_len = 57 < 58 chars → truncation must fire.
+        // Old byte-slicing code slices at byte 54 (= 57-3) → panic.
+        // New char-aware code takes 54 chars safely.
+        let result = truncate_chars(&line, 57);
         assert!(result.ends_with("..."));
-        assert!(result.chars().count() <= 58);
+        assert!(result.chars().count() <= 57);
     }
 
     #[test]
     fn truncate_chars_max_len_smaller_than_ellipsis() {
         assert_eq!(truncate_chars("hello world", 2), "...");
+    }
+
+    #[test]
+    fn truncate_chars_no_spurious_truncation_of_multibyte_string() {
+        // Regression for the Gemini review finding: a string of 5 emojis is
+        // 20 bytes but only 5 chars. With max_len = 10, the byte fast-path
+        // (20 > 10) falls through — but the char check (5 <= 10) must catch
+        // it and return the string unmodified. Without the `|| chars().count()
+        // <= max_len` guard, this would be spuriously truncated.
+        let s = "\u{1F600}".repeat(5); // 5 chars, 20 bytes
+        assert_eq!(s.len(), 20);
+        assert_eq!(s.chars().count(), 5);
+        assert_eq!(truncate_chars(&s, 10), s); // must NOT truncate
     }
 }

--- a/crates/nono-cli/src/command_display.rs
+++ b/crates/nono-cli/src/command_display.rs
@@ -44,33 +44,41 @@ pub(crate) fn format_command_line(command: &[String]) -> String {
         .join(" ")
 }
 
-/// Render a command via [`format_command_line`] and truncate it to at most
-/// `max_len` characters, appending an ellipsis (`...`) when truncated.
+/// Truncate a string to at most `max_len` characters, appending an
+/// ellipsis (`...`) when truncated.
 ///
 /// Truncation operates on Unicode scalar values (`char`s), not bytes, so it
-/// will never split a multi-byte UTF-8 sequence — byte slicing the result
-/// of `format_command_line` is a panic hazard whenever a recorded command
-/// contains non-ASCII text. Grapheme-cluster width (e.g. emoji ZWJ
-/// sequences, combining marks) is out of scope; callers that render to a
-/// fixed-width terminal column should size `max_len` conservatively.
+/// will never split a multi-byte UTF-8 sequence — byte slicing arbitrary
+/// strings is a panic hazard whenever the input contains non-ASCII text.
+/// Grapheme-cluster width (e.g. emoji ZWJ sequences, combining marks) is
+/// out of scope; callers that render to a fixed-width terminal column
+/// should size `max_len` conservatively.
 ///
 /// Edge case: when `max_len < 3` and truncation is needed, the result is
 /// just `"..."` (3 chars), which technically exceeds `max_len`. This
 /// preserves the prior behaviour and matches the only sensible thing to
 /// do — there is no shorter way to signal truncation. Callers should pass
 /// `max_len >= 3`.
-pub(crate) fn truncate_command(command: &[String], max_len: usize) -> String {
-    let full = format_command_line(command);
+pub(crate) fn truncate_chars(s: &str, max_len: usize) -> String {
     // Fast path: byte length is always >= char count, so when bytes fit, we
     // know the char count fits too and no truncation (or char counting) is
     // needed.
-    if full.len() <= max_len {
-        return full;
+    if s.len() <= max_len {
+        return s.to_string();
     }
     let keep = max_len.saturating_sub(3);
-    let mut truncated: String = full.chars().take(keep).collect();
+    let mut truncated: String = s.chars().take(keep).collect();
     truncated.push_str("...");
     truncated
+}
+
+/// Render a command via [`format_command_line`] and truncate it to at most
+/// `max_len` characters, appending an ellipsis (`...`) when truncated.
+///
+/// Thin wrapper over [`truncate_chars`]; see that function for truncation
+/// semantics.
+pub(crate) fn truncate_command(command: &[String], max_len: usize) -> String {
+    truncate_chars(&format_command_line(command), max_len)
 }
 
 #[cfg(test)]
@@ -168,5 +176,33 @@ mod tests {
         let cmd = vec!["echo".to_string(), "hello world".to_string()];
         let result = truncate_command(&cmd, 2);
         assert_eq!(result, "...");
+    }
+
+    #[test]
+    fn truncate_chars_short_passes_through() {
+        assert_eq!(truncate_chars("hello", 40), "hello");
+    }
+
+    #[test]
+    fn truncate_chars_handles_multibyte_utf8_at_byte_boundary() {
+        // Mirrors the panic shape that bit `truncate_str` in
+        // `rollback_commands::print_side_by_side_diff`: `col_width` defaults
+        // to `(120 - 3) / 2 = 58`, so byte slicing at index 55 panics when a
+        // 4-byte UTF-8 sequence straddles that boundary.
+        //
+        // 53 ASCII bytes + 😀 (bytes 53..57) → byte 55 is mid-character.
+        let prefix: String = "x".repeat(53);
+        let line = format!("{prefix}\u{1F600}tail");
+        assert!(line.len() > 58);
+        assert!(!line.is_char_boundary(55));
+
+        let result = truncate_chars(&line, 58);
+        assert!(result.ends_with("..."));
+        assert!(result.chars().count() <= 58);
+    }
+
+    #[test]
+    fn truncate_chars_max_len_smaller_than_ellipsis() {
+        assert_eq!(truncate_chars("hello world", 2), "...");
     }
 }

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -6,7 +6,7 @@ use crate::cli::{
     RollbackArgs, RollbackCleanupArgs, RollbackCommands, RollbackListArgs, RollbackRestoreArgs,
     RollbackShowArgs, RollbackVerifyArgs,
 };
-use crate::command_display::format_command_line;
+use crate::command_display::{format_command_line, truncate_chars};
 use crate::config::user::load_user_config;
 use crate::rollback_base_exclusions;
 use crate::rollback_session::{
@@ -239,7 +239,6 @@ fn get_session_total_changes(s: &SessionInfo) -> (usize, usize, usize) {
     (total_created, total_modified, total_deleted)
 }
 
-/// Truncate command for display, adding ... if too long
 /// Format change summary for display
 fn format_change_summary(created: usize, modified: usize, deleted: usize) -> String {
     let mut parts = Vec::new();
@@ -494,7 +493,7 @@ fn print_side_by_side_diff(
 
             match change_op.tag() {
                 ChangeTag::Equal => {
-                    let truncated = truncate_str(line_trimmed, col_width);
+                    let truncated = truncate_chars(line_trimmed, col_width);
                     eprintln!(
                         "{:<width$} | {:<width$}",
                         truncated,
@@ -503,11 +502,11 @@ fn print_side_by_side_diff(
                     );
                 }
                 ChangeTag::Delete => {
-                    let truncated = truncate_str(line_trimmed, col_width);
+                    let truncated = truncate_chars(line_trimmed, col_width);
                     eprintln!("{} < {:<width$}", truncated.red(), "", width = col_width);
                 }
                 ChangeTag::Insert => {
-                    let truncated = truncate_str(line_trimmed, col_width);
+                    let truncated = truncate_chars(line_trimmed, col_width);
                     eprintln!("{:<width$} > {}", "", truncated.green(), width = col_width);
                 }
             }
@@ -563,14 +562,6 @@ fn count_lines(content: &[u8]) -> usize {
         .filter(|&&b| b == b'\n')
         .count()
         .saturating_add(1)
-}
-
-fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
-    }
 }
 
 fn print_show_json(session: &SessionInfo) -> Result<()> {


### PR DESCRIPTION
The core logic for truncating strings and appending an ellipsis has been extracted into a new, generic utility function called `truncate_chars` in `command_display.rs`.

This refactoring makes `truncate_command` a thin wrapper around `truncate_chars`. It also replaces the ad-hoc `truncate_str` helper previously defined in `rollback_commands.rs` with this new, robust utility.

`truncate_chars` correctly handles Unicode scalar values (chars), ensuring that multi-byte UTF-8 sequences are not split mid-character. This prevents potential panics when truncating strings containing non-ASCII characters, particularly at byte boundaries. New tests have been added to verify this behavior.

Thank you to @hackerman70000 for reporting