### PR TITLE
feat(landlock): add landlock v6 signal and abstract unix socket scoping

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1761,6 +1761,10 @@ pub struct WhyArgs {
     #[arg(long, help_heading = "QUERY")]
     pub host: Option<String>,
 
+    /// Landlock scope to check
+    #[arg(long, value_enum, value_name = "SCOPE", help_heading = "QUERY")]
+    pub scope: Option<WhyScope>,
+
     /// Network port (default 443)
     #[arg(long, default_value = "443", help_heading = "QUERY")]
     pub port: u16,
@@ -1866,6 +1870,16 @@ pub enum WhyOp {
     /// Read and write access
     #[value(name = "readwrite")]
     ReadWrite,
+}
+
+/// Landlock scope type for why command
+#[derive(Clone, Debug, ValueEnum)]
+pub enum WhyScope {
+    /// Signal scoping
+    Signal,
+    /// Abstract UNIX socket scoping
+    #[value(name = "abstract-unix-socket")]
+    AbstractUnixSocket,
 }
 
 #[derive(Parser, Debug)]
@@ -3198,6 +3212,14 @@ mod tests {
         match cli.command {
             Commands::Why(args) => {
                 assert!(args.block_net);
+            }
+            _ => panic!("Expected Why command"),
+        }
+
+        let cli = Cli::parse_from(["nono", "why", "--scope", "abstract-unix-socket"]);
+        match cli.command {
+            Commands::Why(args) => {
+                assert!(matches!(args.scope, Some(WhyScope::AbstractUnixSocket)));
             }
             _ => panic!("Expected Why command"),
         }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1360,7 +1360,9 @@ fn build_policy_explanations(
                 // Path is actually allowed by policy — the denial came from
                 // a different layer (e.g. Landlock timing). Skip.
             }
-            Ok(crate::query_ext::QueryResult::NotSandboxed { .. }) | Err(_) => {}
+            Ok(crate::query_ext::QueryResult::NotSandboxed { .. })
+            | Ok(crate::query_ext::QueryResult::Scope { .. })
+            | Err(_) => {}
         }
     }
 

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -323,6 +323,89 @@ pub fn print_abi_info(silent: bool) {
     }
 }
 
+/// Print the Landlock scope policy derived from the current capabilities.
+#[cfg(target_os = "linux")]
+pub fn print_landlock_scope_policy(caps: &CapabilitySet, verbose: u8, silent: bool) {
+    if silent || verbose == 0 {
+        return;
+    }
+
+    let t = theme::current();
+    match nono::landlock_scope_policy(caps) {
+        Ok(policy) => {
+            eprintln!(
+                "  {} {}",
+                badge(" scope ", t.blue, BADGE_FG_DARK),
+                fg(
+                    &format!("Landlock {} detected", policy.abi_version),
+                    t.subtext,
+                )
+            );
+            eprintln!(
+                "          {} {}",
+                fg("signal:", t.subtext),
+                fg(
+                    &format_scope_status(
+                        policy.signal_requested,
+                        policy.signal_enforced,
+                        policy.scoping_supported,
+                    ),
+                    scope_status_color(
+                        policy.signal_requested,
+                        policy.signal_enforced,
+                        policy.scoping_supported,
+                        t,
+                    ),
+                )
+            );
+            eprintln!(
+                "          {} {}",
+                fg("abstract-unix-socket:", t.subtext),
+                fg(
+                    &format_scope_status(
+                        policy.abstract_unix_socket_requested,
+                        policy.abstract_unix_socket_enforced,
+                        policy.scoping_supported,
+                    ),
+                    scope_status_color(
+                        policy.abstract_unix_socket_requested,
+                        policy.abstract_unix_socket_enforced,
+                        policy.scoping_supported,
+                        t,
+                    ),
+                )
+            );
+        }
+        Err(err) => {
+            eprintln!(
+                "  {} {}",
+                badge(" scope ", t.red, BADGE_FG_DARK),
+                fg(&format!("Landlock scope policy unavailable: {err}"), t.red),
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn format_scope_status(requested: bool, enforced: bool, supported: bool) -> String {
+    match (requested, enforced, supported) {
+        (true, true, _) => "requested, enforced".to_string(),
+        (true, false, false) => "requested, unsupported by detected ABI".to_string(),
+        (true, false, true) => "requested, not enforced".to_string(),
+        (false, _, true) => "not requested".to_string(),
+        (false, _, false) => "not requested; detected ABI has no scope support".to_string(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn scope_status_color(requested: bool, enforced: bool, supported: bool, t: &theme::Theme) -> Rgb {
+    match (requested, enforced, supported) {
+        (true, true, _) => t.green,
+        (true, false, _) => t.yellow,
+        (false, _, _) => t.subtext,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Status messages
 // ---------------------------------------------------------------------------

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -21,6 +21,24 @@ pub struct CapabilityMatch {
     pub source: String,
 }
 
+/// Scope type for Landlock scope policy queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeQuery {
+    /// `LANDLOCK_SCOPE_SIGNAL`.
+    Signal,
+    /// `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET`.
+    AbstractUnixSocket,
+}
+
+impl ScopeQuery {
+    fn as_str(self) -> &'static str {
+        match self {
+            ScopeQuery::Signal => "signal",
+            ScopeQuery::AbstractUnixSocket => "abstract-unix-socket",
+        }
+    }
+}
+
 /// Result of querying whether an operation is permitted
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status")]
@@ -52,6 +70,19 @@ pub enum QueryResult {
     /// Not running inside a sandbox
     #[serde(rename = "not_sandboxed")]
     NotSandboxed { message: String },
+    /// Landlock scope policy status.
+    #[serde(rename = "scope")]
+    Scope {
+        scope: String,
+        state: String,
+        requested: bool,
+        enforced: bool,
+        supported: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kernel_abi: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        details: Option<String>,
+    },
 }
 
 /// Query whether a path operation is permitted
@@ -238,6 +269,91 @@ pub fn query_network(
     }
 }
 
+/// Query whether a Landlock scope is requested and enforced.
+#[cfg(target_os = "linux")]
+pub fn query_scope(scope: ScopeQuery, caps: &CapabilitySet) -> QueryResult {
+    match nono::landlock_scope_policy(caps) {
+        Ok(policy) => {
+            let (requested, enforced) = match scope {
+                ScopeQuery::Signal => (policy.signal_requested, policy.signal_enforced),
+                ScopeQuery::AbstractUnixSocket => (
+                    policy.abstract_unix_socket_requested,
+                    policy.abstract_unix_socket_enforced,
+                ),
+            };
+            QueryResult::Scope {
+                scope: scope.as_str().to_string(),
+                state: scope_state(requested, enforced, policy.scoping_supported).to_string(),
+                requested,
+                enforced,
+                supported: policy.scoping_supported,
+                kernel_abi: Some(policy.abi_version.to_string()),
+                details: Some(scope_details(
+                    scope,
+                    requested,
+                    enforced,
+                    policy.scoping_supported,
+                )),
+            }
+        }
+        Err(err) => QueryResult::Scope {
+            scope: scope.as_str().to_string(),
+            state: "unavailable".to_string(),
+            requested: false,
+            enforced: false,
+            supported: false,
+            kernel_abi: None,
+            details: Some(format!(
+                "Landlock scope policy could not be resolved: {err}"
+            )),
+        },
+    }
+}
+
+/// Query whether a Landlock scope is requested and enforced.
+#[cfg(not(target_os = "linux"))]
+pub fn query_scope(scope: ScopeQuery, _caps: &CapabilitySet) -> QueryResult {
+    QueryResult::Scope {
+        scope: scope.as_str().to_string(),
+        state: "not_applicable".to_string(),
+        requested: false,
+        enforced: false,
+        supported: false,
+        kernel_abi: None,
+        details: Some("Landlock scope queries are only available on Linux.".to_string()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn scope_state(requested: bool, enforced: bool, supported: bool) -> &'static str {
+    match (requested, enforced, supported) {
+        (true, true, _) => "enforced",
+        (true, false, false) => "unsupported",
+        (true, false, true) => "not_enforced",
+        (false, _, _) => "not_requested",
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn scope_details(scope: ScopeQuery, requested: bool, enforced: bool, supported: bool) -> String {
+    let label = scope.as_str();
+    match (requested, enforced, supported) {
+        (true, true, _) => {
+            format!("{label} scope is requested by the capability set and enforced.")
+        }
+        (true, false, false) => {
+            format!("{label} scope is requested, but this Landlock ABI does not support scoping.")
+        }
+        (true, false, true) => {
+            format!("{label} scope is requested, but it is not enforced.")
+        }
+        (false, _, true) => format!("{label} scope is not requested by the capability set."),
+        (false, _, false) => {
+            format!("{label} scope is not requested; this Landlock ABI has no scope support.")
+        }
+    }
+}
+
 /// Print a query result in human-readable format
 pub fn print_result(result: &QueryResult) {
     match result {
@@ -287,6 +403,28 @@ pub fn print_result(result: &QueryResult) {
         QueryResult::NotSandboxed { message } => {
             println!("{}", "NOT SANDBOXED".yellow().bold());
             println!("  {}", message);
+        }
+        QueryResult::Scope {
+            scope,
+            state,
+            requested,
+            enforced,
+            supported,
+            kernel_abi,
+            details,
+        } => {
+            println!("{}", "SCOPE".blue().bold());
+            println!("  Scope: {}", scope);
+            println!("  State: {}", state);
+            println!("  Requested: {}", requested);
+            println!("  Enforced: {}", enforced);
+            println!("  Supported: {}", supported);
+            if let Some(abi) = kernel_abi {
+                println!("  Kernel ABI: {}", abi);
+            }
+            if let Some(detail) = details {
+                println!("  Details: {}", detail);
+            }
         }
     }
 }
@@ -523,6 +661,26 @@ mod tests {
         let caps = CapabilitySet::new().block_network();
         let result = query_network("example.com", 443, &caps, &[]);
         assert!(matches!(result, QueryResult::Denied { .. }));
+    }
+
+    #[test]
+    fn test_query_scope_returns_structured_result() {
+        let caps = CapabilitySet::new();
+        let result = query_scope(ScopeQuery::AbstractUnixSocket, &caps);
+        match result {
+            QueryResult::Scope {
+                scope,
+                state,
+                requested,
+                enforced,
+                ..
+            } => {
+                assert_eq!(scope, "abstract-unix-socket");
+                assert!(!state.is_empty());
+                assert!(!enforced || requested);
+            }
+            _ => panic!("expected scope result"),
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -542,6 +542,8 @@ fn finalize_prepared_sandbox(
 
     #[cfg(target_os = "linux")]
     output::print_abi_info(silent);
+    #[cfg(target_os = "linux")]
+    output::print_landlock_scope_policy(&prepared.caps, args.verbose, silent);
 
     if !Sandbox::is_supported() {
         return Err(NonoError::SandboxInit(Sandbox::support_info().details));

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -193,6 +193,13 @@ impl SetupRunner {
         for feature in detected.feature_names() {
             println!("      - {}", feature);
         }
+        if detected.has_scoping() {
+            println!("  * Landlock scoping policy:");
+            println!("    - Signal scoping: enforced for same-sandbox signal isolation modes");
+            println!(
+                "    - Abstract UNIX socket scoping: enforced for shared-memory-only IPC mode"
+            );
+        }
 
         println!("  * Filesystem ruleset creation verified");
 

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -1,5 +1,6 @@
 use crate::capability_ext::CapabilitySetExt;
-use crate::cli::{SandboxArgs, WhyArgs, WhyOp};
+use crate::cli::{SandboxArgs, WhyArgs, WhyOp, WhyScope};
+use crate::query_ext::ScopeQuery;
 use crate::{network_policy, policy, profile, query_ext, sandbox_state};
 use nono::{AccessMode, CapabilitySet, NonoError, Result};
 
@@ -42,7 +43,7 @@ fn resolve_allowed_domains(profile: &profile::Profile) -> Vec<String> {
 }
 
 pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
-    use query_ext::{QueryResult, print_result, query_network, query_path};
+    use query_ext::{QueryResult, print_result, query_network, query_path, query_scope};
     use sandbox_state::load_sandbox_state;
 
     let ctx: WhyContext = if args.self_query {
@@ -149,9 +150,11 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
         query_path(path, op, &ctx.caps, &ctx.overridden_paths)?
     } else if let Some(ref host) = args.host {
         query_network(host, args.port, &ctx.caps, &ctx.allowed_domains)
+    } else if let Some(ref scope) = args.scope {
+        query_scope(scope_query(scope), &ctx.caps)
     } else {
         return Err(NonoError::ConfigParse(
-            "--path or --host is required".to_string(),
+            "--path, --host, or --scope is required".to_string(),
         ));
     };
 
@@ -164,4 +167,11 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn scope_query(scope: &WhyScope) -> ScopeQuery {
+    match scope {
+        WhyScope::Signal => ScopeQuery::Signal,
+        WhyScope::AbstractUnixSocket => ScopeQuery::AbstractUnixSocket,
+    }
 }

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -592,6 +592,10 @@ fn tokenize_sexp(input: &str) -> Result<Vec<String>> {
 ///
 /// Controls whether the sandboxed process can send signals to processes
 /// outside its own sandbox.
+///
+/// On Linux, restricted signal modes use Landlock V6 signal scoping when
+/// available. Older kernels cannot enforce process signal filtering; see each
+/// variant for whether nono degrades or fails closed.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SignalMode {
     /// Signals restricted to the current sandbox.
@@ -603,10 +607,11 @@ pub enum SignalMode {
     /// generated signals (e.g., Ctrl+C delivering SIGINT to the foreground
     /// process group) are delivered by the kernel and bypass the sandbox.
     ///
-    /// On Linux: Landlock V6 `LANDLOCK_SCOPE_SIGNAL` restricts signaling
-    /// to processes in the same sandbox. Landlock cannot distinguish "self
-    /// only" from "same sandbox", so `Isolated` and `AllowSameSandbox`
-    /// produce identical enforcement.
+    /// On Linux: requests Landlock V6 `LANDLOCK_SCOPE_SIGNAL` when available,
+    /// restricting signals to processes in the same sandbox domain. Landlock
+    /// cannot distinguish "self only" from "same sandbox", so `Isolated` and
+    /// `AllowSameSandbox` produce identical enforcement on V6. Older kernels
+    /// cannot enforce this mode and continue without signal scoping.
     #[default]
     Isolated,
     /// Signals allowed to child processes in the same sandbox only.
@@ -615,11 +620,14 @@ pub enum SignalMode {
     /// Permits signaling any process that inherited the sandbox (i.e., forked
     /// or exec'd children), but blocks signals to external processes.
     ///
-    /// On Linux: enforced on Landlock V6+ with `LANDLOCK_SCOPE_SIGNAL`.
-    /// This blocks signaling processes outside the current sandbox while
-    /// still allowing signals to same-sandbox descendants.
+    /// On Linux: requests Landlock V6 `LANDLOCK_SCOPE_SIGNAL`, blocking
+    /// signals to processes outside the current sandbox domain while still
+    /// allowing signals to same-sandbox descendants. This mode requires V6
+    /// support and fails closed if the detected kernel cannot enforce it.
     AllowSameSandbox,
     /// Signals allowed to any process (no filtering).
+    ///
+    /// On Linux: does not request Landlock signal scoping.
     AllowAll,
 }
 

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -656,10 +656,10 @@ pub enum ProcessInfoMode {
 
 /// IPC mode for the sandbox.
 ///
-/// Controls whether the sandboxed process can use POSIX IPC primitives
-/// (semaphores) beyond shared memory. Shared memory (`shm_open`) is always
-/// allowed; this mode gates semaphore operations needed by multiprocessing
-/// runtimes (e.g., Python `multiprocessing`, Ruby `parallel`).
+/// Controls whether the sandboxed process can use IPC primitives beyond
+/// shared memory. Shared memory (`shm_open`) is always allowed; this mode gates
+/// semaphore operations needed by multiprocessing runtimes (e.g., Python
+/// `multiprocessing`, Ruby `parallel`) and Linux abstract UNIX socket access.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IpcMode {
     /// POSIX shared memory only (default). Semaphore operations are denied.
@@ -667,7 +667,8 @@ pub enum IpcMode {
     /// On macOS: only `ipc-posix-shm-*` rules emitted. `sem_open()` etc.
     /// are blocked by the `(deny default)` baseline.
     ///
-    /// On Linux: no-op (Landlock does not restrict IPC primitives).
+    /// On Linux: requests Landlock V6 abstract UNIX socket scoping when
+    /// available. Older kernels cannot enforce this and continue without it.
     #[default]
     SharedMemoryOnly,
     /// Full POSIX IPC: shared memory + semaphores.
@@ -676,7 +677,8 @@ pub enum IpcMode {
     /// Required for Python `multiprocessing`, Node `worker_threads` with
     /// shared memory, and similar multiprocess coordination.
     ///
-    /// On Linux: no-op (Landlock does not restrict IPC primitives).
+    /// On Linux: does not request abstract UNIX socket scoping, preserving
+    /// compatibility with runtimes that use external abstract socket IPC.
     Full,
 }
 

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -81,7 +81,7 @@ pub use keystore::{
 pub use net_filter::{FilterResult, HostFilter};
 pub use path::try_canonicalize;
 #[cfg(target_os = "linux")]
-pub use sandbox::{DetectedAbi, detect_abi, is_wsl2};
+pub use sandbox::{DetectedAbi, LandlockScopePolicy, detect_abi, is_wsl2, landlock_scope_policy};
 pub use sandbox::{Sandbox, SupportInfo};
 pub use scrub::{
     ScrubPolicy, ScrubPolicyDiff, scrub_argv, scrub_argv_with_policy, scrub_header,

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -2491,10 +2491,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn errno_to_u8(errno: i32) -> u8 {
-        match u8::try_from(errno) {
-            Ok(value) => value,
-            Err(_) => u8::MAX,
-        }
+        u8::try_from(errno).unwrap_or(u8::MAX)
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -1,6 +1,6 @@
 //! Linux sandbox implementation using Landlock LSM
 
-use crate::capability::{AccessMode, CapabilitySet, NetworkMode, SignalMode};
+use crate::capability::{AccessMode, CapabilitySet, IpcMode, NetworkMode, SignalMode};
 use crate::error::{NonoError, Result};
 use crate::sandbox::SupportInfo;
 use landlock::{
@@ -19,6 +19,23 @@ use tracing::{debug, info, warn};
 pub struct DetectedAbi {
     /// The detected ABI version
     pub abi: ABI,
+}
+
+/// Landlock scope policy derived from a capability set and kernel ABI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LandlockScopePolicy {
+    /// Detected Landlock ABI version string.
+    pub abi_version: &'static str,
+    /// Whether this kernel supports Landlock scope flags.
+    pub scoping_supported: bool,
+    /// Whether signal scoping was requested by the capability set.
+    pub signal_requested: bool,
+    /// Whether signal scoping will be enforced.
+    pub signal_enforced: bool,
+    /// Whether abstract UNIX socket scoping was requested by the capability set.
+    pub abstract_unix_socket_requested: bool,
+    /// Whether abstract UNIX socket scoping will be enforced.
+    pub abstract_unix_socket_enforced: bool,
 }
 
 impl DetectedAbi {
@@ -52,7 +69,7 @@ impl DetectedAbi {
         AccessFs::from_all(self.abi).contains(AccessFs::IoctlDev)
     }
 
-    /// Whether process scoping (signals and abstract UNIX sockets) is supported (V6+).
+    /// Whether scoped signals and abstract UNIX sockets are supported (V6+).
     #[must_use]
     pub fn has_scoping(&self) -> bool {
         !Scope::from_all(self.abi).is_empty()
@@ -92,10 +109,42 @@ impl DetectedAbi {
             features.push("Device ioctl filtering".to_string());
         }
         if self.has_scoping() {
-            features.push("Process scoping".to_string());
+            features.push("Signal and abstract UNIX socket scoping".to_string());
         }
         features
     }
+}
+
+/// Report the Landlock scope policy that would be applied for these capabilities.
+///
+/// # Errors
+///
+/// Returns an error if ABI detection fails, or if the capability set requests a
+/// mandatory scope that the detected ABI cannot enforce.
+pub fn landlock_scope_policy(caps: &CapabilitySet) -> Result<LandlockScopePolicy> {
+    let detected = detect_abi()?;
+    landlock_scope_policy_with_abi(caps, &detected)
+}
+
+/// Report the Landlock scope policy for an already-detected ABI.
+///
+/// # Errors
+///
+/// Returns an error if the capability set requests a mandatory scope that this
+/// ABI cannot enforce.
+pub fn landlock_scope_policy_with_abi(
+    caps: &CapabilitySet,
+    abi: &DetectedAbi,
+) -> Result<LandlockScopePolicy> {
+    let scopes = requested_scopes(caps, abi)?;
+    Ok(LandlockScopePolicy {
+        abi_version: abi.version_string(),
+        scoping_supported: abi.has_scoping(),
+        signal_requested: !matches!(caps.signal_mode(), SignalMode::AllowAll),
+        signal_enforced: scopes.contains(Scope::Signal),
+        abstract_unix_socket_requested: caps.ipc_mode() == IpcMode::SharedMemoryOnly,
+        abstract_unix_socket_enforced: scopes.contains(Scope::AbstractUnixSocket),
+    })
 }
 
 impl std::fmt::Display for DetectedAbi {
@@ -363,17 +412,21 @@ fn is_device_directory(path: &Path) -> bool {
 
 /// Determine which Landlock scopes must be enabled for these capabilities.
 ///
-/// Only `SignalMode::AllowSameSandbox` has an exact Landlock mapping today.
-/// `SignalMode::Isolated` cannot be represented because Landlock scopes to the
-/// sandbox domain, not to the calling process alone.
+/// `SignalMode::AllowSameSandbox` has an exact Landlock mapping.
+/// `SignalMode::Isolated` cannot be represented exactly because Landlock scopes
+/// to the sandbox domain, not to the calling process alone.
+///
+/// Landlock's abstract UNIX socket scope is all-or-nothing. `IpcMode::Full`
+/// therefore leaves abstract sockets unscoped as the explicit compatibility
+/// mode, while `IpcMode::SharedMemoryOnly` requests the V6 IPC hardening.
 fn requested_scopes(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<BitFlags<Scope>> {
+    let mut scopes = BitFlags::EMPTY;
+
     match caps.signal_mode() {
-        SignalMode::AllowAll => Ok(BitFlags::EMPTY),
+        SignalMode::AllowAll => {}
         SignalMode::Isolated => {
             if abi.has_scoping() {
-                Ok(Scope::Signal.into())
-            } else {
-                Ok(BitFlags::EMPTY)
+                scopes |= BitFlags::from(Scope::Signal);
             }
         }
         SignalMode::AllowSameSandbox => {
@@ -384,9 +437,15 @@ fn requested_scopes(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<BitFlags<
                         .to_string(),
                 ));
             }
-            Ok(Scope::Signal.into())
+            scopes |= BitFlags::from(Scope::Signal);
         }
     }
+
+    if caps.ipc_mode() == IpcMode::SharedMemoryOnly && abi.has_scoping() {
+        scopes |= BitFlags::from(Scope::AbstractUnixSocket);
+    }
+
+    Ok(scopes)
 }
 
 /// Apply Landlock sandbox with the given capabilities, auto-detecting ABI.
@@ -504,7 +563,7 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
             .scope(scopes)
             .map_err(|e| {
                 NonoError::SandboxInit(format!(
-                    "Signal scoping requested but unsupported by this kernel: {}",
+                    "Landlock scoping requested but unsupported by this kernel: {}",
                     e
                 ))
             })?
@@ -2214,14 +2273,18 @@ mod tests {
 
     #[test]
     fn test_requested_scopes_allow_all_is_empty() {
-        let caps = CapabilitySet::new().set_signal_mode(SignalMode::AllowAll);
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::Full);
         let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
         assert!(matches!(scopes, Ok(actual) if actual.is_empty()));
     }
 
     #[test]
     fn test_requested_scopes_isolated_uses_signal_scope_on_v6() {
-        let caps = CapabilitySet::new().set_signal_mode(SignalMode::Isolated);
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::Isolated)
+            .set_ipc_mode(IpcMode::Full);
         let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
         assert!(matches!(scopes, Ok(actual) if actual == BitFlags::from(Scope::Signal)));
     }
@@ -2244,9 +2307,289 @@ mod tests {
 
     #[test]
     fn test_requested_scopes_allow_same_sandbox_uses_signal_scope() {
-        let caps = CapabilitySet::new().set_signal_mode(SignalMode::AllowSameSandbox);
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowSameSandbox)
+            .set_ipc_mode(IpcMode::Full);
         let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
         assert!(matches!(scopes, Ok(actual) if actual == BitFlags::from(Scope::Signal)));
+    }
+
+    #[test]
+    fn test_requested_scopes_shared_memory_only_uses_abstract_socket_scope_on_v6() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
+        assert!(
+            matches!(scopes, Ok(actual) if actual == BitFlags::from(Scope::AbstractUnixSocket))
+        );
+    }
+
+    #[test]
+    fn test_requested_scopes_full_ipc_does_not_use_abstract_socket_scope() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::Full);
+        let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
+        assert!(matches!(scopes, Ok(actual) if actual.is_empty()));
+    }
+
+    #[test]
+    fn test_requested_scopes_combines_signal_and_abstract_socket_scopes() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowSameSandbox)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V6));
+        let expected = BitFlags::from(Scope::Signal) | BitFlags::from(Scope::AbstractUnixSocket);
+        assert!(matches!(scopes, Ok(actual) if actual == expected));
+    }
+
+    #[test]
+    fn test_requested_scopes_shared_memory_only_degrades_without_v6() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let scopes = requested_scopes(&caps, &DetectedAbi::new(ABI::V5));
+        assert!(matches!(scopes, Ok(actual) if actual.is_empty()));
+    }
+
+    #[test]
+    fn test_landlock_scope_policy_reports_requested_and_enforced_scopes() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowSameSandbox)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let policy = match landlock_scope_policy_with_abi(&caps, &DetectedAbi::new(ABI::V6)) {
+            Ok(policy) => policy,
+            Err(err) => panic!("V6 should support requested scopes: {err}"),
+        };
+
+        assert_eq!(policy.abi_version, "V6");
+        assert!(policy.scoping_supported);
+        assert!(policy.signal_requested);
+        assert!(policy.signal_enforced);
+        assert!(policy.abstract_unix_socket_requested);
+        assert!(policy.abstract_unix_socket_enforced);
+    }
+
+    #[test]
+    fn test_landlock_scope_policy_reports_unsupported_abstract_socket_scope() {
+        let caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let policy = match landlock_scope_policy_with_abi(&caps, &DetectedAbi::new(ABI::V5)) {
+            Ok(policy) => policy,
+            Err(err) => panic!("SharedMemoryOnly should degrade without V6: {err}"),
+        };
+
+        assert_eq!(policy.abi_version, "V5");
+        assert!(!policy.scoping_supported);
+        assert!(!policy.signal_requested);
+        assert!(!policy.signal_enforced);
+        assert!(policy.abstract_unix_socket_requested);
+        assert!(!policy.abstract_unix_socket_enforced);
+    }
+
+    #[cfg(target_os = "linux")]
+    struct FdGuard(libc::c_int);
+
+    #[cfg(target_os = "linux")]
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            if self.0 >= 0 {
+                // SAFETY: fd ownership is held by FdGuard and close is safe for a valid fd.
+                unsafe {
+                    libc::close(self.0);
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn abstract_sockaddr(name: &[u8]) -> Option<(libc::sockaddr_un, libc::socklen_t)> {
+        // SAFETY: sockaddr_un is a plain C struct; zero initialization is valid.
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        if name.len().saturating_add(1) > addr.sun_path.len() {
+            return None;
+        }
+
+        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+        addr.sun_path[0] = 0;
+        for (index, byte) in name.iter().enumerate() {
+            addr.sun_path[index + 1] = *byte as libc::c_char;
+        }
+
+        let addr_len = std::mem::size_of::<libc::sa_family_t>() + 1 + name.len();
+        Some((addr, addr_len as libc::socklen_t))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn bind_abstract_listener(name: &[u8]) -> FdGuard {
+        // SAFETY: socket is called with constant domain/type/protocol values.
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
+        assert!(fd >= 0, "socket(AF_UNIX) failed");
+        let guard = FdGuard(fd);
+
+        let (addr, addr_len) = match abstract_sockaddr(name) {
+            Some(sockaddr) => sockaddr,
+            None => {
+                panic!("abstract socket name is too long");
+            }
+        };
+
+        // SAFETY: addr points to a valid sockaddr_un and addr_len covers initialized bytes.
+        let bind_result = unsafe {
+            libc::bind(
+                guard.0,
+                (&addr as *const libc::sockaddr_un).cast::<libc::sockaddr>(),
+                addr_len,
+            )
+        };
+        assert_eq!(bind_result, 0, "bind(AF_UNIX abstract) failed");
+
+        // SAFETY: guard.0 is a valid stream socket created above.
+        let listen_result = unsafe { libc::listen(guard.0, 4) };
+        assert_eq!(listen_result, 0, "listen(AF_UNIX abstract) failed");
+        guard
+    }
+
+    #[cfg(target_os = "linux")]
+    fn connect_abstract_socket(name: &[u8]) -> (bool, i32) {
+        // SAFETY: socket is called with constant domain/type/protocol values.
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
+        if fd < 0 {
+            let errno = std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(255);
+            return (false, errno);
+        }
+        let guard = FdGuard(fd);
+
+        let (addr, addr_len) = match abstract_sockaddr(name) {
+            Some(sockaddr) => sockaddr,
+            None => return (false, libc::EINVAL),
+        };
+
+        // SAFETY: addr points to a valid sockaddr_un and addr_len covers initialized bytes.
+        let connect_result = unsafe {
+            libc::connect(
+                guard.0,
+                (&addr as *const libc::sockaddr_un).cast::<libc::sockaddr>(),
+                addr_len,
+            )
+        };
+        if connect_result == 0 {
+            (true, 0)
+        } else {
+            (
+                false,
+                std::io::Error::last_os_error()
+                    .raw_os_error()
+                    .unwrap_or(255),
+            )
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn errno_to_u8(errno: i32) -> u8 {
+        match u8::try_from(errno) {
+            Ok(value) => value,
+            Err(_) => u8::MAX,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn run_abstract_connect_probe(
+        name: &[u8],
+        listener_fd: libc::c_int,
+        caps: CapabilitySet,
+        detected: DetectedAbi,
+    ) -> [u8; 2] {
+        let mut report_pipe = [0; 2];
+        // SAFETY: report_pipe points to two writable file descriptor slots.
+        let pipe_result = unsafe { libc::pipe(report_pipe.as_mut_ptr()) };
+        assert_eq!(pipe_result, 0, "pipe() failed");
+
+        // SAFETY: fork is used in a test helper; child exits via _exit.
+        let child_pid = unsafe { libc::fork() };
+        assert!(child_pid >= 0, "fork() for abstract socket probe failed");
+
+        if child_pid == 0 {
+            let mut payload = [0_u8; 2];
+            // SAFETY: these are inherited file descriptors in the child process.
+            unsafe {
+                libc::close(report_pipe[0]);
+                libc::close(listener_fd);
+            }
+
+            match apply_with_abi(&caps, &detected) {
+                Ok(_) => {
+                    let (connected, errno) = connect_abstract_socket(name);
+                    payload[0] = if connected { 0 } else { 1 };
+                    payload[1] = errno_to_u8(errno);
+                }
+                Err(_) => {
+                    payload[0] = 2;
+                    payload[1] = 0;
+                }
+            }
+
+            let write_len = payload.len();
+            // SAFETY: payload is a valid buffer and report_pipe[1] is the pipe write end.
+            let wrote = unsafe {
+                libc::write(
+                    report_pipe[1],
+                    payload.as_ptr().cast::<libc::c_void>(),
+                    write_len,
+                )
+            };
+            let expected_write = isize::try_from(write_len).unwrap_or(-1);
+            let exit_code = if wrote == expected_write { 0 } else { 3 };
+            // SAFETY: close operates on the inherited pipe fd; _exit terminates the child.
+            unsafe {
+                libc::close(report_pipe[1]);
+                libc::_exit(exit_code);
+            }
+        }
+
+        // SAFETY: parent no longer writes to the pipe.
+        unsafe {
+            libc::close(report_pipe[1]);
+        }
+
+        let mut child_status = 0;
+        // SAFETY: child_pid is the pid returned by fork in the parent.
+        let waited = unsafe { libc::waitpid(child_pid, &mut child_status, 0) };
+        assert_eq!(waited, child_pid, "waitpid() for probe child failed");
+        assert!(
+            libc::WIFEXITED(child_status),
+            "abstract socket probe child did not exit normally"
+        );
+        assert_eq!(
+            libc::WEXITSTATUS(child_status),
+            0,
+            "abstract socket probe child returned failure"
+        );
+
+        let mut payload = [0_u8; 2];
+        let read_len = payload.len();
+        // SAFETY: payload is a valid writable buffer and report_pipe[0] is the read end.
+        let read_result = unsafe {
+            libc::read(
+                report_pipe[0],
+                payload.as_mut_ptr().cast::<libc::c_void>(),
+                read_len,
+            )
+        };
+        // SAFETY: parent is done reading from the pipe.
+        unsafe {
+            libc::close(report_pipe[0]);
+        }
+        assert_eq!(
+            read_result,
+            isize::try_from(read_len).unwrap_or(-1),
+            "failed to read abstract socket probe report"
+        );
+        payload
     }
 
     #[cfg(target_os = "linux")]
@@ -2402,6 +2745,46 @@ mod tests {
         cleanup.target_pid = None;
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_abstract_unix_socket_scope_blocks_external_connect_on_v6() {
+        let detected = match detect_abi() {
+            Ok(detected) => detected,
+            Err(_) => return,
+        };
+
+        if !detected.has_scoping() {
+            return;
+        }
+
+        let socket_name = format!(
+            "nono-landlock-v6-abstract-{}-{}",
+            std::process::id(),
+            // SAFETY: getpid has no preconditions.
+            unsafe { libc::getpid() }
+        );
+        let listener = bind_abstract_listener(socket_name.as_bytes());
+
+        let scoped_caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::SharedMemoryOnly);
+        let scoped_report =
+            run_abstract_connect_probe(socket_name.as_bytes(), listener.0, scoped_caps, detected);
+        assert_eq!(scoped_report[0], 1, "scoped abstract connect succeeded");
+        assert_eq!(
+            i32::from(scoped_report[1]),
+            libc::EPERM,
+            "scoped abstract connect should fail with EPERM"
+        );
+
+        let full_ipc_caps = CapabilitySet::new()
+            .set_signal_mode(SignalMode::AllowAll)
+            .set_ipc_mode(IpcMode::Full);
+        let full_report =
+            run_abstract_connect_probe(socket_name.as_bytes(), listener.0, full_ipc_caps, detected);
+        assert_eq!(full_report[0], 0, "IpcMode::Full connect was denied");
+    }
+
     #[test]
     fn test_detected_abi_version_string() {
         assert_eq!(DetectedAbi::new(ABI::V1).version_string(), "V1");
@@ -2431,6 +2814,14 @@ mod tests {
                 .any(|n| n == "File rename across directories (Refer)")
         );
         assert!(names.iter().any(|n| n == "File truncation (Truncate)"));
+
+        let v6 = DetectedAbi::new(ABI::V6);
+        let names = v6.feature_names();
+        assert!(
+            names
+                .iter()
+                .any(|n| n == "Signal and abstract UNIX socket scoping")
+        );
     }
 
     #[test]

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -18,9 +18,9 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::{extension_consume, extension_issue_file, extension_release};
 
-// Re-export Linux Landlock ABI detection
+// Re-export Linux Landlock ABI detection and scope policy reporting
 #[cfg(target_os = "linux")]
-pub use linux::{DetectedAbi, detect_abi};
+pub use linux::{DetectedAbi, LandlockScopePolicy, detect_abi, landlock_scope_policy};
 
 // Re-export Linux WSL2 detection
 #[cfg(target_os = "linux")]

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -237,6 +237,33 @@ Groups are referenced by name in the `groups.include` field. See [Profiles & Gro
   The `groups.include` key was renamed from its former location under `security` in issue #594. The legacy key still deserializes with a deprecation warning; see `nono profile guide` for the full migration table. Legacy keys will be removed in v1.0.0.
 </Note>
 
+## Process and IPC Isolation
+
+The `security` section controls process-level isolation knobs that are not filesystem path grants:
+
+```json
+{
+  "security": {
+    "signal_mode": "isolated",
+    "process_info_mode": "isolated",
+    "ipc_mode": "shared_memory_only"
+  }
+}
+```
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `signal_mode` | `isolated`, `allow_same_sandbox`, `allow_all` | Controls which processes the sandboxed command may signal. On Linux V6, restricted modes use Landlock signal scoping when available. |
+| `process_info_mode` | `isolated`, `allow_same_sandbox`, `allow_all` | Controls visibility of other process metadata. |
+| `ipc_mode` | `shared_memory_only`, `full` | Controls IPC compatibility. On Linux V6, `shared_memory_only` requests abstract UNIX socket scoping; `full` leaves abstract UNIX sockets unscoped for runtimes that require broader IPC compatibility. |
+
+Use `nono why --scope` to inspect the effective scope policy for a profile:
+
+```bash
+nono why --scope signal --profile my-agent
+nono why --scope abstract-unix-socket --profile my-agent
+```
+
 ## Common Patterns
 
 ### Agent with API Credentials

--- a/docs/cli/internals/landlock.mdx
+++ b/docs/cli/internals/landlock.mdx
@@ -43,7 +43,8 @@ Landlock capabilities have evolved across kernel versions:
 | 5.19+ | v2 | `REFER` - rename/link across directories |
 | 6.2+ | v3 | `TRUNCATE` - file truncation |
 | 6.7+ | v4 | TCP `bind` and `connect` filtering |
-| 6.10+ | v5 | `IOCTL_DEV`, signal/socket scoping |
+| 6.10+ | v5 | `IOCTL_DEV` - device ioctl filtering |
+| 6.12+ | v6 | Signal and abstract UNIX socket scoping |
 
 nono automatically detects the highest available ABI and uses it. On older kernels, some features are unavailable but core filesystem sandboxing still works.
 
@@ -94,6 +95,40 @@ AccessNet::ConnectTcp // Control outbound connections
 <Warning>
   Network filtering requires kernel 6.7+. On older kernels, nono cannot enforce network restrictions via Landlock and will warn you.
 </Warning>
+
+## Signal and IPC Scoping
+
+Landlock ABI v6 added scope restrictions for process signals and abstract UNIX sockets:
+
+```rust
+Scope::Signal
+Scope::AbstractUnixSocket
+```
+
+nono derives these scopes from the effective capability set:
+
+| Profile / capability setting | Linux V6 behavior |
+|------------------------------|-------------------|
+| `security.signal_mode: "allow_same_sandbox"` | Requests signal scoping and fails closed if the kernel cannot enforce it |
+| `security.signal_mode: "isolated"` | Requests signal scoping when available |
+| `security.signal_mode: "allow_all"` | Does not request signal scoping |
+| `security.ipc_mode: "shared_memory_only"` | Requests abstract UNIX socket scoping when available |
+| `security.ipc_mode: "full"` | Does not request abstract UNIX socket scoping |
+
+`shared_memory_only` is the default IPC mode. On V6 kernels it prevents connecting to abstract UNIX sockets created outside the current Landlock domain. Profiles that need broader runtime IPC compatibility can opt into `ipc_mode: "full"`.
+
+Use verbose dry-run output to see what would be requested and enforced:
+
+```bash
+nono run --dry-run -v --profile claude-code -- claude
+```
+
+Use `nono why` for a focused scope query:
+
+```bash
+nono why --scope signal --profile claude-code
+nono why --scope abstract-unix-socket --profile claude-code
+```
 
 ## Enforcement Status
 
@@ -176,6 +211,7 @@ If a command fails with permission errors:
 - Basic sandboxing requires kernel 5.13+
 - Full filesystem control requires kernel 6.2+
 - Network filtering requires kernel 6.7+
+- Signal and abstract UNIX socket scoping requires Landlock ABI v6
 
 ### No Network Filtering on Older Kernels
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -107,6 +107,7 @@ Check why a path or network operation would be allowed or denied. Designed for b
 ```bash
 nono why --path <PATH> --op <OP> [OPTIONS]
 nono why --host <HOST> [--port <PORT>] [OPTIONS]
+nono why --scope <SCOPE> [OPTIONS]
 nono why --self --path <PATH> --op <OP> [OPTIONS]  # Inside sandbox
 ```
 
@@ -1042,6 +1043,12 @@ Capabilities that would be granted:
 Would execute: my-agent
 ```
 
+On Linux, combine `--dry-run` with `-v` to include detected Landlock ABI details and requested/enforced scope state:
+
+```bash
+nono run --dry-run -v --profile claude-code -- claude
+```
+
 #### `--verbose`, `-v`
 
 Increase logging verbosity. Can be specified multiple times.
@@ -1127,6 +1134,17 @@ Network port (default: 443). Used with `--host`.
 ```bash
 nono why --host example.com --port 8080
 ```
+
+### `--scope`
+
+Landlock scope to check. Supported values are `signal` and `abstract-unix-socket`.
+
+```bash
+nono why --scope signal --profile claude-code
+nono why --scope abstract-unix-socket --profile claude-code
+```
+
+On Linux, scope queries report whether the effective capability set requested the scope, whether the detected Landlock ABI can support it, and whether nono will enforce it. On non-Linux platforms, scope queries return `not_applicable`.
 
 ### `--json`
 


### PR DESCRIPTION
This release introduces support for Landlock v6's signal and abstract UNIX socket scoping, enhancing process and IPC isolation on compatible Linux kernels.

- **`nono why --scope <SCOPE>` command**: A new `why` subcommand argument allows querying the effective Landlock scope policy for `signal` or `abstract-unix-socket`. This reports whether a scope is requested by the capability set, supported by the kernel's Landlock ABI, and ultimately enforced.
- **Improved IPC isolation**: The `IpcMode::SharedMemoryOnly` setting now requests abstract UNIX socket scoping on Landlock v6 kernels, preventing connections to abstract UNIX sockets outside the sandbox. `IpcMode::Full` disables this to maintain broader IPC compatibility.
- **Signal isolation**: `SignalMode::Isolated` and `SignalMode::AllowSameSandbox` now utilize Landlock signal scoping on v6 kernels for stronger signal isolation.
- **Verbose output**: `nono run --dry-run -v` output now includes detailed Landlock ABI information, including the detected version and the requested/enforced state of signal and abstract UNIX socket scopes.
- **`nono setup` enhancements**: The setup command now reports detected Landlock scoping policies.
- **Core library updates**: The `nono` crate includes new `LandlockScopePolicy` structures and functions to derive scope policies from capability sets.
- **Comprehensive testing**: New Linux-specific integration tests have been added to verify abstract UNIX socket scoping.
- **Documentation**: CLI usage, internal Landlock details, and profile authoring guides have been updated to reflect the new scoping features and their impact on `signal_mode` and `ipc_mode`.

Closes #255 

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
