### PR TITLE
feat(cli): add recursive unix socket directory grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Notes
+
+- Socket grant state now records explicit socket scope. New subtree socket
+  grants require this metadata; rolling back to older nono builds may read
+  those state entries as file-scoped grants.
+
 ## [0.54.0] - 2026-05-13
 
 ### Bug Fixes

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -78,7 +78,23 @@ fn try_new_unix_socket_dir(
     }
 }
 
-/// Apply all four `--allow-unix-socket*` flag groups to `caps`.
+/// Try to create a subtree-scoped AF_UNIX socket capability.
+fn try_new_unix_socket_subtree(
+    path: &Path,
+    mode: UnixSocketMode,
+    label: &str,
+) -> Result<Option<UnixSocketCapability>> {
+    match UnixSocketCapability::new_dir_subtree(path, mode) {
+        Ok(cap) => Ok(Some(cap)),
+        Err(NonoError::PathNotFound(_)) => {
+            info!("{}: {}", label, path.display());
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Apply all `--allow-unix-socket*` flag groups to `caps`.
 ///
 /// Each flag adds a [`UnixSocketCapability`] and auto-registers the
 /// implied [`FsCapability`] (CLI-side sugar per #696). The socket-level
@@ -99,6 +115,9 @@ fn add_cli_unix_socket_caps(
     const LBL_FS_FILE_IMPLIED: &str = "Skipping implied fs grant for non-existent unix socket";
     const LBL_FS_DIR_IMPLIED: &str =
         "Skipping implied fs grant for non-existent unix socket directory";
+    const LBL_SOCK_SUBTREE: &str = "Skipping non-existent unix socket subtree (connect grant)";
+    const LBL_SOCK_SUBTREE_BIND: &str =
+        "Skipping non-existent unix socket subtree (connect+bind grant)";
     const LBL_FS_DIR_IMPLIED_BIND_PARENT: &str =
         "Skipping implied fs grant on parent of pending unix socket bind path";
 
@@ -182,6 +201,30 @@ fn add_cli_unix_socket_caps(
         validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
         let sock_cap =
             try_new_unix_socket_dir(path, UnixSocketMode::ConnectBind, LBL_SOCK_DIR_BIND)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, LBL_FS_DIR_IMPLIED)? {
+                caps.add_fs(cap);
+            }
+        }
+    }
+
+    for path in &args.allow_unix_socket_subtree {
+        validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
+        let sock_cap =
+            try_new_unix_socket_subtree(path, UnixSocketMode::Connect, LBL_SOCK_SUBTREE)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            if let Some(cap) = try_new_dir(path, AccessMode::Read, LBL_FS_DIR_IMPLIED)? {
+                caps.add_fs(cap);
+            }
+        }
+    }
+
+    for path in &args.allow_unix_socket_subtree_bind {
+        validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
+        let sock_cap =
+            try_new_unix_socket_subtree(path, UnixSocketMode::ConnectBind, LBL_SOCK_SUBTREE_BIND)?;
         if let Some(cap) = sock_cap {
             caps.add_unix_socket(cap);
             if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, LBL_FS_DIR_IMPLIED)? {
@@ -818,6 +861,54 @@ impl CapabilitySetExt for CapabilitySet {
             }
         }
 
+        for path_template in &fs.unix_socket_subtree {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            let label = format!(
+                "Profile unix socket subtree '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) =
+                try_new_unix_socket_subtree(&path, UnixSocketMode::Connect, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
+                }
+            }
+        }
+
+        for path_template in &fs.unix_socket_subtree_bind {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            let label = format!(
+                "Profile unix socket subtree '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) =
+                try_new_unix_socket_subtree(&path, UnixSocketMode::ConnectBind, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
+                }
+            }
+        }
+
         // Additional profile filesystem grants (canonical fields
         // `filesystem.deny` / `filesystem.bypass_protection` + historical
         // drain sources `filesystem.allow` / `.read` / `.write`). The core
@@ -1112,6 +1203,7 @@ fn add_cli_overrides(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nono::SocketScope;
     use tempfile::tempdir;
 
     fn with_env_lock<T>(f: impl FnOnce() -> T) -> T {
@@ -2641,7 +2733,7 @@ mod tests {
         let socks = caps.unix_socket_capabilities();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::Connect);
-        assert!(!socks[0].is_directory);
+        assert!(!socks[0].is_directory());
 
         // Exactly one implied FsCapability at Read.
         let fs_matches: Vec<_> = caps
@@ -2730,7 +2822,7 @@ mod tests {
         let socks = caps.unix_socket_capabilities();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
-        assert!(!socks[0].is_directory);
+        assert!(!socks[0].is_directory());
 
         // Implied fs grant should cover the parent dir with ReadWrite.
         let canonical_parent = dir.path().canonicalize().expect("canonicalize dir");
@@ -2783,7 +2875,8 @@ mod tests {
         let socks = caps.unix_socket_capabilities();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
-        assert!(socks[0].is_directory);
+        assert!(socks[0].is_directory());
+        assert_eq!(socks[0].scope, SocketScope::DirChildren);
 
         let fs_match = caps
             .fs_capabilities()
@@ -2809,7 +2902,9 @@ mod tests {
         let socks = caps.unix_socket_capabilities();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::Connect);
-        assert!(socks[0].is_directory);
+        assert!(socks[0].is_directory());
+        assert_eq!(socks[0].scope, SocketScope::DirChildren);
+        assert_eq!(socks[0].scope, SocketScope::DirChildren);
 
         let fs_match = caps
             .fs_capabilities()
@@ -2819,6 +2914,58 @@ mod tests {
             })
             .expect("implied fs dir cap not found");
         assert_eq!(fs_match.access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_subtree_implies_read_fs_grant() {
+        let dir = tempdir().expect("tempdir");
+
+        let args = SandboxArgs {
+            allow_unix_socket_subtree: vec![dir.path().to_path_buf()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert_eq!(socks[0].scope, SocketScope::DirSubtree);
+
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| {
+                !c.is_file && c.resolved == dir.path().canonicalize().expect("canonicalize dir")
+            })
+            .expect("implied fs dir cap not found");
+        assert_eq!(fs_match.access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_subtree_bind_implies_readwrite_fs_grant() {
+        let dir = tempdir().expect("tempdir");
+
+        let args = SandboxArgs {
+            allow_unix_socket_subtree_bind: vec![dir.path().to_path_buf()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert_eq!(socks[0].scope, SocketScope::DirSubtree);
+
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| {
+                !c.is_file && c.resolved == dir.path().canonicalize().expect("canonicalize dir")
+            })
+            .expect("implied fs dir cap not found");
+        assert_eq!(fs_match.access, AccessMode::ReadWrite);
     }
 
     /// Build a minimal profile JSON with a single filesystem field set,
@@ -2851,7 +2998,7 @@ mod tests {
             .collect();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::Connect);
-        assert!(!socks[0].is_directory);
+        assert!(!socks[0].is_directory());
     }
 
     #[test]
@@ -2871,7 +3018,7 @@ mod tests {
             .collect();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
-        assert!(!socks[0].is_directory);
+        assert!(!socks[0].is_directory());
     }
 
     #[test]
@@ -2889,7 +3036,7 @@ mod tests {
             .collect();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::Connect);
-        assert!(socks[0].is_directory);
+        assert!(socks[0].is_directory());
     }
 
     #[test]
@@ -2909,6 +3056,47 @@ mod tests {
             .collect();
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
-        assert!(socks[0].is_directory);
+        assert!(socks[0].is_directory());
+        assert_eq!(socks[0].scope, SocketScope::DirChildren);
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_subtree() {
+        let dir = tempdir().expect("tempdir");
+        let profile =
+            profile_with_fs_field("unix_socket_subtree", &dir.path().display().to_string());
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert_eq!(socks[0].scope, SocketScope::DirSubtree);
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_bind_subtree() {
+        let dir = tempdir().expect("tempdir");
+        let profile = profile_with_fs_field(
+            "unix_socket_subtree_bind",
+            &dir.path().display().to_string(),
+        );
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert_eq!(socks[0].scope, SocketScope::DirSubtree);
     }
 }

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -8,7 +8,7 @@ use crate::policy;
 use crate::profile::{Profile, expand_vars};
 use crate::protected_paths::{self, ProtectedRoots};
 use nono::{
-    AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result,
+    AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result, SocketScope,
     UnixSocketCapability, UnixSocketMode,
 };
 use std::path::{Path, PathBuf};
@@ -62,29 +62,23 @@ fn try_new_unix_socket_file(
     }
 }
 
-/// Try to create a directory-scoped AF_UNIX socket capability.
-fn try_new_unix_socket_dir(
+/// Try to create a directory-backed AF_UNIX socket capability.
+fn try_new_unix_socket_dir_scoped(
     path: &Path,
     mode: UnixSocketMode,
+    scope: SocketScope,
     label: &str,
 ) -> Result<Option<UnixSocketCapability>> {
-    match UnixSocketCapability::new_dir(path, mode) {
-        Ok(cap) => Ok(Some(cap)),
-        Err(NonoError::PathNotFound(_)) => {
-            info!("{}: {}", label, path.display());
-            Ok(None)
+    let result = match scope {
+        SocketScope::DirChildren => UnixSocketCapability::new_dir(path, mode),
+        SocketScope::DirSubtree => UnixSocketCapability::new_dir_subtree(path, mode),
+        SocketScope::File => {
+            return Err(NonoError::SandboxInit(
+                "unix socket directory grant requires a directory scope".to_string(),
+            ));
         }
-        Err(e) => Err(e),
-    }
-}
-
-/// Try to create a subtree-scoped AF_UNIX socket capability.
-fn try_new_unix_socket_subtree(
-    path: &Path,
-    mode: UnixSocketMode,
-    label: &str,
-) -> Result<Option<UnixSocketCapability>> {
-    match UnixSocketCapability::new_dir_subtree(path, mode) {
+    };
+    match result {
         Ok(cap) => Ok(Some(cap)),
         Err(NonoError::PathNotFound(_)) => {
             info!("{}: {}", label, path.display());
@@ -188,7 +182,12 @@ fn add_cli_unix_socket_caps(
 
     for path in &args.allow_unix_socket_dir {
         validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
-        let sock_cap = try_new_unix_socket_dir(path, UnixSocketMode::Connect, LBL_SOCK_DIR)?;
+        let sock_cap = try_new_unix_socket_dir_scoped(
+            path,
+            UnixSocketMode::Connect,
+            SocketScope::DirChildren,
+            LBL_SOCK_DIR,
+        )?;
         if let Some(cap) = sock_cap {
             caps.add_unix_socket(cap);
             if let Some(cap) = try_new_dir(path, AccessMode::Read, LBL_FS_DIR_IMPLIED)? {
@@ -199,8 +198,12 @@ fn add_cli_unix_socket_caps(
 
     for path in &args.allow_unix_socket_dir_bind {
         validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
-        let sock_cap =
-            try_new_unix_socket_dir(path, UnixSocketMode::ConnectBind, LBL_SOCK_DIR_BIND)?;
+        let sock_cap = try_new_unix_socket_dir_scoped(
+            path,
+            UnixSocketMode::ConnectBind,
+            SocketScope::DirChildren,
+            LBL_SOCK_DIR_BIND,
+        )?;
         if let Some(cap) = sock_cap {
             caps.add_unix_socket(cap);
             if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, LBL_FS_DIR_IMPLIED)? {
@@ -211,8 +214,12 @@ fn add_cli_unix_socket_caps(
 
     for path in &args.allow_unix_socket_subtree {
         validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
-        let sock_cap =
-            try_new_unix_socket_subtree(path, UnixSocketMode::Connect, LBL_SOCK_SUBTREE)?;
+        let sock_cap = try_new_unix_socket_dir_scoped(
+            path,
+            UnixSocketMode::Connect,
+            SocketScope::DirSubtree,
+            LBL_SOCK_SUBTREE,
+        )?;
         if let Some(cap) = sock_cap {
             caps.add_unix_socket(cap);
             if let Some(cap) = try_new_dir(path, AccessMode::Read, LBL_FS_DIR_IMPLIED)? {
@@ -223,8 +230,12 @@ fn add_cli_unix_socket_caps(
 
     for path in &args.allow_unix_socket_subtree_bind {
         validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
-        let sock_cap =
-            try_new_unix_socket_subtree(path, UnixSocketMode::ConnectBind, LBL_SOCK_SUBTREE_BIND)?;
+        let sock_cap = try_new_unix_socket_dir_scoped(
+            path,
+            UnixSocketMode::ConnectBind,
+            SocketScope::DirSubtree,
+            LBL_SOCK_SUBTREE_BIND,
+        )?;
         if let Some(cap) = sock_cap {
             caps.add_unix_socket(cap);
             if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, LBL_FS_DIR_IMPLIED)? {
@@ -826,8 +837,12 @@ impl CapabilitySetExt for CapabilitySet {
                 "Profile unix socket dir '{}' does not exist, skipping",
                 path_template
             );
-            if let Some(mut cap) = try_new_unix_socket_dir(&path, UnixSocketMode::Connect, &label)?
-            {
+            if let Some(mut cap) = try_new_unix_socket_dir_scoped(
+                &path,
+                UnixSocketMode::Connect,
+                SocketScope::DirChildren,
+                &label,
+            )? {
                 cap.source = CapabilitySource::Profile;
                 caps.add_unix_socket(cap);
                 if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
@@ -849,9 +864,12 @@ impl CapabilitySetExt for CapabilitySet {
                 "Profile unix socket dir '{}' does not exist, skipping",
                 path_template
             );
-            if let Some(mut cap) =
-                try_new_unix_socket_dir(&path, UnixSocketMode::ConnectBind, &label)?
-            {
+            if let Some(mut cap) = try_new_unix_socket_dir_scoped(
+                &path,
+                UnixSocketMode::ConnectBind,
+                SocketScope::DirChildren,
+                &label,
+            )? {
                 cap.source = CapabilitySource::Profile;
                 caps.add_unix_socket(cap);
                 if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
@@ -873,9 +891,12 @@ impl CapabilitySetExt for CapabilitySet {
                 "Profile unix socket subtree '{}' does not exist, skipping",
                 path_template
             );
-            if let Some(mut cap) =
-                try_new_unix_socket_subtree(&path, UnixSocketMode::Connect, &label)?
-            {
+            if let Some(mut cap) = try_new_unix_socket_dir_scoped(
+                &path,
+                UnixSocketMode::Connect,
+                SocketScope::DirSubtree,
+                &label,
+            )? {
                 cap.source = CapabilitySource::Profile;
                 caps.add_unix_socket(cap);
                 if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
@@ -897,9 +918,12 @@ impl CapabilitySetExt for CapabilitySet {
                 "Profile unix socket subtree '{}' does not exist, skipping",
                 path_template
             );
-            if let Some(mut cap) =
-                try_new_unix_socket_subtree(&path, UnixSocketMode::ConnectBind, &label)?
-            {
+            if let Some(mut cap) = try_new_unix_socket_dir_scoped(
+                &path,
+                UnixSocketMode::ConnectBind,
+                SocketScope::DirSubtree,
+                &label,
+            )? {
                 cap.source = CapabilitySource::Profile;
                 caps.add_unix_socket(cap);
                 if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
@@ -2903,7 +2927,6 @@ mod tests {
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::Connect);
         assert!(socks[0].is_directory());
-        assert_eq!(socks[0].scope, SocketScope::DirChildren);
         assert_eq!(socks[0].scope, SocketScope::DirChildren);
 
         let fs_match = caps

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1079,6 +1079,16 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 
+    /// Allow connect() to any AF_UNIX socket within this directory subtree
+    /// (recursive; implies --read)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_subtree: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on any AF_UNIX socket within this directory
+    /// subtree (recursive; implies --allow).
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_subtree_bind: Vec<PathBuf>,
+
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     /// ALIAS(canonical="--bypass-protection", introduced="v0.41.0", remove_by="v1.0.0", issue="#594")
     #[arg(
@@ -1299,6 +1309,7 @@ pub struct SandboxArgs {
             "allow", "read", "write", "allow_file", "read_file", "write_file",
             "allow_unix_socket", "allow_unix_socket_bind",
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
+            "allow_unix_socket_subtree", "allow_unix_socket_subtree_bind",
             "profile", "bypass_protection", "suppress_save_prompt", "allow_cwd",
             "block_net", "allow_net", "network_profile", "allow_proxy",
             "allow_bind", "allow_port", "allow_connect_port", "external_proxy", "proxy_port",
@@ -1385,6 +1396,16 @@ pub struct WrapSandboxArgs {
     /// socket filenames (PID-derived paths, etc.).
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
+
+    /// Allow connect() to any AF_UNIX socket within this directory subtree
+    /// (recursive; implies --read)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_subtree: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on any AF_UNIX socket within this directory
+    /// subtree (recursive; implies --allow).
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_subtree_bind: Vec<PathBuf>,
 
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     /// ALIAS(canonical="--bypass-protection", introduced="v0.41.0", remove_by="v1.0.0", issue="#594")
@@ -1513,6 +1534,7 @@ pub struct WrapSandboxArgs {
             "allow", "read", "write", "allow_file", "read_file", "write_file",
             "allow_unix_socket", "allow_unix_socket_bind",
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
+            "allow_unix_socket_subtree", "allow_unix_socket_subtree_bind",
             "profile", "bypass_protection", "suppress_save_prompt", "allow_cwd",
             "block_net", "allow_bind", "allow_port", "allow_connect_port",
             "env_credential", "env_credential_map",
@@ -1544,6 +1566,8 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow_unix_socket_bind: args.allow_unix_socket_bind,
             allow_unix_socket_dir: args.allow_unix_socket_dir,
             allow_unix_socket_dir_bind: args.allow_unix_socket_dir_bind,
+            allow_unix_socket_subtree: args.allow_unix_socket_subtree,
+            allow_unix_socket_subtree_bind: args.allow_unix_socket_subtree_bind,
             bypass_protection: args.bypass_protection,
             suppress_save_prompt: args.suppress_save_prompt,
             allow_cwd: args.allow_cwd,
@@ -3222,6 +3246,32 @@ mod tests {
                 assert!(matches!(args.scope, Some(WhyScope::AbstractUnixSocket)));
             }
             _ => panic!("Expected Why command"),
+        }
+    }
+
+    #[test]
+    fn test_unix_socket_subtree_flags_parse() {
+        let cli = Cli::parse_from([
+            "nono",
+            "run",
+            "--allow-unix-socket-subtree",
+            "/tmp/nx",
+            "--allow-unix-socket-subtree-bind",
+            "/tmp/nx-bind",
+            "echo",
+        ]);
+        match cli.command {
+            Commands::Run(args) => {
+                assert_eq!(
+                    args.sandbox.allow_unix_socket_subtree,
+                    vec![PathBuf::from("/tmp/nx")]
+                );
+                assert_eq!(
+                    args.sandbox.allow_unix_socket_subtree_bind,
+                    vec![PathBuf::from("/tmp/nx-bind")]
+                );
+            }
+            _ => panic!("Expected Run command"),
         }
     }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1068,14 +1068,16 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_bind: Vec<PathBuf>,
 
-    /// Allow connect() to any AF_UNIX socket directly within this directory
-    /// (non-recursive; implies --read)
+    /// Allow connect() to any AF_UNIX socket directly within this directory.
+    /// Non-recursive on macOS and future Linux AF_UNIX mediation; current
+    /// Linux Landlock filesystem fallback is recursive.
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir: Vec<PathBuf>,
 
     /// Allow connect() and bind() on any AF_UNIX socket directly within this
-    /// directory (non-recursive; implies --allow). Use for runtime-generated
-    /// socket filenames (PID-derived paths, etc.).
+    /// directory. Non-recursive on macOS and future Linux AF_UNIX mediation;
+    /// current Linux Landlock filesystem fallback is recursive. Use for
+    /// runtime-generated socket filenames (PID-derived paths, etc.).
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 
@@ -1386,14 +1388,16 @@ pub struct WrapSandboxArgs {
     #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_bind: Vec<PathBuf>,
 
-    /// Allow connect() to any AF_UNIX socket directly within this directory
-    /// (non-recursive; implies --read)
+    /// Allow connect() to any AF_UNIX socket directly within this directory.
+    /// Non-recursive on macOS and future Linux AF_UNIX mediation; current
+    /// Linux Landlock filesystem fallback is recursive.
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir: Vec<PathBuf>,
 
     /// Allow connect() and bind() on any AF_UNIX socket directly within this
-    /// directory (non-recursive; implies --allow). Use for runtime-generated
-    /// socket filenames (PID-derived paths, etc.).
+    /// directory. Non-recursive on macOS and future Linux AF_UNIX mediation;
+    /// current Linux Landlock filesystem fallback is recursive. Use for
+    /// runtime-generated socket filenames (PID-derived paths, etc.).
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -127,10 +127,10 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
 
         for cap in &user_caps {
             let mode_badge = format_unix_socket_mode_badge(cap.mode);
-            let scope_suffix = if cap.is_directory {
-                "  (directory grant — sockets inside only, non-recursive)"
-            } else {
-                ""
+            let scope_suffix = match cap.scope {
+                nono::SocketScope::File => "",
+                nono::SocketScope::DirChildren => "  (directory grant — direct child sockets only)",
+                nono::SocketScope::DirSubtree => "  (subtree grant — recursive socket paths)",
             };
             if verbose > 0 {
                 let source_str = format!("{}", cap.source);

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -152,6 +152,14 @@ pub struct FilesystemConfig {
     /// or bound. Non-recursive. Implies read+write access on the directory.
     #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
     pub unix_socket_dir_bind: Vec<String>,
+    /// Directories where any descendant AF_UNIX socket may be connected to.
+    /// Recursive. Implies read access on the directory.
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
+    pub unix_socket_subtree: Vec<String>,
+    /// Directories where any descendant AF_UNIX socket may be connected to or
+    /// bound. Recursive. Implies read+write access on the directory.
+    #[serde(default, deserialize_with = "deserialize_conditional_path_vec")]
+    pub unix_socket_subtree_bind: Vec<String>,
     /// Paths denied filesystem access. Canonical location for deny entries
     /// in the #594 schema; the legacy deny-access key drains here via
     /// `deprecated_schema::LegacyPolicyPatch`.
@@ -2345,6 +2353,14 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.filesystem.unix_socket_dir_bind,
                 &child.filesystem.unix_socket_dir_bind,
             ),
+            unix_socket_subtree: dedup_append(
+                &base.filesystem.unix_socket_subtree,
+                &child.filesystem.unix_socket_subtree,
+            ),
+            unix_socket_subtree_bind: dedup_append(
+                &base.filesystem.unix_socket_subtree_bind,
+                &child.filesystem.unix_socket_subtree_bind,
+            ),
             deny: dedup_append(&base.filesystem.deny, &child.filesystem.deny),
             bypass_protection: dedup_append(
                 &base.filesystem.bypass_protection,
@@ -4224,6 +4240,8 @@ mod tests {
                 unix_socket_bind: vec![],
                 unix_socket_dir: vec![],
                 unix_socket_dir_bind: vec![],
+                unix_socket_subtree: vec![],
+                unix_socket_subtree_bind: vec![],
                 deny: vec!["/base/policy-deny".to_string()],
                 bypass_protection: vec!["/base/override-deny".to_string()],
                 suppress_save_prompt: vec!["/base/no-prompt".to_string()],
@@ -4299,6 +4317,8 @@ mod tests {
                 unix_socket_bind: vec![],
                 unix_socket_dir: vec![],
                 unix_socket_dir_bind: vec![],
+                unix_socket_subtree: vec![],
+                unix_socket_subtree_bind: vec![],
                 deny: vec!["/child/policy-deny".to_string()],
                 bypass_protection: vec!["/child/override-deny".to_string()],
                 suppress_save_prompt: vec!["/child/no-prompt".to_string()],

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -232,6 +232,43 @@ impl std::fmt::Display for UnixSocketOp {
     }
 }
 
+/// Path matching scope for a pathname AF_UNIX socket capability.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SocketScope {
+    /// A single socket path; matches only the canonical file path.
+    #[default]
+    File,
+    /// Any direct child of a directory; does not match grandchildren.
+    DirChildren,
+    /// Any descendant of a directory subtree.
+    DirSubtree,
+}
+
+impl SocketScope {
+    /// Human-readable label for summaries and diagnostics.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            SocketScope::File => "file",
+            SocketScope::DirChildren => "dir-children",
+            SocketScope::DirSubtree => "dir-subtree",
+        }
+    }
+
+    /// Whether this scope is directory-backed.
+    #[must_use]
+    pub fn is_directory(self) -> bool {
+        matches!(self, SocketScope::DirChildren | SocketScope::DirSubtree)
+    }
+}
+
+impl std::fmt::Display for SocketScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
 /// A capability granting AF_UNIX socket access on a filesystem path.
 ///
 /// Only pathname sockets (filesystem-backed) are grantable through this
@@ -247,7 +284,7 @@ impl std::fmt::Display for UnixSocketOp {
 ///   socket file).
 /// - `lib-policy-free`: this is a pure data type. Policy coupling (e.g.
 ///   auto-granting an implied `FsCapability`) lives in `nono-cli`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct UnixSocketCapability {
     /// Original path as specified by the caller, pre-canonicalisation.
     /// Retained for diagnostic output and for macOS dual-path emission
@@ -255,15 +292,49 @@ pub struct UnixSocketCapability {
     pub original: PathBuf,
     /// Canonical absolute path.
     pub resolved: PathBuf,
-    /// If `true`, the grant covers any pathname socket *directly* within
-    /// `resolved` (non-recursive: children only, not grandchildren).
-    /// If `false`, the grant is file-scoped and matches only `resolved`.
-    pub is_directory: bool,
+    /// Path matching scope for this grant.
+    pub scope: SocketScope,
     /// Which socket operations are permitted.
     pub mode: UnixSocketMode,
     /// Where this capability originated.
     #[serde(default)]
     pub source: CapabilitySource,
+}
+
+impl<'de> Deserialize<'de> for UnixSocketCapability {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            original: PathBuf,
+            resolved: PathBuf,
+            #[serde(default)]
+            scope: Option<SocketScope>,
+            #[serde(default)]
+            is_directory: Option<bool>,
+            mode: UnixSocketMode,
+            #[serde(default)]
+            source: CapabilitySource,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let scope = wire.scope.unwrap_or_else(|| {
+            if wire.is_directory.unwrap_or(false) {
+                SocketScope::DirChildren
+            } else {
+                SocketScope::File
+            }
+        });
+        Ok(Self {
+            original: wire.original,
+            resolved: wire.resolved,
+            scope,
+            mode: wire.mode,
+            source: wire.source,
+        })
+    }
 }
 
 impl UnixSocketCapability {
@@ -335,7 +406,7 @@ impl UnixSocketCapability {
         Ok(Self {
             original: path.to_path_buf(),
             resolved,
-            is_directory: false,
+            scope: SocketScope::File,
             mode,
             source: CapabilitySource::User,
         })
@@ -351,7 +422,28 @@ impl UnixSocketCapability {
     /// (cf. [`validate_platform_rule`]'s rejection of root-level subpath
     /// grants for filesystem rules). Use explicit subdirectory paths.
     pub fn new_dir(path: impl AsRef<Path>, mode: UnixSocketMode) -> Result<Self> {
+        Self::new_dir_with_scope(path, mode, SocketScope::DirChildren)
+    }
+
+    /// Grant for any pathname socket within a directory subtree.
+    ///
+    /// Recursive: sockets in nested subdirectories are covered. The directory
+    /// itself must already exist.
+    pub fn new_dir_subtree(path: impl AsRef<Path>, mode: UnixSocketMode) -> Result<Self> {
+        Self::new_dir_with_scope(path, mode, SocketScope::DirSubtree)
+    }
+
+    fn new_dir_with_scope(
+        path: impl AsRef<Path>,
+        mode: UnixSocketMode,
+        scope: SocketScope,
+    ) -> Result<Self> {
         let path = path.as_ref();
+        if !scope.is_directory() {
+            return Err(NonoError::SandboxInit(
+                "unix socket directory constructor requires a directory scope".to_string(),
+            ));
+        }
 
         let resolved = path.canonicalize().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -377,7 +469,7 @@ impl UnixSocketCapability {
         Ok(Self {
             original: path.to_path_buf(),
             resolved,
-            is_directory: true,
+            scope,
             mode,
             source: CapabilitySource::User,
         })
@@ -386,25 +478,41 @@ impl UnixSocketCapability {
     /// True if `sockaddr_path` is covered by this grant.
     ///
     /// - File grants: `sockaddr_path == resolved` exactly.
-    /// - Directory grants: `sockaddr_path`'s parent equals `resolved`,
-    ///   component-wise (non-recursive). Subdirectories are not covered.
+    /// - Direct-child directory grants: `sockaddr_path`'s parent equals
+    ///   `resolved`, component-wise (non-recursive).
+    /// - Subtree directory grants: `sockaddr_path` starts with `resolved`,
+    ///   component-wise.
     ///
     /// Uses `Path` component semantics; never string prefix
     /// (`path-component-compare` invariant).
     #[must_use]
     pub fn covers(&self, sockaddr_path: &Path) -> bool {
-        if self.is_directory {
-            sockaddr_path.parent() == Some(self.resolved.as_path())
-        } else {
-            sockaddr_path == self.resolved.as_path()
+        match self.scope {
+            SocketScope::File => sockaddr_path == self.resolved.as_path(),
+            SocketScope::DirChildren => sockaddr_path.parent() == Some(self.resolved.as_path()),
+            SocketScope::DirSubtree => {
+                sockaddr_path != self.resolved.as_path()
+                    && sockaddr_path.starts_with(&self.resolved)
+            }
         }
+    }
+
+    /// Whether this grant is directory-backed.
+    #[must_use]
+    pub fn is_directory(&self) -> bool {
+        self.scope.is_directory()
     }
 }
 
 impl std::fmt::Display for UnixSocketCapability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let scope = if self.is_directory { "dir " } else { "" };
-        write!(f, "{}{} ({})", scope, self.resolved.display(), self.mode)
+        write!(
+            f,
+            "{} {} ({})",
+            self.scope.label(),
+            self.resolved.display(),
+            self.mode
+        )
     }
 }
 
@@ -866,6 +974,20 @@ impl CapabilitySet {
         mode: UnixSocketMode,
     ) -> Result<Self> {
         let cap = UnixSocketCapability::new_dir(path, mode)?;
+        self.unix_sockets.push(cap);
+        Ok(self)
+    }
+
+    /// Add a subtree-scoped AF_UNIX socket capability (builder pattern).
+    ///
+    /// Grants cover any pathname socket below the directory recursively. The
+    /// directory must exist at grant time.
+    pub fn allow_unix_socket_subtree(
+        mut self,
+        path: impl AsRef<Path>,
+        mode: UnixSocketMode,
+    ) -> Result<Self> {
+        let cap = UnixSocketCapability::new_dir_subtree(path, mode)?;
         self.unix_sockets.push(cap);
         Ok(self)
     }
@@ -1473,7 +1595,7 @@ impl CapabilitySet {
 
     /// Deduplicate [`UnixSocketCapability`] entries in-place.
     ///
-    /// Two entries collide when they share `(resolved, is_directory)`.
+    /// Two entries collide when they share `(resolved, scope)`.
     /// Merge rules match [`Self::deduplicate`]'s user-intent policy:
     ///
     /// - **User-intent beats system/group.** When a user- or profile-
@@ -1491,13 +1613,13 @@ impl CapabilitySet {
     fn deduplicate_unix_sockets(&mut self) {
         use std::collections::HashMap;
 
-        let mut seen: HashMap<(PathBuf, bool), usize> = HashMap::new();
+        let mut seen: HashMap<(PathBuf, SocketScope), usize> = HashMap::new();
         let mut to_remove: Vec<usize> = Vec::new();
         let mut mode_upgrades: Vec<(usize, UnixSocketMode)> = Vec::new();
         let mut original_updates: Vec<(usize, PathBuf)> = Vec::new();
 
         for (i, cap) in self.unix_sockets.iter().enumerate() {
-            let key = (cap.resolved.clone(), cap.is_directory);
+            let key = (cap.resolved.clone(), cap.scope);
             if let Some(&existing_idx) = seen.get(&key) {
                 let existing = &self.unix_sockets[existing_idx];
 
@@ -1610,12 +1732,11 @@ impl CapabilitySet {
         if !self.unix_sockets.is_empty() {
             lines.push("Unix sockets:".to_string());
             for cap in &self.unix_sockets {
-                let scope = if cap.is_directory { "dir" } else { "file" };
                 lines.push(format!(
                     "  {} [{}] ({})",
                     cap.resolved.display(),
                     cap.mode,
-                    scope
+                    cap.scope
                 ));
             }
         }
@@ -2835,7 +2956,7 @@ mod tests {
 
         let cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
         assert_eq!(cap.mode, UnixSocketMode::Connect);
-        assert!(!cap.is_directory);
+        assert!(!cap.is_directory());
         assert!(cap.resolved.is_absolute());
     }
 
@@ -2848,7 +2969,7 @@ mod tests {
 
         let cap = UnixSocketCapability::new_file(&missing, UnixSocketMode::ConnectBind).unwrap();
         assert_eq!(cap.mode, UnixSocketMode::ConnectBind);
-        assert!(!cap.is_directory);
+        assert!(!cap.is_directory());
         // Resolved path is canonical-parent + final component
         assert_eq!(cap.resolved.file_name().unwrap(), "pending.sock");
         assert!(cap.resolved.parent().unwrap().is_absolute());
@@ -2882,7 +3003,19 @@ mod tests {
         let dir = tempdir().unwrap();
 
         let cap = UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::Connect).unwrap();
-        assert!(cap.is_directory);
+        assert!(cap.is_directory());
+        assert_eq!(cap.scope, SocketScope::DirChildren);
+        assert!(cap.resolved.is_absolute());
+    }
+
+    #[test]
+    fn test_unix_socket_subtree_on_existing_directory() {
+        let dir = tempdir().unwrap();
+
+        let cap =
+            UnixSocketCapability::new_dir_subtree(dir.path(), UnixSocketMode::Connect).unwrap();
+        assert!(cap.is_directory());
+        assert_eq!(cap.scope, SocketScope::DirSubtree);
         assert!(cap.resolved.is_absolute());
     }
 
@@ -2949,6 +3082,24 @@ mod tests {
     }
 
     #[test]
+    fn test_unix_socket_covers_directory_subtree() {
+        let dir = tempdir().unwrap();
+        let cap =
+            UnixSocketCapability::new_dir_subtree(dir.path(), UnixSocketMode::Connect).unwrap();
+
+        let child = cap.resolved.join("x.sock");
+        assert!(cap.covers(&child), "direct child should be covered");
+
+        let grandchild = cap.resolved.join("sub").join("x.sock");
+        assert!(cap.covers(&grandchild), "grandchild should be covered");
+
+        assert!(
+            !cap.covers(&cap.resolved),
+            "directory itself is not a socket"
+        );
+    }
+
+    #[test]
     fn test_unix_socket_covers_does_not_string_prefix() {
         // Regression: a directory grant for /tmp/foo must NOT cover
         // /tmp/foobar/x.sock, which a naive string starts_with would match.
@@ -2972,13 +3123,18 @@ mod tests {
         let file_cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
         let rendered = format!("{file_cap}");
         assert!(rendered.contains("connect"));
-        assert!(!rendered.starts_with("dir"));
+        assert!(rendered.starts_with("file "));
 
         let dir_cap =
             UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::ConnectBind).unwrap();
         let rendered = format!("{dir_cap}");
         assert!(rendered.contains("connect+bind"));
-        assert!(rendered.starts_with("dir "));
+        assert!(rendered.starts_with("dir-children "));
+
+        let subtree_cap =
+            UnixSocketCapability::new_dir_subtree(dir.path(), UnixSocketMode::Connect).unwrap();
+        let rendered = format!("{subtree_cap}");
+        assert!(rendered.starts_with("dir-subtree "));
     }
 
     #[test]
@@ -3057,6 +3213,26 @@ mod tests {
     }
 
     #[test]
+    fn test_capability_set_unix_socket_allowed_subtree_grant() {
+        let dir = tempdir().unwrap();
+        let caps = CapabilitySet::new()
+            .allow_unix_socket_subtree(dir.path(), UnixSocketMode::Connect)
+            .unwrap();
+
+        let direct_child = dir.path().canonicalize().unwrap().join("x.sock");
+        let grandchild = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("nested")
+            .join("x.sock");
+
+        assert!(caps.unix_socket_allowed(&direct_child, UnixSocketOp::Connect));
+        assert!(caps.unix_socket_allowed(&grandchild, UnixSocketOp::Connect));
+        assert!(!caps.unix_socket_allowed(&direct_child, UnixSocketOp::Bind));
+    }
+
+    #[test]
     fn test_deduplicate_unix_sockets_merges_identical_grants() {
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
@@ -3105,14 +3281,14 @@ mod tests {
         let group_cap = UnixSocketCapability {
             original: sock.clone(),
             resolved: sock.canonicalize().unwrap(),
-            is_directory: false,
+            scope: SocketScope::File,
             mode: UnixSocketMode::ConnectBind,
             source: CapabilitySource::Group("example_group".to_string()),
         };
         let user_cap = UnixSocketCapability {
             original: sock.clone(),
             resolved: sock.canonicalize().unwrap(),
-            is_directory: false,
+            scope: SocketScope::File,
             mode: UnixSocketMode::Connect,
             source: CapabilitySource::User,
         };

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -64,7 +64,7 @@ pub mod undo;
 // Re-exports for convenience
 pub use capability::{
     AccessMode, CapabilitySet, CapabilitySource, FsCapability, IpcMode, NetworkMode,
-    ProcessInfoMode, SignalMode, UnixSocketCapability, UnixSocketMode, UnixSocketOp,
+    ProcessInfoMode, SignalMode, SocketScope, UnixSocketCapability, UnixSocketMode, UnixSocketOp,
 };
 pub use diagnostic::{
     CommandContext, DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode,

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -664,9 +664,17 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         }
     }
 
-    // Add rules for each filesystem capability
-    // These MUST succeed - caller explicitly requested these capabilities
-    // Failing silently would violate the principle of least surprise and fail-secure design
+    // Add rules for each filesystem capability.
+    //
+    // These MUST succeed - caller explicitly requested these capabilities.
+    // Failing silently would violate the principle of least surprise and
+    // fail-secure design.
+    //
+    // Pathname AF_UNIX socket grants currently enter Linux enforcement only
+    // through their implied FsCapability. Landlock PathBeneath is recursive for
+    // directory grants, so SocketScope::DirChildren and SocketScope::DirSubtree
+    // are not distinguishable on this Linux path until the seccomp AF_UNIX
+    // allowlist work enforces UnixSocketCapability::covers().
     let ioctl_dev_available = AccessFs::from_all(target_abi).contains(AccessFs::IoctlDev);
 
     for cap in caps.fs_capabilities() {

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -420,24 +420,37 @@ fn emit_unix_socket_rules(profile: &mut String, caps: &CapabilitySet) -> Result<
             &["network-outbound"]
         };
 
-        if cap.is_directory {
-            let escaped = regex_escape_path_for_seatbelt(resolved_str)?;
-            let escaped_orig = original_str
-                .map(regex_escape_path_for_seatbelt)
-                .transpose()?;
-            for op in operations {
-                profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, escaped));
-                if let Some(ref e) = escaped_orig {
-                    profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, e));
+        match cap.scope {
+            crate::SocketScope::File => {
+                let escaped = escape_path(resolved_str)?;
+                let escaped_orig = original_str.map(escape_path).transpose()?;
+                for op in operations {
+                    profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, escaped));
+                    if let Some(ref e) = escaped_orig {
+                        profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, e));
+                    }
                 }
             }
-        } else {
-            let escaped = escape_path(resolved_str)?;
-            let escaped_orig = original_str.map(escape_path).transpose()?;
-            for op in operations {
-                profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, escaped));
-                if let Some(ref e) = escaped_orig {
-                    profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, e));
+            crate::SocketScope::DirChildren => {
+                let escaped = regex_escape_path_for_seatbelt(resolved_str)?;
+                let escaped_orig = original_str
+                    .map(regex_escape_path_for_seatbelt)
+                    .transpose()?;
+                for op in operations {
+                    profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, escaped));
+                    if let Some(ref e) = escaped_orig {
+                        profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, e));
+                    }
+                }
+            }
+            crate::SocketScope::DirSubtree => {
+                let escaped = escape_path(resolved_str)?;
+                let escaped_orig = original_str.map(escape_path).transpose()?;
+                for op in operations {
+                    profile.push_str(&format!("(allow {} (subpath \"{}\"))\n", op, escaped));
+                    if let Some(ref e) = escaped_orig {
+                        profile.push_str(&format!("(allow {} (subpath \"{}\"))\n", op, e));
+                    }
                 }
             }
         }
@@ -1391,7 +1404,7 @@ mod tests {
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/test.sock"),
             resolved: PathBuf::from("/private/tmp/test.sock"),
-            is_directory: false,
+            scope: crate::SocketScope::File,
             mode: crate::UnixSocketMode::Connect,
             source: CapabilitySource::User,
         });
@@ -1416,7 +1429,7 @@ mod tests {
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/var/run/app.sock"),
             resolved: PathBuf::from("/private/var/run/app.sock"),
-            is_directory: false,
+            scope: crate::SocketScope::File,
             mode: crate::UnixSocketMode::ConnectBind,
             source: CapabilitySource::User,
         });
@@ -1455,7 +1468,7 @@ mod tests {
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/var/run/client.sock"),
             resolved: PathBuf::from("/private/var/run/client.sock"),
-            is_directory: false,
+            scope: crate::SocketScope::File,
             mode: crate::UnixSocketMode::Connect,
             source: CapabilitySource::User,
         });
@@ -1481,7 +1494,7 @@ mod tests {
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/mydir"),
             resolved: PathBuf::from("/private/tmp/mydir"),
-            is_directory: true,
+            scope: crate::SocketScope::DirChildren,
             mode: crate::UnixSocketMode::ConnectBind,
             source: CapabilitySource::User,
         });
@@ -1504,6 +1517,37 @@ mod tests {
         assert!(
             !profile.contains("(allow network-outbound (subpath"),
             "directory unix socket grants must NOT use recursive subpath"
+        );
+    }
+
+    #[test]
+    fn test_generate_profile_unix_socket_subtree_emits_subpath() {
+        let mut caps = CapabilitySet::new().proxy_only(54321);
+        caps.add_unix_socket(crate::UnixSocketCapability {
+            original: PathBuf::from("/tmp/mydir"),
+            resolved: PathBuf::from("/private/tmp/mydir"),
+            scope: crate::SocketScope::DirSubtree,
+            mode: crate::UnixSocketMode::ConnectBind,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(
+            profile.contains("(allow network-outbound (subpath \"/private/tmp/mydir\"))"),
+            "subtree unix socket grants must emit recursive subpath: {profile}"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (subpath \"/tmp/mydir\"))"),
+            "symlinked original must also emit subpath form"
+        );
+        assert!(
+            profile.contains("(allow network-bind (subpath \"/private/tmp/mydir\"))"),
+            "ConnectBind subtree grant must emit network-bind subpath"
+        );
+        assert!(
+            !profile.contains("(regex \"^/private/tmp/mydir/[^/]+$\")"),
+            "subtree grant must not use direct-child regex"
         );
     }
 
@@ -1580,7 +1624,7 @@ mod tests {
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/test.sock"),
             resolved: PathBuf::from("/private/tmp/test.sock"),
-            is_directory: false,
+            scope: crate::SocketScope::File,
             mode: crate::UnixSocketMode::Connect,
             source: CapabilitySource::User,
         });

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -1523,6 +1523,13 @@ mod tests {
     #[test]
     fn test_generate_profile_unix_socket_subtree_emits_subpath() {
         let mut caps = CapabilitySet::new().proxy_only(54321);
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/tmp/mydir"),
+            resolved: PathBuf::from("/private/tmp/mydir"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
         caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/mydir"),
             resolved: PathBuf::from("/private/tmp/mydir"),
@@ -1536,6 +1543,10 @@ mod tests {
         assert!(
             profile.contains("(allow network-outbound (subpath \"/private/tmp/mydir\"))"),
             "subtree unix socket grants must emit recursive subpath: {profile}"
+        );
+        assert!(
+            profile.contains("(allow file-read* (subpath \"/private/tmp/mydir\"))"),
+            "subtree unix socket implied filesystem grant must allow recursive traversal: {profile}"
         );
         assert!(
             profile.contains("(allow network-outbound (subpath \"/tmp/mydir\"))"),

--- a/crates/nono/src/state.rs
+++ b/crates/nono/src/state.rs
@@ -3,7 +3,7 @@
 //! This module provides serialization of capability state for diagnostic purposes.
 
 use crate::capability::{
-    AccessMode, CapabilitySet, FsCapability, UnixSocketCapability, UnixSocketMode,
+    AccessMode, CapabilitySet, FsCapability, SocketScope, UnixSocketCapability, UnixSocketMode,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -41,8 +41,12 @@ pub struct UnixSocketCapState {
     pub original: PathBuf,
     /// Resolved canonical path
     pub resolved: PathBuf,
-    /// Whether the grant is directory-scoped (non-recursive)
-    pub is_directory: bool,
+    /// Path matching scope for this socket grant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SocketScope>,
+    /// Legacy state field from before `SocketScope`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_directory: Option<bool>,
     /// Mode string: "connect" or "connect+bind"
     pub mode: String,
 }
@@ -68,7 +72,8 @@ impl SandboxState {
                 .map(|cap| UnixSocketCapState {
                     original: cap.original.clone(),
                     resolved: cap.resolved.clone(),
-                    is_directory: cap.is_directory,
+                    scope: Some(cap.scope),
+                    is_directory: None,
                     mode: cap.mode.to_string(),
                 })
                 .collect(),
@@ -131,10 +136,20 @@ impl SandboxState {
             // - Crafted JSON smuggling: attacker sets an evil `original`
             //   and legit `resolved`; the reconstructed cap's actual
             //   resolved won't match the crafted one, so we reject.
-            let cap = if sock.is_directory {
-                UnixSocketCapability::new_dir(&sock.original, mode)?
-            } else {
-                UnixSocketCapability::new_file(&sock.original, mode)?
+            let scope = sock.scope.unwrap_or_else(|| {
+                if sock.is_directory.unwrap_or(false) {
+                    SocketScope::DirChildren
+                } else {
+                    SocketScope::File
+                }
+            });
+
+            let cap = match scope {
+                SocketScope::File => UnixSocketCapability::new_file(&sock.original, mode)?,
+                SocketScope::DirChildren => UnixSocketCapability::new_dir(&sock.original, mode)?,
+                SocketScope::DirSubtree => {
+                    UnixSocketCapability::new_dir_subtree(&sock.original, mode)?
+                }
             };
             if cap.resolved != sock.resolved {
                 return Err(crate::error::NonoError::ConfigParse(format!(
@@ -238,7 +253,32 @@ mod tests {
         assert_eq!(after.resolved, before.resolved);
         assert_eq!(after.original, before.original);
         assert_eq!(after.mode, before.mode);
-        assert_eq!(after.is_directory, before.is_directory);
+        assert_eq!(after.scope, before.scope);
+    }
+
+    #[test]
+    fn test_unix_socket_state_legacy_is_directory_maps_to_dir_children() {
+        use tempfile::tempdir;
+        let dir = tempdir().expect("tempdir");
+        let json = format!(
+            r#"{{
+            "fs": [],
+            "unix_sockets": [{{
+                "original": "{}",
+                "resolved": "{}",
+                "is_directory": true,
+                "mode": "connect"
+            }}],
+            "net_blocked": false
+        }}"#,
+            dir.path().display(),
+            dir.path().canonicalize().expect("canonicalize").display()
+        );
+        let state = SandboxState::from_json(&json).expect("state json");
+        let caps = state.to_caps().expect("to_caps");
+        let sockets = caps.unix_socket_capabilities();
+        assert_eq!(sockets.len(), 1);
+        assert_eq!(sockets[0].scope, SocketScope::DirChildren);
     }
 
     #[test]

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -85,6 +85,12 @@ With `--full`, additional sections are included as empty stubs for all additive 
     "allow_file": [],
     "read_file": [],
     "write_file": [],
+    "unix_socket": [],
+    "unix_socket_bind": [],
+    "unix_socket_dir": [],
+    "unix_socket_dir_bind": [],
+    "unix_socket_subtree": [],
+    "unix_socket_subtree_bind": [],
     "deny": [],
     "bypass_protection": [],
     "suppress_save_prompt": []

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -74,7 +74,9 @@ Profiles use JSON format:
     "unix_socket": [],
     "unix_socket_bind": [],
     "unix_socket_dir": [],
-    "unix_socket_dir_bind": []
+    "unix_socket_dir_bind": [],
+    "unix_socket_subtree": [],
+    "unix_socket_subtree_bind": []
   },
   "network": {
     "block": false
@@ -94,12 +96,15 @@ sockets are never grantable — only filesystem-backed socket paths.
 | `unix_socket_bind` | `connect` + `bind`, single socket file | ReadWrite on the file (exists) or on the parent directory (pending — bind will create the file) |
 | `unix_socket_dir` | `connect` only, any direct child of a directory | Read on the directory (recursive) |
 | `unix_socket_dir_bind` | `connect` + `bind`, any direct child of a directory | ReadWrite on the directory (recursive) |
+| `unix_socket_subtree` | `connect` only, any descendant of a directory | Read on the directory (recursive) |
+| `unix_socket_subtree_bind` | `connect` + `bind`, any descendant of a directory | ReadWrite on the directory (recursive) |
 
-Directory forms are **non-recursive at the socket layer**: only sockets
-directly inside the named directory are covered, not those in
+`unix_socket_dir*` forms are **non-recursive at the socket layer**: only
+sockets directly inside the named directory are covered. Use
+`unix_socket_subtree*` when a tool creates sockets below nested
 subdirectories. The implied filesystem grant is recursive (Landlock's
-only expressible granularity), so the non-recursion is enforced
-separately by the supervisor (Linux) or Seatbelt regex emission (macOS).
+only expressible granularity), so socket scope is enforced separately by
+the supervisor (Linux) or Seatbelt path emission (macOS).
 
 Under restricted network modes (`--block-net` or `--network-profile`),
 `connect(2)` to a Unix socket requires an explicit `unix_socket*` grant

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -106,6 +106,11 @@ subdirectories. The implied filesystem grant is recursive (Landlock's
 only expressible granularity), so socket scope is enforced separately by
 the supervisor (Linux) or Seatbelt path emission (macOS).
 
+Today, macOS enforces the direct-child versus subtree distinction in Seatbelt.
+Linux V4+ currently relies on Landlock filesystem rules for pathname AF_UNIX,
+so directory socket grants are recursive there until the seccomp AF_UNIX
+allowlist mediation path is enabled.
+
 Under restricted network modes (`--block-net` or `--network-profile`),
 `connect(2)` to a Unix socket requires an explicit `unix_socket*` grant
 — a plain `allow_file`/`allow` grant no longer implicitly permits it.

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -365,6 +365,25 @@ directory. Non-recursive. Use for runtime-generated socket filenames.
 nono run --block-net --allow-unix-socket-dir-bind $TMPDIR/tsx-$UID -- tsx app.ts
 ```
 
+#### `--allow-unix-socket-subtree`
+
+Allow `connect(2)` to any AF_UNIX socket within this directory subtree
+(recursive — nested subdirectories are covered). Implies read access on the
+directory.
+
+```bash
+nono run --block-net --allow-unix-socket-subtree $TMPDIR/nx -- nx serve
+```
+
+#### `--allow-unix-socket-subtree-bind`
+
+Allow `connect(2)` and `bind(2)` on any AF_UNIX socket within this directory
+subtree. Implies read/write access on the directory.
+
+```bash
+nono run --block-net --allow-unix-socket-subtree-bind $TMPDIR/nx -- nx serve
+```
+
 ### Network Control
 
 #### `--block-net`

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -365,6 +365,14 @@ directory. Non-recursive. Use for runtime-generated socket filenames.
 nono run --block-net --allow-unix-socket-dir-bind $TMPDIR/tsx-$UID -- tsx app.ts
 ```
 
+<Note>
+  On macOS, `--allow-unix-socket-dir*` is enforced as direct-child-only socket
+  access. On current Linux, pathname AF_UNIX grants are enforced through the
+  implied Landlock filesystem directory grant, which is recursive. The
+  direct-child distinction becomes enforceable on Linux when the seccomp
+  AF_UNIX allowlist path is active.
+</Note>
+
 #### `--allow-unix-socket-subtree`
 
 Allow `connect(2)` to any AF_UNIX socket within this directory subtree


### PR DESCRIPTION
This introduces new CLI flags and profile fields to grant AF_UNIX socket
access recursively within a directory subtree.

New flags:
- `--allow-unix-socket-subtree <DIR>`: connect-only access recursively.
- `--allow-unix-socket-subtree-bind <DIR>`: connect+bind access recursively.

Corresponding profile fields `filesystem.unix_socket_subtree` and
`filesystem.unix_socket_subtree_bind` are also added.

To support this, a `SocketScope` enum (File, DirChildren, DirSubtree) now
explicitly defines the matching behavior of Unix socket capabilities.
Existing `--allow-unix-socket-dir*` and `filesystem.unix_socket_dir*` grants
are now explicitly defined as `SocketScope::DirChildren`, meaning they apply
only to direct children of the specified directory.

The macOS Seatbelt sandbox now generates `(subpath ...)` rules for subtree
grants, ensuring correct recursive enforcement. Backward compatibility for
serialized `UnixSocketCapability` state (which previously used an
`is_directory` boolean) is maintained. Documentation has been updated to
reflect these new capabilities and clarify the different scopes.

Resolves: #773

Signed-off-by: Luke Hinds <lukehinds@gmail.com>

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
