### PR TITLE
feat(core): scrub command arguments for secrets

### DIFF
--- a/crates/nono-cli/src/audit_attestation.rs
+++ b/crates/nono-cli/src/audit_attestation.rs
@@ -49,6 +49,8 @@ struct AuditAttestationPredicate<'a> {
     started: &'a str,
     ended: &'a Option<String>,
     command: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redaction_policy: Option<nono::ScrubPolicyDiff>,
     audit_log: AuditLogPredicate<'a>,
     signer: AuditSignerPredicate<'a>,
 }
@@ -97,6 +99,7 @@ pub(crate) fn write_audit_attestation(
     session_dir: &Path,
     metadata: &SessionMetadata,
     signer: &AuditSigner,
+    redaction_policy: &nono::ScrubPolicy,
 ) -> Result<AuditAttestationSummary> {
     let integrity = metadata
         .audit_integrity
@@ -106,12 +109,14 @@ pub(crate) fn write_audit_attestation(
             reason: "audit attestation requires audit integrity to be enabled".to_string(),
         })?;
 
+    let scrubbed_command = nono::scrub_argv_with_policy(&metadata.command, redaction_policy);
     let predicate = serde_json::to_value(AuditAttestationPredicate {
         version: 1,
         session_id: &metadata.session_id,
         started: &metadata.started,
         ended: &metadata.ended,
-        command: &metadata.command,
+        command: &scrubbed_command,
+        redaction_policy: redaction_policy.diff_from_secure_default().into_option(),
         audit_log: AuditLogPredicate {
             hash_algorithm: &integrity.hash_algorithm,
             event_count: integrity.event_count,
@@ -468,7 +473,13 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             public_key_b64: trust::base64::base64_encode(public_key.as_bytes()),
         };
         let mut metadata = sample_metadata();
-        let summary = write_audit_attestation(dir.path(), &metadata, &signer).unwrap();
+        let summary = write_audit_attestation(
+            dir.path(),
+            &metadata,
+            &signer,
+            &nono::ScrubPolicy::secure_default(),
+        )
+        .unwrap();
         metadata.audit_attestation = Some(summary);
 
         let verified = verify_audit_attestation(dir.path(), &metadata, None).unwrap();
@@ -479,6 +490,83 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         assert!(verified.session_id_matches);
         assert_eq!(verified.expected_public_key_matches, None);
         assert!(verified.verification_error.is_none());
+    }
+
+    #[test]
+    fn audit_attestation_predicate_scrubs_command_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_pair = trust::generate_signing_key().unwrap();
+        let key_id = trust::key_id_hex(&key_pair).unwrap();
+        let public_key = trust::export_public_key(&key_pair).unwrap();
+        let signer = AuditSigner {
+            key_pair,
+            key_id,
+            public_key_b64: trust::base64::base64_encode(public_key.as_bytes()),
+        };
+        let mut metadata = sample_metadata();
+        metadata.command = vec![
+            "curl".to_string(),
+            "-H".to_string(),
+            "Authorization: Bearer real-token".to_string(),
+            "https://example.com/api?token=query-secret&format=json".to_string(),
+        ];
+
+        write_audit_attestation(
+            dir.path(),
+            &metadata,
+            &signer,
+            &nono::ScrubPolicy::secure_default(),
+        )
+        .unwrap();
+
+        let bundle_path = dir.path().join(AUDIT_ATTESTATION_BUNDLE_FILENAME);
+        let bundle = trust::load_bundle(&bundle_path).unwrap();
+        let statement = extract_statement(&bundle).unwrap();
+        let command_json = statement
+            .predicate
+            .get("command")
+            .and_then(|value| serde_json::to_string(value).ok())
+            .unwrap();
+
+        assert!(command_json.contains("[REDACTED]"));
+        assert!(!command_json.contains("real-token"));
+        assert!(!command_json.contains("query-secret"));
+    }
+
+    #[test]
+    fn audit_attestation_predicate_records_redaction_policy_diff() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_pair = trust::generate_signing_key().unwrap();
+        let key_id = trust::key_id_hex(&key_pair).unwrap();
+        let public_key = trust::export_public_key(&key_pair).unwrap();
+        let signer = AuditSigner {
+            key_pair,
+            key_id,
+            public_key_b64: trust::base64::base64_encode(public_key.as_bytes()),
+        };
+        let mut metadata = sample_metadata();
+        metadata.command = vec![
+            "curl".to_string(),
+            "--private-token=private-secret".to_string(),
+            "https://example.com/callback?state=visible&token=hidden".to_string(),
+        ];
+        let mut redactions = nono::ScrubPolicy::secure_default();
+        redactions.add_flag("--private-token");
+        redactions.remove_query_key("state");
+
+        write_audit_attestation(dir.path(), &metadata, &signer, &redactions).unwrap();
+
+        let bundle_path = dir.path().join(AUDIT_ATTESTATION_BUNDLE_FILENAME);
+        let bundle = trust::load_bundle(&bundle_path).unwrap();
+        let statement = extract_statement(&bundle).unwrap();
+        let predicate_json = serde_json::to_string(&statement.predicate).unwrap();
+
+        assert!(predicate_json.contains("--private-token=[REDACTED]"));
+        assert!(predicate_json.contains("state=visible"));
+        assert!(predicate_json.contains("\"added_flags\":[\"--private-token\"]"));
+        assert!(predicate_json.contains("\"removed_query_keys\":[\"state\"]"));
+        assert!(!predicate_json.contains("private-secret"));
+        assert!(!predicate_json.contains("token=hidden"));
     }
 
     #[test]
@@ -507,7 +595,13 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             public_key_b64: trust::base64::base64_encode(public_key.as_bytes()),
         };
         let mut metadata = sample_metadata();
-        let summary = write_audit_attestation(dir.path(), &metadata, &signer).unwrap();
+        let summary = write_audit_attestation(
+            dir.path(),
+            &metadata,
+            &signer,
+            &nono::ScrubPolicy::secure_default(),
+        )
+        .unwrap();
         metadata.audit_attestation = Some(summary);
         metadata.session_id = "tampered-session".to_string();
 

--- a/crates/nono-cli/src/audit_integrity.rs
+++ b/crates/nono-cli/src/audit_integrity.rs
@@ -20,6 +20,8 @@ pub(crate) enum AuditEventPayload {
     SessionStarted {
         started: String,
         command: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        redaction_policy: Option<nono::ScrubPolicyDiff>,
     },
     SessionEnded {
         ended: String,
@@ -68,10 +70,19 @@ pub(crate) struct AuditRecorder {
     next_sequence: u64,
     previous_chain: Option<ContentHash>,
     leaf_hashes: Vec<ContentHash>,
+    redaction_policy: nono::ScrubPolicy,
 }
 
 impl AuditRecorder {
+    #[cfg(test)]
     pub(crate) fn new(session_dir: PathBuf) -> Result<Self> {
+        Self::new_with_policy(session_dir, nono::ScrubPolicy::secure_default())
+    }
+
+    pub(crate) fn new_with_policy(
+        session_dir: PathBuf,
+        redaction_policy: nono::ScrubPolicy,
+    ) -> Result<Self> {
         let path = session_dir.join(AUDIT_EVENTS_FILENAME);
         let file = OpenOptions::new()
             .create(true)
@@ -88,6 +99,7 @@ impl AuditRecorder {
             next_sequence: 0,
             previous_chain: None,
             leaf_hashes: Vec::new(),
+            redaction_policy,
         })
     }
 
@@ -96,7 +108,14 @@ impl AuditRecorder {
         started: String,
         command: Vec<String>,
     ) -> Result<()> {
-        self.append_event(AuditEventPayload::SessionStarted { started, command })
+        self.append_event(AuditEventPayload::SessionStarted {
+            started,
+            command: nono::scrub_argv_with_policy(&command, &self.redaction_policy),
+            redaction_policy: self
+                .redaction_policy
+                .diff_from_secure_default()
+                .into_option(),
+        })
     }
 
     pub(crate) fn record_session_ended(&mut self, ended: String, exit_code: i32) -> Result<()> {
@@ -411,6 +430,61 @@ mod tests {
             .unwrap();
 
         assert_eq!(recorder.event_count(), 1);
+    }
+
+    #[test]
+    fn record_session_started_scrubs_command_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        recorder
+            .record_session_started(
+                "2026-04-21T00:00:00Z".to_string(),
+                vec![
+                    "curl".to_string(),
+                    "--password".to_string(),
+                    "real-password".to_string(),
+                    "-H".to_string(),
+                    "Authorization: Bearer real-token".to_string(),
+                    "https://example.com/api?token=query-secret".to_string(),
+                ],
+            )
+            .unwrap();
+
+        let contents = std::fs::read_to_string(dir.path().join(AUDIT_EVENTS_FILENAME)).unwrap();
+
+        assert!(contents.contains("[REDACTED]"));
+        assert!(!contents.contains("real-password"));
+        assert!(!contents.contains("real-token"));
+        assert!(!contents.contains("query-secret"));
+    }
+
+    #[test]
+    fn record_session_started_uses_configured_redaction_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut redactions = nono::ScrubPolicy::secure_default();
+        redactions.add_flag("--private-token");
+        redactions.remove_query_key("state");
+        let mut recorder =
+            AuditRecorder::new_with_policy(dir.path().to_path_buf(), redactions).unwrap();
+        recorder
+            .record_session_started(
+                "2026-04-21T00:00:00Z".to_string(),
+                vec![
+                    "curl".to_string(),
+                    "--private-token=private-secret".to_string(),
+                    "https://example.com/callback?state=visible&token=hidden".to_string(),
+                ],
+            )
+            .unwrap();
+
+        let contents = std::fs::read_to_string(dir.path().join(AUDIT_EVENTS_FILENAME)).unwrap();
+
+        assert!(contents.contains("--private-token=[REDACTED]"));
+        assert!(contents.contains("state=visible"));
+        assert!(contents.contains("\"added_flags\":[\"--private-token\"]"));
+        assert!(contents.contains("\"removed_query_keys\":[\"state\"]"));
+        assert!(!contents.contains("private-secret"));
+        assert!(!contents.contains("token=hidden"));
     }
 
     #[test]

--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -115,6 +115,8 @@ fn path_bytes(path: &std::path::Path) -> Vec<u8> {
 }
 
 pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord> {
+    validate_ledger_session_id(&metadata.session_id)?;
+
     let root = audit_root()?;
     std::fs::create_dir_all(&root).map_err(|e| {
         NonoError::Snapshot(format!(
@@ -138,6 +140,21 @@ pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord>
             ))
         })?;
     append_locked(&mut file, metadata)
+}
+
+fn validate_ledger_session_id(session_id: &str) -> Result<()> {
+    let valid = !session_id.is_empty()
+        && session_id.len() <= 64
+        && session_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'));
+    if valid {
+        Ok(())
+    } else {
+        Err(NonoError::ConfigParse(format!(
+            "invalid audit session id: {session_id}"
+        )))
+    }
 }
 
 fn append_locked(file: &mut std::fs::File, metadata: &SessionMetadata) -> Result<LedgerRecord> {
@@ -395,6 +412,22 @@ mod tests {
         assert!(verified.session_digest_matches);
         assert!(verified.ledger_chain_verified);
         assert_eq!(verified.entry_count, 1);
+    }
+
+    #[test]
+    fn ledger_rejects_malformed_session_id() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home)]);
+
+        let meta = sample_metadata("real-token\\|real-key");
+        let err = match append_session(&meta) {
+            Ok(_) => panic!("malformed session id should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("invalid audit session id"));
     }
 
     #[test]

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -2,8 +2,9 @@ use crate::cli::{RunArgs, SandboxArgs, ShellArgs, WrapArgs};
 use crate::exec_strategy;
 use crate::execution_runtime::execute_sandboxed;
 use crate::launch_runtime::{
-    load_configured_detach_sequence, prepare_run_launch_plan, resolve_requested_workdir,
-    select_exec_strategy, ExecutionFlags, LaunchPlan, SessionLaunchOptions,
+    load_configured_detach_sequence, load_configured_redaction_policy, prepare_run_launch_plan,
+    resolve_requested_workdir, select_exec_strategy, ExecutionFlags, LaunchPlan,
+    SessionLaunchOptions,
 };
 use crate::output;
 use crate::profile;
@@ -72,7 +73,8 @@ pub(crate) fn run_sandbox(mut run_args: RunArgs, silent: bool) -> Result<()> {
                 prepared.secrets.len()
             );
         }
-        output::print_dry_run(&program, &cmd_args, silent);
+        let redaction_policy = load_configured_redaction_policy()?;
+        output::print_dry_run(&program, &cmd_args, &redaction_policy, silent);
         return Ok(());
     }
 
@@ -99,7 +101,8 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
                 prepared.secrets.len()
             );
         }
-        output::print_dry_run(shell_path.as_os_str(), &[], silent);
+        let redaction_policy = load_configured_redaction_policy()?;
+        output::print_dry_run(shell_path.as_os_str(), &[], &redaction_policy, silent);
         return Ok(());
     }
 
@@ -146,6 +149,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
             proxy,
+            redaction_policy: load_configured_redaction_policy()?,
             session: SessionLaunchOptions {
                 session_name: args.name,
                 detach_sequence: load_configured_detach_sequence()?,
@@ -177,7 +181,8 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
                 prepared.secrets.len()
             );
         }
-        output::print_dry_run(&program, &cmd_args, silent);
+        let redaction_policy = load_configured_redaction_policy()?;
+        output::print_dry_run(&program, &cmd_args, &redaction_policy, silent);
         return Ok(());
     }
 

--- a/crates/nono-cli/src/config/user.rs
+++ b/crates/nono-cli/src/config/user.rs
@@ -31,6 +31,8 @@ pub struct UserConfig {
     pub updates: UpdateSettings,
     #[serde(default)]
     pub ui: UiSettings,
+    #[serde(default)]
+    pub redaction: RedactionSettings,
 }
 
 /// UI display settings
@@ -42,6 +44,60 @@ pub struct UiSettings {
     /// In-band PTY detach sequence, e.g. "ctrl-] d"
     #[serde(default)]
     pub detach_sequence: Option<DetachSequence>,
+}
+
+/// Output redaction settings for command context persisted in sessions and audit logs.
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RedactionSettings {
+    /// Additional command flags whose following value, or `--flag=value` value,
+    /// should be redacted.
+    #[serde(default)]
+    pub extra_flags: Vec<String>,
+    /// Additional HTTP header names whose value should be redacted.
+    #[serde(default)]
+    pub extra_headers: Vec<String>,
+    /// Additional URL query parameter names whose value should be redacted.
+    #[serde(default)]
+    pub extra_query_keys: Vec<String>,
+    /// Required before any secure default redaction names can be removed.
+    #[serde(default)]
+    pub unsafe_redaction_overrides: bool,
+    /// Secure default names to stop redacting for unsafe debugging sessions.
+    #[serde(default)]
+    pub allow_unredacted_defaults: Vec<String>,
+}
+
+impl RedactionSettings {
+    pub fn to_scrub_policy(&self) -> Result<nono::ScrubPolicy> {
+        if !self.unsafe_redaction_overrides && !self.allow_unredacted_defaults.is_empty() {
+            return Err(NonoError::ConfigParse(
+                "[redaction].allow_unredacted_defaults requires \
+                 unsafe_redaction_overrides = true"
+                    .to_string(),
+            ));
+        }
+
+        let mut redactions = nono::ScrubPolicy::secure_default();
+        for flag in &self.extra_flags {
+            redactions.add_flag(flag);
+        }
+        for header in &self.extra_headers {
+            redactions.add_header(header);
+        }
+        for key in &self.extra_query_keys {
+            redactions.add_query_key(key);
+        }
+
+        if self.unsafe_redaction_overrides {
+            for name in &self.allow_unredacted_defaults {
+                redactions.remove_flag(name);
+                redactions.remove_header(name);
+                redactions.remove_query_key(name);
+            }
+        }
+
+        Ok(redactions)
+    }
 }
 
 /// Parsed in-band PTY detach sequence.
@@ -358,6 +414,60 @@ alice = { name = "Alice", fingerprint = "abc123" }
         assert!(config.overrides.sensitive_paths.is_empty());
         assert!(config.overrides.commands.is_empty());
         assert!(config.ui.detach_sequence.is_none());
+        assert!(config.redaction.extra_flags.is_empty());
+    }
+
+    #[test]
+    fn test_redaction_settings_add_extra_patterns() {
+        let toml = r#"
+[redaction]
+extra_flags = ["--private-token"]
+extra_headers = ["Private-Token"]
+extra_query_keys = ["signature"]
+"#;
+        let config: UserConfig = toml::from_str(toml).expect("Failed to parse");
+        let policy = config
+            .redaction
+            .to_scrub_policy()
+            .expect("Failed to build policy");
+
+        let diff = policy.diff_from_secure_default();
+        assert_eq!(diff.added_flags, vec!["--private-token".to_string()]);
+        assert_eq!(diff.added_headers, vec!["private-token".to_string()]);
+        assert_eq!(diff.added_query_keys, vec!["signature".to_string()]);
+    }
+
+    #[test]
+    fn test_redaction_settings_require_unsafe_override_for_removals() {
+        let toml = r#"
+[redaction]
+allow_unredacted_defaults = ["state"]
+"#;
+        let config: UserConfig = toml::from_str(toml).expect("Failed to parse");
+        let err = config
+            .redaction
+            .to_scrub_policy()
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(err.contains("unsafe_redaction_overrides = true"));
+    }
+
+    #[test]
+    fn test_redaction_settings_can_remove_defaults_when_unsafe_enabled() {
+        let toml = r#"
+[redaction]
+unsafe_redaction_overrides = true
+allow_unredacted_defaults = ["state"]
+"#;
+        let config: UserConfig = toml::from_str(toml).expect("Failed to parse");
+        let policy = config
+            .redaction
+            .to_scrub_policy()
+            .expect("Failed to build policy");
+
+        let diff = policy.diff_from_secure_default();
+        assert_eq!(diff.removed_query_keys, vec!["state".to_string()]);
     }
 
     #[test]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -274,6 +274,8 @@ pub struct SupervisorConfig<'a> {
     pub open_url_allow_localhost: bool,
     /// Optional append-only audit recorder for supervisor events.
     pub audit_recorder: Option<&'a Mutex<crate::audit_integrity::AuditRecorder>>,
+    /// Redaction policy for command context in diagnostics.
+    pub redaction_policy: &'a nono::ScrubPolicy,
     /// Whether direct LaunchServices opening is enabled for this session.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub allow_launch_services_active: bool,
@@ -1222,6 +1224,14 @@ pub fn execute_supervised(
                     None
                 };
 
+                let default_redaction_policy;
+                let redaction_policy = if let Some(supervisor_config) = supervisor {
+                    supervisor_config.redaction_policy
+                } else {
+                    default_redaction_policy = nono::ScrubPolicy::secure_default();
+                    &default_redaction_policy
+                };
+
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
                     .with_denials(&denials)
@@ -1235,7 +1245,7 @@ pub fn execute_supervised(
                     formatter = formatter.with_command(nono::diagnostic::CommandContext {
                         program: program.clone(),
                         resolved_path: config.resolved_program.to_path_buf(),
-                        args: config.command.to_vec(),
+                        args: nono::scrub_argv_with_policy(config.command, redaction_policy),
                     });
                 }
                 let footer = formatter.format_footer(exit_code);
@@ -3690,6 +3700,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -3789,6 +3800,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 8080,
@@ -3864,6 +3876,7 @@ mod tests {
             open_url_origins: &origins,
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -3897,6 +3910,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -3928,6 +3942,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: true,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -3943,6 +3958,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -3979,6 +3995,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
@@ -4118,6 +4135,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: true,
             #[cfg(target_os = "linux")]
             proxy_port: 0,

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -972,6 +972,8 @@ mod tests {
             proxy_port: u16,
             proxy_bind_ports: Vec<u16>,
         ) -> SupervisorConfig<'a> {
+            static REDACTION_POLICY: std::sync::LazyLock<nono::ScrubPolicy> =
+                std::sync::LazyLock::new(nono::ScrubPolicy::secure_default);
             SupervisorConfig {
                 protected_roots: &[],
                 approval_backend: backend,
@@ -981,6 +983,7 @@ mod tests {
                 open_url_origins: &[],
                 open_url_allow_localhost: false,
                 audit_recorder: None,
+                redaction_policy: &REDACTION_POLICY,
                 allow_launch_services_active: false,
                 proxy_port,
                 proxy_bind_ports,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -352,6 +352,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 proxy_handle: proxy_handle.as_ref(),
                 executable_identity: executable_identity.as_ref(),
                 audit_signer: audit_signer.as_ref(),
+                redaction_policy: &flags.redaction_policy,
                 silent: flags.silent,
             })?;
 

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -101,6 +101,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) rollback: RollbackLaunchOptions,
     pub(crate) trust: TrustLaunchOptions,
     pub(crate) proxy: ProxyLaunchOptions,
+    pub(crate) redaction_policy: nono::ScrubPolicy,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -126,6 +127,7 @@ impl ExecutionFlags {
                 ..TrustLaunchOptions::default()
             },
             proxy: ProxyLaunchOptions::default(),
+            redaction_policy: nono::ScrubPolicy::secure_default(),
             allowed_env_vars: None,
             denied_env_vars: None,
         })
@@ -139,6 +141,7 @@ pub(crate) fn prepare_run_launch_plan(
     silent: bool,
 ) -> Result<LaunchPlan> {
     let detach_sequence = load_configured_detach_sequence()?;
+    let redaction_policy = load_configured_redaction_policy()?;
     let args = run_args.sandbox;
     let no_diagnostics = run_args.no_diagnostics;
     let rollback = run_args.rollback;
@@ -255,6 +258,7 @@ pub(crate) fn prepare_run_launch_plan(
             },
             trust,
             proxy,
+            redaction_policy,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
         },
@@ -265,6 +269,13 @@ pub(crate) fn load_configured_detach_sequence() -> Result<Option<Vec<u8>>> {
     Ok(config::user::load_user_config()?
         .and_then(|user_config| user_config.ui.detach_sequence)
         .map(|sequence| sequence.bytes().to_vec()))
+}
+
+pub(crate) fn load_configured_redaction_policy() -> Result<nono::ScrubPolicy> {
+    config::user::load_user_config()?.map_or_else(
+        || Ok(nono::ScrubPolicy::secure_default()),
+        |user_config| user_config.redaction.to_scrub_policy(),
+    )
 }
 
 fn prepare_trust_launch_options(

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -509,18 +509,17 @@ fn render_diagnostic_line(idx: usize, line: &str, t: &theme::Theme) -> String {
 }
 
 /// Print dry run message
-pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
+pub fn print_dry_run(
+    program: &OsStr,
+    cmd_args: &[OsString],
+    redaction_policy: &nono::ScrubPolicy,
+    silent: bool,
+) {
     if silent {
         return;
     }
     let t = theme::current();
-    let mut command = Vec::with_capacity(1 + cmd_args.len());
-    command.push(program.to_string_lossy().into_owned());
-    command.extend(
-        cmd_args
-            .iter()
-            .map(|arg| arg.to_string_lossy().into_owned()),
-    );
+    let command_line = dry_run_command_line(program, cmd_args, redaction_policy);
 
     eprintln!(
         "  {} {}",
@@ -530,11 +529,23 @@ pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
             t.subtext,
         ),
     );
-    eprintln!(
-        "  {} {}",
-        fg("$", t.subtext),
-        fg(&format_command_line(&command), t.text)
+    eprintln!("  {} {}", fg("$", t.subtext), fg(&command_line, t.text));
+}
+
+fn dry_run_command_line(
+    program: &OsStr,
+    cmd_args: &[OsString],
+    redaction_policy: &nono::ScrubPolicy,
+) -> String {
+    let mut command = Vec::with_capacity(1 + cmd_args.len());
+    command.push(program.to_string_lossy().into_owned());
+    command.extend(
+        cmd_args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned()),
     );
+
+    format_command_line(&nono::scrub_argv_with_policy(&command, redaction_policy))
 }
 
 // ---------------------------------------------------------------------------
@@ -769,10 +780,11 @@ pub fn print_profile_hint(program: &str, profile: &str, silent: bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_unix_socket_mode_badge, print_capabilities, print_profile_hint,
-        render_diagnostic_footer, render_terminal_block_for_tty,
+        dry_run_command_line, format_unix_socket_mode_badge, print_capabilities,
+        print_profile_hint, render_diagnostic_footer, render_terminal_block_for_tty,
     };
     use nono::{CapabilitySet, UnixSocketMode};
+    use std::ffi::{OsStr, OsString};
     use tempfile::tempdir;
 
     #[test]
@@ -793,6 +805,38 @@ mod tests {
     #[test]
     fn print_profile_hint_is_noop_when_silent() {
         print_profile_hint("claude", "claude-code", true);
+    }
+
+    #[test]
+    fn dry_run_command_line_redacts_default_secrets() {
+        let line = dry_run_command_line(
+            OsStr::new("curl"),
+            &[
+                OsString::from("--token"),
+                OsString::from("real-token"),
+                OsString::from("https://example.com/api?token=real-secret"),
+            ],
+            &nono::ScrubPolicy::secure_default(),
+        );
+
+        assert!(line.contains("[REDACTED]"));
+        assert!(!line.contains("real-token"));
+        assert!(!line.contains("real-secret"));
+    }
+
+    #[test]
+    fn dry_run_command_line_uses_configured_redaction_policy() {
+        let mut redactions = nono::ScrubPolicy::secure_default();
+        redactions.add_flag("--private-token");
+
+        let line = dry_run_command_line(
+            OsStr::new("curl"),
+            &[OsString::from("--private-token=private-secret")],
+            &redactions,
+        );
+
+        assert_eq!(line, "curl '--private-token=[REDACTED]'");
+        assert!(!line.contains("private-secret"));
     }
 
     #[test]

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -40,6 +40,7 @@ pub(crate) struct RollbackExitContext<'a> {
     pub(crate) proxy_handle: Option<&'a nono_proxy::server::ProxyHandle>,
     pub(crate) executable_identity: Option<&'a ExecutableIdentity>,
     pub(crate) audit_signer: Option<&'a AuditSigner>,
+    pub(crate) redaction_policy: &'a nono::ScrubPolicy,
     pub(crate) started: &'a str,
     pub(crate) ended: &'a str,
     pub(crate) command: &'a [String],
@@ -463,6 +464,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         proxy_handle,
         executable_identity,
         audit_signer,
+        redaction_policy,
         started,
         ended,
         command,
@@ -494,6 +496,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         (0, None)
     };
 
+    let scrubbed_command = nono::scrub_argv_with_policy(command, redaction_policy);
     let mut audit_saved = false;
 
     if let Some(RollbackRuntimeState {
@@ -512,7 +515,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
             session_id: rb_session_id,
             started: started.to_string(),
             ended: Some(ended.to_string()),
-            command: command.to_vec(),
+            command: scrubbed_command.clone(),
             executable_identity: executable_identity.cloned(),
             tracked_paths,
             snapshot_count: manager.snapshot_count(),
@@ -528,6 +531,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
                 attestation_session_dir(&session_dir, audit_state),
                 &meta,
                 signer,
+                redaction_policy,
             )?);
         }
         manager.save_session_metadata(&meta)?;
@@ -561,7 +565,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
                 session_id: audit_state.session_id.clone(),
                 started: started.to_string(),
                 ended: Some(ended.to_string()),
-                command: command.to_vec(),
+                command: scrubbed_command,
                 executable_identity: executable_identity.cloned(),
                 tracked_paths,
                 snapshot_count: 0,
@@ -577,6 +581,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
                     &audit_state.session_dir,
                     &meta,
                     signer,
+                    redaction_policy,
                 )?);
             }
             nono::undo::SnapshotManager::write_session_metadata(&audit_state.session_dir, &meta)?;
@@ -870,6 +875,7 @@ mod tests {
             ),
             &metadata,
             &signer,
+            &nono::ScrubPolicy::secure_default(),
         )
         .expect("write attestation");
 

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -35,6 +35,7 @@ pub(crate) struct SupervisedRuntimeContext<'a> {
     pub(crate) proxy_handle: Option<&'a nono_proxy::server::ProxyHandle>,
     pub(crate) executable_identity: Option<&'a ExecutableIdentity>,
     pub(crate) audit_signer: Option<&'a AuditSigner>,
+    pub(crate) redaction_policy: &'a nono::ScrubPolicy,
     pub(crate) silent: bool,
 }
 
@@ -84,6 +85,7 @@ fn create_session_runtime_state(
     caps: &CapabilitySet,
     session: &SessionLaunchOptions,
     audit_state: Option<&AuditState>,
+    redaction_policy: &nono::ScrubPolicy,
 ) -> Result<SessionRuntimeState> {
     let started = chrono::Local::now().to_rfc3339();
     let short_session_id = std::env::var(DETACHED_SESSION_ID_ENV)
@@ -109,7 +111,7 @@ fn create_session_runtime_state(
             session::SessionAttachment::Attached
         },
         exit_code: None,
-        command: command.to_vec(),
+        command: nono::scrub_argv_with_policy(command, redaction_policy),
         profile: session.profile_name.clone(),
         workdir: std::env::current_dir().unwrap_or_default(),
         network: match caps.network_mode() {
@@ -160,6 +162,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         proxy_handle,
         executable_identity,
         audit_signer,
+        redaction_policy,
         silent,
     } = ctx;
 
@@ -175,8 +178,13 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     // until after the baseline walk, the 30-second startup timeout can fire
     // before the session becomes attachable.
     let trust_interceptor = create_trust_interceptor(trust);
-    let session_runtime =
-        create_session_runtime_state(command, caps, session, audit_state.as_ref())?;
+    let session_runtime = create_session_runtime_state(
+        command,
+        caps,
+        session,
+        audit_state.as_ref(),
+        redaction_policy,
+    )?;
     let SessionRuntimeState {
         started,
         short_session_id,
@@ -197,7 +205,10 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     let audit_recorder = if audit_state.is_some() && !rollback.no_audit_integrity {
         audit_state
             .as_ref()
-            .map(|state| AuditRecorder::new(state.session_dir.clone()).map(Mutex::new))
+            .map(|state| {
+                AuditRecorder::new_with_policy(state.session_dir.clone(), redaction_policy.clone())
+                    .map(Mutex::new)
+            })
             .transpose()?
     } else {
         None
@@ -221,6 +232,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         open_url_origins: &proxy.open_url_origins,
         open_url_allow_localhost: proxy.open_url_allow_localhost,
         audit_recorder: audit_recorder.as_ref(),
+        redaction_policy,
         allow_launch_services_active: proxy.allow_launch_services_active,
         #[cfg(target_os = "linux")]
         proxy_port: match caps.network_mode() {
@@ -263,6 +275,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         proxy_handle,
         executable_identity,
         audit_signer,
+        redaction_policy,
         started: &started,
         ended: &ended,
         command,

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -55,6 +55,7 @@ pub mod net_filter;
 pub mod path;
 pub mod query;
 pub mod sandbox;
+pub mod scrub;
 pub mod state;
 pub mod supervisor;
 pub mod trust;
@@ -81,6 +82,10 @@ pub use path::try_canonicalize;
 #[cfg(target_os = "linux")]
 pub use sandbox::{detect_abi, is_wsl2, DetectedAbi};
 pub use sandbox::{Sandbox, SupportInfo};
+pub use scrub::{
+    scrub_argv, scrub_argv_with_policy, scrub_header, scrub_header_with_policy, scrub_value,
+    scrub_value_with_policy, ScrubPolicy, ScrubPolicyDiff,
+};
 pub use state::SandboxState;
 pub use supervisor::{
     ApprovalBackend, ApprovalDecision, CapabilityRequest, SupervisorSocket, UrlOpenRequest,

--- a/crates/nono/src/scrub.rs
+++ b/crates/nono/src/scrub.rs
@@ -1,0 +1,559 @@
+//! Best-effort redaction for values that may be written to diagnostics or audit records.
+//!
+//! This module is output hygiene, not sandbox policy. It intentionally favors
+//! false positives for well-known secret-bearing flag, header, and query names.
+
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+
+const REDACTED: &str = "[REDACTED]";
+
+const SENSITIVE_FLAGS: &[&str] = &[
+    "--token",
+    "--password",
+    "--api-key",
+    "--apikey",
+    "--secret",
+    "--auth",
+    "--bearer",
+    "--access-token",
+    "--client-secret",
+];
+
+const SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "x-auth-token",
+    "cookie",
+    "set-cookie",
+];
+
+const SENSITIVE_QUERY_KEYS: &[&str] = &[
+    "token",
+    "access_token",
+    "api_key",
+    "apikey",
+    "key",
+    "secret",
+    "password",
+    "code",
+    "state",
+    "nonce",
+    "client_secret",
+];
+
+/// Redaction policy for diagnostics and persisted command context.
+///
+/// The secure default policy redacts well-known secret-bearing flags,
+/// headers, and URL query keys. Callers may add entries for local tools, or
+/// explicitly remove defaults when they need unsafe debugging output.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScrubPolicy {
+    sensitive_flags: BTreeSet<String>,
+    sensitive_headers: BTreeSet<String>,
+    sensitive_query_keys: BTreeSet<String>,
+}
+
+/// Difference between a scrub policy and the secure default policy.
+///
+/// This is intended for audit records so a session can explain why its
+/// persisted command context was scrubbed differently from the default.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScrubPolicyDiff {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_flags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_flags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_headers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_headers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_query_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_query_keys: Vec<String>,
+}
+
+impl ScrubPolicyDiff {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added_flags.is_empty()
+            && self.removed_flags.is_empty()
+            && self.added_headers.is_empty()
+            && self.removed_headers.is_empty()
+            && self.added_query_keys.is_empty()
+            && self.removed_query_keys.is_empty()
+    }
+
+    #[must_use]
+    pub fn into_option(self) -> Option<Self> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
+
+impl Default for ScrubPolicy {
+    fn default() -> Self {
+        Self::secure_default()
+    }
+}
+
+impl ScrubPolicy {
+    #[must_use]
+    pub fn secure_default() -> Self {
+        Self {
+            sensitive_flags: normalized_set(SENSITIVE_FLAGS),
+            sensitive_headers: normalized_set(SENSITIVE_HEADERS),
+            sensitive_query_keys: normalized_set(SENSITIVE_QUERY_KEYS),
+        }
+    }
+
+    pub fn add_flag(&mut self, flag: impl AsRef<str>) {
+        insert_normalized(&mut self.sensitive_flags, flag.as_ref());
+    }
+
+    pub fn add_header(&mut self, header: impl AsRef<str>) {
+        insert_normalized(&mut self.sensitive_headers, header.as_ref());
+    }
+
+    pub fn add_query_key(&mut self, key: impl AsRef<str>) {
+        insert_normalized(&mut self.sensitive_query_keys, key.as_ref());
+    }
+
+    pub fn remove_flag(&mut self, flag: &str) {
+        remove_normalized(&mut self.sensitive_flags, flag);
+    }
+
+    pub fn remove_header(&mut self, header: &str) {
+        remove_normalized(&mut self.sensitive_headers, header);
+    }
+
+    pub fn remove_query_key(&mut self, key: &str) {
+        remove_normalized(&mut self.sensitive_query_keys, key);
+    }
+
+    #[must_use]
+    pub fn diff_from_secure_default(&self) -> ScrubPolicyDiff {
+        let default = Self::secure_default();
+        ScrubPolicyDiff {
+            added_flags: set_difference(&self.sensitive_flags, &default.sensitive_flags),
+            removed_flags: set_difference(&default.sensitive_flags, &self.sensitive_flags),
+            added_headers: set_difference(&self.sensitive_headers, &default.sensitive_headers),
+            removed_headers: set_difference(&default.sensitive_headers, &self.sensitive_headers),
+            added_query_keys: set_difference(
+                &self.sensitive_query_keys,
+                &default.sensitive_query_keys,
+            ),
+            removed_query_keys: set_difference(
+                &default.sensitive_query_keys,
+                &self.sensitive_query_keys,
+            ),
+        }
+    }
+
+    fn is_sensitive_flag(&self, flag: &str) -> bool {
+        self.sensitive_flags.contains(normalize_name(flag).as_str())
+    }
+
+    fn is_sensitive_header(&self, name: &str) -> bool {
+        self.sensitive_headers
+            .contains(normalize_name(name).as_str())
+    }
+
+    fn is_sensitive_query_key(&self, name: &str) -> bool {
+        self.sensitive_query_keys
+            .contains(normalize_name(name).as_str())
+    }
+}
+
+/// Redact sensitive values in a single string.
+///
+/// Handles URL userinfo, sensitive URL query parameters, and complete HTTP
+/// header lines such as `Authorization: Bearer ...`.
+#[must_use]
+pub fn scrub_value(s: &str) -> Cow<'_, str> {
+    scrub_value_with_policy(s, &ScrubPolicy::secure_default())
+}
+
+/// Redact sensitive values in a single string using a configured policy.
+#[must_use]
+pub fn scrub_value_with_policy<'a>(s: &'a str, policy: &ScrubPolicy) -> Cow<'a, str> {
+    let header_scrubbed = scrub_header_line(s, policy);
+    let url_scrubbed = scrub_url_userinfo(header_scrubbed.as_ref());
+    let query_scrubbed = scrub_query_params(url_scrubbed.as_ref(), policy);
+
+    if query_scrubbed == s {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(query_scrubbed)
+    }
+}
+
+/// Redact sensitive values across an argv vector.
+///
+/// Sensitive flags with a following value redact that value. Sensitive
+/// `--flag=value` forms redact only the value side. Header flags redact their
+/// following value only when the header name itself is sensitive.
+#[must_use]
+pub fn scrub_argv(args: &[String]) -> Vec<String> {
+    scrub_argv_with_policy(args, &ScrubPolicy::secure_default())
+}
+
+/// Redact sensitive values across an argv vector using a configured policy.
+#[must_use]
+pub fn scrub_argv_with_policy(args: &[String], policy: &ScrubPolicy) -> Vec<String> {
+    let mut scrubbed = Vec::with_capacity(args.len());
+    let mut redact_next = false;
+    let mut scrub_next_header = false;
+
+    for arg in args {
+        if redact_next {
+            scrubbed.push(REDACTED.to_string());
+            redact_next = false;
+            continue;
+        }
+
+        if scrub_next_header {
+            scrubbed.push(scrub_header_arg(arg, policy).into_owned());
+            scrub_next_header = false;
+            continue;
+        }
+
+        let lower = arg.to_ascii_lowercase();
+        if policy.is_sensitive_flag(&lower) {
+            scrubbed.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        if is_header_flag(arg) {
+            scrubbed.push(arg.clone());
+            scrub_next_header = true;
+            continue;
+        }
+
+        if let Some((name, _)) = lower.split_once('=') {
+            if policy.is_sensitive_flag(name) {
+                if let Some((original_name, _)) = arg.split_once('=') {
+                    scrubbed.push(format!("{original_name}={REDACTED}"));
+                    continue;
+                }
+            }
+
+            if is_header_flag(&arg[..name.len()]) {
+                if let Some((original_name, value)) = arg.split_once('=') {
+                    scrubbed.push(format!(
+                        "{original_name}={}",
+                        scrub_header_arg(value, policy)
+                    ));
+                    continue;
+                }
+            }
+        }
+
+        scrubbed.push(scrub_value_with_policy(arg, policy).into_owned());
+    }
+
+    scrubbed
+}
+
+/// Redact an HTTP header value when its name is sensitive.
+#[must_use]
+pub fn scrub_header<'a>(name: &str, value: &'a str) -> Cow<'a, str> {
+    scrub_header_with_policy(name, value, &ScrubPolicy::secure_default())
+}
+
+/// Redact an HTTP header value with a configured policy when its name is sensitive.
+#[must_use]
+pub fn scrub_header_with_policy<'a>(
+    name: &str,
+    value: &'a str,
+    policy: &ScrubPolicy,
+) -> Cow<'a, str> {
+    if policy.is_sensitive_header(name) {
+        Cow::Borrowed(REDACTED)
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+fn scrub_header_arg<'a>(value: &'a str, policy: &ScrubPolicy) -> Cow<'a, str> {
+    if let Some((name, header_value)) = value.split_once(':') {
+        let scrubbed = scrub_header_with_policy(name.trim(), header_value.trim_start(), policy);
+        if scrubbed.as_ref() != header_value.trim_start() {
+            return Cow::Owned(format!("{}: {}", name, scrubbed));
+        }
+    }
+    scrub_value_with_policy(value, policy)
+}
+
+fn scrub_header_line<'a>(value: &'a str, policy: &ScrubPolicy) -> Cow<'a, str> {
+    let Some((name, header_value)) = value.split_once(':') else {
+        return Cow::Borrowed(value);
+    };
+
+    let trimmed_name = name.trim();
+    if !policy.is_sensitive_header(trimmed_name) {
+        return Cow::Borrowed(value);
+    }
+
+    let leading = &header_value[..header_value.len() - header_value.trim_start().len()];
+    Cow::Owned(format!("{name}:{leading}{REDACTED}"))
+}
+
+fn scrub_url_userinfo(value: &str) -> Cow<'_, str> {
+    let mut result = String::with_capacity(value.len());
+    let mut changed = false;
+    let mut cursor = 0;
+
+    while let Some(relative_scheme_end) = value[cursor..].find("://") {
+        let scheme_end = cursor + relative_scheme_end;
+        let authority_start = scheme_end + 3;
+        let authority_end = value[authority_start..]
+            .find(['/', '?', '#', ' ', '\t', '\r', '\n'])
+            .map_or(value.len(), |offset| authority_start + offset);
+
+        let authority = &value[authority_start..authority_end];
+        if let Some(at_offset) = authority.rfind('@') {
+            let userinfo = &authority[..at_offset];
+            if let Some((user, _password)) = userinfo.split_once(':') {
+                result.push_str(&value[cursor..authority_start]);
+                result.push_str(user);
+                result.push(':');
+                result.push_str(REDACTED);
+                result.push('@');
+                result.push_str(&authority[at_offset + 1..]);
+                cursor = authority_end;
+                changed = true;
+                continue;
+            }
+        }
+
+        result.push_str(&value[cursor..authority_end]);
+        cursor = authority_end;
+    }
+
+    if changed {
+        result.push_str(&value[cursor..]);
+        Cow::Owned(result)
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+fn scrub_query_params(value: &str, policy: &ScrubPolicy) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut cursor = 0;
+    let mut changed = false;
+
+    while let Some(relative_query_start) = value[cursor..].find('?') {
+        let query_start = cursor + relative_query_start;
+        result.push_str(&value[cursor..=query_start]);
+
+        let query_end = value[query_start + 1..]
+            .find(['#', ' ', '\t', '\r', '\n'])
+            .map_or(value.len(), |offset| query_start + 1 + offset);
+        let query = &value[query_start + 1..query_end];
+
+        let mut segment_start = 0;
+        for (idx, ch) in query.char_indices() {
+            if matches!(ch, '&' | ';') {
+                let segment = &query[segment_start..idx];
+                changed |= push_scrubbed_query_segment(&mut result, segment, policy);
+                result.push(ch);
+                segment_start = idx + ch.len_utf8();
+            }
+        }
+        let segment = &query[segment_start..];
+        changed |= push_scrubbed_query_segment(&mut result, segment, policy);
+
+        cursor = query_end;
+    }
+
+    result.push_str(&value[cursor..]);
+
+    if changed {
+        result
+    } else {
+        value.to_string()
+    }
+}
+
+fn push_scrubbed_query_segment(result: &mut String, segment: &str, policy: &ScrubPolicy) -> bool {
+    let Some((name, _value)) = segment.split_once('=') else {
+        result.push_str(segment);
+        return false;
+    };
+
+    if policy.is_sensitive_query_key(name) {
+        result.push_str(name);
+        result.push('=');
+        result.push_str(REDACTED);
+        true
+    } else {
+        result.push_str(segment);
+        false
+    }
+}
+
+fn is_header_flag(flag: &str) -> bool {
+    flag == "-H" || flag.eq_ignore_ascii_case("--header")
+}
+
+fn normalized_set(values: &[&str]) -> BTreeSet<String> {
+    values.iter().map(|value| normalize_name(value)).collect()
+}
+
+fn normalize_name(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn insert_normalized(set: &mut BTreeSet<String>, value: &str) {
+    let normalized = normalize_name(value);
+    if !normalized.is_empty() {
+        set.insert(normalized);
+    }
+}
+
+fn remove_normalized(set: &mut BTreeSet<String>, value: &str) {
+    set.remove(normalize_name(value).as_str());
+}
+
+fn set_difference(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
+    left.difference(right).cloned().collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_value_leaves_safe_strings_unchanged() {
+        let value = "https://example.com/path?format=json";
+        assert!(matches!(scrub_value(value), Cow::Borrowed(_)));
+        assert_eq!(scrub_value(value), value);
+    }
+
+    #[test]
+    fn scrub_value_redacts_url_userinfo() {
+        assert_eq!(
+            scrub_value("https://alice:secret@example.com/api"),
+            "https://alice:[REDACTED]@example.com/api"
+        );
+    }
+
+    #[test]
+    fn scrub_value_redacts_sensitive_query_parameters() {
+        assert_eq!(
+            scrub_value("https://example.com/api?token=abc&format=json&nonce=xyz"),
+            "https://example.com/api?token=[REDACTED]&format=json&nonce=[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn scrub_header_redacts_sensitive_header_values() {
+        assert_eq!(scrub_header("Authorization", "Bearer secret"), REDACTED);
+        assert_eq!(scrub_header("X-Api-Key", "secret"), REDACTED);
+        assert_eq!(
+            scrub_header("Accept", "application/json"),
+            "application/json"
+        );
+    }
+
+    #[test]
+    fn scrub_argv_redacts_sensitive_flag_pairs_and_equals_forms() {
+        let args = vec![
+            "curl".to_string(),
+            "--token".to_string(),
+            "secret-token".to_string(),
+            "--api-key=secret-key".to_string(),
+            "--format=json".to_string(),
+        ];
+
+        assert_eq!(
+            scrub_argv(&args),
+            vec![
+                "curl".to_string(),
+                "--token".to_string(),
+                REDACTED.to_string(),
+                format!("--api-key={REDACTED}"),
+                "--format=json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn scrub_argv_redacts_sensitive_header_arguments() {
+        let args = vec![
+            "curl".to_string(),
+            "-H".to_string(),
+            "Authorization: Bearer secret".to_string(),
+            "--header=X-Api-Key: secret".to_string(),
+            "-H".to_string(),
+            "Accept: application/json".to_string(),
+        ];
+
+        assert_eq!(
+            scrub_argv(&args),
+            vec![
+                "curl".to_string(),
+                "-H".to_string(),
+                "Authorization: [REDACTED]".to_string(),
+                "--header=X-Api-Key: [REDACTED]".to_string(),
+                "-H".to_string(),
+                "Accept: application/json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn scrub_policy_adds_local_sensitive_names() {
+        let mut redactions = ScrubPolicy::secure_default();
+        redactions.add_flag("--private-token");
+        redactions.add_header("Private-Token");
+        redactions.add_query_key("signature");
+
+        let args = vec![
+            "curl".to_string(),
+            "--private-token=secret".to_string(),
+            "-H".to_string(),
+            "Private-Token: secret".to_string(),
+            "https://example.com/api?signature=secret&format=json".to_string(),
+        ];
+
+        assert_eq!(
+            scrub_argv_with_policy(&args, &redactions),
+            vec![
+                "curl".to_string(),
+                format!("--private-token={REDACTED}"),
+                "-H".to_string(),
+                "Private-Token: [REDACTED]".to_string(),
+                "https://example.com/api?signature=[REDACTED]&format=json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn scrub_policy_can_remove_defaults_for_unsafe_debugging() {
+        let mut redactions = ScrubPolicy::secure_default();
+        redactions.remove_query_key("state");
+
+        assert_eq!(
+            scrub_value_with_policy(
+                "https://example.com/callback?state=debug&token=secret",
+                &redactions
+            ),
+            "https://example.com/callback?state=debug&token=[REDACTED]"
+        );
+
+        let diff = redactions.diff_from_secure_default();
+        assert!(diff.added_query_keys.is_empty());
+        assert_eq!(diff.removed_query_keys, vec!["state".to_string()]);
+    }
+}

--- a/crates/nono/src/scrub.rs
+++ b/crates/nono/src/scrub.rs
@@ -157,17 +157,15 @@ impl ScrubPolicy {
     }
 
     fn is_sensitive_flag(&self, flag: &str) -> bool {
-        self.sensitive_flags.contains(normalize_name(flag).as_str())
+        contains_normalized_ascii(&self.sensitive_flags, flag)
     }
 
     fn is_sensitive_header(&self, name: &str) -> bool {
-        self.sensitive_headers
-            .contains(normalize_name(name).as_str())
+        contains_normalized_ascii(&self.sensitive_headers, name)
     }
 
     fn is_sensitive_query_key(&self, name: &str) -> bool {
-        self.sensitive_query_keys
-            .contains(normalize_name(name).as_str())
+        contains_normalized_ascii(&self.sensitive_query_keys, name)
     }
 }
 
@@ -187,10 +185,10 @@ pub fn scrub_value_with_policy<'a>(s: &'a str, policy: &ScrubPolicy) -> Cow<'a, 
     let url_scrubbed = scrub_url_userinfo(header_scrubbed.as_ref());
     let query_scrubbed = scrub_query_params(url_scrubbed.as_ref(), policy);
 
-    if query_scrubbed == s {
+    if query_scrubbed.as_ref() == s {
         Cow::Borrowed(s)
     } else {
-        Cow::Owned(query_scrubbed)
+        Cow::Owned(query_scrubbed.into_owned())
     }
 }
 
@@ -224,8 +222,7 @@ pub fn scrub_argv_with_policy(args: &[String], policy: &ScrubPolicy) -> Vec<Stri
             continue;
         }
 
-        let lower = arg.to_ascii_lowercase();
-        if policy.is_sensitive_flag(&lower) {
+        if policy.is_sensitive_flag(arg) {
             scrubbed.push(arg.clone());
             redact_next = true;
             continue;
@@ -237,22 +234,15 @@ pub fn scrub_argv_with_policy(args: &[String], policy: &ScrubPolicy) -> Vec<Stri
             continue;
         }
 
-        if let Some((name, _)) = lower.split_once('=') {
+        if let Some((name, value)) = arg.split_once('=') {
             if policy.is_sensitive_flag(name) {
-                if let Some((original_name, _)) = arg.split_once('=') {
-                    scrubbed.push(format!("{original_name}={REDACTED}"));
-                    continue;
-                }
+                scrubbed.push(format!("{name}={REDACTED}"));
+                continue;
             }
 
-            if is_header_flag(&arg[..name.len()]) {
-                if let Some((original_name, value)) = arg.split_once('=') {
-                    scrubbed.push(format!(
-                        "{original_name}={}",
-                        scrub_header_arg(value, policy)
-                    ));
-                    continue;
-                }
+            if is_header_flag(name) {
+                scrubbed.push(format!("{name}={}", scrub_header_arg(value, policy)));
+                continue;
             }
         }
 
@@ -307,6 +297,10 @@ fn scrub_header_line<'a>(value: &'a str, policy: &ScrubPolicy) -> Cow<'a, str> {
 }
 
 fn scrub_url_userinfo(value: &str) -> Cow<'_, str> {
+    if !value.contains("://") {
+        return Cow::Borrowed(value);
+    }
+
     let mut result = String::with_capacity(value.len());
     let mut changed = false;
     let mut cursor = 0;
@@ -346,7 +340,11 @@ fn scrub_url_userinfo(value: &str) -> Cow<'_, str> {
     }
 }
 
-fn scrub_query_params(value: &str, policy: &ScrubPolicy) -> String {
+fn scrub_query_params<'a>(value: &'a str, policy: &ScrubPolicy) -> Cow<'a, str> {
+    if !value.contains('?') {
+        return Cow::Borrowed(value);
+    }
+
     let mut result = String::with_capacity(value.len());
     let mut cursor = 0;
     let mut changed = false;
@@ -378,9 +376,9 @@ fn scrub_query_params(value: &str, policy: &ScrubPolicy) -> String {
     result.push_str(&value[cursor..]);
 
     if changed {
-        result
+        Cow::Owned(result)
     } else {
-        value.to_string()
+        Cow::Borrowed(value)
     }
 }
 
@@ -422,6 +420,12 @@ fn insert_normalized(set: &mut BTreeSet<String>, value: &str) {
 
 fn remove_normalized(set: &mut BTreeSet<String>, value: &str) {
     set.remove(normalize_name(value).as_str());
+}
+
+fn contains_normalized_ascii(set: &BTreeSet<String>, value: &str) -> bool {
+    let trimmed = value.trim();
+    set.iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(trimmed))
 }
 
 fn set_difference(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -40,7 +40,7 @@ Each session records:
 
 | Field | Meaning |
 |--------|---------|
-| **Command** | The exact command and arguments |
+| **Command** | The command and arguments, with best-effort redaction for common secret-bearing argv, header, and URL patterns |
 | **Timestamps** | Start time, end time, duration |
 | **Exit code** | How the process terminated |
 | **Audit events** | Session start/end plus supervisor-observed events such as capability decisions and URL opens |
@@ -160,6 +160,31 @@ nono run --audit-sign-key op://Development/Nono/audit-key --profile claude-code 
 ```
 
 The signing key is loaded by the trusted supervisor before sandbox activation. After the session ends, the resulting keyed DSSE bundle is written into the audit session directory as `audit-attestation.bundle`, and a summary is stored in `session.json`.
+
+<Note>
+  Command arguments included in session metadata and audit attestations are best-effort redacted before they are written. This protects common forms such as `--token VALUE`, `--api-key=VALUE`, `Authorization: ...`, URL userinfo, and sensitive query parameters, but it is not a complete secret detector. Prefer nono's credential injection features instead of passing secrets on the command line.
+</Note>
+
+### Redaction Policy
+
+The default redaction policy covers common secret-bearing command flags, HTTP headers, URL userinfo, and URL query keys. You can extend it for local tools in `~/.config/nono/config.toml`:
+
+```toml
+[redaction]
+extra_flags = ["--private-token", "--pat"]
+extra_headers = ["Private-Token"]
+extra_query_keys = ["sig", "signature"]
+```
+
+Removing a built-in default is allowed only for explicit debugging:
+
+```toml
+[redaction]
+unsafe_redaction_overrides = true
+allow_unredacted_defaults = ["state"]
+```
+
+When a run uses a non-default redaction policy, the session audit event log and audit attestation predicate include the policy diff so reviewers can see which names were added or removed.
 
 ## Commands
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -99,9 +99,13 @@ nono's trust boundary is agent containment — restricting what the sandboxed ch
 
 ### Session metadata on disk
 
-Session JSON files in `~/.nono/sessions/` contain supervisor and child PIDs, the full command line, profile name, working directory, and network mode. These files are protected by directory permissions (`0o700`) and file permissions (`0o600`), but are readable by any process running as the same user.
+Session JSON files in `~/.nono/sessions/` contain supervisor and child PIDs, the command line, profile name, working directory, and network mode. These files are protected by directory permissions (`0o700`) and file permissions (`0o600`), but are readable by any process running as the same user.
 
-Command-line arguments are persisted verbatim. Avoid passing secrets as CLI arguments — use the keystore or environment variables instead.
+nono applies best-effort redaction before persisting command arguments in session metadata, audit records, rollback metadata, and audit attestations. It scrubs common secret-bearing forms such as `--token VALUE`, `--api-key=VALUE`, sensitive HTTP headers, URL userinfo, and sensitive query parameters.
+
+The default redaction policy can be extended in `~/.config/nono/config.toml` with `[redaction].extra_flags`, `[redaction].extra_headers`, and `[redaction].extra_query_keys`. Removing a built-in default is treated as unsafe debugging behavior: `[redaction].allow_unredacted_defaults` is rejected unless `[redaction].unsafe_redaction_overrides = true` is also set. When a session uses a non-default redaction policy, audit events and audit attestations include a redaction-policy diff.
+
+This is a safety net, not a secret-management boundary. Avoid passing secrets as CLI arguments — use keystore-backed credential injection or proxy credential injection instead.
 
 ## The Two-Layer Architecture
 
@@ -265,6 +269,7 @@ The audit subsystem has a narrower security claim than the sandbox itself.
 - For supervised sessions, the supervisor hashes the resolved main executable binary and binds that `{ resolved_path, sha256 }` identity into session metadata and the global audit ledger.
 - When `--audit-sign-key` is configured, the supervisor also signs the session's audit Merkle root and session context using a keyed DSSE/in-toto attestation. The signature is written into the session directory and can later be checked with the corresponding public key.
 - That signature is produced once, at session finalization. nono does not sign each individual audit event.
+- Command arguments in session metadata and signed audit predicates are best-effort redacted before persistence. The redaction list is intentionally conservative for common flag, header, and URL patterns, but it is not a complete secret detector. User config may add local redaction names; removing defaults requires an explicit unsafe redaction override and is recorded as a policy diff in audit data.
 - That executable identity is not full runtime provenance. Shared libraries, interpreter chains, scripts passed as arguments, and dynamically loaded runtime dependencies are not covered by that binary hash.
 - The executable hash is computed before `exec`, not from the final kernel-loaded file descriptor. A privileged attacker with write access to the executable path could still race between hash and execution.
 - The keyed audit attestation is only as strong as the signing key distribution model. If the verifier does not pin the expected public key, a rewritten session could also rewrite the embedded public key and remain self-consistent.

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -49,6 +49,27 @@ NONO_THEME=latte nono run --allow-cwd -- codex
 
 If an unknown theme is supplied, nono falls back to `mocha`.
 
+### Redaction Policy
+
+Command arguments persisted in sessions, audit logs, rollback metadata, and audit attestations are redacted with a secure default policy. You can extend the policy in `~/.config/nono/config.toml`:
+
+```toml
+[redaction]
+extra_flags = ["--private-token", "--pat"]
+extra_headers = ["Private-Token"]
+extra_query_keys = ["sig", "signature"]
+```
+
+To stop redacting a built-in default for debugging, you must opt in explicitly:
+
+```toml
+[redaction]
+unsafe_redaction_overrides = true
+allow_unredacted_defaults = ["state"]
+```
+
+Non-default redaction policies are recorded as a diff in audit event logs and audit attestations.
+
 ## Commands
 
 ### `nono run`
@@ -886,7 +907,7 @@ The supervisor:
 
 1. records audit events during the session
 2. computes the session's final audit Merkle root
-3. signs that final root plus session context
+3. signs that final root plus redacted session context
 4. writes the resulting keyed DSSE attestation to `audit-attestation.bundle`
 
 A summary is also recorded in `session.json`.
@@ -918,7 +939,7 @@ nono audit verify <session-id> --public-key-file ./audit-signing-key.pub
 ```
 
 <Note>
-  `--audit-sign-key` signs the session audit Merkle root and session context once, after the session completes. It does not, by itself, add an external timestamp, Rekor entry, or full runtime-closure attestation.
+  `--audit-sign-key` signs the session audit Merkle root and session context once, after the session completes. Command arguments in that context are best-effort redacted for common secret-bearing flags, headers, and URLs. This does not, by itself, add an external timestamp, Rekor entry, or full runtime-closure attestation.
 </Note>
 
 #### `--rollback-exclude`


### PR DESCRIPTION
Implement redaction of sensitive data from command arguments, HTTP headers, and URL query parameters before persistence and display. This scrubbing is applied to:

- Audit attestations
- Session metadata
- Diagnostic command displays

This feature introduces a safety net to prevent accidental leakage of common secret patterns (e.g., `--token VALUE`, `Authorization` headers, URL query parameters). It is not a comprehensive secret detector; users should still prefer credential injection for sensitive data.

Documentation has been updated across audit features, the security model, and flag usage to reflect this new behavior and reinforce best practices.

Closes: #782

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed
