### PR TITLE
feat(profile): add platform-conditional profile fields

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -210,6 +210,59 @@
       "enum": ["shared_memory_only", "full"],
       "description": "IPC mode for the sandboxed process. 'shared_memory_only' allows POSIX shared memory but denies semaphores. 'full' enables both shared memory and semaphores (required for Python multiprocessing and similar runtimes)."
     },
+    "WhenPredicate": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      ],
+      "description": "Platform predicate string or any-of array, e.g. linux, macos:>=15, linux:fedora-like:>=43, or !linux:nixos."
+    },
+    "ConditionalPath": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path"],
+          "properties": {
+            "path": { "type": "string" },
+            "when": { "$ref": "#/$defs/WhenPredicate" }
+          }
+        }
+      ]
+    },
+    "ConditionalName": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": { "type": "string" },
+            "when": { "$ref": "#/$defs/WhenPredicate" }
+          }
+        }
+      ]
+    },
+    "ConditionalOrigin": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["origin"],
+          "properties": {
+            "origin": { "type": "string" },
+            "when": { "$ref": "#/$defs/WhenPredicate" }
+          }
+        }
+      ]
+    },
     "FilesystemConfig": {
       "type": "object",
       "description": "Filesystem access rules for the sandboxed process.",
@@ -217,52 +270,52 @@
       "properties": {
         "allow": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Directories with read+write access."
         },
         "read": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Directories with read-only access."
         },
         "write": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Directories with write-only access."
         },
         "allow_file": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Single files with read+write access."
         },
         "read_file": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Single files with read-only access."
         },
         "write_file": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Single files with write-only access."
         },
         "deny": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Paths denied filesystem access. Denies apply regardless of other allow rules."
         },
         "bypass_protection": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Paths exempted from group-level deny rules. Each path must also appear in an allow/read/write section to actually grant access; bypass_protection only removes the deny."
         },
         "suppress_save_prompt": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Paths whose runtime denials should not be offered in the save-profile prompt. Does not grant access, remove deny rules, or hide diagnostic output."
         },
         "ignore": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Alias for suppress_save_prompt. Prefer filesystem.suppress_save_prompt in new profiles."
         }
       }
@@ -274,12 +327,12 @@
       "properties": {
         "include": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalName" },
           "description": "Policy group names to include. Groups are resolved against policy.json."
         },
         "exclude": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalName" },
           "description": "Policy group names to remove from the resolved group set (subtractive composition)."
         }
       }
@@ -596,8 +649,24 @@
       "type": "object",
       "description": "Maps keystore account names (or op://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore under the service name \"nono\".",
       "additionalProperties": {
-        "type": "string",
-        "description": "Environment variable name to inject the secret value into."
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Environment variable name to inject the secret value into."
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["env_var"],
+            "properties": {
+              "env_var": {
+                "type": "string",
+                "description": "Environment variable name to inject the secret value into."
+              },
+              "when": { "$ref": "#/$defs/WhenPredicate" }
+            }
+          }
+        ]
       }
     },
     "EnvironmentConfig": {
@@ -685,7 +754,7 @@
       "properties": {
         "allow_origins": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "$ref": "#/$defs/ConditionalOrigin" },
           "description": "Allowed URL origins (scheme + host, e.g., \"https://console.anthropic.com\"). The supervisor validates each URL open request against this list. An empty list means no URLs are allowed."
         },
         "allow_localhost": {

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -219,7 +219,7 @@
           "minItems": 1
         }
       ],
-      "description": "Platform predicate string or any-of array, e.g. linux, macos:>=15, linux:fedora-like:>=43, or !linux:nixos."
+      "description": "Platform predicate string or any-of array, e.g. linux, macos:>=15, linux:fedora-like:>=43, linux:fedora:>=43:workstation, or !linux:nixos."
     },
     "ConditionalPath": {
       "oneOf": [

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -515,18 +515,46 @@ The following variables are expanded in all path fields (`filesystem.*`, includi
 
 Always use these variables instead of hardcoded absolute paths to keep profiles portable across machines and users.
 
-## 7. Key Rules
+## 7. Platform Predicates
+
+Profile entries that list paths, group names, URL origins, or env credentials can be unconditional strings or conditional objects with `when`.
+
+```json
+{
+  "groups": {
+    "include": [
+      "agent_common",
+      { "name": "agent_linux", "when": "linux" },
+      { "name": "agent_macos", "when": "macos" }
+    ]
+  },
+  "filesystem": {
+    "read": [
+      "$HOME/.agent",
+      { "path": "$HOME/Library/Application Support/Agent", "when": "macos" },
+      { "path": "$XDG_CONFIG_HOME/agent", "when": "linux" }
+    ]
+  },
+  "env_credentials": {
+    "agent_key": { "env_var": "AGENT_API_KEY", "when": ["linux", "macos:>=15"] }
+  }
+}
+```
+
+Supported predicate forms include `linux`, `macos`, `linux:fedora`, `linux:rhel-like`, `linux:ubuntu:>=24.04`, `macos:>=15`, negation such as `!linux:nixos`, and arrays for any-of matching.
+
+## 8. Key Rules
 
 - A profile with no `groups.include` has no deny rules. Always include appropriate deny groups for untrusted workloads.
 - `filesystem.bypass_protection` only removes the deny rule. It does not grant access. You must also add the path via `filesystem.allow`, `filesystem.read`, or `filesystem.write` (or the matching `*_file` variant).
 - `filesystem.suppress_save_prompt` only suppresses save-profile suggestions. It does not grant access, remove deny rules, or hide diagnostics.
 - `groups.exclude` removes groups from the resolved set. This weakens the sandbox. Use it only when you understand which protections you are removing.
 - `extends` chains resolve recursively up to depth 10. Circular inheritance is an error.
-- Platform-specific groups (suffix `_macos` or `_linux`) are filtered at resolution time. Include both variants for cross-platform profiles.
+- Prefer `when` predicates for package-specific platform differences. Put shared OS baseline paths in built-in policy groups instead.
 - `network.block: true` blocks all network access. It cannot be combined with proxy settings.
 - `custom_credentials` upstream URLs must use HTTPS. HTTP is only accepted for loopback addresses (localhost, 127.0.0.1, ::1).
 
-## 8. Migration from previous schema
+## 9. Migration from previous schema
 
 Issue [#594](https://github.com/always-further/nono/issues/594) restructured the profile JSON schema. The old `policy.*` namespace has been dissolved into `filesystem`, `groups`, and `commands`; `security.groups` and `security.allowed_commands` have moved to top-level `groups.include` and `commands.allow`.
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -34,6 +34,7 @@ mod output;
 mod package;
 mod package_cmd;
 mod package_status;
+mod platform;
 mod policy;
 mod profile;
 mod profile_cmd;

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -904,13 +904,7 @@ fn validate_relative_path(path: &str) -> Result<()> {
 }
 
 fn current_platform() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "macos"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else {
-        "unknown"
-    }
+    crate::platform::current_os_name()
 }
 
 fn compare_versions(left: &str, right: &str) -> Result<Ordering> {

--- a/crates/nono-cli/src/platform.rs
+++ b/crates/nono-cli/src/platform.rs
@@ -1,0 +1,659 @@
+//! Host platform detection and package/profile `when` predicates.
+//!
+//! Predicates are intentionally a small closed grammar. Unknown values in
+//! known slots evaluate to false; unknown syntax is a parse error.
+
+use nono::{NonoError, Result};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::Ordering;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformInfo {
+    pub os: Os,
+    pub linux: Option<LinuxInfo>,
+    pub macos: Option<MacosInfo>,
+    pub windows: Option<WindowsInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Os {
+    Linux,
+    Macos,
+    Windows,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LinuxInfo {
+    pub distro: Option<String>,
+    pub distro_like: Vec<String>,
+    pub version_id: Option<String>,
+    pub variant_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MacosInfo {
+    pub product_version: String,
+    pub build_version: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WindowsInfo {
+    pub product_name: String,
+    pub version: String,
+    pub edition: Option<String>,
+}
+
+pub fn current() -> &'static PlatformInfo {
+    static CURRENT: OnceLock<PlatformInfo> = OnceLock::new();
+    CURRENT.get_or_init(detect)
+}
+
+pub fn current_os_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "unknown"
+    }
+}
+
+fn detect() -> PlatformInfo {
+    if cfg!(target_os = "linux") {
+        PlatformInfo {
+            os: Os::Linux,
+            linux: Some(detect_linux()),
+            macos: None,
+            windows: None,
+        }
+    } else if cfg!(target_os = "macos") {
+        PlatformInfo {
+            os: Os::Macos,
+            linux: None,
+            macos: Some(detect_macos()),
+            windows: None,
+        }
+    } else if cfg!(target_os = "windows") {
+        PlatformInfo {
+            os: Os::Windows,
+            linux: None,
+            macos: None,
+            windows: Some(WindowsInfo::default()),
+        }
+    } else {
+        PlatformInfo {
+            os: Os::Unknown(current_os_name().to_string()),
+            linux: None,
+            macos: None,
+            windows: None,
+        }
+    }
+}
+
+fn detect_linux() -> LinuxInfo {
+    match std::fs::read_to_string("/etc/os-release") {
+        Ok(content) => parse_os_release(&content),
+        Err(_) => LinuxInfo::default(),
+    }
+}
+
+fn detect_macos() -> MacosInfo {
+    MacosInfo {
+        product_version: run_sw_vers("-productVersion").unwrap_or_default(),
+        build_version: run_sw_vers("-buildVersion").unwrap_or_default(),
+    }
+}
+
+fn run_sw_vers(arg: &str) -> Option<String> {
+    let output = std::process::Command::new("sw_vers")
+        .arg(arg)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn parse_os_release(content: &str) -> LinuxInfo {
+    let mut info = LinuxInfo::default();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = unquote_os_release_value(raw_value.trim());
+        match key {
+            "ID" => info.distro = Some(value),
+            "ID_LIKE" => {
+                info.distro_like = value
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect::<Vec<_>>();
+            }
+            "VERSION_ID" => info.version_id = Some(value),
+            "VARIANT_ID" => info.variant_id = Some(value),
+            _ => {}
+        }
+    }
+    info
+}
+
+fn unquote_os_release_value(value: &str) -> String {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        return value[1..value.len() - 1].to_string();
+    }
+    value.to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct When {
+    predicates: Vec<Predicate>,
+}
+
+impl When {
+    #[cfg(test)]
+    pub fn parse(input: &str) -> Result<Self> {
+        Ok(Self {
+            predicates: vec![Predicate::parse(input)?],
+        })
+    }
+
+    pub fn matches(&self, platform: &PlatformInfo) -> bool {
+        self.predicates
+            .iter()
+            .any(|predicate| predicate.matches(platform))
+    }
+}
+
+impl Serialize for When {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let rendered = self
+            .predicates
+            .iter()
+            .map(Predicate::as_str)
+            .collect::<Vec<_>>();
+        if rendered.len() == 1 {
+            rendered[0].serialize(serializer)
+        } else {
+            rendered.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for When {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawWhen {
+            One(String),
+            Any(Vec<String>),
+        }
+
+        let raw = RawWhen::deserialize(deserializer)?;
+        let values = match raw {
+            RawWhen::One(value) => vec![value],
+            RawWhen::Any(values) => values,
+        };
+        if values.is_empty() {
+            return Err(serde::de::Error::custom(
+                "when predicate array must not be empty",
+            ));
+        }
+        let mut predicates = Vec::with_capacity(values.len());
+        for value in values {
+            predicates.push(Predicate::parse(&value).map_err(serde::de::Error::custom)?);
+        }
+        Ok(Self { predicates })
+    }
+}
+
+pub fn when_matches_current(when: Option<&When>) -> Result<bool> {
+    Ok(when.map_or(true, |predicate| predicate.matches(current())))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Predicate {
+    raw: String,
+    negated: bool,
+    os: PredicateOs,
+    id: Option<String>,
+    version: Option<VersionConstraint>,
+    build: Option<VersionConstraint>,
+    variant: Option<String>,
+}
+
+impl Predicate {
+    fn parse(input: &str) -> Result<Self> {
+        let raw = input.trim();
+        if raw.is_empty() {
+            return Err(NonoError::ConfigParse(
+                "when predicate must not be empty".to_string(),
+            ));
+        }
+        let (negated, body) = match raw.strip_prefix('!') {
+            Some(rest) if !rest.is_empty() => (true, rest),
+            Some(_) => {
+                return Err(NonoError::ConfigParse(format!(
+                    "invalid when predicate '{raw}': negation requires a predicate"
+                )));
+            }
+            None => (false, raw),
+        };
+        if body.contains('!') {
+            return Err(NonoError::ConfigParse(format!(
+                "invalid when predicate '{raw}': '!' is only allowed at the start"
+            )));
+        }
+
+        let parts = body.split(':').collect::<Vec<_>>();
+        if parts.iter().any(|part| part.is_empty()) {
+            return Err(NonoError::ConfigParse(format!(
+                "invalid when predicate '{raw}': empty ':' segment"
+            )));
+        }
+
+        let os = PredicateOs::from_token(parts[0])?;
+        let mut id = None;
+        let mut version = None;
+        let mut build = None;
+        let mut variant = None;
+
+        match os {
+            PredicateOs::Linux => match parts.len() {
+                1 => {}
+                2 => id = Some(validate_id(parts[1], raw)?.to_string()),
+                3 => {
+                    id = Some(validate_id(parts[1], raw)?.to_string());
+                    version = Some(VersionConstraint::parse(parts[2], raw)?);
+                }
+                4 => {
+                    id = Some(validate_id(parts[1], raw)?.to_string());
+                    version = Some(VersionConstraint::parse(parts[2], raw)?);
+                    variant = Some(validate_id(parts[3], raw)?.to_string());
+                }
+                _ => {
+                    return Err(NonoError::ConfigParse(format!(
+                        "invalid when predicate '{raw}': too many ':' segments"
+                    )));
+                }
+            },
+            PredicateOs::Macos => match parts.len() {
+                1 => {}
+                2 => version = Some(VersionConstraint::parse(parts[1], raw)?),
+                _ => {
+                    return Err(NonoError::ConfigParse(format!(
+                        "invalid when predicate '{raw}': too many ':' segments"
+                    )));
+                }
+            },
+            PredicateOs::Windows => match parts.len() {
+                1 => {}
+                2 => version = Some(VersionConstraint::parse(parts[1], raw)?),
+                3 => {
+                    version = Some(VersionConstraint::parse(parts[1], raw)?);
+                    build = Some(VersionConstraint::parse(parts[2], raw)?);
+                }
+                _ => {
+                    return Err(NonoError::ConfigParse(format!(
+                        "invalid when predicate '{raw}': too many ':' segments"
+                    )));
+                }
+            },
+            PredicateOs::Unknown(_) => {
+                if parts.len() > 1 {
+                    for part in &parts[1..] {
+                        validate_id(part, raw)?;
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            raw: raw.to_string(),
+            negated,
+            os,
+            id,
+            version,
+            build,
+            variant,
+        })
+    }
+
+    fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    fn matches(&self, platform: &PlatformInfo) -> bool {
+        let matched = match &self.os {
+            PredicateOs::Linux => self.matches_linux(platform),
+            PredicateOs::Macos => self.matches_macos(platform),
+            PredicateOs::Windows => self.matches_windows(platform),
+            PredicateOs::Unknown(_) => false,
+        };
+        if self.negated {
+            !matched
+        } else {
+            matched
+        }
+    }
+
+    fn matches_linux(&self, platform: &PlatformInfo) -> bool {
+        if platform.os != Os::Linux {
+            return false;
+        }
+        let Some(info) = &platform.linux else {
+            return false;
+        };
+        if let Some(id) = &self.id {
+            if let Some(base) = id.strip_suffix("-like") {
+                if info.distro.as_deref() != Some(base)
+                    && !info.distro_like.iter().any(|like| like == base)
+                {
+                    return false;
+                }
+            } else if info.distro.as_deref() != Some(id.as_str()) {
+                return false;
+            }
+        }
+        if let Some(version) = &self.version {
+            let Some(version_id) = info.version_id.as_deref() else {
+                return false;
+            };
+            if !version.matches(version_id) {
+                return false;
+            }
+        }
+        if let Some(variant) = &self.variant {
+            if info.variant_id.as_deref() != Some(variant.as_str()) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn matches_macos(&self, platform: &PlatformInfo) -> bool {
+        if platform.os != Os::Macos {
+            return false;
+        }
+        let Some(info) = &platform.macos else {
+            return false;
+        };
+        match &self.version {
+            Some(version) => version.matches(&info.product_version),
+            None => true,
+        }
+    }
+
+    fn matches_windows(&self, platform: &PlatformInfo) -> bool {
+        if platform.os != Os::Windows {
+            return false;
+        }
+        let Some(info) = &platform.windows else {
+            return false;
+        };
+        if let Some(version) = &self.version {
+            if !version.matches(&info.version) {
+                return false;
+            }
+        }
+        if let Some(build) = &self.build {
+            let build_version = info.version.rsplit('.').next().unwrap_or(&info.version);
+            if !build.matches(build_version) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn validate_id<'a>(value: &'a str, raw: &str) -> Result<&'a str> {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+    {
+        Ok(value)
+    } else {
+        Err(NonoError::ConfigParse(format!(
+            "invalid when predicate '{raw}': invalid identifier segment '{value}'"
+        )))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PredicateOs {
+    Linux,
+    Macos,
+    Windows,
+    Unknown(String),
+}
+
+impl PredicateOs {
+    fn from_token(token: &str) -> Result<Self> {
+        validate_id(token, token)?;
+        Ok(match token {
+            "linux" => Self::Linux,
+            "macos" => Self::Macos,
+            "windows" => Self::Windows,
+            other => Self::Unknown(other.to_string()),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VersionConstraint {
+    op: VersionOp,
+    version: String,
+}
+
+impl VersionConstraint {
+    fn parse(value: &str, raw: &str) -> Result<Self> {
+        let (op, version) = if let Some(rest) = value.strip_prefix("==") {
+            (VersionOp::Eq, rest)
+        } else if let Some(rest) = value.strip_prefix(">=") {
+            (VersionOp::Gte, rest)
+        } else if let Some(rest) = value.strip_prefix("<=") {
+            (VersionOp::Lte, rest)
+        } else if let Some(rest) = value.strip_prefix('>') {
+            (VersionOp::Gt, rest)
+        } else if let Some(rest) = value.strip_prefix('<') {
+            (VersionOp::Lt, rest)
+        } else if value.starts_with(|c: char| !c.is_ascii_alphanumeric()) {
+            return Err(NonoError::ConfigParse(format!(
+                "invalid when predicate '{raw}': unsupported version comparator in '{value}'"
+            )));
+        } else {
+            (VersionOp::Eq, value)
+        };
+        if version.is_empty() {
+            return Err(NonoError::ConfigParse(format!(
+                "invalid when predicate '{raw}': missing version"
+            )));
+        }
+        validate_id(version, raw)?;
+        Ok(Self {
+            op,
+            version: version.to_string(),
+        })
+    }
+
+    fn matches(&self, actual: &str) -> bool {
+        let ordering = compare_versions(actual, &self.version);
+        match self.op {
+            VersionOp::Eq => ordering == Ordering::Equal,
+            VersionOp::Gte => matches!(ordering, Ordering::Greater | Ordering::Equal),
+            VersionOp::Gt => ordering == Ordering::Greater,
+            VersionOp::Lte => matches!(ordering, Ordering::Less | Ordering::Equal),
+            VersionOp::Lt => ordering == Ordering::Less,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VersionOp {
+    Eq,
+    Gte,
+    Gt,
+    Lte,
+    Lt,
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    let left_parts = left.split('.').collect::<Vec<_>>();
+    let right_parts = right.split('.').collect::<Vec<_>>();
+    for (left_part, right_part) in left_parts.iter().zip(right_parts.iter()) {
+        let ordering = match (left_part.parse::<u64>(), right_part.parse::<u64>()) {
+            (Ok(left_num), Ok(right_num)) => left_num.cmp(&right_num),
+            _ => left_part.cmp(right_part),
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    left_parts.len().cmp(&right_parts.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fedora() -> PlatformInfo {
+        PlatformInfo {
+            os: Os::Linux,
+            linux: Some(LinuxInfo {
+                distro: Some("fedora".to_string()),
+                distro_like: vec!["rhel".to_string()],
+                version_id: Some("43".to_string()),
+                variant_id: Some("workstation".to_string()),
+            }),
+            macos: None,
+            windows: None,
+        }
+    }
+
+    fn macos() -> PlatformInfo {
+        PlatformInfo {
+            os: Os::Macos,
+            linux: None,
+            macos: Some(MacosInfo {
+                product_version: "15.6.1".to_string(),
+                build_version: "24G90".to_string(),
+            }),
+            windows: None,
+        }
+    }
+
+    #[test]
+    fn parse_os_release_handles_quotes_and_id_like() {
+        let info = parse_os_release(
+            r#"
+ID=fedora
+ID_LIKE="rhel centos"
+VERSION_ID="43"
+VARIANT_ID=workstation
+"#,
+        );
+        assert_eq!(info.distro.as_deref(), Some("fedora"));
+        assert_eq!(info.distro_like, vec!["rhel", "centos"]);
+        assert_eq!(info.version_id.as_deref(), Some("43"));
+        assert_eq!(info.variant_id.as_deref(), Some("workstation"));
+    }
+
+    #[test]
+    fn linux_predicates_match_distro_like_version_and_variant() {
+        let platform = fedora();
+        assert!(When::parse("linux").expect("parse").matches(&platform));
+        assert!(When::parse("linux:fedora")
+            .expect("parse")
+            .matches(&platform));
+        assert!(When::parse("linux:rhel-like")
+            .expect("parse")
+            .matches(&platform));
+        assert!(When::parse("linux:fedora:>=42")
+            .expect("parse")
+            .matches(&platform));
+        assert!(When::parse("linux:fedora:43:workstation")
+            .expect("parse")
+            .matches(&platform));
+        assert!(!When::parse("linux:ubuntu")
+            .expect("parse")
+            .matches(&platform));
+    }
+
+    #[test]
+    fn macos_version_predicates_match() {
+        let platform = macos();
+        assert!(When::parse("macos").expect("parse").matches(&platform));
+        assert!(When::parse("macos:>=15").expect("parse").matches(&platform));
+        assert!(!When::parse("macos:<15").expect("parse").matches(&platform));
+    }
+
+    #[test]
+    fn windows_build_predicate_parses_and_matches() {
+        let platform = PlatformInfo {
+            os: Os::Windows,
+            linux: None,
+            macos: None,
+            windows: Some(WindowsInfo {
+                product_name: "Windows 11 Pro".to_string(),
+                version: "10.0.22631".to_string(),
+                edition: Some("Professional".to_string()),
+            }),
+        };
+        assert!(When::parse("windows:>=10:>=22000")
+            .expect("parse")
+            .matches(&platform));
+        assert!(When::parse("windows:>=10:22631")
+            .expect("parse")
+            .matches(&platform));
+        assert!(!When::parse("windows:>=10:>30000")
+            .expect("parse")
+            .matches(&platform));
+    }
+
+    #[test]
+    fn negation_and_any_of_work() {
+        let platform = fedora();
+        assert!(When::parse("!macos").expect("parse").matches(&platform));
+        let when: When = serde_json::from_str(r#"["macos", "linux:fedora:>=43"]"#).expect("parse");
+        assert!(when.matches(&platform));
+    }
+
+    #[test]
+    fn unknown_os_is_false_not_error() {
+        let platform = fedora();
+        assert!(!When::parse("freebsd").expect("parse").matches(&platform));
+    }
+
+    #[test]
+    fn unknown_comparator_is_error() {
+        assert!(When::parse("linux:fedora:~=43").is_err());
+    }
+
+    #[test]
+    fn version_segments_compare_numerically_when_possible() {
+        assert_eq!(compare_versions("24.10", "24.4"), Ordering::Greater);
+        assert_eq!(compare_versions("24", "24.04"), Ordering::Less);
+        assert_eq!(compare_versions("unstable", "25.05"), Ordering::Greater);
+    }
+}

--- a/crates/nono-cli/src/platform.rs
+++ b/crates/nono-cli/src/platform.rs
@@ -149,9 +149,19 @@ fn parse_windows_registry_value(output: &str, name: &str) -> Option<String> {
         if parts.next() != Some(name) {
             continue;
         }
-        let _kind = parts.next()?;
+        let kind = parts.next()?;
         let value = parts.collect::<Vec<_>>().join(" ");
         if !value.is_empty() {
+            if kind == "REG_DWORD" {
+                if let Some(hex) = value
+                    .strip_prefix("0x")
+                    .or_else(|| value.strip_prefix("0X"))
+                {
+                    if let Ok(number) = u64::from_str_radix(hex, 16) {
+                        return Some(number.to_string());
+                    }
+                }
+            }
             return Some(value);
         }
     }
@@ -470,7 +480,7 @@ impl Predicate {
             }
         }
         if let Some(build) = &self.build {
-            let build_version = info.version.rsplit('.').next().unwrap_or_default();
+            let build_version = info.version.rsplit('.').next().map_or("", |part| part);
             if !build.matches(build_version) {
                 return false;
             }
@@ -682,6 +692,18 @@ VARIANT_ID=workstation
         assert!(!When::parse("windows:>=10:>30000")
             .expect("parse")
             .matches(&platform));
+    }
+
+    #[test]
+    fn windows_registry_dword_values_are_decimalized() {
+        let output = r#"
+HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion
+    CurrentMajorVersionNumber    REG_DWORD    0xa
+"#;
+        assert_eq!(
+            parse_windows_registry_value(output, "CurrentMajorVersionNumber").as_deref(),
+            Some("10")
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/platform.rs
+++ b/crates/nono-cli/src/platform.rs
@@ -82,7 +82,7 @@ fn detect() -> PlatformInfo {
             os: Os::Windows,
             linux: None,
             macos: None,
-            windows: Some(WindowsInfo::default()),
+            windows: Some(detect_windows()),
         }
     } else {
         PlatformInfo {
@@ -106,6 +106,56 @@ fn detect_macos() -> MacosInfo {
         product_version: run_sw_vers("-productVersion").unwrap_or_default(),
         build_version: run_sw_vers("-buildVersion").unwrap_or_default(),
     }
+}
+
+fn detect_windows() -> WindowsInfo {
+    WindowsInfo {
+        product_name: query_windows_registry_value("ProductName").unwrap_or_default(),
+        version: detect_windows_version(),
+        edition: query_windows_registry_value("EditionID"),
+    }
+}
+
+fn detect_windows_version() -> String {
+    let major = query_windows_registry_value("CurrentMajorVersionNumber");
+    let minor = query_windows_registry_value("CurrentMinorVersionNumber");
+    let build = query_windows_registry_value("CurrentBuildNumber");
+    match (major, minor, build) {
+        (Some(major), Some(minor), Some(build)) => format!("{major}.{minor}.{build}"),
+        (Some(major), None, Some(build)) => format!("{major}.0.{build}"),
+        _ => query_windows_registry_value("CurrentVersion").unwrap_or_default(),
+    }
+}
+
+fn query_windows_registry_value(name: &str) -> Option<String> {
+    let output = std::process::Command::new("reg")
+        .args([
+            "query",
+            r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
+            "/v",
+            name,
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_windows_registry_value(&String::from_utf8(output.stdout).ok()?, name)
+}
+
+fn parse_windows_registry_value(output: &str, name: &str) -> Option<String> {
+    for line in output.lines() {
+        let mut parts = line.split_whitespace();
+        if parts.next() != Some(name) {
+            continue;
+        }
+        let _kind = parts.next()?;
+        let value = parts.collect::<Vec<_>>().join(" ");
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+    None
 }
 
 fn run_sw_vers(arg: &str) -> Option<String> {
@@ -166,8 +216,7 @@ pub struct When {
 }
 
 impl When {
-    #[cfg(test)]
-    pub fn parse(input: &str) -> Result<Self> {
+    pub(crate) fn parse(input: &str) -> Result<Self> {
         Ok(Self {
             predicates: vec![Predicate::parse(input)?],
         })
@@ -219,6 +268,9 @@ impl<'de> Deserialize<'de> for When {
             return Err(serde::de::Error::custom(
                 "when predicate array must not be empty",
             ));
+        }
+        if values.len() == 1 {
+            return Self::parse(&values[0]).map_err(serde::de::Error::custom);
         }
         let mut predicates = Vec::with_capacity(values.len());
         for value in values {
@@ -418,7 +470,7 @@ impl Predicate {
             }
         }
         if let Some(build) = &self.build {
-            let build_version = info.version.rsplit('.').next().unwrap_or(&info.version);
+            let build_version = info.version.rsplit('.').next().unwrap_or_default();
             if !build.matches(build_version) {
                 return false;
             }
@@ -524,7 +576,8 @@ fn compare_versions(left: &str, right: &str) -> Ordering {
     for (left_part, right_part) in left_parts.iter().zip(right_parts.iter()) {
         let ordering = match (left_part.parse::<u64>(), right_part.parse::<u64>()) {
             (Ok(left_num), Ok(right_num)) => left_num.cmp(&right_num),
-            _ => left_part.cmp(right_part),
+            _ if left_part == right_part => Ordering::Equal,
+            _ => Ordering::Less,
         };
         if ordering != Ordering::Equal {
             return ordering;
@@ -654,6 +707,7 @@ VARIANT_ID=workstation
     fn version_segments_compare_numerically_when_possible() {
         assert_eq!(compare_versions("24.10", "24.4"), Ordering::Greater);
         assert_eq!(compare_versions("24", "24.04"), Ordering::Less);
-        assert_eq!(compare_versions("unstable", "25.05"), Ordering::Greater);
+        assert_eq!(compare_versions("unstable", "25.05"), Ordering::Less);
+        assert_eq!(compare_versions("unstable", "unstable"), Ordering::Equal);
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -61,13 +61,22 @@ pub struct Group {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct AllowOps {
     /// Paths granted read access
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "profile::deserialize_conditional_path_vec"
+    )]
     pub read: Vec<String>,
     /// Paths granted write-only access
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "profile::deserialize_conditional_path_vec"
+    )]
     pub write: Vec<String>,
     /// Paths granted read+write access
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "profile::deserialize_conditional_path_vec"
+    )]
     pub readwrite: Vec<String>,
 }
 
@@ -75,7 +84,10 @@ pub struct AllowOps {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DenyOps {
     /// Paths denied all content access (read+write; metadata still allowed)
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "profile::deserialize_conditional_path_vec"
+    )]
     pub access: Vec<String>,
     /// Block file deletion globally
     #[serde(default)]
@@ -175,13 +187,7 @@ impl ProfileDef {
 
 /// Current platform identifier
 pub(crate) fn current_platform() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "macos"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else {
-        "unknown"
-    }
+    crate::platform::current_os_name()
 }
 
 /// Check if a group applies to the current platform

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -87,6 +87,12 @@ where
                     ),
                     None => None,
                 };
+                if !object.is_empty() {
+                    let keys = object.keys().cloned().collect::<Vec<_>>().join(", ");
+                    return Err(serde::de::Error::custom(format!(
+                        "conditional entry has unknown field(s): {keys}"
+                    )));
+                }
                 if crate::platform::when_matches_current(when.as_ref())
                     .map_err(serde::de::Error::custom)?
                 {
@@ -1049,30 +1055,45 @@ impl<'de> Deserialize<'de> for SecretsConfig {
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum CredentialValue {
-            EnvVar(String),
-            Conditional {
-                env_var: String,
-                #[serde(default)]
-                when: Option<crate::platform::When>,
-            },
-        }
-
-        let raw = HashMap::<String, CredentialValue>::deserialize(deserializer)?;
+        let raw = HashMap::<String, serde_json::Value>::deserialize(deserializer)?;
         let mut mappings = HashMap::with_capacity(raw.len());
         for (key, value) in raw {
             match value {
-                CredentialValue::EnvVar(env_var) => {
+                serde_json::Value::String(env_var) => {
                     mappings.insert(key, env_var);
                 }
-                CredentialValue::Conditional { env_var, when } => {
+                serde_json::Value::Object(mut object) => {
+                    let env_var = object
+                        .remove("env_var")
+                        .and_then(|value| value.as_str().map(str::to_string))
+                        .ok_or_else(|| {
+                            serde::de::Error::custom(
+                                "conditional credential entry is missing string 'env_var'",
+                            )
+                        })?;
+                    let when = match object.remove("when") {
+                        Some(when_value) => Some(
+                            crate::platform::When::deserialize(when_value)
+                                .map_err(serde::de::Error::custom)?,
+                        ),
+                        None => None,
+                    };
+                    if !object.is_empty() {
+                        let keys = object.keys().cloned().collect::<Vec<_>>().join(", ");
+                        return Err(serde::de::Error::custom(format!(
+                            "conditional credential entry has unknown field(s): {keys}"
+                        )));
+                    }
                     if crate::platform::when_matches_current(when.as_ref())
                         .map_err(serde::de::Error::custom)?
                     {
                         mappings.insert(key, env_var);
                     }
+                }
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "credential entry must be a string or object with 'env_var'",
+                    ));
                 }
             }
         }
@@ -6128,6 +6149,24 @@ mod tests {
                 "https://always.example".to_string(),
                 "https://match.example".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn conditional_profile_entries_reject_unknown_fields() {
+        let json = br#"{
+            "meta": { "name": "conditional-unknown-field-test" },
+            "filesystem": {
+                "read": [
+                    { "path": "/tmp/example", "whenn": "linux" }
+                ]
+            }
+        }"#;
+
+        let err = parse_profile_bytes(json).expect_err("unknown conditional field should error");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -29,31 +29,105 @@ pub struct ProfileMeta {
     pub author: Option<String>,
 }
 
+pub(crate) fn deserialize_conditional_path_vec<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_conditional_string_vec(deserializer, "path")
+}
+
+fn deserialize_conditional_name_vec<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_conditional_string_vec(deserializer, "name")
+}
+
+fn deserialize_conditional_origin_vec<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_conditional_string_vec(deserializer, "origin")
+}
+
+fn deserialize_conditional_string_vec<'de, D>(
+    deserializer: D,
+    value_key: &'static str,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    let mut result = Vec::with_capacity(values.len());
+    for value in values {
+        match value {
+            serde_json::Value::String(item) => result.push(item),
+            serde_json::Value::Object(mut object) => {
+                let item_value = object.remove(value_key).ok_or_else(|| {
+                    serde::de::Error::custom(format!("conditional entry is missing '{value_key}'"))
+                })?;
+                let item = item_value
+                    .as_str()
+                    .ok_or_else(|| {
+                        serde::de::Error::custom(format!(
+                            "conditional entry '{value_key}' must be a string"
+                        ))
+                    })?
+                    .to_string();
+                let when = match object.remove("when") {
+                    Some(when_value) => Some(
+                        crate::platform::When::deserialize(when_value)
+                            .map_err(serde::de::Error::custom)?,
+                    ),
+                    None => None,
+                };
+                if crate::platform::when_matches_current(when.as_ref())
+                    .map_err(serde::de::Error::custom)?
+                {
+                    result.push(item);
+                }
+            }
+            _ => {
+                return Err(serde::de::Error::custom(format!(
+                    "conditional entry must be a string or object with '{value_key}'"
+                )));
+            }
+        }
+    }
+    Ok(result)
+}
+
 /// Filesystem configuration in a profile
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FilesystemConfig {
     /// Directories with read+write access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub allow: Vec<String>,
     /// Directories with read-only access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub read: Vec<String>,
     /// Directories with write-only access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub write: Vec<String>,
     /// Single files with read+write access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub allow_file: Vec<String>,
     /// Single files with read-only access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub read_file: Vec<String>,
     /// Single files with write-only access
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub write_file: Vec<String>,
     /// Single AF_UNIX socket paths — connect only.
     /// Implies read access on the socket path. See issue #685.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub unix_socket: Vec<String>,
     /// Single AF_UNIX socket paths — connect and bind.
     /// Implies read+write access on the socket path when it exists, or
@@ -62,20 +136,20 @@ pub struct FilesystemConfig {
     /// Dangling symlinks are rejected at grant time. For runtime-generated
     /// filenames (e.g. PID-suffixed paths) prefer `unix_socket_dir_bind`
     /// so the implied fs grant stays scoped to a dedicated directory.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub unix_socket_bind: Vec<String>,
     /// Directories where any direct-child AF_UNIX socket may be connected to.
     /// Non-recursive. Implies read access on the directory.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub unix_socket_dir: Vec<String>,
     /// Directories where any direct-child AF_UNIX socket may be connected to
     /// or bound. Non-recursive. Implies read+write access on the directory.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub unix_socket_dir_bind: Vec<String>,
     /// Paths denied filesystem access. Canonical location for deny entries
     /// in the #594 schema; the legacy deny-access key drains here via
     /// `deprecated_schema::LegacyPolicyPatch`.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub deny: Vec<String>,
     /// Paths exempted from group-level deny rules.
     ///
@@ -87,14 +161,18 @@ pub struct FilesystemConfig {
     ///
     /// Renamed from the legacy deny-override key in the #594 schema;
     /// the new name makes the "does not grant access" semantics explicit.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub bypass_protection: Vec<String>,
     /// Paths whose runtime denials should not be offered in the save-profile
     /// prompt. This does not grant access, remove deny rules, or hide the
     /// diagnostic footer; it only suppresses repeated save suggestions for
     /// paths the user has decided not to grant.
     /// ALIAS(canonical="suppress_save_prompt", introduced="v0.52.0", remove_by="indefinite", issue="#875")
-    #[serde(default, alias = "ignore")]
+    #[serde(
+        default,
+        alias = "ignore",
+        deserialize_with = "deserialize_conditional_path_vec"
+    )]
     pub suppress_save_prompt: Vec<String>,
 }
 
@@ -102,9 +180,9 @@ pub struct FilesystemConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GroupsConfig {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_name_vec")]
     pub include: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_name_vec")]
     pub exclude: Vec<String>,
 }
 
@@ -958,12 +1036,48 @@ impl NetworkConfig {
 /// Maps keystore account names to environment variable names.
 /// Secrets are loaded from the system keystore (macOS Keychain / Linux Secret Service)
 /// under the service name "nono".
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct SecretsConfig {
     /// Map of keystore account name -> environment variable name
     /// Example: { "openai_api_key" = "OPENAI_API_KEY" }
     #[serde(flatten)]
     pub mappings: HashMap<String, String>,
+}
+
+impl<'de> Deserialize<'de> for SecretsConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum CredentialValue {
+            EnvVar(String),
+            Conditional {
+                env_var: String,
+                #[serde(default)]
+                when: Option<crate::platform::When>,
+            },
+        }
+
+        let raw = HashMap::<String, CredentialValue>::deserialize(deserializer)?;
+        let mut mappings = HashMap::with_capacity(raw.len());
+        for (key, value) in raw {
+            match value {
+                CredentialValue::EnvVar(env_var) => {
+                    mappings.insert(key, env_var);
+                }
+                CredentialValue::Conditional { env_var, when } => {
+                    if crate::platform::when_matches_current(when.as_ref())
+                        .map_err(serde::de::Error::custom)?
+                    {
+                        mappings.insert(key, env_var);
+                    }
+                }
+            }
+        }
+        Ok(Self { mappings })
+    }
 }
 
 /// Hook configuration for an agent
@@ -1215,7 +1329,7 @@ pub struct OpenUrlConfig {
     /// Allowed URL origins (scheme + host, e.g., "https://console.anthropic.com").
     /// The supervisor validates each URL open request against this list.
     /// An empty list means no URLs are allowed.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_conditional_origin_vec")]
     pub allow_origins: Vec<String>,
     /// Allow opening http://localhost and http://127.0.0.1 URLs (for OAuth2 callbacks).
     #[serde(default)]
@@ -5946,5 +6060,74 @@ mod tests {
             Some("file:///run/secrets/api-token".to_string())
         );
         assert_eq!(cred.env_var, Some("MY_API_KEY".to_string()));
+    }
+
+    #[test]
+    fn profile_when_filters_filesystem_groups_credentials_and_open_urls() {
+        let current = crate::platform::current_os_name();
+        let other = if current == "linux" { "macos" } else { "linux" };
+        let json = format!(
+            r#"{{
+                "meta": {{ "name": "conditional-test" }},
+                "groups": {{
+                    "include": [
+                        "always_group",
+                        {{ "name": "matching_group", "when": "{current}" }},
+                        {{ "name": "skipped_group", "when": "{other}" }}
+                    ]
+                }},
+                "filesystem": {{
+                    "read": [
+                        "/always",
+                        {{ "path": "/matching", "when": "{current}" }},
+                        {{ "path": "/skipped", "when": "{other}" }}
+                    ],
+                    "deny": [
+                        {{ "path": "/denied", "when": "{current}" }},
+                        {{ "path": "/not-denied", "when": "{other}" }}
+                    ]
+                }},
+                "env_credentials": {{
+                    "plain": "PLAIN_TOKEN",
+                    "matching": {{ "env_var": "MATCH_TOKEN", "when": "{current}" }},
+                    "skipped": {{ "env_var": "SKIP_TOKEN", "when": "{other}" }}
+                }},
+                "open_urls": {{
+                    "allow_origins": [
+                        "https://always.example",
+                        {{ "origin": "https://match.example", "when": "{current}" }},
+                        {{ "origin": "https://skip.example", "when": "{other}" }}
+                    ]
+                }}
+            }}"#
+        );
+
+        let profile = parse_profile_bytes(json.as_bytes()).expect("parse profile");
+        assert_eq!(
+            profile.groups.include,
+            vec!["always_group".to_string(), "matching_group".to_string()]
+        );
+        assert_eq!(
+            profile.filesystem.read,
+            vec!["/always".to_string(), "/matching".to_string()]
+        );
+        assert_eq!(profile.filesystem.deny, vec!["/denied".to_string()]);
+        assert_eq!(
+            profile.env_credentials.mappings.get("plain"),
+            Some(&"PLAIN_TOKEN".to_string())
+        );
+        assert_eq!(
+            profile.env_credentials.mappings.get("matching"),
+            Some(&"MATCH_TOKEN".to_string())
+        );
+        assert!(!profile.env_credentials.mappings.contains_key("skipped"));
+        let origins = profile.open_urls.expect("open urls").allow_origins;
+        assert_eq!(
+            origins,
+            vec![
+                "https://always.example".to_string(),
+                "https://match.example".to_string()
+            ]
+        );
     }
 }

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -33,9 +33,14 @@ use std::path::{Path, PathBuf};
 
 /// A single declarative wiring step. Tagged by `type` so the manifest
 /// JSON reads naturally — `{ "type": "symlink", ... }`.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WiringDirective {
+    /// Internal no-op produced when a manifest directive's `when`
+    /// predicate does not match this host. This variant is never
+    /// recorded in the lockfile.
+    Skipped,
+
     /// Create a symlink at `link` pointing to `target`. Both fields
     /// are variable-expanded. If `link` already exists as a symlink
     /// pointing at the right `target`, no-op. If it points elsewhere,
@@ -87,6 +92,87 @@ pub enum WiringDirective {
     /// trip, same as `JsonMerge` on formatting). Mapping keys must
     /// be strings; custom YAML tags are rejected.
     YamlMerge { file: String, patch: String },
+}
+
+impl<'de> Deserialize<'de> for WiringDirective {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut value = serde_json::Value::deserialize(deserializer)?;
+        if let serde_json::Value::Object(object) = &mut value {
+            if let Some(when_value) = object.remove("when") {
+                let when = crate::platform::When::deserialize(when_value)
+                    .map_err(serde::de::Error::custom)?;
+                if !crate::platform::when_matches_current(Some(&when))
+                    .map_err(serde::de::Error::custom)?
+                {
+                    return Ok(Self::Skipped);
+                }
+            }
+        }
+
+        #[derive(Deserialize)]
+        #[serde(tag = "type", rename_all = "snake_case")]
+        enum RawWiringDirective {
+            Symlink {
+                link: String,
+                target: String,
+            },
+            WriteFile {
+                source: String,
+                dest: String,
+            },
+            JsonMerge {
+                file: String,
+                patch: String,
+            },
+            JsonArrayAppend {
+                file: String,
+                path: String,
+                patch_entries: String,
+                key_field: String,
+            },
+            TomlBlock {
+                file: String,
+                marker_id: String,
+                content: String,
+            },
+            YamlMerge {
+                file: String,
+                patch: String,
+            },
+        }
+
+        let raw = serde_json::from_value::<RawWiringDirective>(value)
+            .map_err(serde::de::Error::custom)?;
+        Ok(match raw {
+            RawWiringDirective::Symlink { link, target } => Self::Symlink { link, target },
+            RawWiringDirective::WriteFile { source, dest } => Self::WriteFile { source, dest },
+            RawWiringDirective::JsonMerge { file, patch } => Self::JsonMerge { file, patch },
+            RawWiringDirective::JsonArrayAppend {
+                file,
+                path,
+                patch_entries,
+                key_field,
+            } => Self::JsonArrayAppend {
+                file,
+                path,
+                patch_entries,
+                key_field,
+            },
+            RawWiringDirective::TomlBlock {
+                file,
+                marker_id,
+                content,
+            } => Self::TomlBlock {
+                file,
+                marker_id,
+                content,
+            },
+            RawWiringDirective::YamlMerge { file, patch } => Self::YamlMerge { file, patch },
+        })
+    }
 }
 
 /// What a single directive did, recorded into the lockfile so removal
@@ -252,6 +338,7 @@ fn execute_one(
     report: &mut WiringReport,
 ) -> Result<()> {
     match directive {
+        WiringDirective::Skipped => {}
         WiringDirective::Symlink { link, target } => {
             let link_path = expand_to_path(link, ctx)?;
             let target_path = expand_to_path(target, ctx)?;
@@ -2149,6 +2236,43 @@ mod tests {
                 "summary should identify the directive: {}",
                 failures[0].record_summary
             );
+        });
+    }
+
+    #[test]
+    fn wiring_when_filters_directives_before_execution() {
+        let current = crate::platform::current_os_name();
+        let other = if current == "linux" { "macos" } else { "linux" };
+        let json = format!(
+            r#"[
+                {{
+                    "type": "write_file",
+                    "source": "match.txt",
+                    "dest": "$HOME/match.txt",
+                    "when": "{current}"
+                }},
+                {{
+                    "type": "write_file",
+                    "source": "skip.txt",
+                    "dest": "$HOME/skip.txt",
+                    "when": "{other}"
+                }}
+            ]"#
+        );
+        let directives: Vec<WiringDirective> = serde_json::from_str(&json).expect("parse wiring");
+        assert!(matches!(directives[1], WiringDirective::Skipped));
+
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(pack.join("match.txt"), "match").expect("write match");
+            fs::write(pack.join("skip.txt"), "skip").expect("write skip");
+            let ctx = ctx_in(home, pack);
+            let report = exec(&directives, &ctx).expect("execute");
+
+            assert!(home.join("match.txt").exists());
+            assert!(!home.join("skip.txt").exists());
+            assert_eq!(report.records.len(), 1);
         });
     }
 }

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -39,6 +39,7 @@ pub enum WiringDirective {
     /// Internal no-op produced when a manifest directive's `when`
     /// predicate does not match this host. This variant is never
     /// recorded in the lockfile.
+    #[serde(skip_serializing)]
     Skipped,
 
     /// Create a symlink at `link` pointing to `target`. Both fields
@@ -112,6 +113,9 @@ impl<'de> Deserialize<'de> for WiringDirective {
             }
         }
 
+        // Keep this in lockstep with `WiringDirective`. The duplicate raw
+        // enum lets deserialization remove manifest-only `when` before
+        // applying the closed tagged directive vocabulary.
         #[derive(Deserialize)]
         #[serde(tag = "type", rename_all = "snake_case")]
         enum RawWiringDirective {

--- a/docs/cli/features/package-publishing.mdx
+++ b/docs/cli/features/package-publishing.mdx
@@ -92,6 +92,56 @@ Important constraints:
 - `plugin` artifacts without `install_dir` install at their relative path inside the pack store. With `install_dir`, they're also fan-out copied into the user's home — useful for shared scripts but rarely needed for Claude Code packs (the marketplace symlink exposes the whole pack tree).
 - `min_nono_version` should be set to the lowest CLI version your pack will work on. Older clients refuse to install.
 
+### Platform-Specific Content
+
+Use `platforms` for install compatibility, and `when` for content inside a pack:
+
+- `platforms: ["linux", "macos"]` means the package can be pulled on those operating systems.
+- `when` on individual profile entries or wiring directives means that entry applies only on matching hosts.
+
+Profiles accept object entries anywhere paths or group names are listed:
+
+```json
+{
+  "groups": {
+    "include": [
+      "agent_common",
+      { "name": "agent_linux", "when": "linux" },
+      { "name": "agent_macos", "when": "macos" }
+    ]
+  },
+  "filesystem": {
+    "read": [
+      "$HOME/.agent",
+      { "path": "$HOME/Library/Application Support/Agent", "when": "macos" },
+      { "path": "$XDG_CONFIG_HOME/agent", "when": "linux" }
+    ]
+  }
+}
+```
+
+Wiring directives also accept `when`:
+
+```json
+{
+  "type": "symlink",
+  "link": "$HOME/.agent/plugin",
+  "target": "$PACK_DIR/.agent-plugin",
+  "when": "linux"
+}
+```
+
+Predicates support OS, Linux distro and distro-family, version comparisons, negation, and any-of arrays:
+
+```json
+{ "path": "/etc/pki", "when": "linux:rhel-like" }
+{ "path": "/private/var/db/sudo", "when": "macos:>=15" }
+{ "path": "/some/path", "when": ["linux:fedora:>=43", "linux:rhel-like:>=9"] }
+{ "path": "/legacy/path", "when": "!linux:nixos" }
+```
+
+If a pack uses `when`, set `min_nono_version` to a CLI release that supports predicates. Older CLIs must refuse the pack rather than silently applying conditional entries unconditionally.
+
 ### Profiles That Replace a Former Preset
 
 If your pack ships a profile with an `install_as` name that used to be compiled into the CLI (e.g. `claude-code` was a preset until v0.43), you also need to register it in the migration table so users on older versions get a friendly auto-pull prompt instead of a "profile not found" error. See [PACK_PROVIDED_PROFILES](#registering-a-pack-provided-profile) below.


### PR DESCRIPTION
## Linked Issue

Introduce 'when' predicates to allow profile fields and wiring directives to be conditionally applied based on the host platform, based on the OS

- Enables platform-specific paths, group inclusions/exclusions, environment
  credentials, and allowed URL origins within a single profile definition.
- Extends the profile JSON schema to support conditional objects for paths,
  names, and origins, along with a new 'WhenPredicate' definition.
- Integrates predicate evaluation directly into profile and wiring directive
  deserialization, skipping non-matching entries.
- A new `platform` module handles OS, distro, and version detection.
- Documentation for profile authoring and package publishing has been updated.
- Packages using 'when' predicates must set `min_nono_version` to guarantee
  compatibility with supporting CLI versions.

Closes: #792

Signed-off-by: Luke Hinds <lukehinds@gmail.com>

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
