### PR TITLE
feat(sandbox): add explicit allowlist for pathname af_unix sockets

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -285,6 +285,9 @@ pub struct SupervisorConfig<'a> {
     /// Bind ports allowed for seccomp proxy-only fallback.
     #[cfg(target_os = "linux")]
     pub proxy_bind_ports: Vec<u16>,
+    /// Pathname AF_UNIX socket grants allowed for seccomp proxy-only fallback.
+    #[cfg(target_os = "linux")]
+    pub unix_socket_allowlist: &'a [nono::UnixSocketCapability],
 }
 
 #[cfg(target_os = "macos")]
@@ -3705,6 +3708,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         // Fork a child that closes its socket end and exits immediately.
@@ -3805,6 +3810,8 @@ mod tests {
             proxy_port: 8080,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         match unsafe { fork() } {
@@ -3881,6 +3888,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         // Allowed origin: validation passes
@@ -3917,6 +3926,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         let result = validate_url("file:///etc/passwd", &config);
@@ -3951,6 +3962,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
         let config_deny = SupervisorConfig {
             protected_roots: &[],
@@ -3967,6 +3980,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         // Localhost denied when not allowed
@@ -4006,6 +4021,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
@@ -4148,6 +4165,8 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            unix_socket_allowlist: &[],
         };
 
         assert!(

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -1216,6 +1216,7 @@ mod tests {
             let backend = DenyAllBackend;
             let dir = tempfile::tempdir().expect("tempdir");
             let path = socket_path(&dir, "test.sock");
+            let _listener = UnixListener::bind(&path).expect("bind unix listener");
             let allowlist = vec![
                 UnixSocketCapability::new_file(&path, UnixSocketMode::Connect)
                     .expect("socket grant"),

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -11,7 +11,7 @@
 
 use super::*;
 use crate::trust_intercept::TrustInterceptor;
-use nono::{AccessMode, try_canonicalize};
+use nono::{AccessMode, UnixSocketCapability, UnixSocketOp, try_canonicalize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InitialCapability {
@@ -553,19 +553,15 @@ pub(super) enum NetworkDecision {
 ///
 /// Policy:
 ///
-/// 1. **Pathname `AF_UNIX` is allowed** (issue #685). Filesystem-backed Unix
-///    sockets like `/tmp/test.sock` are IPC bound to a real path, so
-///    Landlock's filesystem rules decide access: a bind/connect succeeds
-///    only if the path is inside an allowed grant, and fails otherwise.
-///    This restores parity with Landlock V4+, where `LANDLOCK_ACCESS_NET_*`
-///    only scopes TCP and pathname `AF_UNIX` is governed by fs rules.
+/// 1. **Pathname `AF_UNIX` is allowlist-mediated.** Filesystem-backed Unix
+///    sockets like `/tmp/test.sock` are IPC bound to a real path, so the
+///    supervisor canonicalizes that path and checks it against explicit
+///    [`UnixSocketCapability`] grants.
 ///
 ///    **Abstract and unnamed `AF_UNIX` are denied.** The abstract namespace
-///    (`sun_path[0] == '\0'`) lives outside the filesystem, so Landlock has
-///    no way to mediate it — a blanket allow would open a covert IPC
-///    channel that bypasses the sandbox. Unnamed sockets (addrlen == 2)
-///    have no path to check and no use case that motivated this fix.
-///    Future work (#696) may add an explicit allowlist for abstract paths.
+///    (`sun_path[0] == '\0'`) lives outside the filesystem, so pathname
+///    capabilities cannot mediate it. Unnamed sockets (addrlen == 2) have
+///    no path to check.
 ///
 /// 2. For `AF_INET`/`AF_INET6`:
 ///    - `connect()` is allowed only to `127.0.0.1:proxy_port` (the nono proxy).
@@ -578,23 +574,18 @@ pub(super) fn decide_network_notification(
 ) -> NetworkDecision {
     use nono::sandbox::{SYS_BIND, SYS_CONNECT, UnixSocketKind};
 
-    // AF_UNIX: allow only filesystem-backed (pathname) sockets — Landlock's
-    // filesystem rules will then decide whether the specific path is
-    // reachable. Abstract/unnamed sockets bypass fs rules, so deny them.
+    // AF_UNIX: allow only filesystem-backed (pathname) sockets that match an
+    // explicit socket capability. Abstract/unnamed sockets bypass pathname
+    // mediation, so deny them.
     if sockaddr.family == libc::AF_UNIX as u16 {
         match sockaddr.unix_kind {
             Some(UnixSocketKind::Pathname) => {
-                debug!(
-                    "Proxy seccomp: allowing AF_UNIX pathname syscall (nr={}); \
-                     governed by Landlock fs rules",
-                    syscall
-                );
-                return NetworkDecision::Allow;
+                return decide_af_unix_pathname(syscall, sockaddr, config);
             }
             Some(UnixSocketKind::Abstract) => {
                 debug!(
                     "Proxy seccomp: denying AF_UNIX abstract-namespace syscall (nr={}); \
-                     not mediated by Landlock fs rules",
+                     not mediated by pathname socket capabilities",
                     syscall
                 );
                 return NetworkDecision::Deny;
@@ -646,6 +637,124 @@ pub(super) fn decide_network_notification(
             );
             NetworkDecision::Deny
         }
+    }
+}
+
+fn decide_af_unix_pathname(
+    syscall: i32,
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    config: &SupervisorConfig<'_>,
+) -> NetworkDecision {
+    let Some(path) = sockaddr.unix_path.as_deref() else {
+        debug!(
+            "Proxy seccomp: denying AF_UNIX pathname syscall (nr={}) without parsed path",
+            syscall
+        );
+        return NetworkDecision::Deny;
+    };
+
+    let Some(op) = unix_socket_op_for_syscall(syscall) else {
+        warn!(
+            "Unexpected AF_UNIX syscall {} in proxy seccomp handler, denying",
+            syscall
+        );
+        return NetworkDecision::Deny;
+    };
+
+    let canonical = match op {
+        UnixSocketOp::Connect => match path.canonicalize() {
+            Ok(path) => path,
+            Err(err) => {
+                debug!(
+                    "Proxy seccomp: denying AF_UNIX connect to {}: canonicalize failed: {}",
+                    path.display(),
+                    err
+                );
+                return NetworkDecision::Deny;
+            }
+        },
+        UnixSocketOp::Bind => match canonicalize_unix_socket_bind_path(path) {
+            Ok(path) => path,
+            Err(err) => {
+                debug!(
+                    "Proxy seccomp: denying AF_UNIX bind to {}: canonicalize failed: {}",
+                    path.display(),
+                    err
+                );
+                return NetworkDecision::Deny;
+            }
+        },
+    };
+
+    if unix_socket_allowlist_allows(config.unix_socket_allowlist, canonical.as_path(), op) {
+        debug!(
+            "Proxy seccomp: allowing AF_UNIX {} on {}",
+            op,
+            canonical.display()
+        );
+        NetworkDecision::Allow
+    } else {
+        debug!(
+            "Proxy seccomp: denying AF_UNIX {} on {}: no matching capability",
+            op,
+            canonical.display()
+        );
+        NetworkDecision::Deny
+    }
+}
+
+fn unix_socket_op_for_syscall(syscall: i32) -> Option<UnixSocketOp> {
+    use nono::sandbox::{SYS_BIND, SYS_CONNECT};
+
+    match syscall {
+        SYS_CONNECT => Some(UnixSocketOp::Connect),
+        SYS_BIND => Some(UnixSocketOp::Bind),
+        _ => None,
+    }
+}
+
+fn unix_socket_allowlist_allows(
+    allowlist: &[UnixSocketCapability],
+    path: &std::path::Path,
+    op: UnixSocketOp,
+) -> bool {
+    allowlist.iter().any(|cap| {
+        cap.covers(path)
+            && match op {
+                UnixSocketOp::Connect => true,
+                UnixSocketOp::Bind => cap.mode.permits_bind(),
+            }
+    })
+}
+
+fn canonicalize_unix_socket_bind_path(
+    path: &std::path::Path,
+) -> std::io::Result<std::path::PathBuf> {
+    match path.canonicalize() {
+        Ok(path) => Ok(path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let parent = path.parent().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "socket path has no parent directory",
+                )
+            })?;
+            let file_name = path.file_name().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "socket path has no final component",
+                )
+            })?;
+            let resolved_parent = parent.canonicalize()?;
+            if !resolved_parent.is_dir() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "socket parent is not a directory",
+                ));
+            }
+            Ok(resolved_parent.join(file_name))
+        }
+        Err(err) => Err(err),
     }
 }
 
@@ -941,16 +1050,18 @@ mod tests {
     // --- decide_network_notification tests (issue #685) ---------------------
     //
     // These exercise the proxy-only seccomp fallback path that runs on
-    // Landlock < V4 kernels. The key invariant: `AF_UNIX` must be allowed
-    // through so Landlock's filesystem rules decide access, matching V4+
-    // behavior where `LANDLOCK_ACCESS_NET_*` only scopes TCP.
+    // Landlock < V4 kernels. The key invariant: pathname `AF_UNIX` must be
+    // checked against the explicit Unix-socket allowlist instead of being
+    // decided by TCP proxy ports.
 
     mod network_decision {
         use super::super::{NetworkDecision, SupervisorConfig, decide_network_notification};
         use nix::libc;
-        use nono::ApprovalBackend;
         use nono::sandbox::{SYS_BIND, SYS_CONNECT, SockaddrInfo, UnixSocketKind};
         use nono::supervisor::{ApprovalDecision, CapabilityRequest};
+        use nono::{ApprovalBackend, UnixSocketCapability, UnixSocketMode};
+        use std::os::unix::net::UnixListener;
+        use std::path::{Path, PathBuf};
 
         struct DenyAllBackend;
         impl ApprovalBackend for DenyAllBackend {
@@ -971,6 +1082,7 @@ mod tests {
             backend: &'a DenyAllBackend,
             proxy_port: u16,
             proxy_bind_ports: Vec<u16>,
+            unix_socket_allowlist: &'a [UnixSocketCapability],
         ) -> SupervisorConfig<'a> {
             static REDACTION_POLICY: std::sync::LazyLock<nono::ScrubPolicy> =
                 std::sync::LazyLock::new(nono::ScrubPolicy::secure_default);
@@ -987,10 +1099,11 @@ mod tests {
                 allow_launch_services_active: false,
                 proxy_port,
                 proxy_bind_ports,
+                unix_socket_allowlist,
             }
         }
 
-        fn unix_pathname() -> SockaddrInfo {
+        fn unix_pathname(path: &Path) -> SockaddrInfo {
             // Matches what read_notif_sockaddr() produces for a
             // filesystem-backed AF_UNIX socket (e.g. /tmp/test.sock).
             SockaddrInfo {
@@ -998,6 +1111,7 @@ mod tests {
                 port: 0,
                 is_loopback: true,
                 unix_kind: Some(UnixSocketKind::Pathname),
+                unix_path: Some(path.to_path_buf()),
             }
         }
 
@@ -1007,6 +1121,7 @@ mod tests {
                 port: 0,
                 is_loopback: true,
                 unix_kind: Some(UnixSocketKind::Abstract),
+                unix_path: None,
             }
         }
 
@@ -1016,6 +1131,7 @@ mod tests {
                 port: 0,
                 is_loopback: true,
                 unix_kind: Some(UnixSocketKind::Unnamed),
+                unix_path: None,
             }
         }
 
@@ -1025,6 +1141,7 @@ mod tests {
                 port,
                 is_loopback: true,
                 unix_kind: None,
+                unix_path: None,
             }
         }
 
@@ -1034,50 +1151,134 @@ mod tests {
                 port,
                 is_loopback: false,
                 unix_kind: None,
+                unix_path: None,
             }
         }
 
-        /// Regression test for #685: pathname `bind(AF_UNIX, "/tmp/…")` was
-        /// being denied because `SockaddrInfo.port` is 0 for unix sockets
-        /// and port 0 is never in `proxy_bind_ports`. It must now allow so
-        /// Landlock's filesystem rules decide whether the path is reachable.
+        fn socket_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+            dir.path().join(name)
+        }
+
+        /// Pathname `bind(AF_UNIX, "/tmp/…")` is mediated by explicit
+        /// Unix-socket grants, not TCP bind ports.
         #[test]
-        fn af_unix_pathname_bind_is_allowed() {
+        fn af_unix_pathname_bind_is_allowed_by_connect_bind_grant() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 0, Vec::new());
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = socket_path(&dir, "test.sock");
+            let allowlist = vec![
+                UnixSocketCapability::new_file(&path, UnixSocketMode::ConnectBind)
+                    .expect("socket grant"),
+            ];
+            let config = make_config(&backend, 0, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(), &config),
+                decide_network_notification(SYS_BIND, &unix_pathname(&path), &config),
                 NetworkDecision::Allow,
-                "pathname AF_UNIX bind must be allowed so Landlock fs rules govern access"
+                "pathname AF_UNIX bind must be allowed when a connect+bind grant covers it"
             );
         }
 
-        /// Regression test for #685: pathname `connect(AF_UNIX, "/tmp/…")`
-        /// was the failure mode for `tsx`'s IPC pipe and other runtimes.
+        /// Pathname `connect(AF_UNIX, "/tmp/…")` is allowed only when the
+        /// canonical socket path matches the explicit allowlist.
         #[test]
-        fn af_unix_pathname_connect_is_allowed() {
+        fn af_unix_pathname_connect_is_allowed_by_grant() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 8080, Vec::new());
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = socket_path(&dir, "test.sock");
+            let _listener = UnixListener::bind(&path).expect("bind unix listener");
+            let allowlist = vec![
+                UnixSocketCapability::new_file(&path, UnixSocketMode::Connect)
+                    .expect("socket grant"),
+            ];
+            let config = make_config(&backend, 8080, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_CONNECT, &unix_pathname(), &config),
+                decide_network_notification(SYS_CONNECT, &unix_pathname(&path), &config),
                 NetworkDecision::Allow,
-                "pathname AF_UNIX connect must be allowed independent of proxy_port"
+                "pathname AF_UNIX connect must be allowed when a connect grant covers it"
+            );
+        }
+
+        #[test]
+        fn af_unix_pathname_connect_without_grant_is_denied() {
+            let backend = DenyAllBackend;
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = socket_path(&dir, "test.sock");
+            let _listener = UnixListener::bind(&path).expect("bind unix listener");
+            let config = make_config(&backend, 8080, Vec::new(), &[]);
+            assert_eq!(
+                decide_network_notification(SYS_CONNECT, &unix_pathname(&path), &config),
+                NetworkDecision::Deny
+            );
+        }
+
+        #[test]
+        fn af_unix_pathname_bind_requires_connect_bind_grant() {
+            let backend = DenyAllBackend;
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = socket_path(&dir, "test.sock");
+            let allowlist = vec![
+                UnixSocketCapability::new_file(&path, UnixSocketMode::Connect)
+                    .expect("socket grant"),
+            ];
+            let config = make_config(&backend, 0, Vec::new(), &allowlist);
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_pathname(&path), &config),
+                NetworkDecision::Deny
+            );
+        }
+
+        #[test]
+        fn af_unix_dir_children_does_not_allow_nested_path() {
+            let backend = DenyAllBackend;
+            let dir = tempfile::tempdir().expect("tempdir");
+            let nested = dir.path().join("nested");
+            std::fs::create_dir(&nested).expect("create nested dir");
+            let direct_path = socket_path(&dir, "direct.sock");
+            let nested_path = nested.join("nested.sock");
+            let allowlist = vec![
+                UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::ConnectBind)
+                    .expect("socket dir grant"),
+            ];
+            let config = make_config(&backend, 0, Vec::new(), &allowlist);
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_pathname(&direct_path), &config),
+                NetworkDecision::Allow
+            );
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_pathname(&nested_path), &config),
+                NetworkDecision::Deny
+            );
+        }
+
+        #[test]
+        fn af_unix_dir_subtree_allows_nested_path() {
+            let backend = DenyAllBackend;
+            let dir = tempfile::tempdir().expect("tempdir");
+            let nested = dir.path().join("nested");
+            std::fs::create_dir(&nested).expect("create nested dir");
+            let nested_path = nested.join("nested.sock");
+            let allowlist = vec![
+                UnixSocketCapability::new_dir_subtree(dir.path(), UnixSocketMode::ConnectBind)
+                    .expect("socket subtree grant"),
+            ];
+            let config = make_config(&backend, 0, Vec::new(), &allowlist);
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_pathname(&nested_path), &config),
+                NetworkDecision::Allow
             );
         }
 
         /// Scope-limit test: abstract-namespace AF_UNIX (`sun_path[0] == 0`)
-        /// is *not* governed by Landlock filesystem rules, so a blanket
-        /// allow would open a covert IPC channel that bypasses the sandbox.
-        /// #685 is explicitly about filesystem-path sockets; abstract stays
-        /// denied pending #696 (explicit allowlist).
+        /// is not covered by pathname socket capabilities, so it stays
+        /// denied.
         #[test]
         fn af_unix_abstract_is_denied() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 0, Vec::new());
+            let config = make_config(&backend, 0, Vec::new(), &[]);
             assert_eq!(
                 decide_network_notification(SYS_BIND, &unix_abstract(), &config),
                 NetworkDecision::Deny,
-                "abstract AF_UNIX must be denied — Landlock fs rules do not reach it"
+                "abstract AF_UNIX must be denied because pathname grants do not cover it"
             );
             assert_eq!(
                 decide_network_notification(SYS_CONNECT, &unix_abstract(), &config),
@@ -1086,12 +1287,11 @@ mod tests {
         }
 
         /// Unnamed AF_UNIX (`addrlen == 2`) has no path to check, so fail
-        /// closed — consistent with abstract handling and outside #685's
-        /// scope.
+        /// closed — consistent with abstract handling.
         #[test]
         fn af_unix_unnamed_is_denied() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 0, Vec::new());
+            let config = make_config(&backend, 0, Vec::new(), &[]);
             assert_eq!(
                 decide_network_notification(SYS_BIND, &unix_unnamed(), &config),
                 NetworkDecision::Deny
@@ -1105,7 +1305,7 @@ mod tests {
         #[test]
         fn af_inet_connect_to_external_host_denied() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 8080, Vec::new());
+            let config = make_config(&backend, 8080, Vec::new(), &[]);
             assert_eq!(
                 decide_network_notification(SYS_CONNECT, &inet_external(8080), &config),
                 NetworkDecision::Deny
@@ -1117,7 +1317,7 @@ mod tests {
         #[test]
         fn af_inet_bind_on_disallowed_port_denied() {
             let backend = DenyAllBackend;
-            let config = make_config(&backend, 0, vec![3000]);
+            let config = make_config(&backend, 0, vec![3000], &[]);
             assert_eq!(
                 decide_network_notification(SYS_BIND, &inet_loopback(4000), &config),
                 NetworkDecision::Deny

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -568,6 +568,7 @@ pub(super) enum NetworkDecision {
 ///    - `bind()` is allowed only on ports in `proxy_bind_ports`.
 ///    - Everything else is denied.
 pub(super) fn decide_network_notification(
+    child_pid: u32,
     syscall: i32,
     sockaddr: &nono::sandbox::SockaddrInfo,
     config: &SupervisorConfig<'_>,
@@ -580,7 +581,7 @@ pub(super) fn decide_network_notification(
     if sockaddr.family == libc::AF_UNIX as u16 {
         match sockaddr.unix_kind {
             Some(UnixSocketKind::Pathname) => {
-                return decide_af_unix_pathname(syscall, sockaddr, config);
+                return decide_af_unix_pathname(child_pid, syscall, sockaddr, config);
             }
             Some(UnixSocketKind::Abstract) => {
                 debug!(
@@ -641,6 +642,7 @@ pub(super) fn decide_network_notification(
 }
 
 fn decide_af_unix_pathname(
+    child_pid: u32,
     syscall: i32,
     sockaddr: &nono::sandbox::SockaddrInfo,
     config: &SupervisorConfig<'_>,
@@ -661,24 +663,37 @@ fn decide_af_unix_pathname(
         return NetworkDecision::Deny;
     };
 
+    let resolved_path = match resolve_af_unix_sockaddr_path(child_pid, path) {
+        Ok(path) => path,
+        Err(err) => {
+            debug!(
+                "Proxy seccomp: denying AF_UNIX {} on {}: child-relative resolution failed: {}",
+                op,
+                path.display(),
+                err
+            );
+            return NetworkDecision::Deny;
+        }
+    };
+
     let canonical = match op {
-        UnixSocketOp::Connect => match path.canonicalize() {
+        UnixSocketOp::Connect => match resolved_path.canonicalize() {
             Ok(path) => path,
             Err(err) => {
                 debug!(
                     "Proxy seccomp: denying AF_UNIX connect to {}: canonicalize failed: {}",
-                    path.display(),
+                    resolved_path.display(),
                     err
                 );
                 return NetworkDecision::Deny;
             }
         },
-        UnixSocketOp::Bind => match canonicalize_unix_socket_bind_path(path) {
+        UnixSocketOp::Bind => match canonicalize_unix_socket_bind_path(&resolved_path) {
             Ok(path) => path,
             Err(err) => {
                 debug!(
                     "Proxy seccomp: denying AF_UNIX bind to {}: canonicalize failed: {}",
-                    path.display(),
+                    resolved_path.display(),
                     err
                 );
                 return NetworkDecision::Deny;
@@ -701,6 +716,16 @@ fn decide_af_unix_pathname(
         );
         NetworkDecision::Deny
     }
+}
+
+fn resolve_af_unix_sockaddr_path(
+    child_pid: u32,
+    path: &std::path::Path,
+) -> nono::Result<std::path::PathBuf> {
+    use nono::sandbox::resolve_notif_path;
+
+    let at_fdcwd = libc::AT_FDCWD as i64 as u64;
+    resolve_notif_path(child_pid, at_fdcwd, path)
 }
 
 fn unix_socket_op_for_syscall(syscall: i32) -> Option<UnixSocketOp> {
@@ -802,7 +827,7 @@ pub(super) fn handle_network_notification(
         return Ok(());
     }
 
-    match decide_network_notification(notif.data.nr, &sockaddr, config) {
+    match decide_network_notification(notif.pid, notif.data.nr, &sockaddr, config) {
         NetworkDecision::Allow => {
             // SECCOMP_USER_NOTIF_FLAG_CONTINUE: let the kernel proceed with its
             // already-copied sockaddr. Safe for connect/bind (move_addr_to_kernel).
@@ -1159,6 +1184,10 @@ mod tests {
             dir.path().join(name)
         }
 
+        fn test_pid() -> u32 {
+            std::process::id()
+        }
+
         /// Pathname `bind(AF_UNIX, "/tmp/…")` is mediated by explicit
         /// Unix-socket grants, not TCP bind ports.
         #[test]
@@ -1172,7 +1201,7 @@ mod tests {
             ];
             let config = make_config(&backend, 0, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(&path), &config),
+                decide_network_notification(test_pid(), SYS_BIND, &unix_pathname(&path), &config),
                 NetworkDecision::Allow,
                 "pathname AF_UNIX bind must be allowed when a connect+bind grant covers it"
             );
@@ -1192,7 +1221,12 @@ mod tests {
             ];
             let config = make_config(&backend, 8080, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_CONNECT, &unix_pathname(&path), &config),
+                decide_network_notification(
+                    test_pid(),
+                    SYS_CONNECT,
+                    &unix_pathname(&path),
+                    &config,
+                ),
                 NetworkDecision::Allow,
                 "pathname AF_UNIX connect must be allowed when a connect grant covers it"
             );
@@ -1206,7 +1240,12 @@ mod tests {
             let _listener = UnixListener::bind(&path).expect("bind unix listener");
             let config = make_config(&backend, 8080, Vec::new(), &[]);
             assert_eq!(
-                decide_network_notification(SYS_CONNECT, &unix_pathname(&path), &config),
+                decide_network_notification(
+                    test_pid(),
+                    SYS_CONNECT,
+                    &unix_pathname(&path),
+                    &config,
+                ),
                 NetworkDecision::Deny
             );
         }
@@ -1223,7 +1262,7 @@ mod tests {
             ];
             let config = make_config(&backend, 0, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(&path), &config),
+                decide_network_notification(test_pid(), SYS_BIND, &unix_pathname(&path), &config),
                 NetworkDecision::Deny
             );
         }
@@ -1242,11 +1281,21 @@ mod tests {
             ];
             let config = make_config(&backend, 0, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(&direct_path), &config),
+                decide_network_notification(
+                    test_pid(),
+                    SYS_BIND,
+                    &unix_pathname(&direct_path),
+                    &config,
+                ),
                 NetworkDecision::Allow
             );
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(&nested_path), &config),
+                decide_network_notification(
+                    test_pid(),
+                    SYS_BIND,
+                    &unix_pathname(&nested_path),
+                    &config,
+                ),
                 NetworkDecision::Deny
             );
         }
@@ -1264,7 +1313,12 @@ mod tests {
             ];
             let config = make_config(&backend, 0, Vec::new(), &allowlist);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_pathname(&nested_path), &config),
+                decide_network_notification(
+                    test_pid(),
+                    SYS_BIND,
+                    &unix_pathname(&nested_path),
+                    &config,
+                ),
                 NetworkDecision::Allow
             );
         }
@@ -1277,12 +1331,12 @@ mod tests {
             let backend = DenyAllBackend;
             let config = make_config(&backend, 0, Vec::new(), &[]);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_abstract(), &config),
+                decide_network_notification(test_pid(), SYS_BIND, &unix_abstract(), &config),
                 NetworkDecision::Deny,
                 "abstract AF_UNIX must be denied because pathname grants do not cover it"
             );
             assert_eq!(
-                decide_network_notification(SYS_CONNECT, &unix_abstract(), &config),
+                decide_network_notification(test_pid(), SYS_CONNECT, &unix_abstract(), &config),
                 NetworkDecision::Deny,
             );
         }
@@ -1294,7 +1348,7 @@ mod tests {
             let backend = DenyAllBackend;
             let config = make_config(&backend, 0, Vec::new(), &[]);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &unix_unnamed(), &config),
+                decide_network_notification(test_pid(), SYS_BIND, &unix_unnamed(), &config),
                 NetworkDecision::Deny
             );
         }
@@ -1308,7 +1362,7 @@ mod tests {
             let backend = DenyAllBackend;
             let config = make_config(&backend, 8080, Vec::new(), &[]);
             assert_eq!(
-                decide_network_notification(SYS_CONNECT, &inet_external(8080), &config),
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_external(8080), &config),
                 NetworkDecision::Deny
             );
         }
@@ -1320,7 +1374,7 @@ mod tests {
             let backend = DenyAllBackend;
             let config = make_config(&backend, 0, vec![3000], &[]);
             assert_eq!(
-                decide_network_notification(SYS_BIND, &inet_loopback(4000), &config),
+                decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(4000), &config),
                 NetworkDecision::Deny
             );
         }

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -244,6 +244,8 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
             nono::NetworkMode::ProxyOnly { bind_ports, .. } => bind_ports.clone(),
             _ => Vec::new(),
         },
+        #[cfg(target_os = "linux")]
+        unix_socket_allowlist: caps.unix_socket_capabilities(),
     };
 
     let exit_code = {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -7,7 +7,7 @@ use landlock::{
     ABI, Access, AccessFs, AccessNet, BitFlags, CompatLevel, Compatible, NetPort, PathBeneath,
     PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr, Scope,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tracing::{debug, info, warn};
 
@@ -1608,15 +1608,14 @@ pub fn deny_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
 /// Kind of AF_UNIX socket, determined from `sun_path` and `addrlen`.
 ///
 /// See `unix(7)`. This distinction matters for policy because only
-/// [`UnixSocketKind::Pathname`] sockets are governed by filesystem rules.
-/// Abstract and unnamed sockets live in a separate namespace that Landlock's
-/// filesystem rules cannot reach, so the supervisor must decide them
-/// explicitly.
+/// [`UnixSocketKind::Pathname`] sockets can be matched against filesystem
+/// paths. Abstract and unnamed sockets live in a separate namespace, so the
+/// supervisor must decide them explicitly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnixSocketKind {
     /// Filesystem-backed: `sun_path` is a null-terminated filesystem path
     /// (e.g. `/tmp/test.sock`). Access is governed by filesystem permissions
-    /// and — in our case — by Landlock's filesystem rules.
+    /// and nono's pathname socket capability allowlist.
     Pathname,
     /// Linux abstract namespace: `sun_path[0] == '\0'` and bytes `[1..]` form
     /// the abstract name. Not backed by any filesystem, so Landlock's
@@ -1662,6 +1661,9 @@ pub struct SockaddrInfo {
     /// For `AF_UNIX`: kind of socket (pathname / abstract / unnamed). `None`
     /// for non-UNIX address families.
     pub unix_kind: Option<UnixSocketKind>,
+    /// For pathname `AF_UNIX`: filesystem path from `sockaddr_un.sun_path`.
+    /// `None` for non-UNIX, abstract, unnamed, or unclassified sockets.
+    pub unix_path: Option<PathBuf>,
 }
 
 /// Seccomp network fallback mode determined during sandbox apply.
@@ -1719,8 +1721,8 @@ pub fn seccomp_network_fallback_mode(caps: &CapabilitySet) -> SeccompNetFallback
 ///
 /// - `AF_INET`/`AF_INET6`: allow connect to `localhost:proxy_port`;
 ///   allow bind on ports in the configured bind-ports list; deny others.
-/// - pathname `AF_UNIX` (#685): allow both connect and bind. Landlock's
-///   filesystem rules are the upstream gate on which paths are reachable.
+/// - pathname `AF_UNIX`: route to the supervisor, which checks the explicit
+///   Unix socket capability allowlist against the requested path.
 /// - abstract/unnamed `AF_UNIX`: deny (see `decide_network_notification`).
 ///
 /// `has_bind_ports` is retained for API compatibility but no longer
@@ -1759,9 +1761,9 @@ fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
     let errno_ret = SECCOMP_RET_ERRNO | (libc::EACCES as u32);
 
     // bind() always routes to USER_NOTIF so the supervisor can make the
-    // per-family decision (deny AF_INET to non-allowed TCP ports; allow
-    // pathname AF_UNIX per issue #685). The previous variant took a
-    // has_bind_ports short-circuit to ERRNO when no TCP bind ports were
+    // per-family decision (deny AF_INET to non-allowed TCP ports; check
+    // pathname AF_UNIX against the explicit socket allowlist). The previous
+    // variant took a has_bind_ports short-circuit to ERRNO when no TCP bind ports were
     // configured, which unconditionally failed AF_UNIX bind — a real
     // regression that only manifested on Landlock V2 kernels (where this
     // seccomp fallback fires). The has_bind_ports parameter is retained
@@ -2026,6 +2028,7 @@ pub fn install_seccomp_proxy_filter(has_bind_ports: bool) -> Result<std::os::fd:
 /// too small to parse.
 pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<SockaddrInfo> {
     use std::io::Read;
+    use std::os::unix::ffi::OsStringExt;
 
     // Minimum size: sa_family (2 bytes)
     if addrlen < 2 {
@@ -2041,9 +2044,13 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
     std::io::Seek::seek(&mut file, std::io::SeekFrom::Start(addr_ptr))
         .map_err(|e| NonoError::SandboxInit(format!("Failed to seek in {}: {}", mem_path, e)))?;
 
-    // Read up to sizeof(sockaddr_in6) = 28 bytes. This covers both IPv4 (16) and IPv6 (28).
-    let read_len = std::cmp::min(addrlen as usize, 28);
-    let mut buf = [0u8; 28];
+    let sockaddr_un_len = std::mem::size_of::<libc::sockaddr_un>();
+    let max_sockaddr_len = sockaddr_un_len.max(28);
+    let requested_len = usize::try_from(addrlen).map_err(|_| {
+        NonoError::SandboxInit(format!("sockaddr length too large to parse: {addrlen}"))
+    })?;
+    let read_len = std::cmp::min(requested_len, max_sockaddr_len);
+    let mut buf = vec![0u8; read_len];
     let n = file.read(&mut buf[..read_len]).map_err(|e| {
         NonoError::SandboxInit(format!("Failed to read sockaddr from {}: {}", mem_path, e))
     })?;
@@ -2076,6 +2083,7 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
                 port,
                 is_loopback,
                 unix_kind: None,
+                unix_path: None,
             })
         }
         libc::AF_INET6 => {
@@ -2100,17 +2108,40 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
                 port,
                 is_loopback: is_loopback || is_v4_mapped_loopback,
                 unix_kind: None,
+                unix_path: None,
             })
         }
         libc::AF_UNIX => {
+            if requested_len > sockaddr_un_len {
+                return Err(NonoError::SandboxInit(format!(
+                    "sockaddr_un length {} exceeds maximum {}",
+                    requested_len, sockaddr_un_len
+                )));
+            }
             // sun_path starts at offset 2. buf has `n` bytes total; we need
             // addrlen to distinguish unnamed from path-bearing sockets.
             let sun_path_first_byte = if n >= 3 { Some(buf[2]) } else { None };
+            let unix_kind = classify_af_unix(addrlen, sun_path_first_byte);
+            let unix_path = if matches!(unix_kind, UnixSocketKind::Pathname) {
+                let path_bytes = &buf[2..n];
+                let nul_pos = path_bytes
+                    .iter()
+                    .position(|byte| *byte == 0)
+                    .unwrap_or(path_bytes.len());
+                if nul_pos == 0 {
+                    None
+                } else {
+                    Some(std::ffi::OsString::from_vec(path_bytes[..nul_pos].to_vec()).into())
+                }
+            } else {
+                None
+            };
             Ok(SockaddrInfo {
                 family,
                 port: 0,
                 is_loopback: true, // Unix sockets are always local
-                unix_kind: Some(classify_af_unix(addrlen, sun_path_first_byte)),
+                unix_kind: Some(unix_kind),
+                unix_path,
             })
         }
         _ => Ok(SockaddrInfo {
@@ -2118,6 +2149,7 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
             port: 0,
             is_loopback: false,
             unix_kind: None,
+            unix_path: None,
         }),
     }
 }
@@ -3203,6 +3235,7 @@ mod tests {
             port: 8080,
             is_loopback: true,
             unix_kind: None,
+            unix_path: None,
         };
         assert!(info.is_loopback);
         assert_eq!(info.port, 8080);
@@ -3215,6 +3248,7 @@ mod tests {
             port: 443,
             is_loopback: true,
             unix_kind: None,
+            unix_path: None,
         };
         assert!(info.is_loopback);
     }
@@ -3226,6 +3260,7 @@ mod tests {
             port: 80,
             is_loopback: false,
             unix_kind: None,
+            unix_path: None,
         };
         assert!(!info.is_loopback);
     }
@@ -3237,6 +3272,7 @@ mod tests {
             port: 0,
             is_loopback: true,
             unix_kind: Some(UnixSocketKind::Pathname),
+            unix_path: Some(PathBuf::from("/tmp/test.sock")),
         };
         assert!(info.is_loopback);
         assert_eq!(info.port, 0);

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -2049,8 +2049,15 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
     let requested_len = usize::try_from(addrlen).map_err(|_| {
         NonoError::SandboxInit(format!("sockaddr length too large to parse: {addrlen}"))
     })?;
+    const SOCKADDR_STACK_LEN: usize = 128;
+    if max_sockaddr_len > SOCKADDR_STACK_LEN {
+        return Err(NonoError::SandboxInit(format!(
+            "maximum sockaddr length {} exceeds stack buffer {}",
+            max_sockaddr_len, SOCKADDR_STACK_LEN
+        )));
+    }
     let read_len = std::cmp::min(requested_len, max_sockaddr_len);
-    let mut buf = vec![0u8; read_len];
+    let mut buf = [0u8; SOCKADDR_STACK_LEN];
     let n = file.read(&mut buf[..read_len]).map_err(|e| {
         NonoError::SandboxInit(format!("Failed to read sockaddr from {}: {}", mem_path, e))
     })?;


### PR DESCRIPTION
The seccomp-based network fallback (used on Landlock < V4 kernels) now requires explicit capabilities for pathname AF_UNIX sockets.

Previously, pathname AF_UNIX bind/connect calls were unconditionally allowed, relying solely on Landlock filesystem rules. This exposed a channel for IPC that bypassed nono's explicit network policy.

This change introduces a `unix_socket_allowlist` on `SupervisorConfig` to mediate access:
- When a pathname AF_UNIX syscall (bind or connect) occurs, the socket path is canonicalized.
- The canonical path and operation (connect/bind) are checked against the `unix_socket_allowlist`.
- Abstract and unnamed AF_UNIX sockets continue to be denied as they cannot be mediated by filesystem paths.

This provides more granular control and closes a security gap by aligning the seccomp fallback policy more closely with Landlock V4+ where `LANDLOCK_ACCESS_NET` does not apply to pathname AF_UNIX.

Closes: #527

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

