### PR TITLE
feat(profile-save): suppress save-profile prompts for denied paths

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -247,6 +247,16 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Paths exempted from group-level deny rules. Each path must also appear in an allow/read/write section to actually grant access; bypass_protection only removes the deny."
+        },
+        "suppress_save_prompt": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths whose runtime denials should not be offered in the save-profile prompt. Does not grant access, remove deny rules, or hide diagnostic output."
+        },
+        "ignore": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Alias for suppress_save_prompt. Prefer filesystem.suppress_save_prompt in new profiles."
         }
       }
     },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -101,6 +101,7 @@ All filesystem grants, denials, and deny-rule exemptions live under this single 
 | `write_file`        | array of string | Single files with write-only access. |
 | `deny`              | array of string | Paths denied filesystem access. |
 | `bypass_protection` | array of string | Paths exempted from deny groups. **This flag does not implicitly grant access** — `bypass_protection` only removes the deny rule; each path must also appear in `filesystem.allow`, `filesystem.read`, or `filesystem.write` (or the matching `*_file` variant) to become accessible. |
+| `ignore`            | array of string | Paths whose runtime denials should not be offered in save-profile prompts. Does not grant access or hide diagnostics. |
 
 All path fields support variable expansion (see Section 6).
 
@@ -337,6 +338,29 @@ When a deny group blocks a path you need access to, use `filesystem.bypass_prote
 }
 ```
 
+### Suppress repeated save suggestions
+
+Use `filesystem.suppress_save_prompt` for paths you intentionally do not want
+to grant, but also do not want offered in the save-profile prompt every run:
+
+```json
+{
+  "extends": "default",
+  "meta": {
+    "name": "copilot-local",
+    "description": "Local prompt-suppression choices"
+  },
+  "filesystem": {
+    "suppress_save_prompt": ["$HOME/.copilot/settings.json"]
+  }
+}
+```
+
+The sandbox still denies these paths. `filesystem.suppress_save_prompt` only
+filters the save-profile suggestion. `filesystem.ignore` is accepted as an
+alias, but new profiles should use the explicit suppress name so it is not
+mistaken for an access grant.
+
 ### Denying specific project files
 
 Block access to a file in the working directory while keeping the rest accessible. Use `$WORKDIR` to reference the current working directory — relative paths like `./` are not expanded:
@@ -475,7 +499,7 @@ nono profile diff <a> <b>         # Compare two profiles
 
 ## 6. Variable Expansion
 
-The following variables are expanded in all path fields (`filesystem.*`, including `filesystem.allow`, `filesystem.read`, `filesystem.write`, `filesystem.deny`, and `filesystem.bypass_protection`).
+The following variables are expanded in all path fields (`filesystem.*`, including `filesystem.allow`, `filesystem.read`, `filesystem.write`, `filesystem.deny`, `filesystem.bypass_protection`, and `filesystem.suppress_save_prompt`).
 
 | Variable           | Expands to |
 |--------------------|------------|
@@ -495,6 +519,7 @@ Always use these variables instead of hardcoded absolute paths to keep profiles 
 
 - A profile with no `groups.include` has no deny rules. Always include appropriate deny groups for untrusted workloads.
 - `filesystem.bypass_protection` only removes the deny rule. It does not grant access. You must also add the path via `filesystem.allow`, `filesystem.read`, or `filesystem.write` (or the matching `*_file` variant).
+- `filesystem.suppress_save_prompt` only suppresses save-profile suggestions. It does not grant access, remove deny rules, or hide diagnostics.
 - `groups.exclude` removes groups from the resolved set. This weakens the sandbox. Use it only when you understand which protections you are removing.
 - `extends` chains resolve recursively up to depth 10. Circular inheritance is an error.
 - Platform-specific groups (suffix `_macos` or `_linux`) are filtered at resolution time. Include both variants for cross-platform profiles.

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -994,6 +994,16 @@ pub struct SandboxArgs {
     )]
     pub bypass_protection: Vec<PathBuf>,
 
+    /// Suppress save-profile prompts for denials under this path. Does not grant access
+    /// ALIAS(canonical="--suppress-save-prompt", introduced="v0.52.0", remove_by="indefinite", issue="#875")
+    #[arg(
+        long = "suppress-save-prompt",
+        alias = "ignore-denied",
+        value_name = "PATH",
+        help_heading = "FILESYSTEM"
+    )]
+    pub suppress_save_prompt: Vec<PathBuf>,
+
     /// Allow CWD access without prompting (level set by profile, defaults to read-only)
     #[arg(long, help_heading = "FILESYSTEM")]
     pub allow_cwd: bool,
@@ -1194,7 +1204,7 @@ pub struct SandboxArgs {
             "allow", "read", "write", "allow_file", "read_file", "write_file",
             "allow_unix_socket", "allow_unix_socket_bind",
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
-            "profile", "bypass_protection", "allow_cwd",
+            "profile", "bypass_protection", "suppress_save_prompt", "allow_cwd",
             "block_net", "allow_net", "network_profile", "allow_proxy",
             "allow_bind", "allow_port", "allow_connect_port", "external_proxy", "proxy_port",
             "proxy_credential", "allow_endpoint", "env_credential", "env_credential_map",
@@ -1290,6 +1300,16 @@ pub struct WrapSandboxArgs {
         help_heading = "FILESYSTEM"
     )]
     pub bypass_protection: Vec<PathBuf>,
+
+    /// Suppress save-profile prompts for denials under this path. Does not grant access
+    /// ALIAS(canonical="--suppress-save-prompt", introduced="v0.52.0", remove_by="indefinite", issue="#875")
+    #[arg(
+        long = "suppress-save-prompt",
+        alias = "ignore-denied",
+        value_name = "PATH",
+        help_heading = "FILESYSTEM"
+    )]
+    pub suppress_save_prompt: Vec<PathBuf>,
 
     /// Allow CWD access without prompting (level set by profile, defaults to read-only)
     #[arg(long, help_heading = "FILESYSTEM")]
@@ -1398,7 +1418,7 @@ pub struct WrapSandboxArgs {
             "allow", "read", "write", "allow_file", "read_file", "write_file",
             "allow_unix_socket", "allow_unix_socket_bind",
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
-            "profile", "bypass_protection", "allow_cwd",
+            "profile", "bypass_protection", "suppress_save_prompt", "allow_cwd",
             "block_net", "allow_bind", "allow_port", "allow_connect_port",
             "env_credential", "env_credential_map",
             "allow_command", "block_command", "allow_launch_services", "allow_gpu",
@@ -1430,6 +1450,7 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow_unix_socket_dir: args.allow_unix_socket_dir,
             allow_unix_socket_dir_bind: args.allow_unix_socket_dir_bind,
             bypass_protection: args.bypass_protection,
+            suppress_save_prompt: args.suppress_save_prompt,
             allow_cwd: args.allow_cwd,
             workdir: args.workdir,
             block_net: args.block_net,
@@ -3182,6 +3203,57 @@ mod tests {
                 assert_eq!(
                     args.sandbox.bypass_protection[0],
                     PathBuf::from("/tmp/test")
+                );
+            }
+            _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_suppress_save_prompt_multiple() {
+        let cli = Cli::parse_from([
+            "nono",
+            "run",
+            "--suppress-save-prompt",
+            "/tmp/a",
+            "--suppress-save-prompt",
+            "/tmp/b",
+            "--allow",
+            ".",
+            "echo",
+        ]);
+        match cli.command {
+            Commands::Run(args) => {
+                assert_eq!(args.sandbox.suppress_save_prompt.len(), 2);
+                assert_eq!(
+                    args.sandbox.suppress_save_prompt[0],
+                    PathBuf::from("/tmp/a")
+                );
+                assert_eq!(
+                    args.sandbox.suppress_save_prompt[1],
+                    PathBuf::from("/tmp/b")
+                );
+            }
+            _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_ignore_denied_alias_maps_to_suppress_save_prompt() {
+        let cli = Cli::parse_from([
+            "nono",
+            "run",
+            "--ignore-denied",
+            "/tmp/a",
+            "--allow",
+            ".",
+            "echo",
+        ]);
+        match cli.command {
+            Commands::Run(args) => {
+                assert_eq!(
+                    args.sandbox.suppress_save_prompt,
+                    vec![PathBuf::from("/tmp/a")]
                 );
             }
             _ => panic!("Expected Run command"),

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -142,6 +142,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             bypass_protection_paths: prepared.bypass_protection_paths,
+            ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
             proxy,
@@ -212,6 +213,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             workdir: resolve_requested_workdir(args.workdir.as_ref()),
             no_diagnostics,
             bypass_protection_paths: prepared.bypass_protection_paths,
+            ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
             ..ExecutionFlags::defaults(silent)?

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -73,34 +73,41 @@ const MAX_TRACKED_REQUEST_IDS: usize = 4096;
 /// diagnostics/prompts take over the terminal.
 const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 
+struct ProfileSaveOffer<'a> {
+    policy_explanations: &'a [nono::diagnostic::PolicyExplanation],
+    error_observation: &'a nono::diagnostic::ErrorObservation,
+    caps: &'a CapabilitySet,
+    command: &'a [String],
+    compared_profile: Option<&'a str>,
+    sandbox_violations: &'a [nono::SandboxViolation],
+    ignored_denial_paths: &'a [std::path::PathBuf],
+}
+
 fn offer_profile_save_for_child(
     pty: Option<&mut crate::pty_proxy::PtyProxy>,
-    policy_explanations: &[nono::diagnostic::PolicyExplanation],
-    error_observation: &nono::diagnostic::ErrorObservation,
-    caps: &CapabilitySet,
-    command: &[String],
-    compared_profile: Option<&str>,
-    sandbox_violations: &[nono::SandboxViolation],
+    offer: ProfileSaveOffer<'_>,
 ) -> Result<()> {
     if let Some(proxy) = pty {
         let _released_terminal = proxy.release_terminal_for_prompt();
         return crate::profile_save_runtime::offer_save_run_profile(
-            policy_explanations,
-            error_observation,
-            caps,
-            command,
-            compared_profile,
-            sandbox_violations,
+            offer.policy_explanations,
+            offer.error_observation,
+            offer.caps,
+            offer.command,
+            offer.compared_profile,
+            offer.sandbox_violations,
+            offer.ignored_denial_paths,
         );
     }
 
     crate::profile_save_runtime::offer_save_run_profile(
-        policy_explanations,
-        error_observation,
-        caps,
-        command,
-        compared_profile,
-        sandbox_violations,
+        offer.policy_explanations,
+        offer.error_observation,
+        offer.caps,
+        offer.command,
+        offer.compared_profile,
+        offer.sandbox_violations,
+        offer.ignored_denial_paths,
     )
 }
 
@@ -208,6 +215,8 @@ pub struct ExecConfig<'a> {
     pub protected_paths: &'a [std::path::PathBuf],
     /// Base profile name to derive a saved user patch from after run-time denials.
     pub profile_save_base: Option<&'a str>,
+    /// Denied paths that should not be offered in the save-profile prompt.
+    pub ignored_denial_paths: &'a [std::path::PathBuf],
     /// Optional startup timeout for known interactive CLIs that were launched
     /// without their recommended built-in profile.
     pub startup_timeout: Option<StartupTimeoutConfig<'a>>,
@@ -1246,12 +1255,15 @@ pub fn execute_supervised(
                 clear_signal_forwarding_target();
                 offer_profile_save_for_child(
                     pty_proxy.as_mut(),
-                    &prompt_policy_explanations,
-                    &prompt_error_observation,
-                    config.caps,
-                    config.command,
-                    config.profile_save_base,
-                    &sandbox_violations,
+                    ProfileSaveOffer {
+                        policy_explanations: &prompt_policy_explanations,
+                        error_observation: &prompt_error_observation,
+                        caps: config.caps,
+                        command: config.command,
+                        compared_profile: config.profile_save_base,
+                        sandbox_violations: &sandbox_violations,
+                        ignored_denial_paths: config.ignored_denial_paths,
+                    },
                 )?;
             }
 

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -313,6 +313,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             .profile_name
             .as_deref()
             .or(recommended_profile),
+        ignored_denial_paths: &flags.ignored_denial_paths,
         startup_timeout: if should_apply_startup_timeout(startup_timeout_profile, &cmd_args) {
             startup_timeout_profile.map(|profile| exec_strategy::StartupTimeoutConfig {
                 timeout: PROFILE_HINT_STARTUP_TIMEOUT,

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -96,6 +96,7 @@ pub(crate) struct ExecutionFlags {
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
+    pub(crate) ignored_denial_paths: Vec<PathBuf>,
     pub(crate) session: SessionLaunchOptions,
     pub(crate) rollback: RollbackLaunchOptions,
     pub(crate) trust: TrustLaunchOptions,
@@ -116,6 +117,7 @@ impl ExecutionFlags {
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
             bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
             session: SessionLaunchOptions::default(),
             rollback: RollbackLaunchOptions::default(),
             trust: TrustLaunchOptions {
@@ -233,6 +235,7 @@ pub(crate) fn prepare_run_launch_plan(
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             bypass_protection_paths: prepared.bypass_protection_paths,
+            ignored_denial_paths: prepared.ignored_denial_paths,
             session: SessionLaunchOptions {
                 detached_start: run_args.detached,
                 session_name: run_args.name,

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -252,6 +252,7 @@ mod tests {
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
         };
@@ -296,6 +297,7 @@ mod tests {
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
         };

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -89,6 +89,13 @@ pub struct FilesystemConfig {
     /// the new name makes the "does not grant access" semantics explicit.
     #[serde(default)]
     pub bypass_protection: Vec<String>,
+    /// Paths whose runtime denials should not be offered in the save-profile
+    /// prompt. This does not grant access, remove deny rules, or hide the
+    /// diagnostic footer; it only suppresses repeated save suggestions for
+    /// paths the user has decided not to grant.
+    /// ALIAS(canonical="suppress_save_prompt", introduced="v0.52.0", remove_by="indefinite", issue="#875")
+    #[serde(default, alias = "ignore")]
+    pub suppress_save_prompt: Vec<String>,
 }
 
 /// Group composition — include/exclude pair for policy groups.
@@ -2208,6 +2215,10 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.filesystem.bypass_protection,
                 &child.filesystem.bypass_protection,
             ),
+            suppress_save_prompt: dedup_append(
+                &base.filesystem.suppress_save_prompt,
+                &child.filesystem.suppress_save_prompt,
+            ),
         },
         network: NetworkConfig {
             block: base.network.block || child.network.block,
@@ -2682,12 +2693,32 @@ mod tests {
             "meta": {"name": "t"},
             "filesystem": {
                 "deny": ["/blocked"],
-                "bypass_protection": ["$HOME/.docker"]
+                "bypass_protection": ["$HOME/.docker"],
+                "suppress_save_prompt": ["$HOME/.copilot/settings.json"]
             }
         }"#;
         let profile: Profile = serde_json::from_str(json).expect("parse");
         assert_eq!(profile.filesystem.deny, vec!["/blocked"]);
         assert_eq!(profile.filesystem.bypass_protection, vec!["$HOME/.docker"]);
+        assert_eq!(
+            profile.filesystem.suppress_save_prompt,
+            vec!["$HOME/.copilot/settings.json"]
+        );
+    }
+
+    #[test]
+    fn test_filesystem_config_ignore_alias_drains_to_suppress_save_prompt() {
+        let json = r#"{
+            "meta": {"name": "t"},
+            "filesystem": {
+                "ignore": ["$HOME/.copilot/settings.json"]
+            }
+        }"#;
+        let profile: Profile = serde_json::from_str(json).expect("parse");
+        assert_eq!(
+            profile.filesystem.suppress_save_prompt,
+            vec!["$HOME/.copilot/settings.json"]
+        );
     }
 
     #[test]
@@ -4059,6 +4090,7 @@ mod tests {
                 unix_socket_dir_bind: vec![],
                 deny: vec!["/base/policy-deny".to_string()],
                 bypass_protection: vec!["/base/override-deny".to_string()],
+                suppress_save_prompt: vec!["/base/no-prompt".to_string()],
             },
             network: NetworkConfig {
                 block: false,
@@ -4133,6 +4165,7 @@ mod tests {
                 unix_socket_dir_bind: vec![],
                 deny: vec!["/child/policy-deny".to_string()],
                 bypass_protection: vec!["/child/override-deny".to_string()],
+                suppress_save_prompt: vec!["/child/no-prompt".to_string()],
             },
             network: NetworkConfig {
                 block: false,
@@ -4886,6 +4919,14 @@ mod tests {
             .filesystem
             .bypass_protection
             .contains(&"/child/override-deny".to_string()));
+        assert!(merged
+            .filesystem
+            .suppress_save_prompt
+            .contains(&"/base/no-prompt".to_string()));
+        assert!(merged
+            .filesystem
+            .suppress_save_prompt
+            .contains(&"/child/no-prompt".to_string()));
     }
 
     #[test]
@@ -5640,7 +5681,8 @@ mod tests {
                 "allow": ["/tmp/project"],
                 "read": ["/etc", "/opt/data"],
                 "allow_file": ["/tmp/config.json"],
-                "bypass_protection": ["/etc/hosts"]
+                "bypass_protection": ["/etc/hosts"],
+                "suppress_save_prompt": ["/tmp/project/.cache/noisy.json"]
             },
             "network": {
                 "block": false,

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -222,6 +222,10 @@ fn build_skeleton(args: &ProfileInitArgs) -> serde_json::Value {
             "bypass_protection".to_string(),
             serde_json::Value::Array(vec![]),
         );
+        filesystem.insert(
+            "suppress_save_prompt".to_string(),
+            serde_json::Value::Array(vec![]),
+        );
     }
     root.insert(
         "filesystem".to_string(),
@@ -929,7 +933,8 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
         || !fs.read_file.is_empty()
         || !fs.write_file.is_empty()
         || !fs.deny.is_empty()
-        || !fs.bypass_protection.is_empty();
+        || !fs.bypass_protection.is_empty()
+        || !fs.suppress_save_prompt.is_empty();
 
     if has_fs {
         println!();
@@ -941,6 +946,12 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
         print_fs_paths("read_file", &fs.read_file, t, args.raw);
         print_fs_paths("write_file", &fs.write_file, t, args.raw);
         print_fs_paths("deny", &fs.deny, t, args.raw);
+        print_fs_paths(
+            "suppress_save_prompt",
+            &fs.suppress_save_prompt,
+            t,
+            args.raw,
+        );
         if !fs.bypass_protection.is_empty() {
             println!(
                 "    {}: {}",
@@ -1161,6 +1172,7 @@ fn profile_to_json(
         "write_file": profile.filesystem.write_file,
         "deny": profile.filesystem.deny,
         "bypass_protection": profile.filesystem.bypass_protection,
+        "suppress_save_prompt": profile.filesystem.suppress_save_prompt,
     });
 
     // Groups and commands are emitted only when populated, so default-empty
@@ -1340,6 +1352,11 @@ pub(crate) fn cmd_diff(args: ProfileDiffArgs) -> Result<()> {
             "filesystem.bypass_protection",
             &p1.filesystem.bypass_protection,
             &p2.filesystem.bypass_protection,
+        ),
+        (
+            "filesystem.suppress_save_prompt",
+            &p1.filesystem.suppress_save_prompt,
+            &p2.filesystem.suppress_save_prompt,
         ),
         ("commands.deny", &p1.commands.deny, &p2.commands.deny),
     ]);
@@ -1979,6 +1996,10 @@ fn diff_fs_json(
         "allow_file": diff_vec(&fs1.allow_file, &fs2.allow_file),
         "read_file": diff_vec(&fs1.read_file, &fs2.read_file),
         "write_file": diff_vec(&fs1.write_file, &fs2.write_file),
+        "suppress_save_prompt": diff_vec(
+            &fs1.suppress_save_prompt,
+            &fs2.suppress_save_prompt
+        ),
     })
 }
 
@@ -2244,6 +2265,11 @@ pub(crate) fn cmd_validate(args: ProfileValidateArgs) -> Result<()> {
         check_paths(&profile.filesystem.allow, "filesystem.allow", &mut warnings);
         check_paths(&profile.filesystem.read, "filesystem.read", &mut warnings);
         check_paths(&profile.filesystem.write, "filesystem.write", &mut warnings);
+        check_paths(
+            &profile.filesystem.suppress_save_prompt,
+            "filesystem.suppress_save_prompt",
+            &mut warnings,
+        );
     }
 
     if args.json {
@@ -3329,6 +3355,7 @@ mod tests {
         assert!(full_fs.contains_key("write_file"));
         assert!(full_fs.contains_key("deny"));
         assert!(full_fs.contains_key("bypass_protection"));
+        assert!(full_fs.contains_key("suppress_save_prompt"));
 
         // Minimal filesystem has only allow + read; the canonical deny /
         // bypass_protection appear only with --full.
@@ -3337,6 +3364,7 @@ mod tests {
         assert!(!min_fs.contains_key("allow_file"));
         assert!(!min_fs.contains_key("deny"));
         assert!(!min_fs.contains_key("bypass_protection"));
+        assert!(!min_fs.contains_key("suppress_save_prompt"));
 
         // Full groups has both include and exclude; minimal has only include.
         let full_groups = full_obj["groups"].as_object().expect("groups object");

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -25,6 +25,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) allow_gpu: bool,
     pub(crate) allow_parent_of_protected: bool,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
+    pub(crate) ignored_denial_paths: Vec<PathBuf>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -262,6 +263,42 @@ fn collect_bypass_protection_paths(
     paths
 }
 
+fn expand_ignored_denial_path(path: &Path, workdir: &Path) -> PathBuf {
+    let path_str = path.to_string_lossy();
+    let expanded = profile::expand_vars(&path_str, workdir).unwrap_or_else(|_| path.to_path_buf());
+    nono::try_canonicalize(&expanded)
+}
+
+fn collect_ignored_denial_paths(
+    loaded_profile: Option<&profile::Profile>,
+    cli_ignored_denials: &[PathBuf],
+    workdir: &Path,
+) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = loaded_profile
+        .map(|profile| {
+            profile
+                .filesystem
+                .suppress_save_prompt
+                .iter()
+                .filter_map(|template| {
+                    profile::expand_vars(template, workdir)
+                        .ok()
+                        .map(|expanded| nono::try_canonicalize(&expanded))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for path in cli_ignored_denials {
+        let canonical = expand_ignored_denial_path(path, workdir);
+        if !paths.contains(&canonical) {
+            paths.push(canonical);
+        }
+    }
+
+    paths
+}
+
 fn prepare_profile_with_options(
     args: &SandboxArgs,
     workdir: &Path,
@@ -382,6 +419,11 @@ fn prepare_profile_with_options(
             &args.bypass_protection,
             workdir,
         ),
+        ignored_denial_paths: collect_ignored_denial_paths(
+            loaded_profile.as_ref(),
+            &args.suppress_save_prompt,
+            workdir,
+        ),
         allowed_env_vars: loaded_profile.as_ref().and_then(|profile| {
             profile.environment.as_ref().map(|env_config| {
                 if let Some(err) = crate::exec_strategy::validate_env_var_patterns(
@@ -456,6 +498,10 @@ mod tests {
         if let Err(err) = fs::create_dir_all(&cli_override) {
             panic!("failed to create CLI override path: {err}");
         }
+        let cli_ignore = workdir.path().join("cli-ignore");
+        if let Err(err) = fs::create_dir_all(&cli_ignore) {
+            panic!("failed to create CLI ignore path: {err}");
+        }
 
         let profile_path = workdir.path().join("preflight-profile.json");
         if let Err(err) = fs::write(
@@ -471,7 +517,8 @@ mod tests {
                     "listen_port": [8080]
                 },
                 "filesystem": {
-                    "bypass_protection": ["$WORKDIR/.git"]
+                    "bypass_protection": ["$WORKDIR/.git"],
+                    "suppress_save_prompt": ["$WORKDIR/.copilot/settings.json"]
                 }
             }"#,
         ) {
@@ -481,6 +528,7 @@ mod tests {
         let args = SandboxArgs {
             profile: Some(profile_path.to_string_lossy().into_owned()),
             bypass_protection: vec![cli_override],
+            suppress_save_prompt: vec![cli_ignore],
             ..SandboxArgs::default()
         };
 
@@ -526,6 +574,15 @@ mod tests {
             runtime.bypass_protection_paths,
             preflight.bypass_protection_paths
         );
+        assert_eq!(runtime.ignored_denial_paths, preflight.ignored_denial_paths);
+        assert!(runtime
+            .ignored_denial_paths
+            .contains(&nono::try_canonicalize(
+                &workdir.path().join(".copilot/settings.json")
+            )));
+        assert!(runtime
+            .ignored_denial_paths
+            .contains(&nono::try_canonicalize(&workdir.path().join("cli-ignore"))));
         assert_eq!(runtime.allowed_env_vars, preflight.allowed_env_vars);
         assert_eq!(runtime.denied_env_vars, preflight.denied_env_vars);
         assert_eq!(

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -28,6 +28,13 @@ struct PatchGrant {
     bypass_protection: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProfileSaveChoice {
+    Grant,
+    Suppress,
+    Skip,
+}
+
 /// Env var that suppresses the "save denied paths as user profile?"
 /// prompt entirely. Set by integration tests and CI runs that have an
 /// openable `/dev/tty` (so `terminal_prompts_available` would otherwise
@@ -55,6 +62,7 @@ pub(crate) fn offer_save_run_profile(
     command: &[String],
     compared_profile: Option<&str>,
     sandbox_violations: &[SandboxViolation],
+    ignored_denial_paths: &[PathBuf],
 ) -> Result<()> {
     if !terminal_prompts_available() {
         return Ok(());
@@ -65,6 +73,7 @@ pub(crate) fn offer_save_run_profile(
         error_observation,
         caps,
         sandbox_violations,
+        ignored_denial_paths,
     )?
     else {
         return Ok(());
@@ -72,6 +81,7 @@ pub(crate) fn offer_save_run_profile(
 
     let cmd_name = command_name(command)?;
     let has_overrides = patch_has_policy_overrides(&patch);
+    let suppress_patch = build_suppress_save_prompt_patch(&patch);
     let _prompt_terminal = prepare_prompt_terminal();
 
     prompt_println("");
@@ -80,78 +90,99 @@ pub(crate) fn offer_save_run_profile(
     if let Some(existing_profile) = compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && profile::is_user_override(name))
     {
-        let confirmed = if has_overrides {
-            confirm_typed_word(
-                &format!(
-                    "Update existing user profile '{}' with these entries, including unsafe policy overrides? Type 'override' to confirm: ",
-                    existing_profile
-                ),
-                "override",
-            )?
-        } else {
-            confirm(
-                &format!(
-                    "Update existing user profile '{}' with denied paths/rules? [Y/n] ",
-                    existing_profile
-                ),
-                true,
-            )?
+        let choice = prompt_profile_save_choice(Some(existing_profile), suppress_patch.is_some())?;
+        let selected_patch = match choice {
+            ProfileSaveChoice::Grant => {
+                if has_overrides
+                    && !confirm_typed_word(
+                        "Granting the shown entries includes policy overrides. Type 'override' to confirm: ",
+                        "override",
+                    )?
+                {
+                    return Ok(());
+                }
+                &patch
+            }
+            ProfileSaveChoice::Suppress => match suppress_patch.as_ref() {
+                Some(patch) => patch,
+                None => return Ok(()),
+            },
+            ProfileSaveChoice::Skip => return Ok(()),
         };
 
-        if confirmed {
-            let prepared = prepare_profile_save_from_patch(
-                &patch,
-                &cmd_name,
-                existing_profile,
-                compared_profile,
-            )?;
-            write_profile(&prepared)?;
-            print_profile_save(&prepared, command);
+        let prepared = prepare_profile_save_from_patch(
+            selected_patch,
+            &cmd_name,
+            existing_profile,
+            compared_profile,
+        )?;
+        write_profile(&prepared)?;
+        print_profile_save(&prepared, command);
+        if choice == ProfileSaveChoice::Suppress {
+            print_suppression_save_note(selected_patch);
         }
         return Ok(());
     }
+
+    let choice = prompt_profile_save_choice(None, suppress_patch.is_some())?;
+    let selected_patch = match choice {
+        ProfileSaveChoice::Grant => {
+            if has_overrides
+                && !confirm_typed_word(
+                    "Granting the shown entries includes policy overrides. Type 'override' to confirm: ",
+                    "override",
+                )?
+            {
+                return Ok(());
+            }
+            &patch
+        }
+        ProfileSaveChoice::Suppress => match suppress_patch.as_ref() {
+            Some(patch) => patch,
+            None => return Ok(()),
+        },
+        ProfileSaveChoice::Skip => return Ok(()),
+    };
 
     let suggested = suggested_run_profile_name(compared_profile, &cmd_name);
     let Some(profile_name) = prompt_profile_name(suggested.as_deref())? else {
         return Ok(());
     };
 
-    if has_overrides
-        && !confirm_typed_word(
-            "Save profile with the policy overrides shown above? Type 'override' to confirm: ",
-            "override",
-        )?
-    {
-        return Ok(());
-    }
-
-    let prepared =
-        prepare_profile_save_from_patch(&patch, &cmd_name, &profile_name, compared_profile)?;
+    let prepared = prepare_profile_save_from_patch(
+        selected_patch,
+        &cmd_name,
+        &profile_name,
+        compared_profile,
+    )?;
     write_profile(&prepared)?;
     print_profile_save(&prepared, command);
+    if choice == ProfileSaveChoice::Suppress {
+        print_suppression_save_note(selected_patch);
+    }
 
     Ok(())
 }
 
 /// Prompt for a new profile name, re-prompting on invalid or shadowed names
-/// until the user enters a valid name or presses Enter to skip.
+/// until the user enters a valid name. When a suggestion exists, Enter accepts
+/// it; otherwise a typed name is required.
 ///
-/// Returns `Ok(None)` when the user skips.
+/// Returns `Ok(None)` only when the user explicitly types `skip`.
 fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
     let mut first = true;
     loop {
         let prompt = if first {
             if let Some(suggested_name) = suggested {
-                format!(
-                    "Save denied paths as user profile? Enter a name (suggested: {}, or press Enter to skip): ",
-                    suggested_name
-                )
+                format!("User profile name [{}]: ", suggested_name)
             } else {
-                "Save denied paths as user profile? Enter a name (or press Enter to skip): "
-                    .to_string()
+                "User profile name: ".to_string()
             }
         } else {
-            "Enter a name (or press Enter to skip): ".to_string()
+            match suggested {
+                Some(suggested_name) => format!("Enter a name [{}]: ", suggested_name),
+                None => "Enter a name: ".to_string(),
+            }
         };
         prompt_print(&prompt, &[]);
 
@@ -163,6 +194,17 @@ fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
         let candidate = input.trim();
 
         if candidate.is_empty() {
+            if let Some(suggested_name) = suggested {
+                return Ok(Some(suggested_name.to_string()));
+            }
+            prompt_println(&format!(
+                "{}",
+                "Profile name required. Type a name, or type 'skip' to cancel.".red()
+            ));
+            continue;
+        }
+
+        if candidate.eq_ignore_ascii_case("skip") {
             return Ok(None);
         }
 
@@ -187,6 +229,59 @@ fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
         }
 
         return Ok(Some(candidate.to_string()));
+    }
+}
+
+fn prompt_profile_save_choice(
+    existing_profile: Option<&str>,
+    can_suppress: bool,
+) -> Result<ProfileSaveChoice> {
+    loop {
+        let prompt = match (existing_profile, can_suppress) {
+            (Some(name), true) => format!(
+                "Update user profile '{}' with suggestions? [g] grant / [s] suppress / [Enter] skip: ",
+                name
+            ),
+            (Some(name), false) => format!(
+                "Update existing user profile '{}' with the shown rules? [g] save / [Enter] skip: ",
+                name
+            ),
+            (None, true) => {
+                "Save suggestions to a user profile? [g] grant / [s] suppress / [Enter] skip: "
+                    .to_string()
+            }
+            (None, false) => {
+                "Save the shown rules in a user profile? [g] save / [Enter] skip: ".to_string()
+            }
+        };
+
+        prompt_print(&prompt, &[]);
+
+        let input = read_input_line()?;
+        if let Some(choice) = parse_profile_save_choice(&input, can_suppress) {
+            return Ok(choice);
+        }
+
+        let help = if can_suppress {
+            "Enter g to grant, s to suppress, or press Enter to skip."
+        } else {
+            "Enter g to save, or press Enter to skip."
+        };
+        prompt_println(&format!("{}", help.red()));
+    }
+}
+
+fn parse_profile_save_choice(input: &str, can_suppress: bool) -> Option<ProfileSaveChoice> {
+    let normalized = input.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" | "n" | "no" | "skip" => Some(ProfileSaveChoice::Skip),
+        "g" | "grant" | "y" | "yes" | "save" => Some(ProfileSaveChoice::Grant),
+        "s" | "suppress" | "suppress-save-prompt" | "no-nag" | "no_nag" | "nonag"
+            if can_suppress =>
+        {
+            Some(ProfileSaveChoice::Suppress)
+        }
+        _ => None,
     }
 }
 
@@ -413,6 +508,19 @@ pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[Stri
     ));
 }
 
+fn print_suppression_save_note(patch: &profile::Profile) {
+    let count = patch.filesystem.suppress_save_prompt.len();
+    if count == 0 {
+        return;
+    }
+
+    prompt_println(&format!(
+        "  ({} path suggestion{} suppressed; access is still denied)",
+        count,
+        if count == 1 { "" } else { "s" }
+    ));
+}
+
 /// Print a preview of what paths will be written to the profile.
 ///
 /// Highlights `bypass_protection` entries with a visible warning since those
@@ -434,7 +542,7 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
     }
 
     if has_entries {
-        prompt_println("[nono] Paths to be saved:");
+        prompt_println("[nono] Paths to be saved as grants:");
         for (label, paths) in sections {
             for path in *paths {
                 let is_override = patch.filesystem.bypass_protection.contains(path);
@@ -445,6 +553,11 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
                 }
             }
         }
+        prompt_println("");
+        prompt_println(
+            "[nono] Choose suppress to keep denying all listed paths and stop future save suggestions.",
+        );
+        prompt_println("[nono] CLI equivalent for one path: --suppress-save-prompt PATH");
     }
 
     if has_unsafe_rules {
@@ -687,11 +800,17 @@ pub(crate) fn prepare_profile_save_from_patch(
         .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)
         .map(|name| vec![name.to_string()]);
     let has_base = extends.is_some();
+    let suppression_only = patch_is_suppression_only(patch);
     new_profile.extends = extends;
     new_profile.meta = profile::ProfileMeta {
         name: profile_name.to_string(),
         version: "1.0.0".to_string(),
-        description: Some(if has_base {
+        description: Some(if suppression_only {
+            format!(
+                "Runtime-discovered save-prompt suppressions for {}",
+                cmd_name
+            )
+        } else if has_base {
             format!("Runtime-discovered path additions for {}", cmd_name)
         } else {
             format!("Runtime-discovered path profile for {}", cmd_name)
@@ -716,6 +835,7 @@ fn build_run_profile_patch(
     error_observation: &ErrorObservation,
     caps: &CapabilitySet,
     sandbox_violations: &[SandboxViolation],
+    ignored_denial_paths: &[PathBuf],
 ) -> Result<Option<profile::Profile>> {
     let mut grants: BTreeMap<PathBuf, PatchGrant> = BTreeMap::new();
 
@@ -725,6 +845,7 @@ fn build_run_profile_patch(
             &explanation.path,
             explanation.access,
             &explanation.reason,
+            ignored_denial_paths,
         );
     }
 
@@ -736,7 +857,13 @@ fn build_run_profile_patch(
                     "sensitive_path" | "insufficient_access" | "path_not_granted"
                 ) =>
             {
-                add_patch_grant(&mut grants, &hint.path, hint.access, &reason);
+                add_patch_grant(
+                    &mut grants,
+                    &hint.path,
+                    hint.access,
+                    &reason,
+                    ignored_denial_paths,
+                );
             }
             _ => {}
         }
@@ -802,6 +929,45 @@ fn build_run_profile_patch(
     Ok(Some(patch))
 }
 
+fn patch_is_suppression_only(patch: &profile::Profile) -> bool {
+    !patch.filesystem.suppress_save_prompt.is_empty()
+        && patch.filesystem.allow.is_empty()
+        && patch.filesystem.read.is_empty()
+        && patch.filesystem.write.is_empty()
+        && patch.filesystem.allow_file.is_empty()
+        && patch.filesystem.read_file.is_empty()
+        && patch.filesystem.write_file.is_empty()
+        && patch.filesystem.bypass_protection.is_empty()
+        && patch.unsafe_macos_seatbelt_rules.is_empty()
+}
+
+fn build_suppress_save_prompt_patch(grant_patch: &profile::Profile) -> Option<profile::Profile> {
+    let paths = grant_patch_path_suggestions(grant_patch);
+    if paths.is_empty() {
+        return None;
+    }
+
+    let mut patch = profile::Profile::default();
+    patch.filesystem.suppress_save_prompt = paths.into_iter().collect();
+    Some(patch)
+}
+
+fn grant_patch_path_suggestions(patch: &profile::Profile) -> BTreeSet<String> {
+    let sections = [
+        &patch.filesystem.allow,
+        &patch.filesystem.read,
+        &patch.filesystem.write,
+        &patch.filesystem.allow_file,
+        &patch.filesystem.read_file,
+        &patch.filesystem.write_file,
+    ];
+
+    sections
+        .into_iter()
+        .flat_map(|paths| paths.iter().cloned())
+        .collect()
+}
+
 pub(crate) fn has_saveable_system_service_rules(violations: &[SandboxViolation]) -> bool {
     violations
         .iter()
@@ -831,8 +997,15 @@ fn add_patch_grant(
     path: &Path,
     access: AccessMode,
     reason: &str,
+    ignored_denial_paths: &[PathBuf],
 ) {
     let (flag, target) = query_ext::suggested_flag_parts(path, access);
+    if matches_ignored_denial(path, ignored_denial_paths)
+        || matches_ignored_denial(&target, ignored_denial_paths)
+    {
+        return;
+    }
+
     let is_file = matches!(flag, "--read-file" | "--write-file" | "--allow-file");
 
     match grants.get_mut(&target) {
@@ -852,6 +1025,13 @@ fn add_patch_grant(
             );
         }
     }
+}
+
+fn matches_ignored_denial(path: &Path, ignored_denial_paths: &[PathBuf]) -> bool {
+    let canonical = nono::try_canonicalize(path);
+    ignored_denial_paths
+        .iter()
+        .any(|ignored| canonical == *ignored || canonical.starts_with(ignored))
 }
 
 fn merge_access(existing: AccessMode, requested: AccessMode) -> AccessMode {
@@ -878,6 +1058,10 @@ pub(crate) fn merge_profile_patch(profile: &mut profile::Profile, patch: &profil
     profile.filesystem.bypass_protection = profile::dedup_append(
         &profile.filesystem.bypass_protection,
         &patch.filesystem.bypass_protection,
+    );
+    profile.filesystem.suppress_save_prompt = profile::dedup_append(
+        &profile.filesystem.suppress_save_prompt,
+        &patch.filesystem.suppress_save_prompt,
     );
     profile.unsafe_macos_seatbelt_rules = profile::dedup_append(
         &profile.unsafe_macos_seatbelt_rules,
@@ -926,6 +1110,7 @@ mod tests {
             &ErrorObservation::default(),
             &CapabilitySet::new(),
             &[],
+            &[],
         )
         .expect("build patch")
         .expect("patch");
@@ -968,6 +1153,7 @@ mod tests {
             &ErrorObservation::default(),
             &CapabilitySet::new(),
             &[],
+            &[],
         )
         .expect("build patch")
         .expect("patch");
@@ -975,6 +1161,147 @@ mod tests {
         assert_eq!(patch.filesystem.allow_file, vec!["~/config.json"]);
         assert!(patch.filesystem.read_file.is_empty());
         assert!(patch.filesystem.write_file.is_empty());
+    }
+
+    #[test]
+    fn build_run_profile_patch_omits_ignored_denials() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let _env = EnvVarGuard::set_all(&[("HOME", temp_home.path().to_str().expect("home path"))]);
+
+        let ignored = temp_home.path().join(".copilot").join("settings.json");
+        let saved = temp_home.path().join(".copilot").join("config.json");
+        std::fs::create_dir_all(saved.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&ignored, b"{}").expect("write ignored");
+        std::fs::write(&saved, b"{}").expect("write saved");
+
+        let ignored_explanation = PolicyExplanation {
+            path: ignored.clone(),
+            access: AccessMode::Read,
+            reason: "path_not_granted".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+        let saved_explanation = PolicyExplanation {
+            path: saved,
+            access: AccessMode::Read,
+            reason: "path_not_granted".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+
+        let patch = build_run_profile_patch(
+            &[ignored_explanation, saved_explanation],
+            &ErrorObservation::default(),
+            &CapabilitySet::new(),
+            &[],
+            &[nono::try_canonicalize(&ignored)],
+        )
+        .expect("build patch")
+        .expect("patch");
+
+        assert_eq!(patch.filesystem.read_file, vec!["~/.copilot/config.json"]);
+    }
+
+    #[test]
+    fn build_run_profile_patch_returns_none_when_all_denials_are_ignored() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let _env = EnvVarGuard::set_all(&[("HOME", temp_home.path().to_str().expect("home path"))]);
+
+        let target = temp_home.path().join(".copilot").join("settings.json");
+        std::fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&target, b"{}").expect("write");
+
+        let explanation = PolicyExplanation {
+            path: target.clone(),
+            access: AccessMode::Read,
+            reason: "path_not_granted".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+
+        let patch = build_run_profile_patch(
+            &[explanation],
+            &ErrorObservation::default(),
+            &CapabilitySet::new(),
+            &[],
+            &[nono::try_canonicalize(&target)],
+        )
+        .expect("build patch");
+
+        assert!(patch.is_none());
+    }
+
+    #[test]
+    fn build_suppress_save_prompt_patch_collects_all_grant_paths() {
+        let grant_patch = profile::Profile {
+            filesystem: profile::FilesystemConfig {
+                read: vec!["~/workspace".to_string()],
+                read_file: vec!["~/.copilot/settings.json".to_string()],
+                allow_file: vec!["~/.copilot/config.json".to_string()],
+                bypass_protection: vec!["~/.copilot/settings.json".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let suppress_patch =
+            build_suppress_save_prompt_patch(&grant_patch).expect("suppression patch");
+
+        assert_eq!(
+            suppress_patch.filesystem.suppress_save_prompt,
+            vec![
+                "~/.copilot/config.json".to_string(),
+                "~/.copilot/settings.json".to_string(),
+                "~/workspace".to_string(),
+            ]
+        );
+        assert!(suppress_patch.filesystem.read.is_empty());
+        assert!(suppress_patch.filesystem.read_file.is_empty());
+        assert!(suppress_patch.filesystem.bypass_protection.is_empty());
+    }
+
+    #[test]
+    fn build_suppress_save_prompt_patch_ignores_unsafe_only_patch() {
+        let grant_patch = profile::Profile {
+            unsafe_macos_seatbelt_rules: vec![USER_PREFERENCES_SEATBELT_RULE.to_string()],
+            ..Default::default()
+        };
+
+        assert!(build_suppress_save_prompt_patch(&grant_patch).is_none());
+    }
+
+    #[test]
+    fn parse_profile_save_choice_supports_grant_suppress_and_skip() {
+        assert_eq!(
+            parse_profile_save_choice("g", true),
+            Some(ProfileSaveChoice::Grant)
+        );
+        assert_eq!(
+            parse_profile_save_choice("yes", true),
+            Some(ProfileSaveChoice::Grant)
+        );
+        assert_eq!(
+            parse_profile_save_choice("s", true),
+            Some(ProfileSaveChoice::Suppress)
+        );
+        assert_eq!(
+            parse_profile_save_choice("no-nag", true),
+            Some(ProfileSaveChoice::Suppress)
+        );
+        assert_eq!(
+            parse_profile_save_choice("", true),
+            Some(ProfileSaveChoice::Skip)
+        );
+        assert_eq!(
+            parse_profile_save_choice("no", true),
+            Some(ProfileSaveChoice::Skip)
+        );
+        assert_eq!(parse_profile_save_choice("s", false), None);
     }
 
     #[test]
@@ -989,6 +1316,7 @@ mod tests {
             &ErrorObservation::default(),
             &CapabilitySet::new(),
             &violations,
+            &[],
         )
         .expect("build patch")
         .expect("patch");
@@ -1073,8 +1401,8 @@ mod tests {
     #[test]
     fn prompt_line_uses_crlf_for_terminal_layout() {
         assert_eq!(
-            prompt_line("[nono] Paths to be saved:"),
-            "[nono] Paths to be saved:\r\n"
+            prompt_line("[nono] Paths to be saved as grants:"),
+            "[nono] Paths to be saved as grants:\r\n"
         );
         assert_eq!(prompt_line(""), "\r\n");
     }
@@ -1082,8 +1410,8 @@ mod tests {
     #[test]
     fn prompt_tty_rendering_clears_line_tails() {
         assert_eq!(
-            prompt_line_for_tty("[nono] Paths to be saved:"),
-            "\r[nono] Paths to be saved:\u{1b}[K\r\n"
+            prompt_line_for_tty("[nono] Paths to be saved as grants:"),
+            "\r[nono] Paths to be saved as grants:\u{1b}[K\r\n"
         );
         assert_eq!(
             prompt_inline_for_tty("Update profile? [Y/n] "),
@@ -1145,6 +1473,47 @@ mod tests {
             prepared.profile.unsafe_macos_seatbelt_rules,
             vec![USER_PREFERENCES_SEATBELT_RULE.to_string()]
         );
+    }
+
+    #[test]
+    fn prepare_profile_save_from_suppression_patch_uses_suppression_description() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        let patch = profile::Profile {
+            filesystem: profile::FilesystemConfig {
+                suppress_save_prompt: vec!["~/.copilot/settings.json".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let prepared =
+            prepare_profile_save_from_patch(&patch, "claude", "claude-local", Some("claude-code"))
+                .expect("prepare");
+
+        assert!(matches!(prepared.action, SaveAction::Created));
+        assert_eq!(
+            prepared.profile.extends,
+            Some(vec!["claude-code".to_string()])
+        );
+        assert_eq!(
+            prepared.profile.meta.description.as_deref(),
+            Some("Runtime-discovered save-prompt suppressions for claude")
+        );
+        assert_eq!(
+            prepared.profile.filesystem.suppress_save_prompt,
+            vec!["~/.copilot/settings.json"]
+        );
+        assert!(prepared.profile.filesystem.read_file.is_empty());
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -91,23 +91,10 @@ pub(crate) fn offer_save_run_profile(
         .filter(|name| profile::is_valid_profile_name(name) && profile::is_user_override(name))
     {
         let choice = prompt_profile_save_choice(Some(existing_profile), suppress_patch.is_some())?;
-        let selected_patch = match choice {
-            ProfileSaveChoice::Grant => {
-                if has_overrides
-                    && !confirm_typed_word(
-                        "Granting the shown entries includes policy overrides. Type 'override' to confirm: ",
-                        "override",
-                    )?
-                {
-                    return Ok(());
-                }
-                &patch
-            }
-            ProfileSaveChoice::Suppress => match suppress_patch.as_ref() {
-                Some(patch) => patch,
-                None => return Ok(()),
-            },
-            ProfileSaveChoice::Skip => return Ok(()),
+        let Some(selected_patch) =
+            selected_profile_save_patch(choice, &patch, suppress_patch.as_ref(), has_overrides)?
+        else {
+            return Ok(());
         };
 
         let prepared = prepare_profile_save_from_patch(
@@ -125,23 +112,10 @@ pub(crate) fn offer_save_run_profile(
     }
 
     let choice = prompt_profile_save_choice(None, suppress_patch.is_some())?;
-    let selected_patch = match choice {
-        ProfileSaveChoice::Grant => {
-            if has_overrides
-                && !confirm_typed_word(
-                    "Granting the shown entries includes policy overrides. Type 'override' to confirm: ",
-                    "override",
-                )?
-            {
-                return Ok(());
-            }
-            &patch
-        }
-        ProfileSaveChoice::Suppress => match suppress_patch.as_ref() {
-            Some(patch) => patch,
-            None => return Ok(()),
-        },
-        ProfileSaveChoice::Skip => return Ok(()),
+    let Some(selected_patch) =
+        selected_profile_save_patch(choice, &patch, suppress_patch.as_ref(), has_overrides)?
+    else {
+        return Ok(());
     };
 
     let suggested = suggested_run_profile_name(compared_profile, &cmd_name);
@@ -162,6 +136,29 @@ pub(crate) fn offer_save_run_profile(
     }
 
     Ok(())
+}
+
+fn selected_profile_save_patch<'a>(
+    choice: ProfileSaveChoice,
+    grant_patch: &'a profile::Profile,
+    suppress_patch: Option<&'a profile::Profile>,
+    has_overrides: bool,
+) -> Result<Option<&'a profile::Profile>> {
+    match choice {
+        ProfileSaveChoice::Grant => {
+            if has_overrides
+                && !confirm_typed_word(
+                    "Granting the shown entries includes policy overrides. Type 'override' to confirm: ",
+                    "override",
+                )?
+            {
+                return Ok(None);
+            }
+            Ok(Some(grant_patch))
+        }
+        ProfileSaveChoice::Suppress => Ok(suppress_patch),
+        ProfileSaveChoice::Skip => Ok(None),
+    }
 }
 
 /// Prompt for a new profile name, re-prompting on invalid or shadowed names
@@ -1000,8 +997,9 @@ fn add_patch_grant(
     ignored_denial_paths: &[PathBuf],
 ) {
     let (flag, target) = query_ext::suggested_flag_parts(path, access);
-    if matches_ignored_denial(path, ignored_denial_paths)
-        || matches_ignored_denial(&target, ignored_denial_paths)
+    if !ignored_denial_paths.is_empty()
+        && (matches_ignored_denial(path, ignored_denial_paths)
+            || (target.as_path() != path && matches_ignored_denial(&target, ignored_denial_paths)))
     {
         return;
     }
@@ -1028,6 +1026,10 @@ fn add_patch_grant(
 }
 
 fn matches_ignored_denial(path: &Path, ignored_denial_paths: &[PathBuf]) -> bool {
+    if ignored_denial_paths.is_empty() {
+        return false;
+    }
+
     let canonical = nono::try_canonicalize(path);
     ignored_denial_paths
         .iter()

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -434,6 +434,7 @@ pub(crate) struct PreparedSandbox {
     pub(crate) open_url_origins: Vec<String>,
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
+    pub(crate) ignored_denial_paths: Vec<PathBuf>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -1013,6 +1014,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 open_url_origins: Vec::new(),
                 open_url_allow_localhost: false,
                 bypass_protection_paths: Vec::new(),
+                ignored_denial_paths: Vec::new(),
                 allowed_env_vars: None,
                 denied_env_vars: None,
             },
@@ -1043,6 +1045,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allow_gpu: profile_allow_gpu,
         allow_parent_of_protected: profile_allow_parent_of_protected,
         bypass_protection_paths,
+        ignored_denial_paths,
         allowed_env_vars: profile_allowed_env_vars,
         denied_env_vars: profile_denied_env_vars,
     } = prepared_profile;
@@ -1286,6 +1289,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             open_url_origins,
             open_url_allow_localhost,
             bypass_protection_paths,
+            ignored_denial_paths,
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
         },

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -76,6 +76,10 @@ fn test_schema_filesystem_has_deny_and_bypass_protection() {
         props.contains_key("bypass_protection"),
         "FilesystemConfig.bypass_protection missing from canonical schema"
     );
+    assert!(
+        props.contains_key("suppress_save_prompt"),
+        "FilesystemConfig.suppress_save_prompt missing from canonical schema"
+    );
 }
 
 #[test]

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -86,7 +86,8 @@ With `--full`, additional sections are included as empty stubs for all additive 
     "read_file": [],
     "write_file": [],
     "deny": [],
-    "bypass_protection": []
+    "bypass_protection": [],
+    "suppress_save_prompt": []
   },
   "security": {},
   "network": {
@@ -293,6 +294,28 @@ Groups are referenced by name in the `groups.include` field. See [Profiles & Gro
 <Note>
   `filesystem.bypass_protection` only removes the deny rule. You must also grant access via `filesystem.allow`, `filesystem.read`, or `filesystem.write` (or the matching `*_file` variant) for the path to be accessible.
 </Note>
+
+### Suppressing Repeated Save Suggestions
+
+Use `filesystem.suppress_save_prompt` for paths you intentionally do not want
+to grant, but also do not want to see in the save-profile prompt on every run:
+
+```json
+{
+  "filesystem": {
+    "suppress_save_prompt": ["$HOME/.copilot/settings.json"]
+  }
+}
+```
+
+This does not grant access and does not hide diagnostics. It only suppresses
+matching save-profile suggestions. `filesystem.ignore` is accepted as an alias,
+but the canonical name is deliberately explicit so it is not mistaken for
+allowing the denied path.
+
+The post-run save prompt offers the same behavior interactively: choose
+`suppress` to save all listed denied-path suggestions here instead of adding
+them as `read`, `read_file`, `allow`, or `allow_file` grants.
 
 ### Exclude Inherited Groups
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -70,6 +70,7 @@ Profiles use JSON format:
     "write_file": [],
     "deny": [],
     "bypass_protection": [],
+    "suppress_save_prompt": [],
     "unix_socket": [],
     "unix_socket_bind": [],
     "unix_socket_dir": [],
@@ -137,6 +138,7 @@ This is the primary mechanism for surgically customizing inherited profiles with
 | `deny` | `filesystem` | Additional deny rules to apply (block read and write content). On macOS, Unix socket paths also emit a `network-outbound` deny so that `connect(2)` to the socket is blocked. |
 | `deny` | `commands` | Deprecated in v0.33.0. Startup-only command denylist extension. Not enforced for child processes; prefer `filesystem.deny` and narrower grants. |
 | `bypass_protection` | `filesystem` | Paths exempted from deny groups. **Does not grant access** — each path must also appear in `filesystem.allow`, `filesystem.read`, or `filesystem.write`. |
+| `suppress_save_prompt` | `filesystem` | Paths whose runtime denials should not be offered in save-profile prompts. **Does not grant access** and does not hide diagnostics. |
 
 <Note>
   **Renamed in issue #594.** The old top-level `policy` section was dissolved into `filesystem`, `groups`, and `commands` in the canonical schema. Legacy names still deserialize with a deprecation warning; see the migration table in `nono profile guide` for the full mapping. The legacy keys will be removed in v1.0.0.
@@ -248,6 +250,28 @@ This is equivalent to the CLI flag `--bypass-protection`:
 ```bash
 nono run --profile opencode --allow ~/.docker --bypass-protection ~/.docker -- opencode
 ```
+
+#### Suppressing Save Suggestions Without Granting Access
+
+Use `filesystem.suppress_save_prompt` when a path is expected to be denied and
+you do not want nono to keep offering it as a profile addition:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": { "name": "claude-local", "version": "1.0.0" },
+  "filesystem": {
+    "suppress_save_prompt": ["$HOME/.copilot/settings.json"]
+  }
+}
+```
+
+`filesystem.suppress_save_prompt` only suppresses the save-profile suggestion
+for matching denials. The sandbox still denies the path, and the diagnostic
+footer can still show the denial if the run fails.
+
+The interactive save prompt applies this to every listed path suggestion when
+you choose `suppress`; it does not create any allow/read/write grants.
 
 <Note>
   `filesystem`, `groups`, and `commands` fields are additive across inheritance. A child profile's `filesystem.deny` is merged with the base profile's `filesystem.deny`, and `groups.exclude` from both levels are combined.
@@ -447,6 +471,12 @@ Every profile's effective capability set is built through composition:
 4. **profile.filesystem.allow/read/write**, **profile.filesystem.deny**, and **profile.commands.allow/deny** apply additive overrides
 5. **profile.filesystem.bypass_protection** punches targeted holes through deny groups (requires a matching grant in `filesystem.allow`/`read`/`write`)
 6. **CLI overrides** (`--allow`, `--read`, `--bypass-protection`, etc.) are applied last
+
+`profile.filesystem.suppress_save_prompt` and `--suppress-save-prompt` are
+prompt filters only; they do not participate in capability enforcement. The
+older `filesystem.ignore` and `--ignore-denied` forms are accepted as aliases,
+but new examples use the explicit suppress wording to avoid suggesting an
+access grant.
 
 Exclusions are applied after group addition. If the same group appears in both
 `groups.include` and `groups.exclude`, the exclusion wins.

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -264,6 +264,29 @@ Grant write-only access to a single file.
 nono run --write-file ./output.log -- command
 ```
 
+### Denial Prompt Control
+
+#### `--suppress-save-prompt`
+
+Suppress the post-run save-profile prompt for denials under a path. This does
+not grant access and does not remove the diagnostic footer; it only prevents
+the same denied path from being offered as a profile addition repeatedly.
+
+```bash
+nono run --profile claude-code \
+  --suppress-save-prompt ~/.copilot/settings.json \
+  -- claude
+```
+
+For persistent behavior, put the same path in
+`filesystem.suppress_save_prompt` in a user profile. The older
+`--ignore-denied` spelling is accepted as an alias, but the suppress wording is
+preferred because this flag never turns a denial into an allow rule.
+
+When nono offers to save denied paths after a run, choosing `suppress` writes
+all listed path suggestions to `filesystem.suppress_save_prompt` instead of
+adding them as filesystem grants.
+
 ### AF_UNIX Socket Permissions
 
 These flags grant `connect(2)` (and optionally `bind(2)`) on pathname AF_UNIX


### PR DESCRIPTION
Introduce a mechanism to prevent repeatedly suggesting to save specific denied paths to a user profile.

- Add `filesystem.suppress_save_prompt` to the profile schema and `--suppress-save-prompt` CLI flag.
- Support `filesystem.ignore` and `--ignore-denied` as aliases for existing users, but prefer the explicit `suppress_save_prompt` naming in new profiles and documentation.
- Modify the interactive save prompt to include a 'suppress' option, which saves all listed paths into the `suppress_save_prompt` list, preventing future suggestions for those paths without granting access.
- Ensure paths configured for suppression are not offered as grants in the save prompt.
- Update profile merging, command line parsing, and schema to support the new field.
- Document the new feature in the authoring guide and CLI usage.

Resolves: #875
