### PR TITLE
feat(cli): deprecate 'nono learn' and improve diagnostics

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -32,7 +32,7 @@ const STYLES: Styles = Styles::plain().header(Style::new().bold());
   wrap       Apply sandbox and exec into command (nono disappears)
 
 \x1b[1mEXPLORATION & DEBUGGING\x1b[0m
-  learn      Discover required filesystem paths
+  learn      [deprecated] Use `nono run` to learn from sandbox denials
   why        Check why a path or network operation would be allowed or denied
 
 \x1b[1mSESSION MANAGEMENT\x1b[0m
@@ -175,7 +175,8 @@ pub enum Commands {
     Wrap(Box<WrapArgs>),
 
     // ── Exploration & debugging ─────────────────────────────────────────
-    /// Discover required filesystem paths
+    /// [deprecated] Use `nono run` to learn from sandbox denials
+    /// DEPRECATED(canonical="nono run", introduced="v0.50.1", remove_by="v1.0.0", issue="#445")
     #[command(trailing_var_arg = true)]
     #[command(help_template = "\
 {about}
@@ -185,9 +186,13 @@ pub enum Commands {
 
 {all-args}
 {after-help}")]
-    #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono learn -- my-app                         # Discover paths needed by a command
-  nono learn --profile my-profile -- my-app    # Compare against an existing profile
+    #[command(after_help = "\x1b[1mDEPRECATED\x1b[0m
+  Use `nono run --profile <name> -- <command>` instead. `nono run` keeps the
+  command sandboxed, reports denials, and offers to save profile updates.
+
+\x1b[1mEXAMPLES\x1b[0m
+  nono run --profile my-profile -- my-app      # Preferred learning workflow
+  nono learn --profile my-profile -- my-app    # Deprecated compatibility path
   nono learn --json -- node server.js          # Output as JSON for profile
   nono learn --timeout 30 -- my-app            # Limit trace duration
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -32,7 +32,7 @@ const STYLES: Styles = Styles::plain().header(Style::new().bold());
   wrap       Apply sandbox and exec into command (nono disappears)
 
 \x1b[1mEXPLORATION & DEBUGGING\x1b[0m
-  learn      Trace a command to discover required filesystem paths
+  learn      Discover required filesystem paths
   why        Check why a path or network operation would be allowed or denied
 
 \x1b[1mSESSION MANAGEMENT\x1b[0m
@@ -175,7 +175,7 @@ pub enum Commands {
     Wrap(Box<WrapArgs>),
 
     // ── Exploration & debugging ─────────────────────────────────────────
-    /// Trace a command to discover required filesystem paths
+    /// Discover required filesystem paths
     #[command(trailing_var_arg = true)]
     #[command(help_template = "\
 {about}
@@ -193,7 +193,8 @@ pub enum Commands {
 
 \x1b[1mPLATFORM NOTES\x1b[0m
   Linux   Uses strace (install with: apt install strace)
-  macOS   Uses fs_usage (requires sudo)
+  macOS   Prefer: nono run --profile <name> -- <command>
+          Legacy unsandboxed fs_usage/nettop tracing: nono learn --trace -- <command>
 ")]
     Learn(Box<LearnArgs>),
 
@@ -1715,6 +1716,10 @@ pub struct LearnArgs {
     /// Skip reverse DNS lookups for discovered IPs
     #[arg(long, help_heading = "OPTIONS")]
     pub no_rdns: bool,
+
+    /// On macOS, use legacy unsandboxed fs_usage/nettop tracing
+    #[arg(long, help_heading = "OPTIONS")]
+    pub trace: bool,
 
     /// Enable verbose output
     #[arg(long, short = 'v', action = clap::ArgAction::Count, help_heading = "OPTIONS")]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -497,7 +497,8 @@ IN-BAND DETACH:
   nono profile list                            # List all profiles (built-in and user)
   nono profile show claude-code                # Show a fully resolved profile
   nono profile diff default claude-code        # Compare two profiles
-  nono profile validate ~/my-profile.json      # Validate a user profile file
+  nono profile validate my-agent               # Validate a profile by name
+  nono profile validate ~/my-profile.json      # Validate a profile file
   nono profile validate --draft my-profile     # Validate a profile draft
   nono profile promote my-profile              # Review and apply a profile draft
   nono profile groups                          # List all policy groups

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -71,7 +71,7 @@ const MAX_DENIAL_RECORDS: usize = 1000;
 const MAX_TRACKED_REQUEST_IDS: usize = 4096;
 /// Quiet period used to drain final PTY output after child exit before parent
 /// diagnostics/prompts take over the terminal.
-const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 
 fn offer_profile_save_for_child(
     pty: Option<&mut crate::pty_proxy::PtyProxy>,

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1162,23 +1162,40 @@ pub fn execute_supervised(
                 DiagnosticMode::Standard
             };
 
-            let should_print_diagnostics = !config.no_diagnostics
-                && (exit_code != 0 || !denials.is_empty() || error_observation.has_findings());
+            #[cfg(target_os = "macos")]
+            let sandbox_violations = if supervisor.is_some() {
+                let include_historical_sandbox_log =
+                    exit_code != 0 || !denials.is_empty() || error_observation.has_findings();
+                match sandbox_log_collector {
+                    Some(collector) if include_historical_sandbox_log => collector.finish(),
+                    Some(collector) => collector.finish_realtime_only(),
+                    None => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            };
+            #[cfg(not(target_os = "macos"))]
+            let sandbox_violations = Vec::new();
+
+            // Resolve policy explanations for denied paths so the diagnostic
+            // can show group names and fix guidance inline. On macOS this is
+            // also the source for the run-time profile save prompt.
+            let policy_explanations =
+                build_policy_explanations(&denials, &sandbox_violations, config.caps);
+            let prompt_policy_explanations = policy_explanations.clone();
+            let prompt_error_observation = error_observation.clone();
+
+            let should_print_diagnostics = should_print_diagnostic_footer(
+                config.no_diagnostics,
+                exit_code,
+                &denials,
+                &sandbox_violations,
+                &error_observation,
+            );
 
             // Print diagnostic footer on non-zero exit or when the PTY
-            // output shows a likely sandbox-related issue.
+            // output or OS sandbox logs show a likely sandbox-related issue.
             if should_print_diagnostics {
-                #[cfg(target_os = "macos")]
-                let sandbox_violations = if supervisor.is_some() {
-                    sandbox_log_collector
-                        .map(crate::sandbox_log::SandboxLogCollector::finish)
-                        .unwrap_or_default()
-                } else {
-                    Vec::new()
-                };
-                #[cfg(not(target_os = "macos"))]
-                let sandbox_violations = Vec::new();
-
                 let diag_session_id = if supervisor.is_some() {
                     pty_session_id
                         .or_else(|| supervisor.map(|s| s.session_id))
@@ -1186,13 +1203,6 @@ pub fn execute_supervised(
                 } else {
                     None
                 };
-
-                // Resolve policy explanations for denied paths so the
-                // diagnostic can show group names and fix guidance inline.
-                let policy_explanations =
-                    build_policy_explanations(&denials, &sandbox_violations, config.caps);
-                let prompt_policy_explanations = policy_explanations.clone();
-                let prompt_error_observation = error_observation.clone();
 
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
@@ -1212,21 +1222,26 @@ pub fn execute_supervised(
                 }
                 let footer = formatter.format_footer(exit_code);
                 crate::output::print_diagnostic_footer(&footer);
+            }
 
-                if exit_code != 0 {
-                    // Clear the forwarding target before prompting. The child is
-                    // already dead; keeping CHILD_PID set would cause forward_signal
-                    // to send Ctrl-C to the dead PID, swallowing it silently.
-                    clear_signal_forwarding_target();
-                    offer_profile_save_for_child(
-                        pty_proxy.as_mut(),
-                        &prompt_policy_explanations,
-                        &prompt_error_observation,
-                        config.caps,
-                        config.command,
-                        config.profile_save_base,
-                    )?;
-                }
+            if should_offer_profile_save(
+                config.no_diagnostics,
+                exit_code,
+                &prompt_policy_explanations,
+                &prompt_error_observation,
+            ) {
+                // Clear the forwarding target before prompting. The child is
+                // already dead; keeping CHILD_PID set would cause forward_signal
+                // to send Ctrl-C to the dead PID, swallowing it silently.
+                clear_signal_forwarding_target();
+                offer_profile_save_for_child(
+                    pty_proxy.as_mut(),
+                    &prompt_policy_explanations,
+                    &prompt_error_observation,
+                    config.caps,
+                    config.command,
+                    config.profile_save_base,
+                )?;
             }
 
             Ok(exit_code)
@@ -1284,6 +1299,15 @@ fn build_policy_explanations(
             .or_insert(access);
     }
 
+    if has_keychain_service_violation(sandbox_violations) {
+        if let Some(path) = login_keychain_db_path() {
+            paths
+                .entry(path)
+                .and_modify(|a| *a = merge(*a, AccessMode::Read))
+                .or_insert(AccessMode::Read);
+        }
+    }
+
     let mut explanations = Vec::new();
     for (path, access) in paths {
         match crate::query_ext::query_path(&path, access, caps, &[]) {
@@ -1312,6 +1336,59 @@ fn build_policy_explanations(
     }
 
     explanations
+}
+
+fn has_keychain_service_violation(violations: &[nono::SandboxViolation]) -> bool {
+    violations.iter().any(|violation| {
+        violation.operation == "mach-lookup"
+            && violation
+                .target
+                .as_deref()
+                .is_some_and(is_keychain_service_name)
+    })
+}
+
+fn is_keychain_service_name(service: &str) -> bool {
+    matches!(
+        service,
+        "com.apple.SecurityServer"
+            | "com.apple.securityd"
+            | "com.apple.security.keychaind"
+            | "com.apple.secd"
+            | "com.apple.security.agent"
+    )
+}
+
+fn login_keychain_db_path() -> Option<PathBuf> {
+    crate::config::validated_home()
+        .ok()
+        .map(|home| PathBuf::from(home).join("Library/Keychains/login.keychain-db"))
+}
+
+fn should_print_diagnostic_footer(
+    no_diagnostics: bool,
+    exit_code: i32,
+    denials: &[nono::diagnostic::DenialRecord],
+    sandbox_violations: &[nono::SandboxViolation],
+    error_observation: &nono::diagnostic::ErrorObservation,
+) -> bool {
+    !no_diagnostics
+        && (exit_code != 0
+            || !denials.is_empty()
+            || !sandbox_violations.is_empty()
+            || error_observation.has_findings())
+}
+
+fn should_offer_profile_save(
+    no_diagnostics: bool,
+    exit_code: i32,
+    policy_explanations: &[nono::diagnostic::PolicyExplanation],
+    error_observation: &nono::diagnostic::ErrorObservation,
+) -> bool {
+    !no_diagnostics
+        && (exit_code != 0
+            || !policy_explanations.is_empty()
+            || !error_observation.path_hints.is_empty())
 }
 
 /// Close inherited file descriptors, keeping stdin/stdout/stderr and specified FDs.
@@ -1416,7 +1493,7 @@ fn wait_for_child_with_pty(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.has_observed_output();
+                    let has_output = pty.has_visible_output();
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
@@ -1892,7 +1969,7 @@ fn run_supervisor_loop(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.as_ref().is_some_and(|p| p.has_observed_output());
+                    let has_output = pty.as_ref().is_some_and(|p| p.has_visible_output());
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
@@ -2136,7 +2213,7 @@ fn run_supervisor_loop(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.as_ref().is_some_and(|p| p.has_observed_output());
+                    let has_output = pty.as_ref().is_some_and(|p| p.has_visible_output());
                     if Instant::now() >= deadline && !has_output && !startup_prompted {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
@@ -3204,6 +3281,97 @@ mod tests {
             termios.control_chars[SpecialCharacterIndices::VTIME as usize],
             0
         );
+    }
+
+    #[test]
+    fn test_diagnostic_footer_triggers_on_successful_sandbox_violation() {
+        let violations = vec![nono::SandboxViolation {
+            operation: "file-read-data".to_string(),
+            target: Some("/tmp/secret.txt".to_string()),
+        }];
+        let denials = Vec::new();
+        let observation = nono::diagnostic::ErrorObservation::default();
+
+        assert!(should_print_diagnostic_footer(
+            false,
+            0,
+            &denials,
+            &violations,
+            &observation,
+        ));
+        assert!(!should_print_diagnostic_footer(
+            true,
+            0,
+            &denials,
+            &violations,
+            &observation,
+        ));
+    }
+
+    #[test]
+    fn test_profile_save_prompt_triggers_on_policy_explanation_with_zero_exit() {
+        let explanations = vec![nono::diagnostic::PolicyExplanation {
+            path: PathBuf::from("/tmp/secret.txt"),
+            access: nono::AccessMode::Read,
+            reason: "path_not_granted".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: Some("--read-file /tmp/secret.txt".to_string()),
+        }];
+        let observation = nono::diagnostic::ErrorObservation::default();
+
+        assert!(should_offer_profile_save(
+            false,
+            0,
+            &explanations,
+            &observation,
+        ));
+    }
+
+    #[test]
+    fn test_keychain_mach_violation_adds_profile_save_explanation() {
+        let _env_lock = crate::test_env::ENV_LOCK.lock().expect("env lock");
+        let temp_home = tempfile::TempDir::new().expect("temp home");
+        let home = temp_home.path().canonicalize().expect("canonical home");
+        let _env =
+            crate::test_env::EnvVarGuard::set_all(&[("HOME", home.to_str().expect("home path"))]);
+        let keychain = home.join("Library/Keychains/login.keychain-db");
+        std::fs::create_dir_all(keychain.parent().expect("keychain parent")).expect("mkdir");
+        std::fs::write(&keychain, b"db").expect("write keychain fixture");
+
+        let violations = vec![nono::SandboxViolation {
+            operation: "mach-lookup".to_string(),
+            target: Some("com.apple.SecurityServer".to_string()),
+        }];
+
+        let explanations = build_policy_explanations(&[], &violations, &nono::CapabilitySet::new());
+
+        let explanation = explanations
+            .iter()
+            .find(|explanation| explanation.path == keychain)
+            .expect("keychain explanation");
+        assert_eq!(explanation.access, nono::AccessMode::Read);
+        #[cfg(target_os = "macos")]
+        assert_eq!(explanation.reason, "sensitive_path");
+    }
+
+    #[test]
+    fn test_profile_save_prompt_preserves_nonzero_exit_behavior() {
+        let explanations = Vec::new();
+        let observation = nono::diagnostic::ErrorObservation::default();
+
+        assert!(should_offer_profile_save(
+            false,
+            1,
+            &explanations,
+            &observation,
+        ));
+        assert!(!should_offer_profile_save(
+            true,
+            1,
+            &explanations,
+            &observation,
+        ));
     }
 
     #[test]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -69,6 +69,9 @@ const MAX_CRYPTO_THREADS: usize = 7;
 const MAX_DENIAL_RECORDS: usize = 1000;
 /// Hard cap on request IDs tracked for replay detection.
 const MAX_TRACKED_REQUEST_IDS: usize = 4096;
+/// Quiet period used to drain final PTY output after child exit before parent
+/// diagnostics/prompts take over the terminal.
+const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 
 fn offer_profile_save_for_child(
     pty: Option<&mut crate::pty_proxy::PtyProxy>,
@@ -77,6 +80,7 @@ fn offer_profile_save_for_child(
     caps: &CapabilitySet,
     command: &[String],
     compared_profile: Option<&str>,
+    sandbox_violations: &[nono::SandboxViolation],
 ) -> Result<()> {
     if let Some(proxy) = pty {
         let _released_terminal = proxy.release_terminal_for_prompt();
@@ -86,6 +90,7 @@ fn offer_profile_save_for_child(
             caps,
             command,
             compared_profile,
+            sandbox_violations,
         );
     }
 
@@ -95,6 +100,7 @@ fn offer_profile_save_for_child(
         caps,
         command,
         compared_profile,
+        sandbox_violations,
     )
 }
 
@@ -368,8 +374,9 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
 /// 4. Child: apply Landlock, install seccomp-notify, close inherited FDs, exec
 /// 5. Parent: apply PR_SET_DUMPABLE(0) + PT_DENY_ATTACH, receive seccomp fd, run supervisor loop
 ///
-/// Does NOT pipe stdout/stderr. The child inherits the parent's terminal directly,
-/// preserving TTY semantics for interactive programs (e.g., Claude Code, vim).
+/// When a PTY pair is provided, the child runs behind the PTY proxy so the
+/// parent can capture terminal output for diagnostics while the child still sees
+/// a TTY. Otherwise the child inherits the parent's terminal directly.
 /// The parent prints diagnostics and rollback UI after the child exits.
 pub fn execute_supervised(
     config: &ExecConfig<'_>,
@@ -1119,7 +1126,9 @@ pub fn execute_supervised(
             // attaching client gets EPIPE ("Broken pipe") when it
             // tries to send the handshake.
             if let Some(ref mut p) = pty_proxy {
+                p.drain_master_output(POST_EXIT_PTY_DRAIN_TIMEOUT);
                 p.shutdown_attach_listener();
+                p.release_terminal_for_prompt();
             }
 
             let exit_code = match status {
@@ -1229,6 +1238,7 @@ pub fn execute_supervised(
                 exit_code,
                 &prompt_policy_explanations,
                 &prompt_error_observation,
+                &sandbox_violations,
             ) {
                 // Clear the forwarding target before prompting. The child is
                 // already dead; keeping CHILD_PID set would cause forward_signal
@@ -1241,6 +1251,7 @@ pub fn execute_supervised(
                     config.caps,
                     config.command,
                     config.profile_save_base,
+                    &sandbox_violations,
                 )?;
             }
 
@@ -1384,11 +1395,13 @@ fn should_offer_profile_save(
     exit_code: i32,
     policy_explanations: &[nono::diagnostic::PolicyExplanation],
     error_observation: &nono::diagnostic::ErrorObservation,
+    sandbox_violations: &[nono::SandboxViolation],
 ) -> bool {
     !no_diagnostics
         && (exit_code != 0
             || !policy_explanations.is_empty()
-            || !error_observation.path_hints.is_empty())
+            || !error_observation.path_hints.is_empty()
+            || crate::profile_save_runtime::has_saveable_system_service_rules(sandbox_violations))
 }
 
 /// Close inherited file descriptors, keeping stdin/stdout/stderr and specified FDs.
@@ -1754,7 +1767,9 @@ fn handle_pty_poll_events(
     resize_revents: libc::c_short,
     loop_name: &str,
 ) -> bool {
-    if master_revents & libc::POLLIN != 0 && !pty.proxy_master_to_client() {
+    if master_revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0
+        && !pty.proxy_master_to_client()
+    {
         debug!("Stopping {loop_name} after PTY master relay failure");
         return false;
     }
@@ -3325,6 +3340,25 @@ mod tests {
             0,
             &explanations,
             &observation,
+            &[],
+        ));
+    }
+
+    #[test]
+    fn test_profile_save_prompt_triggers_on_user_preferences_violation_with_zero_exit() {
+        let explanations = Vec::new();
+        let observation = nono::diagnostic::ErrorObservation::default();
+        let violations = vec![nono::SandboxViolation {
+            operation: "user-preference-read".to_string(),
+            target: Some("kcfpreferencesanyapplication".to_string()),
+        }];
+
+        assert!(should_offer_profile_save(
+            false,
+            0,
+            &explanations,
+            &observation,
+            &violations,
         ));
     }
 
@@ -3365,12 +3399,14 @@ mod tests {
             1,
             &explanations,
             &observation,
+            &[],
         ));
         assert!(!should_offer_profile_save(
             true,
             1,
             &explanations,
             &observation,
+            &[],
         ));
     }
 

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::time::Duration;
 use tracing::{error, info};
 
-const PROFILE_HINT_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const PROFILE_HINT_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn apply_pre_fork_sandbox(
     strategy: exec_strategy::ExecStrategy,
@@ -136,6 +136,19 @@ fn should_apply_startup_timeout(
     recommended_profile.is_some() && cmd_args.is_empty()
 }
 
+fn startup_timeout_profile<'a>(
+    recommended_profile: Option<&'a str>,
+    explicit_profile: Option<&str>,
+) -> Option<&'a str> {
+    let recommended = recommended_profile?;
+    if let Some(explicit) = explicit_profile {
+        if explicit == recommended || explicit == format!("{recommended}-local") {
+            return None;
+        }
+    }
+    Some(recommended)
+}
+
 pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let LaunchPlan {
         program,
@@ -171,11 +184,14 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     }
 
     let resolved_program = exec_strategy::resolve_program(&command[0])?;
+    let known_builtin_profile = recommended_builtin_profile(&resolved_program);
     let recommended_profile = if flags.session.profile_name.is_none() {
-        recommended_builtin_profile(&resolved_program)
+        known_builtin_profile
     } else {
         None
     };
+    let startup_timeout_profile =
+        startup_timeout_profile(known_builtin_profile, flags.session.profile_name.as_deref());
 
     let recommended_program_name = resolved_program
         .file_name()
@@ -297,8 +313,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             .profile_name
             .as_deref()
             .or(recommended_profile),
-        startup_timeout: if should_apply_startup_timeout(recommended_profile, &cmd_args) {
-            recommended_profile.map(|profile| exec_strategy::StartupTimeoutConfig {
+        startup_timeout: if should_apply_startup_timeout(startup_timeout_profile, &cmd_args) {
+            startup_timeout_profile.map(|profile| exec_strategy::StartupTimeoutConfig {
                 timeout: PROFILE_HINT_STARTUP_TIMEOUT,
                 program: recommended_program_name,
                 profile,
@@ -397,6 +413,7 @@ fn write_capability_state_file(
 mod tests {
     use super::{
         compute_executable_identity, recommended_builtin_profile, should_apply_startup_timeout,
+        startup_timeout_profile,
     };
     use sha2::{Digest, Sha256};
     use std::fs;
@@ -428,6 +445,27 @@ mod tests {
             &["--version"]
         ));
         assert!(!should_apply_startup_timeout(None, &no_args));
+    }
+
+    #[test]
+    fn startup_timeout_profile_ignores_matching_explicit_profile_only() {
+        assert_eq!(
+            startup_timeout_profile(Some("claude-code"), None),
+            Some("claude-code")
+        );
+        assert_eq!(
+            startup_timeout_profile(Some("claude-code"), Some("default")),
+            Some("claude-code")
+        );
+        assert_eq!(
+            startup_timeout_profile(Some("claude-code"), Some("claude-code")),
+            None
+        );
+        assert_eq!(
+            startup_timeout_profile(Some("claude-code"), Some("claude-code-local")),
+            None
+        );
+        assert_eq!(startup_timeout_profile(None, Some("default")), None);
     }
 
     #[test]

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -10,6 +10,8 @@ use colored::Colorize;
 use nono::{NonoError, Result};
 
 pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
+    print_learn_deprecation(&args, silent);
+
     #[cfg(target_os = "macos")]
     if !args.trace {
         return print_macos_run_guidance(&args, silent);
@@ -69,6 +71,49 @@ pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_learn_deprecation(args: &LearnArgs, silent: bool) {
+    if silent {
+        return;
+    }
+
+    eprintln!(
+        "{}",
+        "DEPRECATED: nono learn is deprecated in v0.50.1; use `nono run` instead. Removal target: v1.0.0 (#445).".yellow()
+    );
+    if let Some(profile) = args.profile.as_deref() {
+        eprintln!(
+            "{}",
+            format!(
+                "Use: nono run --profile {} -- {}",
+                profile,
+                crate::command_display::format_command_line(&args.command)
+            )
+            .yellow()
+        );
+    } else {
+        eprintln!(
+            "{}",
+            format!(
+                "Use: nono run --profile <profile> -- {}",
+                crate::command_display::format_command_line(&args.command)
+            )
+            .yellow()
+        );
+    }
+    eprintln!(
+        "{}",
+        "`nono run` keeps the command sandboxed, reports denials, and offers to save profile updates."
+            .yellow()
+    );
+    if args.trace {
+        eprintln!(
+            "{}",
+            "Continuing with legacy unsandboxed trace mode for compatibility.".yellow()
+        );
+    }
+    eprintln!();
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -1,4 +1,6 @@
 use crate::cli::LearnArgs;
+#[cfg(target_os = "macos")]
+use crate::command_display::format_command_line;
 use crate::profile_save_runtime::{
     command_name, confirm, patch_has_policy_overrides, print_patch_preview, print_profile_save,
     suggested_profile_name, write_profile, PreparedProfileSave, SaveAction,
@@ -8,6 +10,11 @@ use colored::Colorize;
 use nono::{NonoError, Result};
 
 pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    if !args.trace {
+        return print_macos_run_guidance(&args, silent);
+    }
+
     if !silent {
         eprintln!(
             "{}",
@@ -60,6 +67,42 @@ pub(crate) fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
             eprintln!("Network activity detected. Use --block-net to restrict network access.");
         }
     }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn print_macos_run_guidance(args: &LearnArgs, silent: bool) -> Result<()> {
+    if args.json {
+        return Err(NonoError::LearnError(
+            "macOS run-based learning does not produce JSON. Use `nono learn --trace --json -- <command>` for the legacy unsandboxed tracer.".to_string(),
+        ));
+    }
+
+    if silent {
+        return Ok(());
+    }
+
+    let command = format_command_line(&args.command);
+    eprintln!(
+        "{}",
+        "macOS learn now uses sandbox denials from `nono run`.".yellow()
+    );
+    eprintln!("This keeps the command sandboxed and reuses the existing profile-save prompt.");
+    eprintln!();
+
+    if let Some(profile) = args.profile.as_deref() {
+        eprintln!("Run:");
+        eprintln!("  nono run --profile {} -- {}", profile, command);
+    } else {
+        eprintln!("Run with the profile you want to improve:");
+        eprintln!("  nono run --profile <profile> -- {}", command);
+    }
+
+    eprintln!();
+    eprintln!("When a path is denied, `nono run` will show diagnostics and offer to save a user profile patch.");
+    eprintln!("Legacy unsandboxed tracing remains available with:");
+    eprintln!("  nono learn --trace -- {}", command);
 
     Ok(())
 }

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -404,11 +404,11 @@ fn render_diagnostic_footer(footer: &str) -> String {
 fn print_terminal_block(message: &str, leading_blank_line: bool) {
     let mut stderr = std::io::stderr();
     if stderr.is_terminal() {
-        let normalized = normalize_terminal_line_endings(message);
         if leading_blank_line {
-            let _ = write!(stderr, "\r\n");
+            let _ = write!(stderr, "\r\x1b[K\r\n");
         }
-        let _ = write!(stderr, "\r{}\r\n", normalized);
+        let _ = write!(stderr, "{}", render_terminal_block_for_tty(message));
+        let _ = stderr.flush();
     } else {
         if leading_blank_line {
             let _ = writeln!(stderr);
@@ -417,8 +417,14 @@ fn print_terminal_block(message: &str, leading_blank_line: bool) {
     }
 }
 
-fn normalize_terminal_line_endings(message: &str) -> String {
-    message.replace('\n', "\r\n")
+fn render_terminal_block_for_tty(message: &str) -> String {
+    let mut out = String::new();
+    for line in message.lines() {
+        out.push('\r');
+        out.push_str(line);
+        out.push_str("\x1b[K\r\n");
+    }
+    out
 }
 
 fn render_diagnostic_line(idx: usize, line: &str, t: &theme::Theme) -> String {
@@ -763,25 +769,25 @@ pub fn print_profile_hint(program: &str, profile: &str, silent: bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_unix_socket_mode_badge, normalize_terminal_line_endings, print_capabilities,
-        print_profile_hint, render_diagnostic_footer,
+        format_unix_socket_mode_badge, print_capabilities, print_profile_hint,
+        render_diagnostic_footer, render_terminal_block_for_tty,
     };
     use nono::{CapabilitySet, UnixSocketMode};
     use tempfile::tempdir;
-
-    #[test]
-    fn normalize_terminal_line_endings_uses_crlf() {
-        assert_eq!(
-            normalize_terminal_line_endings("line one\nline two"),
-            "line one\r\nline two"
-        );
-    }
 
     #[test]
     fn render_diagnostic_footer_preserves_line_structure() {
         let footer = "nono diagnostic\n────────\nThe command failed.\n  Learn: nono learn";
         let rendered = render_diagnostic_footer(footer);
         assert_eq!(rendered.lines().count(), 4);
+    }
+
+    #[test]
+    fn render_terminal_block_for_tty_clears_each_line_tail() {
+        assert_eq!(
+            render_terminal_block_for_tty("short\nnext"),
+            "\rshort\u{1b}[K\r\n\rnext\u{1b}[K\r\n"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -134,7 +134,7 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
     eprintln!(
         "{} Validate with: nono profile validate {}",
         prefix(),
-        output_path.display()
+        profile_validate_target(&args, &output_path)
     );
     eprintln!(
         "{} For editor autocomplete: nono profile schema -o nono-profile.schema.json",
@@ -142,6 +142,13 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn profile_validate_target(args: &ProfileInitArgs, output_path: &Path) -> String {
+    match profile::get_user_profile_path(&args.name) {
+        Ok(default_path) if default_path == output_path => args.name.clone(),
+        _ => output_path.display().to_string(),
+    }
 }
 
 /// Build a skeleton profile JSON value with controlled field ordering.
@@ -720,7 +727,7 @@ pub(crate) fn cmd_list(args: ProfileListArgs) -> Result<()> {
 
     if !pack_entries.is_empty() {
         println!();
-        println!("  {}", theme::fg("Packs:", t.subtext).bold());
+        println!("  {}", theme::fg("Packages:", t.subtext).bold());
         for (name, pack_ref, result) in &pack_entries {
             print_pack_profile_line(name, pack_ref, result, t);
         }
@@ -854,6 +861,16 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
             println!("    {}", theme::fg(g, t.text));
         }
     }
+    if !profile.groups.exclude.is_empty() {
+        println!();
+        println!(
+            "  {}",
+            theme::fg("Excluded security groups:", t.subtext).bold()
+        );
+        for g in &profile.groups.exclude {
+            println!("    {}", theme::fg(g, t.yellow));
+        }
+    }
 
     if !profile.commands.allow.is_empty() {
         println!();
@@ -863,6 +880,16 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
         );
         for cmd in &profile.commands.allow {
             println!("    {}", theme::fg(cmd, t.text));
+        }
+    }
+    if !profile.commands.deny.is_empty() {
+        println!();
+        println!(
+            "  {}",
+            theme::fg("Denied commands (deprecated, startup-only):", t.subtext).bold()
+        );
+        for cmd in &profile.commands.deny {
+            println!("    {}", theme::fg(cmd, t.yellow));
         }
     }
 
@@ -919,43 +946,6 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
                 "    {}: {}",
                 theme::fg("bypass_protection", t.yellow),
                 fs.bypass_protection.join(", ")
-            );
-        }
-    }
-
-    // Groups/commands (canonical additions)
-    let has_group_settings =
-        !profile.groups.include.is_empty() || !profile.groups.exclude.is_empty();
-    let has_cmd_settings = !profile.commands.allow.is_empty() || !profile.commands.deny.is_empty();
-    if has_group_settings || has_cmd_settings {
-        println!();
-        println!("  {}", theme::fg("Policy patches:", t.subtext).bold());
-        if !profile.groups.include.is_empty() {
-            println!(
-                "    {}: {}",
-                theme::fg("groups.include", t.subtext),
-                profile.groups.include.join(", ")
-            );
-        }
-        if !profile.groups.exclude.is_empty() {
-            println!(
-                "    {}: {}",
-                theme::fg("groups.exclude", t.yellow),
-                profile.groups.exclude.join(", ")
-            );
-        }
-        if !profile.commands.allow.is_empty() {
-            println!(
-                "    {}: {}",
-                theme::fg("commands.allow", t.subtext),
-                profile.commands.allow.join(", ")
-            );
-        }
-        if !profile.commands.deny.is_empty() {
-            println!(
-                "    {}: {}",
-                theme::fg("commands.deny (deprecated, startup-only)", t.yellow),
-                profile.commands.deny.join(", ")
             );
         }
     }
@@ -3178,6 +3168,61 @@ mod tests {
         assert!(result.is_err());
         let err = result.expect_err("error");
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn profile_validate_target_prefers_name_for_default_user_profile_path() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let args = ProfileInitArgs {
+            name: "copilot".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        };
+        let output_path = profile::get_user_profile_path("copilot").expect("profile path");
+
+        assert_eq!(profile_validate_target(&args, &output_path), "copilot");
+    }
+
+    #[test]
+    fn profile_validate_target_uses_path_for_custom_output() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let output_path = dir.path().join("custom-copilot.json");
+        let args = ProfileInitArgs {
+            name: "copilot".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(output_path.clone()),
+            force: false,
+        };
+
+        assert_eq!(
+            profile_validate_target(&args, &output_path),
+            output_path.display().to_string()
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -130,21 +130,23 @@ pub(crate) fn offer_save_run_profile(
 fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
     let mut first = true;
     loop {
-        if first {
+        let prompt = if first {
             if let Some(suggested_name) = suggested {
-                prompt_print(
+                format!(
                     "Save denied paths as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
-                    &[suggested_name],
-                );
+                    suggested_name
+                )
             } else {
-                prompt_print(
-                    "Save denied paths as user profile? Enter a name (or press Enter to skip): ",
-                    &[],
-                );
+                "Save denied paths as user profile? Enter a name (or press Enter to skip): "
+                    .to_string()
             }
-            first = false;
         } else {
-            prompt_print("Enter a name (or press Enter to skip): ", &[]);
+            "Enter a name (or press Enter to skip): ".to_string()
+        };
+        prompt_print(&prompt, &[]);
+
+        if first {
+            first = false;
         }
 
         let input = read_input_line()?;

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -2,6 +2,7 @@ use crate::command_display::format_command_line;
 use crate::{profile, query_ext};
 use colored::Colorize;
 use nono::diagnostic::{ErrorObservation, PolicyExplanation};
+use nono::SandboxViolation;
 use nono::{AccessMode, CapabilitySet, NonoError, Result};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufRead, IsTerminal, Write};
@@ -33,6 +34,7 @@ struct PatchGrant {
 /// return true) but no human to answer. Mirrors the `NONO_NO_MIGRATE`
 /// escape hatch on the migration prompt.
 const ENV_NO_SAVE_PROMPT: &str = "NONO_NO_SAVE_PROMPT";
+const USER_PREFERENCES_SEATBELT_RULE: &str = "(allow user-preference-read)";
 
 pub(crate) fn terminal_prompts_available() -> bool {
     if matches!(
@@ -52,17 +54,25 @@ pub(crate) fn offer_save_run_profile(
     caps: &CapabilitySet,
     command: &[String],
     compared_profile: Option<&str>,
+    sandbox_violations: &[SandboxViolation],
 ) -> Result<()> {
-    if compared_profile.is_none() || !terminal_prompts_available() {
+    if !terminal_prompts_available() {
         return Ok(());
     }
 
-    let Some(patch) = build_run_profile_patch(policy_explanations, error_observation, caps)? else {
+    let Some(patch) = build_run_profile_patch(
+        policy_explanations,
+        error_observation,
+        caps,
+        sandbox_violations,
+    )?
+    else {
         return Ok(());
     };
 
     let cmd_name = command_name(command)?;
     let has_overrides = patch_has_policy_overrides(&patch);
+    let _prompt_terminal = prepare_prompt_terminal();
 
     prompt_println("");
     print_patch_preview(&patch);
@@ -73,7 +83,7 @@ pub(crate) fn offer_save_run_profile(
         let confirmed = if has_overrides {
             confirm_typed_word(
                 &format!(
-                    "Update existing user profile '{}' with these paths, including policy overrides? Type 'override' to confirm: ",
+                    "Update existing user profile '{}' with these entries, including unsafe policy overrides? Type 'override' to confirm: ",
                     existing_profile
                 ),
                 "override",
@@ -81,7 +91,7 @@ pub(crate) fn offer_save_run_profile(
         } else {
             confirm(
                 &format!(
-                    "Update existing user profile '{}' with denied paths? [Y/n] ",
+                    "Update existing user profile '{}' with denied paths/rules? [Y/n] ",
                     existing_profile
                 ),
                 true,
@@ -101,7 +111,7 @@ pub(crate) fn offer_save_run_profile(
         return Ok(());
     }
 
-    let suggested = suggested_profile_name(compared_profile);
+    let suggested = suggested_run_profile_name(compared_profile, &cmd_name);
     let Some(profile_name) = prompt_profile_name(suggested.as_deref())? else {
         return Ok(());
     };
@@ -217,6 +227,56 @@ pub(crate) fn suggested_profile_name(compared_profile: Option<&str>) -> Option<S
         .map(|name| format!("{}-local", name))
 }
 
+fn suggested_run_profile_name(compared_profile: Option<&str>, cmd_name: &str) -> Option<String> {
+    if let Some(name) = suggested_profile_name(compared_profile) {
+        return Some(name);
+    }
+
+    let candidate = profile_name_from_command(cmd_name)?;
+    if would_shadow_builtin(&candidate) {
+        return None;
+    }
+
+    Some(candidate)
+}
+
+fn profile_name_from_command(cmd_name: &str) -> Option<String> {
+    let mut out = String::with_capacity(cmd_name.len());
+    let mut last_was_hyphen = false;
+
+    for ch in cmd_name.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            Some(ch.to_ascii_lowercase())
+        } else if ch == '-' || ch == '_' || ch == '.' {
+            Some('-')
+        } else {
+            None
+        };
+
+        if let Some(ch) = mapped {
+            if ch == '-' {
+                if out.is_empty() || last_was_hyphen {
+                    continue;
+                }
+                last_was_hyphen = true;
+            } else {
+                last_was_hyphen = false;
+            }
+            out.push(ch);
+        }
+    }
+
+    while out.ends_with('-') {
+        out.pop();
+    }
+
+    if profile::is_valid_profile_name(&out) {
+        Some(out)
+    } else {
+        None
+    }
+}
+
 /// Return true when writing `~/.config/nono/profiles/<name>.json` would shadow
 /// a built-in profile of the same name. User files are loaded in preference to
 /// built-ins, so saving under a built-in's name silently reroutes all future
@@ -325,9 +385,21 @@ pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[Stri
         prompt_println(&format!(
             "{}",
             format!(
-                "  ({} path{} with filesystem.bypass_protection — review the profile before sharing)",
+                "  ({} path{} with filesystem.bypass_protection - review the profile before sharing)",
                 override_count,
                 if override_count == 1 { "" } else { "s" }
+            )
+            .yellow()
+        ));
+    }
+    let unsafe_rule_count = prepared.profile.unsafe_macos_seatbelt_rules.len();
+    if unsafe_rule_count > 0 {
+        prompt_println(&format!(
+            "{}",
+            format!(
+                "  ({} raw macOS Seatbelt rule{} via unsafe_macos_seatbelt_rules - review the profile before sharing)",
+                unsafe_rule_count,
+                if unsafe_rule_count == 1 { "" } else { "s" }
             )
             .yellow()
         ));
@@ -356,19 +428,36 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
     ];
 
     let has_entries = sections.iter().any(|(_, paths)| !paths.is_empty());
-    if !has_entries && patch.filesystem.bypass_protection.is_empty() {
+    let has_unsafe_rules = !patch.unsafe_macos_seatbelt_rules.is_empty();
+    if !has_entries && patch.filesystem.bypass_protection.is_empty() && !has_unsafe_rules {
         return;
     }
 
-    prompt_println("[nono] Paths to be saved:");
-    for (label, paths) in sections {
-        for path in *paths {
-            let is_override = patch.filesystem.bypass_protection.contains(path);
-            if is_override {
-                prompt_println(&format!("  {}  {} ({})", "⚠".red(), path, label));
-            } else {
-                prompt_println(&format!("  {}  ({})", path, label));
+    if has_entries {
+        prompt_println("[nono] Paths to be saved:");
+        for (label, paths) in sections {
+            for path in *paths {
+                let is_override = patch.filesystem.bypass_protection.contains(path);
+                if is_override {
+                    prompt_println(&format!("  {}  {} ({})", "⚠".red(), path, label));
+                } else {
+                    prompt_println(&format!("  {}  ({})", path, label));
+                }
             }
+        }
+    }
+
+    if has_unsafe_rules {
+        if has_entries {
+            prompt_println("");
+        }
+        prompt_println("[nono] Unsafe macOS Seatbelt rules to be saved:");
+        for rule in &patch.unsafe_macos_seatbelt_rules {
+            prompt_println(&format!(
+                "  {}  {}  (unsafe_macos_seatbelt_rules)",
+                "⚠".red(),
+                rule
+            ));
         }
     }
 
@@ -383,11 +472,23 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
                 .red()
         ));
     }
+
+    if has_unsafe_rules {
+        prompt_println(&format!(
+            "{}",
+            "\n[nono] ⚠  The marked rules are raw macOS Seatbelt policy.".red()
+        ));
+        prompt_println(&format!(
+            "{}",
+            "[nono]    Saving them adds unsafe_macos_seatbelt_rules, which bypasses nono's capability model and can weaken sandbox protection."
+                .red()
+        ));
+    }
 }
 
-/// Return true if the patch includes any `filesystem.bypass_protection` entries.
+/// Return true if the patch includes entries that bypass normal capability policy.
 pub(crate) fn patch_has_policy_overrides(patch: &profile::Profile) -> bool {
-    !patch.filesystem.bypass_protection.is_empty()
+    !patch.filesystem.bypass_protection.is_empty() || !patch.unsafe_macos_seatbelt_rules.is_empty()
 }
 
 fn prompt_print(template: &str, args: &[&str]) {
@@ -485,6 +586,12 @@ impl Drop for PromptTerminalGuard {
     }
 }
 
+fn prepare_prompt_terminal() -> Option<PromptTerminalGuard> {
+    open_tty_prompt_device()
+        .ok()
+        .map(|tty| PromptTerminalGuard::new(&tty))
+}
+
 pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios) {
     use nix::sys::termios::{
         ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
@@ -523,7 +630,7 @@ pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios)
 
 fn prompt_write(message: &str) {
     if let Some(mut tty) = open_tty_writer() {
-        let _ = write!(tty, "{}", message);
+        let _ = write!(tty, "{}", prompt_inline_for_tty(message));
         let _ = tty.flush();
         return;
     }
@@ -534,13 +641,25 @@ fn prompt_write(message: &str) {
 
 fn prompt_writeln(message: &str) {
     if let Some(mut tty) = open_tty_writer() {
-        let _ = writeln!(tty, "{}", message);
+        let _ = write!(tty, "{}", prompt_line_for_tty(message));
         let _ = tty.flush();
         return;
     }
 
-    eprintln!("{}", message);
+    eprint!("{}", prompt_line(message));
     let _ = std::io::stderr().flush();
+}
+
+fn prompt_line(message: &str) -> String {
+    format!("{message}\r\n")
+}
+
+fn prompt_inline_for_tty(message: &str) -> String {
+    format!("\r{message}\x1b[K")
+}
+
+fn prompt_line_for_tty(message: &str) -> String {
+    format!("\r{message}\x1b[K\r\n")
 }
 
 pub(crate) fn prepare_profile_save_from_patch(
@@ -596,6 +715,7 @@ fn build_run_profile_patch(
     policy_explanations: &[PolicyExplanation],
     error_observation: &ErrorObservation,
     caps: &CapabilitySet,
+    sandbox_violations: &[SandboxViolation],
 ) -> Result<Option<profile::Profile>> {
     let mut grants: BTreeMap<PathBuf, PatchGrant> = BTreeMap::new();
 
@@ -622,12 +742,12 @@ fn build_run_profile_patch(
         }
     }
 
-    if grants.is_empty() {
+    let unsafe_rules = unsafe_seatbelt_rules_from_sandbox_violations(sandbox_violations);
+
+    if grants.is_empty() && unsafe_rules.is_empty() {
         return Ok(None);
     }
 
-    let home = crate::config::validated_home()?;
-    let home_path = Path::new(&home);
     let mut allow = BTreeSet::new();
     let mut read = BTreeSet::new();
     let mut write = BTreeSet::new();
@@ -636,30 +756,35 @@ fn build_run_profile_patch(
     let mut write_file = BTreeSet::new();
     let mut bypass_protection = BTreeSet::new();
 
-    for (path, grant) in grants {
-        let shortened = shorten_path_for_profile(&path, home_path);
-        if grant.bypass_protection {
-            bypass_protection.insert(shortened.clone());
-        }
+    if !grants.is_empty() {
+        let home = crate::config::validated_home()?;
+        let home_path = Path::new(&home);
 
-        match (grant.access, grant.is_file) {
-            (AccessMode::Read, false) => {
-                read.insert(shortened);
+        for (path, grant) in grants {
+            let shortened = shorten_path_for_profile(&path, home_path);
+            if grant.bypass_protection {
+                bypass_protection.insert(shortened.clone());
             }
-            (AccessMode::Write, false) => {
-                write.insert(shortened);
-            }
-            (AccessMode::ReadWrite, false) => {
-                allow.insert(shortened);
-            }
-            (AccessMode::Read, true) => {
-                read_file.insert(shortened);
-            }
-            (AccessMode::Write, true) => {
-                write_file.insert(shortened);
-            }
-            (AccessMode::ReadWrite, true) => {
-                allow_file.insert(shortened);
+
+            match (grant.access, grant.is_file) {
+                (AccessMode::Read, false) => {
+                    read.insert(shortened);
+                }
+                (AccessMode::Write, false) => {
+                    write.insert(shortened);
+                }
+                (AccessMode::ReadWrite, false) => {
+                    allow.insert(shortened);
+                }
+                (AccessMode::Read, true) => {
+                    read_file.insert(shortened);
+                }
+                (AccessMode::Write, true) => {
+                    write_file.insert(shortened);
+                }
+                (AccessMode::ReadWrite, true) => {
+                    allow_file.insert(shortened);
+                }
             }
         }
     }
@@ -672,8 +797,33 @@ fn build_run_profile_patch(
     patch.filesystem.read_file = read_file.into_iter().collect();
     patch.filesystem.write_file = write_file.into_iter().collect();
     patch.filesystem.bypass_protection = bypass_protection.into_iter().collect();
+    patch.unsafe_macos_seatbelt_rules = unsafe_rules.into_iter().collect();
 
     Ok(Some(patch))
+}
+
+pub(crate) fn has_saveable_system_service_rules(violations: &[SandboxViolation]) -> bool {
+    violations
+        .iter()
+        .any(is_user_preference_read_sandbox_violation)
+}
+
+fn unsafe_seatbelt_rules_from_sandbox_violations(
+    violations: &[SandboxViolation],
+) -> BTreeSet<String> {
+    let mut rules = BTreeSet::new();
+    if has_saveable_system_service_rules(violations) {
+        rules.insert(USER_PREFERENCES_SEATBELT_RULE.to_string());
+    }
+    rules
+}
+
+fn is_user_preference_read_sandbox_violation(violation: &SandboxViolation) -> bool {
+    violation.operation == "user-preference-read"
+        && violation
+            .target
+            .as_deref()
+            .is_some_and(|target| target.starts_with("kcfpreferences"))
 }
 
 fn add_patch_grant(
@@ -729,6 +879,10 @@ pub(crate) fn merge_profile_patch(profile: &mut profile::Profile, patch: &profil
         &profile.filesystem.bypass_protection,
         &patch.filesystem.bypass_protection,
     );
+    profile.unsafe_macos_seatbelt_rules = profile::dedup_append(
+        &profile.unsafe_macos_seatbelt_rules,
+        &patch.unsafe_macos_seatbelt_rules,
+    );
 }
 
 pub(crate) fn shorten_path_for_profile(path: &Path, home_path: &Path) -> String {
@@ -771,6 +925,7 @@ mod tests {
             &[explanation],
             &ErrorObservation::default(),
             &CapabilitySet::new(),
+            &[],
         )
         .expect("build patch")
         .expect("patch");
@@ -812,6 +967,7 @@ mod tests {
             &[read, write],
             &ErrorObservation::default(),
             &CapabilitySet::new(),
+            &[],
         )
         .expect("build patch")
         .expect("patch");
@@ -819,6 +975,120 @@ mod tests {
         assert_eq!(patch.filesystem.allow_file, vec!["~/config.json"]);
         assert!(patch.filesystem.read_file.is_empty());
         assert!(patch.filesystem.write_file.is_empty());
+    }
+
+    #[test]
+    fn build_run_profile_patch_adds_unsafe_rule_for_user_preferences_violation() {
+        let violations = vec![SandboxViolation {
+            operation: "user-preference-read".to_string(),
+            target: Some("kcfpreferencesanyapplication".to_string()),
+        }];
+
+        let patch = build_run_profile_patch(
+            &[],
+            &ErrorObservation::default(),
+            &CapabilitySet::new(),
+            &violations,
+        )
+        .expect("build patch")
+        .expect("patch");
+
+        assert_eq!(
+            patch.unsafe_macos_seatbelt_rules,
+            vec![USER_PREFERENCES_SEATBELT_RULE.to_string()]
+        );
+        assert!(patch.filesystem.allow.is_empty());
+        assert!(patch.filesystem.read.is_empty());
+        assert!(patch.filesystem.write.is_empty());
+    }
+
+    #[test]
+    fn unsafe_macos_seatbelt_rules_count_as_policy_overrides() {
+        let mut patch = profile::Profile::default();
+        assert!(!patch_has_policy_overrides(&patch));
+
+        patch.unsafe_macos_seatbelt_rules = vec![USER_PREFERENCES_SEATBELT_RULE.to_string()];
+
+        assert!(patch_has_policy_overrides(&patch));
+    }
+
+    #[test]
+    fn suggested_run_profile_name_uses_compared_profile_when_available() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        assert_eq!(
+            suggested_run_profile_name(Some("claude-code"), "copilot"),
+            Some("claude-code-local".to_string())
+        );
+    }
+
+    #[test]
+    fn suggested_run_profile_name_falls_back_to_command_name() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        assert_eq!(
+            suggested_run_profile_name(None, "copilot"),
+            Some("copilot".to_string())
+        );
+        assert_eq!(
+            suggested_run_profile_name(None, "GitHub.Copilot"),
+            Some("github-copilot".to_string())
+        );
+    }
+
+    #[test]
+    fn suggested_run_profile_name_avoids_shadowing_builtin() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        assert_eq!(suggested_run_profile_name(None, "opencode"), None);
+    }
+
+    #[test]
+    fn prompt_line_uses_crlf_for_terminal_layout() {
+        assert_eq!(
+            prompt_line("[nono] Paths to be saved:"),
+            "[nono] Paths to be saved:\r\n"
+        );
+        assert_eq!(prompt_line(""), "\r\n");
+    }
+
+    #[test]
+    fn prompt_tty_rendering_clears_line_tails() {
+        assert_eq!(
+            prompt_line_for_tty("[nono] Paths to be saved:"),
+            "\r[nono] Paths to be saved:\u{1b}[K\r\n"
+        );
+        assert_eq!(
+            prompt_inline_for_tty("Update profile? [Y/n] "),
+            "\rUpdate profile? [Y/n] \u{1b}[K"
+        );
     }
 
     #[test]
@@ -846,6 +1116,7 @@ mod tests {
         let mut patch = profile::Profile::default();
         patch.filesystem.read_file = vec!["~/.claude/settings.json".to_string()];
         patch.filesystem.bypass_protection = vec!["~/.claude/settings.json".to_string()];
+        patch.unsafe_macos_seatbelt_rules = vec![USER_PREFERENCES_SEATBELT_RULE.to_string()];
 
         let prepared = prepare_profile_save_from_patch(
             &patch,
@@ -869,6 +1140,10 @@ mod tests {
                 "~/old.json".to_string(),
                 "~/.claude/settings.json".to_string()
             ]
+        );
+        assert_eq!(
+            prepared.profile.unsafe_macos_seatbelt_rules,
+            vec![USER_PREFERENCES_SEATBELT_RULE.to_string()]
         );
     }
 

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -818,9 +818,12 @@ impl PtyProxy {
         self.screen.render_plaintext()
     }
 
-    /// Returns true once the child has emitted any PTY output.
-    pub fn has_observed_output(&self) -> bool {
-        !self.scrollback.is_empty()
+    /// Returns true once the child has rendered visible terminal content.
+    pub fn has_visible_output(&self) -> bool {
+        self.screen
+            .render_plaintext()
+            .chars()
+            .any(|ch| !ch.is_whitespace())
     }
 
     fn attach_replay_bytes(&self) -> Vec<u8> {

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -25,7 +25,7 @@ use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
 #[cfg(unix)]
@@ -48,6 +48,7 @@ const ATTACH_SCREEN_ENTER_ESCAPE: &[u8] =
 const TERMINAL_RESTORE_ESCAPE: &[u8] = b"\x1b[<u\x1b[>0n\x1b[>1n\x1b[>2n\x1b[>3n\x1b[>4n\x1b[>6n\x1b[>7n\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1004l\x1b[?2004l\x1b[?1049l\x1b[?25h";
 const TERMINAL_RESTORE_AND_CLEAR_ESCAPE: &[u8] =
     b"\x1b[<u\x1b[>0n\x1b[>1n\x1b[>2n\x1b[>3n\x1b[>4n\x1b[>6n\x1b[>7n\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1004l\x1b[?2004l\x1b[?1l\x1b>\x1b[?1049l\x1b[?25h\x1b[2J\x1b[H";
+const CLEAR_PARENT_OUTPUT_AREA: &[u8] = b"\r\x1b[K\x1b[J";
 
 static ATTACH_RESIZE_PIPE_READ: AtomicI32 = AtomicI32::new(-1);
 static ATTACH_RESIZE_PIPE_WRITE: AtomicI32 = AtomicI32::new(-1);
@@ -71,6 +72,12 @@ enum AttachedClient {
 enum ReadFdOutcome {
     Data(usize),
     Eof,
+    Retry,
+}
+
+enum MasterProxyOutcome {
+    Data,
+    Closed,
     Retry,
 }
 
@@ -348,6 +355,7 @@ impl PtyProxy {
 
         leave_attach_screen();
         self.restore_terminal();
+        prepare_parent_output_area();
         self.client = None;
         self.resize_notifier = None;
         self.pending_detach_match_len = 0;
@@ -539,6 +547,13 @@ impl PtyProxy {
     /// Returns false if the PTY master became unavailable.
     #[must_use = "false indicates the PTY master is no longer usable"]
     pub fn proxy_master_to_client(&mut self) -> bool {
+        !matches!(
+            self.proxy_master_to_client_once(),
+            MasterProxyOutcome::Closed
+        )
+    }
+
+    fn proxy_master_to_client_once(&mut self) -> MasterProxyOutcome {
         let client = self
             .client
             .as_ref()
@@ -547,11 +562,11 @@ impl PtyProxy {
         let mut buf = [0u8; 4096];
         let n = match read_fd_once(self.master.as_raw_fd(), &mut buf) {
             Ok(ReadFdOutcome::Data(n)) => n,
-            Ok(ReadFdOutcome::Eof) => return false,
-            Ok(ReadFdOutcome::Retry) => return true,
+            Ok(ReadFdOutcome::Eof) => return MasterProxyOutcome::Closed,
+            Ok(ReadFdOutcome::Retry) => return MasterProxyOutcome::Retry,
             Err(err) => {
                 debug!("PTY proxy: failed reading PTY master: {}", err);
-                return false;
+                return MasterProxyOutcome::Closed;
             }
         };
 
@@ -565,16 +580,69 @@ impl PtyProxy {
                         self.session_id, err
                     );
                     self.detach();
-                    return true;
+                    return MasterProxyOutcome::Data;
                 } else {
                     debug!("PTY proxy: attached socket client disconnected: {}", err);
                     self.detach();
-                    return true;
+                    return MasterProxyOutcome::Data;
                 }
             }
         }
 
-        true
+        MasterProxyOutcome::Data
+    }
+
+    /// Drain child output still queued on the PTY master after the child exits.
+    ///
+    /// `waitpid` can report the child exit before the supervisor has relayed the
+    /// final terminal bytes. Draining here keeps parent-owned diagnostics and
+    /// prompts ordered after the application's own stderr/stdout.
+    pub fn drain_master_output(&mut self, quiet_timeout: Duration) {
+        let mut quiet_deadline = Instant::now() + quiet_timeout;
+
+        loop {
+            let now = Instant::now();
+            if now >= quiet_deadline {
+                break;
+            }
+            let remaining = quiet_deadline.saturating_duration_since(now);
+            let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+            let mut pfd = libc::pollfd {
+                fd: self.master.as_raw_fd(),
+                events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+                revents: 0,
+            };
+
+            let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+            if ret > 0 {
+                if pfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR) != 0 {
+                    match self.proxy_master_to_client_once() {
+                        MasterProxyOutcome::Data => {
+                            quiet_deadline = Instant::now() + quiet_timeout;
+                            continue;
+                        }
+                        MasterProxyOutcome::Retry => {
+                            if pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+                                break;
+                            }
+                            continue;
+                        }
+                        MasterProxyOutcome::Closed => break,
+                    }
+                }
+                if pfd.revents & libc::POLLNVAL != 0 {
+                    break;
+                }
+            } else if ret == 0 {
+                break;
+            } else {
+                let err = std::io::Error::last_os_error();
+                if err.kind() != std::io::ErrorKind::Interrupted {
+                    debug!("PTY proxy: post-exit drain poll failed: {}", err);
+                    break;
+                }
+            }
+        }
     }
 
     /// Proxy data from the attached client to the PTY master (user → child).
@@ -810,12 +878,25 @@ impl PtyProxy {
         self.screen.render()
     }
 
-    /// Return the current screen content as plain text for diagnostic analysis.
+    /// Return captured terminal output as plain text for diagnostic analysis.
     ///
     /// Called after the child exits so the supervisor can search for
     /// sandbox-related error messages in the terminal output.
     pub fn screen_plaintext(&self) -> String {
-        self.screen.render_plaintext()
+        let mut captured = Vec::with_capacity(self.scrollback.len());
+        captured.extend(self.scrollback.iter().copied());
+        let scrollback = String::from_utf8_lossy(&captured).into_owned();
+        let screen = self.screen.render_plaintext();
+
+        if scrollback.trim().is_empty() {
+            return screen;
+        }
+
+        if screen.trim().is_empty() || scrollback.contains(screen.trim_end()) {
+            return scrollback;
+        }
+
+        format!("{scrollback}\n{screen}")
     }
 
     /// Returns true once the child has rendered visible terminal content.
@@ -1518,6 +1599,12 @@ fn recv_attach_resize_socket(stream: &UnixStream) -> Result<Option<UnixDatagram>
 fn leave_attach_screen() {
     let esc = terminal_restore_escape(false);
     let _ = write_all_fd(libc::STDOUT_FILENO, esc);
+    drain_terminal_output(libc::STDOUT_FILENO);
+}
+
+fn prepare_parent_output_area() {
+    let _ = write_all_fd(libc::STDOUT_FILENO, CLEAR_PARENT_OUTPUT_AREA);
+    drain_terminal_output(libc::STDOUT_FILENO);
 }
 
 pub(crate) fn write_detach_terminal_reset(fd: RawFd) {
@@ -1539,6 +1626,26 @@ pub(crate) fn terminal_restore_escape(clear_screen: bool) -> &'static [u8] {
         TERMINAL_RESTORE_AND_CLEAR_ESCAPE
     } else {
         TERMINAL_RESTORE_ESCAPE
+    }
+}
+
+fn drain_terminal_output(fd: RawFd) {
+    // SAFETY: `isatty` only inspects the borrowed fd and does not take ownership.
+    if unsafe { libc::isatty(fd) } != 1 {
+        return;
+    }
+
+    loop {
+        // SAFETY: `tcdrain` waits for queued terminal output on the borrowed fd.
+        let ret = unsafe { libc::tcdrain(fd) };
+        if ret == 0 {
+            break;
+        }
+        let err = std::io::Error::last_os_error();
+        if err.kind() != std::io::ErrorKind::Interrupted {
+            debug!("PTY proxy: terminal output drain failed: {}", err);
+            break;
+        }
     }
 }
 
@@ -2277,6 +2384,33 @@ mod tests {
     fn terminal_restore_escape_can_clear_screen() {
         let esc = std::str::from_utf8(terminal_restore_escape(true)).unwrap_or("");
         assert!(esc.ends_with("\u{1b}[2J\u{1b}[H"));
+    }
+
+    #[test]
+    fn screen_plaintext_includes_raw_scrollback_for_diagnostics() {
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+        proxy.record_output(
+            b"Failed to extract bundled package: Error: EPERM: operation not permitted, mkdir '/tmp/copilot/pkg/darwin-arm64'\r\n",
+        );
+
+        let text = proxy.screen_plaintext();
+        assert!(text.contains("EPERM: operation not permitted"));
+        assert!(text.contains("mkdir '/tmp/copilot/pkg/darwin-arm64'"));
+    }
+
+    #[test]
+    fn drain_master_output_captures_tail_before_parent_prompt() {
+        let (master_reader, mut master_writer) = UnixStream::pair().expect("socket pair");
+        master_writer
+            .write_all(b"final child stderr line\r\n")
+            .expect("write PTY output");
+        drop(master_writer);
+        let master = unsafe { OwnedFd::from_raw_fd(master_reader.into_raw_fd()) };
+        let mut proxy = build_test_proxy_with_master(master, &DEFAULT_DETACH_SEQUENCE);
+
+        proxy.drain_master_output(Duration::from_millis(10));
+
+        assert!(proxy.screen_plaintext().contains("final child stderr line"));
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -154,7 +154,16 @@ impl SandboxLogCollector {
     }
 
     #[must_use]
-    pub fn finish(mut self) -> Vec<SandboxViolation> {
+    pub fn finish(self) -> Vec<SandboxViolation> {
+        self.finish_inner(true)
+    }
+
+    #[must_use]
+    pub fn finish_realtime_only(self) -> Vec<SandboxViolation> {
+        self.finish_inner(false)
+    }
+
+    fn finish_inner(mut self, include_historical_fallback: bool) -> Vec<SandboxViolation> {
         // Kill the real-time stream — it may or may not have captured
         // events depending on timing.
         let _ = self.child.kill();
@@ -179,7 +188,7 @@ impl SandboxLogCollector {
         // (e.g. `cat`). The child can exit before the log system delivers
         // the denial event. Fall back to a historical log query which is
         // deterministic — events are already committed by this point.
-        if violations.is_empty() {
+        if include_historical_fallback && violations.is_empty() {
             let filter = ViolationFilter {
                 pid: Some(self.child_pid),
                 process_name: self.command_name.clone(),

--- a/crates/nono-cli/src/startup_prompt.rs
+++ b/crates/nono-cli/src/startup_prompt.rs
@@ -1,7 +1,7 @@
 use crate::exec_strategy::StartupTimeoutConfig;
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
-use std::io::{self, BufRead, IsTerminal, Write};
+use std::io::{self, IsTerminal, Write};
 use std::time::Duration;
 
 pub(crate) fn print_terminal_safe_stderr(message: &str) {
@@ -29,33 +29,18 @@ fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output:
         )
     };
 
-    let tty_in = match std::fs::File::open("/dev/tty") {
-        Ok(file) => file,
-        Err(_) => {
-            print_terminal_safe_stderr(&format!(
-                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
-                description,
-                timeout_cfg.program,
-                timeout_cfg.profile,
-                timeout_cfg.profile,
-                timeout_cfg.program,
-            ));
-            return false;
-        }
-    };
-
     let mut tty_out = match std::fs::OpenOptions::new().write(true).open("/dev/tty") {
         Ok(file) => file,
         Err(_) => {
             print_terminal_safe_stderr(&format!(
-                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}",
+                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}\n[nono] Terminating startup-blocked process so diagnostics can show denied paths.",
                 description,
                 timeout_cfg.program,
                 timeout_cfg.profile,
                 timeout_cfg.profile,
                 timeout_cfg.program,
             ));
-            return false;
+            return true;
         }
     };
 
@@ -71,23 +56,12 @@ fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output:
         "[nono] Try: nono run --profile {} -- {}",
         timeout_cfg.profile, timeout_cfg.program
     );
-    let _ = write!(tty_out, "[nono] Do you wish to terminate? [y/N] ");
+    let _ = writeln!(
+        tty_out,
+        "[nono] Terminating startup-blocked process so diagnostics can show denied paths."
+    );
     let _ = tty_out.flush();
-
-    let mut reader = io::BufReader::new(tty_in);
-    let mut input = String::new();
-    if reader.read_line(&mut input).is_err() {
-        let _ = writeln!(tty_out, "\n[nono] Continuing to wait.");
-        return false;
-    }
-
-    let affirmative = matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes");
-    if affirmative {
-        let _ = writeln!(tty_out, "[nono] Terminating startup-blocked process.");
-    } else {
-        let _ = writeln!(tty_out, "[nono] Continuing to wait.");
-    }
-    affirmative
+    true
 }
 
 struct StartupPromptTerminalGuard {
@@ -167,7 +141,7 @@ pub(crate) fn prompt_startup_termination_for_child(
     if let Some(proxy) = pty {
         let paused_terminal = proxy.pause_terminal_for_prompt();
         let terminate = prompt_startup_termination(timeout_cfg, has_output);
-        if paused_terminal {
+        if paused_terminal && !terminate {
             proxy.resume_terminal_after_prompt();
         }
         return terminate;

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -14,6 +14,7 @@ use crate::{
 use colored::Colorize;
 use nono::undo::ExecutableIdentity;
 use nono::{CapabilitySet, Result};
+use std::io::IsTerminal;
 use std::sync::Mutex;
 
 struct SessionRuntimeState {
@@ -119,7 +120,12 @@ fn create_session_runtime_state(
         rollback_session: audit_state.map(|state| state.session_id.clone()),
     };
     let session_guard = Some(session::SessionGuard::new(session_record)?);
-    let pty_pair = if session.detached_start {
+    let pty_pair = if should_open_supervised_pty(
+        session.detached_start,
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+        std::io::stderr().is_terminal(),
+    ) {
         Some(pty_proxy::open_pty()?)
     } else {
         None
@@ -131,6 +137,15 @@ fn create_session_runtime_state(
         session_guard,
         pty_pair,
     })
+}
+
+fn should_open_supervised_pty(
+    detached_start: bool,
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+    stderr_is_terminal: bool,
+) -> bool {
+    detached_start || (stdin_is_terminal && stdout_is_terminal && stderr_is_terminal)
 }
 
 pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> Result<i32> {
@@ -257,4 +272,22 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     })?;
 
     Ok(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_open_supervised_pty;
+
+    #[test]
+    fn supervised_pty_is_used_for_attached_terminals() {
+        assert!(should_open_supervised_pty(false, true, true, true));
+        assert!(!should_open_supervised_pty(false, false, true, true));
+        assert!(!should_open_supervised_pty(false, true, false, true));
+        assert!(!should_open_supervised_pty(false, true, true, false));
+    }
+
+    #[test]
+    fn supervised_pty_is_always_used_for_detached_start() {
+        assert!(should_open_supervised_pty(true, false, false, false));
+    }
 }

--- a/crates/nono-cli/tests/profile_cli.rs
+++ b/crates/nono-cli/tests/profile_cli.rs
@@ -86,6 +86,14 @@ fn test_show_profile_output() {
         stdout.contains("Security groups"),
         "expected Security groups section, got:\n{stdout}"
     );
+    assert!(
+        !stdout.contains("Policy patches"),
+        "default profile should not repeat resolved groups as policy patches:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("groups.include"),
+        "human profile show should not leak canonical groups.include for resolved groups:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1509,29 +1509,187 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 }
 
-/// Human-readable descriptions for commonly denied macOS mach services.
-fn describe_mach_service(service: &str) -> Option<&'static str> {
-    Some(match service {
-        s if s.starts_with("com.apple.security") || s == "com.apple.secd" => {
-            "Keychain / Security framework"
+/// Catalog of observed non-filesystem macOS sandbox denials.
+///
+/// Apple's public documentation covers APIs such as CFPreferences, but not a
+/// complete stable taxonomy of Seatbelt operation names. Keep this table
+/// evidence-based: add entries only when they are observed in sandbox logs or
+/// backed by a known framework/daemon mapping.
+#[derive(Debug, Clone, Copy)]
+struct SystemServiceDiagnostic {
+    operation: &'static str,
+    target: SystemServiceTarget,
+    description: &'static str,
+    guidance: Option<SystemServiceGuidance>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SystemServiceTarget {
+    Exact(&'static str),
+    Prefix(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemServiceGuidance {
+    Keychain,
+    UserPreferences,
+}
+
+const SYSTEM_SERVICE_DIAGNOSTICS: &[SystemServiceDiagnostic] = &[
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.SecurityServer",
+        "Keychain / Security framework",
+        Some(SystemServiceGuidance::Keychain),
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.securityd",
+        "Keychain / Security framework",
+        Some(SystemServiceGuidance::Keychain),
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.security.keychaind",
+        "Keychain / Security framework",
+        Some(SystemServiceGuidance::Keychain),
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.secd",
+        "Keychain / Security framework",
+        Some(SystemServiceGuidance::Keychain),
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.security.agent",
+        "Keychain authorization agent",
+        Some(SystemServiceGuidance::Keychain),
+    ),
+    SystemServiceDiagnostic::exact("mach-lookup", "com.apple.logd", "System logging", None),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.system.notification_center",
+        "Distributed notifications",
+        None,
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.distributed_notifications",
+        "Distributed notifications",
+        None,
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.CoreServices.coreservicesd",
+        "Launch Services",
+        None,
+    ),
+    SystemServiceDiagnostic::exact(
+        "mach-lookup",
+        "com.apple.lsd.mapdb",
+        "Launch Services",
+        None,
+    ),
+    SystemServiceDiagnostic::prefix(
+        "mach-lookup",
+        "com.apple.windowserver",
+        "Window Server / GUI",
+        None,
+    ),
+    SystemServiceDiagnostic::prefix(
+        "mach-lookup",
+        "com.apple.cfprefsd",
+        "Preferences (CFPreferences / NSUserDefaults)",
+        None,
+    ),
+    SystemServiceDiagnostic::prefix(
+        "mach-lookup",
+        "com.apple.pasteboard",
+        "Pasteboard / clipboard",
+        None,
+    ),
+    SystemServiceDiagnostic::prefix(
+        "mach-lookup",
+        "com.apple.coreservices",
+        "Core Services",
+        None,
+    ),
+    SystemServiceDiagnostic::exact(
+        "user-preference-read",
+        "kcfpreferencesanyapplication",
+        "Global preferences (CFPreferences any-application domain)",
+        Some(SystemServiceGuidance::UserPreferences),
+    ),
+    SystemServiceDiagnostic::prefix(
+        "user-preference-read",
+        "kcfpreferences",
+        "Preferences (CFPreferences / NSUserDefaults)",
+        Some(SystemServiceGuidance::UserPreferences),
+    ),
+];
+
+impl SystemServiceDiagnostic {
+    const fn exact(
+        operation: &'static str,
+        target: &'static str,
+        description: &'static str,
+        guidance: Option<SystemServiceGuidance>,
+    ) -> Self {
+        Self {
+            operation,
+            target: SystemServiceTarget::Exact(target),
+            description,
+            guidance,
         }
-        "com.apple.logd" => "System logging",
-        "com.apple.system.notification_center" | "com.apple.distributed_notifications" => {
-            "Distributed notifications"
+    }
+
+    const fn prefix(
+        operation: &'static str,
+        target_prefix: &'static str,
+        description: &'static str,
+        guidance: Option<SystemServiceGuidance>,
+    ) -> Self {
+        Self {
+            operation,
+            target: SystemServiceTarget::Prefix(target_prefix),
+            description,
+            guidance,
         }
-        "com.apple.CoreServices.coreservicesd" | "com.apple.lsd.mapdb" => "Launch Services",
-        s if s.starts_with("com.apple.windowserver") => "Window Server / GUI",
-        s if s.starts_with("com.apple.cfprefsd") => "Preferences (NSUserDefaults)",
-        s if s.starts_with("com.apple.pasteboard") => "Pasteboard / clipboard",
-        s if s.starts_with("com.apple.coreservices") => "Core Services",
-        _ => return None,
-    })
+    }
+
+    fn matches(&self, violation: &SandboxViolation) -> bool {
+        violation.operation == self.operation
+            && violation
+                .target
+                .as_deref()
+                .is_some_and(|target| self.target.matches(target))
+    }
+}
+
+impl SystemServiceTarget {
+    fn matches(self, target: &str) -> bool {
+        match self {
+            Self::Exact(expected) => target.eq_ignore_ascii_case(expected),
+            Self::Prefix(prefix) => target
+                .get(..prefix.len())
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix)),
+        }
+    }
+}
+
+fn system_service_diagnostic_for(
+    violation: &SandboxViolation,
+) -> Option<&'static SystemServiceDiagnostic> {
+    SYSTEM_SERVICE_DIAGNOSTICS
+        .iter()
+        .find(|diagnostic| diagnostic.matches(violation))
 }
 
 /// Format non-filesystem violations with human-readable service descriptions.
 fn format_non_fs_violations(lines: &mut Vec<String>, violations: &[&SandboxViolation]) {
     for v in violations {
-        let desc = v.target.as_deref().and_then(describe_mach_service);
+        let desc = system_service_diagnostic_for(v).map(|diagnostic| diagnostic.description);
         match (&v.target, desc) {
             (Some(target), Some(description)) => {
                 lines.push(format!(
@@ -1551,16 +1709,48 @@ fn format_non_fs_violations(lines: &mut Vec<String>, violations: &[&SandboxViola
 
 /// Generate actionable guidance for non-filesystem violations.
 fn format_non_fs_guidance(lines: &mut Vec<String>, violations: &[&SandboxViolation]) {
-    let has_keychain = violations.iter().any(|v| {
-        v.target
-            .as_deref()
-            .is_some_and(|t| t.contains("SecurityServer") || t.contains("securityd"))
-    });
+    let has_guidance = |guidance| {
+        violations.iter().any(|violation| {
+            system_service_diagnostic_for(violation).and_then(|diagnostic| diagnostic.guidance)
+                == Some(guidance)
+        })
+    };
 
-    if has_keychain {
+    if has_guidance(SystemServiceGuidance::Keychain) {
         lines.push("[nono] Keychain access requires granting the login keychain path:".to_string());
-        lines.push("[nono]   --read ~/Library/Keychains/login.keychain-db".to_string());
+        lines.push(keychain_login_grant_guidance());
     }
+
+    if has_guidance(SystemServiceGuidance::UserPreferences) {
+        lines.push("[nono] Preference reads use macOS CFPreferences / NSUserDefaults.".to_string());
+        lines.push(
+            "[nono] They are platform operations, not filesystem paths, so nono does not save them automatically.".to_string(),
+        );
+        lines.push(
+            "[nono] If the tool requires this, add a reviewed user profile rule:".to_string(),
+        );
+        lines.push(
+            "[nono]   \"unsafe_macos_seatbelt_rules\": [\"(allow user-preference-read)\"]"
+                .to_string(),
+        );
+    }
+}
+
+fn keychain_login_grant_guidance() -> String {
+    const DISPLAY_PATH: &str = "~/Library/Keychains/login.keychain-db";
+    let Some(home) = std::env::var_os("HOME") else {
+        return format!("[nono]   --read-file {DISPLAY_PATH}");
+    };
+    let path = PathBuf::from(home).join("Library/Keychains/login.keychain-db");
+    keychain_grant_guidance_for_path(&path, DISPLAY_PATH)
+}
+
+fn keychain_grant_guidance_for_path(path: &Path, display_path: &str) -> String {
+    let flag = match std::fs::metadata(path).map(|metadata| metadata.file_type()) {
+        Ok(file_type) if file_type.is_dir() => "--read",
+        _ => "--read-file",
+    };
+    format!("[nono]   {flag} {display_path}")
 }
 
 /// Deduplicate denials by path, merging access modes. When the same path
@@ -2537,6 +2727,69 @@ mod tests {
         assert!(output.contains("Also blocked (system services):"));
         assert!(output.contains("mach-lookup (com.apple.logd)"));
         assert!(output.contains("System logging"));
+    }
+
+    #[test]
+    fn test_keychain_guidance_uses_file_flag_for_file_targets() {
+        let dir = tempdir().expect("tempdir should be created");
+        let keychain = dir.path().join("login.keychain-db");
+        std::fs::write(&keychain, "db").expect("keychain fixture should be written");
+
+        let guidance =
+            keychain_grant_guidance_for_path(&keychain, "~/Library/Keychains/login.keychain-db");
+
+        assert_eq!(
+            guidance,
+            "[nono]   --read-file ~/Library/Keychains/login.keychain-db"
+        );
+    }
+
+    #[test]
+    fn test_keychain_guidance_uses_directory_flag_for_directory_targets() {
+        let dir = tempdir().expect("tempdir should be created");
+
+        let guidance =
+            keychain_grant_guidance_for_path(dir.path(), "~/Library/Keychains/login.keychain-db");
+
+        assert_eq!(
+            guidance,
+            "[nono]   --read ~/Library/Keychains/login.keychain-db"
+        );
+    }
+
+    #[test]
+    fn test_keychain_guidance_recognizes_keychain_mach_services() {
+        let caps = make_test_caps();
+        let violations = vec![SandboxViolation {
+            operation: "mach-lookup".to_string(),
+            target: Some("com.apple.secd".to_string()),
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains("Keychain access requires granting the login keychain path:"));
+        assert!(output.contains("--read-file ~/Library/Keychains/login.keychain-db"));
+    }
+
+    #[test]
+    fn test_preference_guidance_recognizes_any_application_domain() {
+        let caps = make_test_caps();
+        let violations = vec![SandboxViolation {
+            operation: "user-preference-read".to_string(),
+            target: Some("kcfpreferencesanyapplication".to_string()),
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains("user-preference-read (kcfpreferencesanyapplication)"));
+        assert!(output.contains("Global preferences"));
+        assert!(output.contains("CFPreferences / NSUserDefaults"));
+        assert!(output.contains("unsafe_macos_seatbelt_rules"));
+        assert!(output.contains("(allow user-preference-read)"));
     }
 
     #[test]

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -441,8 +441,40 @@ fn extract_structured_string_property(line: &str, key: &str) -> Option<String> {
         return None;
     }
     let after_quote = after_colon.get(quote.len_utf8()..)?;
-    let end = after_quote.find(quote)?;
-    let value = after_quote[..end].trim();
+    let mut value = String::new();
+    let mut escaped = false;
+    let mut found_end = false;
+
+    for ch in after_quote.chars() {
+        if escaped {
+            if ch == quote || ch == '\\' {
+                value.push(ch);
+            } else {
+                value.push('\\');
+                value.push(ch);
+            }
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            found_end = true;
+            break;
+        }
+
+        value.push(ch);
+    }
+
+    if !found_end {
+        return None;
+    }
+
+    let value = value.trim();
     if value.is_empty() || value.chars().any(char::is_control) {
         return None;
     }
@@ -2346,6 +2378,23 @@ mod tests {
             observation.path_hints,
             vec![ObservedPathHint {
                 path: PathBuf::from("/Users/luke/Library/Caches/copilot/pkg/darwin-arm64"),
+                access: AccessMode::Write,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_analyze_error_output_detects_structured_path_with_escaped_quote() {
+        let observation = analyze_error_output(
+            "Error: EPERM: operation not permitted\n  code: 'EPERM',\n  syscall: 'mkdir',\n  path: '/Users/luke/Library/Caches/it\\'s/pkg'\n",
+            &[],
+            None,
+        );
+
+        assert_eq!(
+            observation.path_hints,
+            vec![ObservedPathHint {
+                path: PathBuf::from("/Users/luke/Library/Caches/it's/pkg"),
                 access: AccessMode::Write,
             }]
         );

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1639,6 +1639,7 @@ struct SystemServiceDiagnostic {
 
 #[derive(Debug, Clone, Copy)]
 enum SystemServiceTarget {
+    Any,
     Exact(&'static str),
     Prefix(&'static str),
 }
@@ -1646,6 +1647,7 @@ enum SystemServiceTarget {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SystemServiceGuidance {
     Keychain,
+    SetuidExec,
     UserPreferences,
 }
 
@@ -1741,9 +1743,27 @@ const SYSTEM_SERVICE_DIAGNOSTICS: &[SystemServiceDiagnostic] = &[
         "Preferences (CFPreferences / NSUserDefaults)",
         Some(SystemServiceGuidance::UserPreferences),
     ),
+    SystemServiceDiagnostic::any(
+        "forbidden-exec-sugid",
+        "Setuid/setgid executable blocked",
+        Some(SystemServiceGuidance::SetuidExec),
+    ),
 ];
 
 impl SystemServiceDiagnostic {
+    const fn any(
+        operation: &'static str,
+        description: &'static str,
+        guidance: Option<SystemServiceGuidance>,
+    ) -> Self {
+        Self {
+            operation,
+            target: SystemServiceTarget::Any,
+            description,
+            guidance,
+        }
+    }
+
     const fn exact(
         operation: &'static str,
         target: &'static str,
@@ -1773,17 +1793,23 @@ impl SystemServiceDiagnostic {
     }
 
     fn matches(&self, violation: &SandboxViolation) -> bool {
-        violation.operation == self.operation
-            && violation
+        if violation.operation != self.operation {
+            return false;
+        }
+        match self.target {
+            SystemServiceTarget::Any => true,
+            _ => violation
                 .target
                 .as_deref()
-                .is_some_and(|target| self.target.matches(target))
+                .is_some_and(|target| self.target.matches(target)),
+        }
     }
 }
 
 impl SystemServiceTarget {
     fn matches(self, target: &str) -> bool {
         match self {
+            Self::Any => true,
             Self::Exact(expected) => target.eq_ignore_ascii_case(expected),
             Self::Prefix(prefix) => target
                 .get(..prefix.len())
@@ -1814,7 +1840,10 @@ fn format_non_fs_violations(lines: &mut Vec<String>, violations: &[&SandboxViola
             (Some(target), None) => {
                 lines.push(format!("[nono]   {} ({})", v.operation, target));
             }
-            (None, _) => {
+            (None, Some(description)) => {
+                lines.push(format!("[nono]   {} — {}", v.operation, description));
+            }
+            (None, None) => {
                 lines.push(format!("[nono]   {}", v.operation));
             }
         }
@@ -1846,6 +1875,18 @@ fn format_non_fs_guidance(lines: &mut Vec<String>, violations: &[&SandboxViolati
         lines.push(
             "[nono]   \"unsafe_macos_seatbelt_rules\": [\"(allow user-preference-read)\"]"
                 .to_string(),
+        );
+    }
+
+    if has_guidance(SystemServiceGuidance::SetuidExec) {
+        lines.push(
+            "[nono] A sandboxed process tried to execute a setuid/setgid binary.".to_string(),
+        );
+        lines.push(
+            "[nono] macOS blocks privilege-changing execs inside this sandbox; this is not a path grant.".to_string(),
+        );
+        lines.push(
+            "[nono] nono does not save this automatically. Prefer a non-setuid helper, or run the privileged helper outside nono after review.".to_string(),
         );
     }
 }
@@ -2983,6 +3024,25 @@ mod tests {
         assert!(output.contains("CFPreferences / NSUserDefaults"));
         assert!(output.contains("unsafe_macos_seatbelt_rules"));
         assert!(output.contains("(allow user-preference-read)"));
+    }
+
+    #[test]
+    fn test_forbidden_exec_sugid_guidance_is_not_saveable() {
+        let caps = make_test_caps();
+        let violations = vec![SandboxViolation {
+            operation: "forbidden-exec-sugid".to_string(),
+            target: None,
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations);
+        let output = formatter.format_footer(0);
+
+        assert!(output.contains("forbidden-exec-sugid"));
+        assert!(output.contains("Setuid/setgid executable blocked"));
+        assert!(output.contains("not a path grant"));
+        assert!(output.contains("does not save this automatically"));
+        assert!(!output.contains("unsafe_macos_seatbelt_rules"));
     }
 
     #[test]

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -186,6 +186,8 @@ pub fn analyze_error_output(
     let mut observed = std::collections::BTreeMap::<PathBuf, AccessMode>::new();
     let mut missing = std::collections::BTreeSet::<PathBuf>::new();
     let mut pending_relative_write: Option<PathBuf> = None;
+    let mut pending_structured_access_denial = false;
+    let mut pending_structured_access: Option<AccessMode> = None;
     let mut non_sandbox_failure = None;
 
     for line in error_output.lines() {
@@ -201,6 +203,29 @@ pub fn analyze_error_output(
             current_dir.and_then(|cwd| extract_relative_write_path_from_line(line, cwd))
         {
             pending_relative_write = Some(path);
+        }
+
+        if looks_like_structured_access_denial_code(line) {
+            pending_structured_access_denial = true;
+        }
+
+        if pending_structured_access_denial {
+            if let Some(access) = infer_access_from_structured_syscall_line(line) {
+                pending_structured_access = Some(access);
+            }
+
+            if let (Some(path), Some(access)) = (
+                extract_structured_path_property(line),
+                pending_structured_access,
+            ) {
+                observed
+                    .entry(path)
+                    .and_modify(|existing| *existing = merge_access_modes(*existing, access))
+                    .or_insert(access);
+                pending_structured_access_denial = false;
+                pending_structured_access = None;
+                continue;
+            }
         }
 
         if looks_like_missing_path(line) {
@@ -304,6 +329,11 @@ fn looks_like_access_denial(line: &str) -> bool {
         || lower.contains("read-only file system")
 }
 
+fn looks_like_structured_access_denial_code(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    (lower.contains("eperm") || lower.contains("eacces")) && looks_like_access_denial(line)
+}
+
 fn looks_like_missing_path(line: &str) -> bool {
     line.to_ascii_lowercase()
         .contains("no such file or directory")
@@ -344,6 +374,10 @@ fn format_command_succeeded_with_stderr_line() -> String {
 }
 
 fn extract_denied_path_from_error_line(line: &str) -> Option<PathBuf> {
+    if let Some(path) = extract_path_after_syscall_word(line) {
+        return Some(path);
+    }
+
     let denial_markers = [
         "Operation not permitted",
         "Permission denied",
@@ -361,7 +395,58 @@ fn extract_denied_path_from_error_line(line: &str) -> Option<PathBuf> {
         }
     }
 
-    extract_path_from_segment(prefix)
+    extract_path_from_segment(prefix).or_else(|| extract_path_from_segment(line))
+}
+
+fn extract_path_after_syscall_word(line: &str) -> Option<PathBuf> {
+    const MARKERS: &[&str] = &["mkdir", "mkdtemp", "open", "copyfile", "rename", "unlink"];
+
+    let lower = line.to_ascii_lowercase();
+    for marker in MARKERS {
+        let needle = format!("{marker} ");
+        let Some(idx) = lower.find(&needle) else {
+            continue;
+        };
+        let segment = line.get(idx + needle.len()..)?;
+        if let Some(path) = extract_path_from_segment(segment) {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+fn infer_access_from_structured_syscall_line(line: &str) -> Option<AccessMode> {
+    let syscall = extract_structured_string_property(line, "syscall")?;
+    Some(match syscall.to_ascii_lowercase().as_str() {
+        "mkdir" | "mkdtemp" | "rmdir" | "unlink" | "rename" | "write" | "copyfile" | "chmod"
+        | "chown" | "utimes" => AccessMode::Write,
+        _ => AccessMode::ReadWrite,
+    })
+}
+
+fn extract_structured_path_property(line: &str) -> Option<PathBuf> {
+    extract_structured_string_property(line, "path").map(PathBuf::from)
+}
+
+fn extract_structured_string_property(line: &str, key: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let after_key = trimmed
+        .strip_prefix(key)
+        .or_else(|| trimmed.strip_prefix(&format!("\"{key}\"")))
+        .or_else(|| trimmed.strip_prefix(&format!("'{key}'")))?;
+    let after_colon = after_key.trim_start().strip_prefix(':')?.trim_start();
+    let quote = after_colon.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let after_quote = after_colon.get(quote.len_utf8()..)?;
+    let end = after_quote.find(quote)?;
+    let value = after_quote[..end].trim();
+    if value.is_empty() || value.chars().any(char::is_control) {
+        return None;
+    }
+    Some(value.to_string())
 }
 
 fn extract_relative_write_path_from_line(line: &str, current_dir: &Path) -> Option<PathBuf> {
@@ -452,6 +537,10 @@ fn infer_access_from_error_line(line: &str, path: &Path) -> AccessMode {
         || lower.contains("can't create")
         || lower.contains("write error")
         || lower.contains("read-only file system")
+        || lower.contains("operation not permitted, mkdir ")
+        || lower.contains("permission denied, mkdir ")
+        || lower.contains("eperm") && lower.contains("mkdir ")
+        || lower.contains("eacces") && lower.contains("mkdir ")
         || lower.starts_with("tee:")
         || lower.starts_with("touch:")
         || lower.starts_with("mkdir:")
@@ -968,12 +1057,13 @@ impl<'a> DiagnosticFormatter<'a> {
 
         // Merge supervisor denials (Linux seccomp) with violation-derived
         // denials (macOS Seatbelt) into a single unified list.
-        let all_denials: Vec<DenialRecord> = self
+        let mut all_denials: Vec<DenialRecord> = self
             .denials
             .iter()
             .cloned()
             .chain(violation_denials)
             .collect();
+        all_denials.extend(self.observed_denials_matching_logged_paths(&all_denials));
 
         if all_denials.is_empty() {
             // No denials from either source.
@@ -1031,6 +1121,30 @@ impl<'a> DiagnosticFormatter<'a> {
                         path: hint.path.clone(),
                         access,
                     })
+            })
+            .collect()
+    }
+
+    fn observed_denials_matching_logged_paths(
+        &self,
+        denials: &[DenialRecord],
+    ) -> Vec<DenialRecord> {
+        if denials.is_empty() {
+            return Vec::new();
+        }
+
+        let logged_paths = denials
+            .iter()
+            .map(|denial| denial.path.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        self.actionable_observed_path_hints()
+            .into_iter()
+            .filter(|hint| logged_paths.contains(&hint.path))
+            .map(|hint| DenialRecord {
+                path: hint.path,
+                access: hint.access,
+                reason: DenialReason::InsufficientAccess,
             })
             .collect()
     }
@@ -1291,7 +1405,7 @@ impl<'a> DiagnosticFormatter<'a> {
         if let Some(flag) = self
             .policy_explanations
             .iter()
-            .find(|e| e.path == denial.path)
+            .find(|e| e.path == denial.path && e.access == denial.access)
             .and_then(|e| e.suggested_flag.clone())
         {
             // explanations' suggested_flag is of the form "--read /path".
@@ -1724,10 +1838,10 @@ fn format_non_fs_guidance(lines: &mut Vec<String>, violations: &[&SandboxViolati
     if has_guidance(SystemServiceGuidance::UserPreferences) {
         lines.push("[nono] Preference reads use macOS CFPreferences / NSUserDefaults.".to_string());
         lines.push(
-            "[nono] They are platform operations, not filesystem paths, so nono does not save them automatically.".to_string(),
+            "[nono] They are platform operations, not filesystem paths; saving them writes a raw macOS Seatbelt rule.".to_string(),
         );
         lines.push(
-            "[nono] If the tool requires this, add a reviewed user profile rule:".to_string(),
+            "[nono] If the tool requires this, accept the profile prompt or add a reviewed user profile rule:".to_string(),
         );
         lines.push(
             "[nono]   \"unsafe_macos_seatbelt_rules\": [\"(allow user-preference-read)\"]"
@@ -2155,6 +2269,42 @@ mod tests {
             observation.path_hints,
             vec![ObservedPathHint {
                 path: PathBuf::from("/tmp/file with spaces.txt"),
+                access: AccessMode::Write,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_analyze_error_output_detects_node_eperm_mkdir_as_write() {
+        let observation = analyze_error_output(
+            "Failed to extract bundled package: Error: EPERM: operation not permitted, mkdir '/Users/luke/Library/Caches/copilot/pkg/darwin-arm64'\n",
+            &[],
+            None,
+        );
+
+        let hint = ObservedPathHint {
+            path: PathBuf::from("/Users/luke/Library/Caches/copilot/pkg/darwin-arm64"),
+            access: AccessMode::Write,
+        };
+        assert_eq!(observation.path_hints, vec![hint.clone()]);
+        assert_eq!(
+            observation.primary_verdict,
+            Some(ErrorVerdict::LikelySandbox(hint))
+        );
+    }
+
+    #[test]
+    fn test_analyze_error_output_detects_structured_node_eperm_mkdir_path() {
+        let observation = analyze_error_output(
+            "Error: EPERM: operation not permitted\n  code: 'EPERM',\n  syscall: 'mkdir',\n  path: '/Users/luke/Library/Caches/copilot/pkg/darwin-arm64'\n",
+            &[],
+            None,
+        );
+
+        assert_eq!(
+            observation.path_hints,
+            vec![ObservedPathHint {
+                path: PathBuf::from("/Users/luke/Library/Caches/copilot/pkg/darwin-arm64"),
                 access: AccessMode::Write,
             }]
         );
@@ -2727,6 +2877,49 @@ mod tests {
         assert!(output.contains("Also blocked (system services):"));
         assert!(output.contains("mach-lookup (com.apple.logd)"));
         assert!(output.contains("System logging"));
+    }
+
+    #[test]
+    fn test_supervised_merges_mkdir_error_hint_with_logged_read_denial() {
+        let temp = tempdir().expect("tempdir should be created");
+        let pkg = temp.path().join("Library/Caches/copilot/pkg");
+        std::fs::create_dir_all(&pkg).expect("pkg fixture should be created");
+        let denied = pkg.join("darwin-arm64");
+
+        let caps = CapabilitySet::new();
+        let violations = vec![SandboxViolation {
+            operation: "file-read-data".to_string(),
+            target: Some(denied.display().to_string()),
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations)
+            .with_error_observation(ErrorObservation {
+                primary_verdict: Some(ErrorVerdict::LikelySandbox(ObservedPathHint {
+                    path: denied.clone(),
+                    access: AccessMode::Write,
+                })),
+                blocked_protected_file: None,
+                path_hints: vec![ObservedPathHint {
+                    path: denied.clone(),
+                    access: AccessMode::Write,
+                }],
+                missing_paths: Vec::new(),
+                non_sandbox_failure: None,
+            })
+            .with_policy_explanations(vec![PolicyExplanation {
+                path: denied.clone(),
+                access: AccessMode::Read,
+                reason: "path_not_granted".to_string(),
+                details: None,
+                policy_source: None,
+                suggested_flag: Some(format!("--read {}", denied.display())),
+            }]);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains(&format!("{} (read+write)", denied.display())));
+        assert!(output.contains(&format!("Fix: --allow {}", pkg.display())));
+        assert!(!output.contains(&format!("Fix: --read {}", denied.display())));
     }
 
     #[test]

--- a/docs/cli/features/package-publishing.mdx
+++ b/docs/cli/features/package-publishing.mdx
@@ -445,7 +445,7 @@ Adding an entry causes three things to happen automatically:
 2. `--profile <other>` where `<other>` extends `<name>` also triggers the prompt (the resolver walks the `extends` chain).
 3. The friendly hint shown when the user declines / runs non-interactively names the right pack ref.
 
-`nono profile list` will surface installed pack profiles under their own `Packs:` section, with the providing pack ref shown next to the name.
+`nono profile list` will surface installed pack profiles under their own `Packages:` section, with the providing pack ref shown next to the name.
 
 ## Recommended Release Pattern
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -89,6 +89,14 @@ nono why --host <HOST> [--port <PORT>] [OPTIONS]
 nono why --self --path <PATH> --op <OP> [OPTIONS]  # Inside sandbox
 ```
 
+### `nono learn`
+
+Discover required filesystem paths and network activity. On Linux, `nono learn` uses `strace`. On macOS, use `nono run --profile <name> -- <command>` for sandboxed profile learning; legacy unsandboxed tracing is available with `nono learn --trace`.
+
+```bash
+nono learn [OPTIONS] -- <COMMAND> [ARGS...]
+```
+
 ### `nono setup`
 
 Set up nono on this system. Verifies installation, tests sandbox support, and optionally generates example profiles.
@@ -133,6 +141,60 @@ Subcommands:
 - `list` - List files and their verification status
 - `keygen` - Generate a new signing key pair
 - `export-key` - Export the public key for a signing key
+
+## `nono learn` Options
+
+<Note>
+  On Linux, `nono learn` runs WITHOUT sandbox restrictions using `strace` (install with `apt install strace`). On macOS, profile learning happens through sandboxed `nono run`; use `nono learn --trace` only when you explicitly want the legacy unsandboxed `fs_usage` + `nettop` tracer.
+</Note>
+
+### `--profile`, `-p`
+
+Compare against an existing profile to show only missing paths.
+
+```bash
+nono learn --profile opencode -- opencode
+```
+
+### `--json`
+
+Output discovered paths as a JSON fragment suitable for a profile.
+
+```bash
+nono learn --json -- my-app > paths.json
+```
+
+### `--timeout`
+
+Limit trace duration in seconds.
+
+```bash
+nono learn --timeout 30 -- my-long-running-app
+```
+
+### `--all`
+
+Show all accessed paths, not just those that would be blocked by the sandbox.
+
+```bash
+nono learn --all -- my-app
+```
+
+### `--trace`
+
+On macOS, use the legacy unsandboxed `fs_usage` + `nettop` tracer.
+
+```bash
+nono learn --trace -- my-app
+```
+
+### `--verbose`, `-v`
+
+Enable verbose output. Can be specified multiple times.
+
+```bash
+nono learn -vv -- my-app
+```
 
 ## `nono run` Options
 

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -316,6 +316,52 @@ uname -r
 
 ---
 
+## Using `nono learn` to Discover Required Paths
+
+If you're getting permission errors and aren't sure which paths your application needs, use `nono learn` on Linux or run the command under the target profile on macOS:
+
+```bash
+# Linux: discover all paths accessed by your app
+nono learn -- my-app
+
+# Linux: compare against an existing profile to see what's missing
+nono learn --profile my-profile -- my-app
+
+# Linux: output as JSON for easy profile creation
+nono learn --json -- my-app
+
+# macOS: collect real Seatbelt denials and offer to save a profile patch
+nono run --profile my-profile -- my-app
+```
+
+<Note>
+  On Linux, `nono learn` requires `strace` and runs without sandbox restrictions. On macOS, prefer sandboxed `nono run`; legacy unsandboxed tracing is still available with `nono learn --trace` and requires `sudo` for `fs_usage` and `nettop`.
+</Note>
+
+### Example Workflow
+
+1. Run the command to discover paths:
+   ```bash
+   nono run --profile opencode -- opencode
+   ```
+
+2. Review the output to see which paths are needed:
+   ```
+   Read paths needed:
+     /usr/share/locale-langpack
+     /home/user/.config/opencode
+
+   Write paths needed:
+     /home/user/.cache/opencode
+   ```
+
+3. Add the paths to your nono command or profile:
+   ```bash
+   nono run --read /usr/share/locale-langpack --allow ~/.config/opencode -- opencode
+   ```
+
+---
+
 ## WSL2-Specific Issues
 
 ### Sandbox initialization: EBUSY on seccomp


### PR DESCRIPTION
## Summary

Deprecate the `nono learn` command in favor of `nono run`.

- The `learn` command now prints a deprecation warning and guidance, directing users to `nono run`.
- `nono run` provides a more robust learning workflow by keeping the command sandboxed, reporting denials, and offering profile updates.
- The profile save prompt now triggers for macOS Seatbelt `user-preference-read` violations.
- It automatically suggests saving a raw `unsafe_macos_seatbelt_rules` entry for these violations.
- Profile save prompts clearly label "unsafe policy overrides" and "raw macOS Seatbelt rules."
- Suggested profile names now intelligently fall back to the command name and avoid shadowing built-in profiles.
- The `learn` command is targeted for removal by `v1.0.0`.

Additionally, a new diagnostic message has been added for `forbidden-exec-sugid` violations. This provides specific guidance when a sandboxed process attempts to execute a setuid/setgid binary, clarifying that macOS blocks such privilege-changing executions inside the sandbox and that this is not a grantable path. Users are advised to prefer non-setuid helpers or run privileged helpers outside nono after review.

Closes #866

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

