### PR TITLE
feat(profiles): verify pack signer identities and allow use of org/repo pull format

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1632,7 +1632,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
 
     // Pack-store: any installed pack that declares a profile artifact with
     // matching `install_as`.
-    if let Some(profile_path) = find_pack_store_profile(name_or_path) {
+    if let Some((profile_path, _)) = find_pack_store_profile(name_or_path) {
         return parse_profile_file(&profile_path)
             .ok()
             .and_then(|p| p.extends);
@@ -1682,12 +1682,16 @@ pub fn load_profile(name_or_path: &str) -> Result<Profile> {
                 // Pull completed AND the wiring interpreter ran during
                 // install — no extra "wire" pass needed here. Just
                 // re-resolve through the pack-store branch and load.
-                if let Some(profile_path) = find_pack_store_profile(name_or_path) {
+                if let Some((profile_path, pack_key)) = find_pack_store_profile(name_or_path) {
                     tracing::info!(
                         "Loading pack-store profile from: {}",
                         profile_path.display()
                     );
-                    return finalize_profile(load_from_file(&profile_path)?);
+                    let mut profile = finalize_profile(load_from_file(&profile_path)?)?;
+                    if !profile.packs.contains(&pack_key) {
+                        profile.packs.push(pack_key);
+                    }
+                    return Ok(profile);
                 }
                 Err(NonoError::ProfileNotFound(format!(
                     "{name_or_path}\n  the registry pack pulled but did not install \
@@ -1770,12 +1774,17 @@ fn load_profile_inner(name_or_path: &str) -> Result<Option<Profile>> {
         tracing::info!("Loading user profile from: {}", profile_path.display());
         return finalize_profile(load_from_file(&profile_path)?).map(Some);
     }
-    if let Some(profile_path) = find_pack_store_profile(name_or_path) {
+    if let Some((profile_path, pack_key)) = find_pack_store_profile(name_or_path) {
         tracing::info!(
             "Loading pack-store profile from: {}",
             profile_path.display()
         );
-        let profile = finalize_profile(load_from_file(&profile_path)?)?;
+        let mut profile = finalize_profile(load_from_file(&profile_path)?)?;
+        // Inject the source pack ref so it's always present in the
+        // verification list, even if the profile JSON doesn't declare it.
+        if !profile.packs.contains(&pack_key) {
+            profile.packs.push(pack_key);
+        }
         // If we just resolved through `always-further/claude`, also offer
         // to strip pre-0.43 inbuilt-hook leftovers. Catches the path
         // where users `nono pull always-further/claude` directly,
@@ -1828,7 +1837,10 @@ fn profile_path_is_in_pack(profile_path: &Path, store: &Path, ns: &str, name: &s
 /// resolved by returning the first (alphabetical by `<namespace>/<name>`)
 /// — collisions are rare and the resolver is best-effort; the operator
 /// can pin via the user profile dir if needed.
-pub(crate) fn find_pack_store_profile(name: &str) -> Option<PathBuf> {
+/// Returns `(profile_path, pack_key)` for the first installed pack that
+/// provides a profile artifact matching `name` (by `install_as` or alias).
+/// Returns `None` if no pack provides a matching profile.
+pub(crate) fn find_pack_store_profile(name: &str) -> Option<(PathBuf, String)> {
     let store = crate::package::package_store_dir().ok()?;
     if !store.exists() {
         return None;
@@ -1890,7 +1902,7 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<PathBuf> {
         }
     }
     matches.sort_by(|a, b| a.0.cmp(&b.0));
-    matches.into_iter().next().map(|(_, p)| p)
+    matches.into_iter().next().map(|(key, path)| (path, key))
 }
 
 /// Returns true if the string looks like a registry package reference
@@ -2246,8 +2258,15 @@ fn load_base_profile_raw(
     }
 
     // 2. Pack-store: any installed pack with a matching `install_as`.
-    if let Some(profile_path) = find_pack_store_profile(name) {
-        return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
+    // Inject the source pack key into `packs` so it propagates through
+    // the merge chain and reaches verification even if the profile JSON
+    // doesn't declare its own pack.
+    if let Some((profile_path, pack_key)) = find_pack_store_profile(name) {
+        let mut base = parse_profile_file(&profile_path)?;
+        if !base.packs.contains(&pack_key) {
+            base.packs.push(pack_key);
+        }
+        return Ok(ResolvedBase::Global(base));
     }
 
     // 3. Built-in profile from embedded policy.
@@ -2270,8 +2289,12 @@ fn load_base_profile_raw(
         let outcome = crate::migration::check_and_run(name)?;
         match outcome {
             crate::migration::MigrationOutcome::Migrated => {
-                if let Some(profile_path) = find_pack_store_profile(name) {
-                    return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
+                if let Some((profile_path, pack_key)) = find_pack_store_profile(name) {
+                    let mut base = parse_profile_file(&profile_path)?;
+                    if !base.packs.contains(&pack_key) {
+                        base.packs.push(pack_key);
+                    }
+                    return Ok(ResolvedBase::Global(base));
                 }
             }
             crate::migration::MigrationOutcome::Skipped => {

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1895,7 +1895,7 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<PathBuf> {
 
 /// Returns true if the string looks like a registry package reference
 /// (`namespace/name` or `namespace/name@version`) rather than a filesystem path.
-fn is_registry_ref(s: &str) -> bool {
+pub(crate) fn is_registry_ref(s: &str) -> bool {
     // Strip optional @version suffix for the path check
     let path_part = s.split_once('@').map_or(s, |(p, _)| p);
     let parts: Vec<&str> = path_part.split('/').collect();

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -2178,7 +2178,7 @@ fn resolve_validate_target(input: &std::path::Path) -> std::path::PathBuf {
     {
         return p;
     }
-    if let Some(p) = profile::find_pack_store_profile(name) {
+    if let Some((p, _)) = profile::find_pack_store_profile(name) {
         return p;
     }
     input.to_path_buf()

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -392,28 +392,19 @@ fn prepare_profile_with_options(
         )?;
         // If the profile was addressed by pack ref (e.g. --profile always-further/hermes),
         // ensure that pack is verified even if the profile JSON doesn't list it in `packs`.
+        // Pack refs are injected into profile.packs at load time for every
+        // pack-store resolution — both direct registry refs and name/alias
+        // paths — so no post-hoc lookup is needed here.
         let mut packs_to_verify = profile.packs.clone();
 
-        // Ensure the source pack is always verified, regardless of how the
-        // profile was addressed:
-        //   - Direct registry ref (--profile always-further/hermes): strip
-        //     any @version suffix and add the pack key.
-        //   - Profile name or alias (--profile claude): look up which pack
-        //     provides it via the pack store index and add that pack key.
-        // In both cases we skip adding if already listed in profile.packs.
-        let source_pack_key: Option<String> = if profile::is_registry_ref(profile_name) {
+        // For direct registry refs the pack key may not yet be in packs if
+        // load_registry_profile found the pack installed but the profile JSON
+        // predates the injection convention. Guard with a fallback.
+        if profile::is_registry_ref(profile_name) {
             let key = profile_name
                 .split_once('@')
                 .map_or(profile_name.as_str(), |(p, _)| p)
                 .to_string();
-            Some(key)
-        } else {
-            profile::list_pack_store_profiles()
-                .into_iter()
-                .find(|(pname, _)| pname == profile_name)
-                .map(|(_, pack_ref)| pack_ref)
-        };
-        if let Some(key) = source_pack_key {
             if !packs_to_verify.contains(&key) {
                 packs_to_verify.push(key);
             }

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -125,10 +125,34 @@ fn verify_profile_packs(packs: &[String]) -> crate::Result<()> {
 
         let bundle_path = install_dir.join(".nono-trust.bundle");
         if bundle_path.exists() {
-            let pinned_signer = locked
-                .and_then(|p| p.provenance.as_ref())
-                .map(|prov| prov.signer_identity.as_str());
-            verify_stored_bundles(&install_dir, &bundle_path, pack_ref, pinned_signer)?;
+            // A trust bundle without a lockfile provenance record means we
+            // cannot verify who signed it. Fail hard rather than silently
+            // accepting any valid Sigstore signer.
+            let pinned_signer = match locked {
+                None => {
+                    return Err(nono::NonoError::PackageVerification {
+                        package: pack_ref.clone(),
+                        reason: format!(
+                            "pack '{}' has a trust bundle but no lockfile entry — \
+                             reinstall with: nono pull {} --force",
+                            pack_ref, pack_ref
+                        ),
+                    });
+                }
+                Some(pkg) => pkg
+                    .provenance
+                    .as_ref()
+                    .map(|p| p.signer_identity.as_str())
+                    .ok_or_else(|| nono::NonoError::PackageVerification {
+                        package: pack_ref.clone(),
+                        reason: format!(
+                            "pack '{}' has a trust bundle but no signer identity in the \
+                             lockfile — reinstall with: nono pull {} --force",
+                            pack_ref, pack_ref
+                        ),
+                    })?,
+            };
+            verify_stored_bundles(&install_dir, &bundle_path, pack_ref, Some(pinned_signer))?;
         }
     }
 
@@ -225,8 +249,7 @@ fn verify_stored_bundles(
         // All artifacts in a pack share the same signer, so we check on each
         // entry and fail fast on any mismatch.
         if let Some(pinned) = pinned_signer {
-            let identity =
-                nono::trust::extract_signer_identity(&bundle, Path::new(artifact_name))?;
+            let identity = nono::trust::extract_signer_identity(&bundle, Path::new(artifact_name))?;
             let verified_uri = match &identity {
                 nono::trust::SignerIdentity::Keyless {
                     repository,
@@ -246,10 +269,7 @@ fn verify_stored_bundles(
                     reason: format!(
                         "signer identity mismatch for '{}': bundle was signed by '{}' \
                          but lockfile pins '{}'. Reinstall with: nono pull {} --force",
-                        artifact_name,
-                        verified_uri,
-                        pinned,
-                        pack_ref
+                        artifact_name, verified_uri, pinned, pack_ref
                     ),
                 });
             }
@@ -373,16 +393,36 @@ fn prepare_profile_with_options(
         // If the profile was addressed by pack ref (e.g. --profile always-further/hermes),
         // ensure that pack is verified even if the profile JSON doesn't list it in `packs`.
         let mut packs_to_verify = profile.packs.clone();
-        let pack_key = profile_name
-            .split_once('@')
-            .map_or(profile_name.as_str(), |(p, _)| p);
-        if profile::is_registry_ref(profile_name) && !packs_to_verify.contains(&pack_key.to_string()) {
-            packs_to_verify.push(pack_key.to_string());
+
+        // Ensure the source pack is always verified, regardless of how the
+        // profile was addressed:
+        //   - Direct registry ref (--profile always-further/hermes): strip
+        //     any @version suffix and add the pack key.
+        //   - Profile name or alias (--profile claude): look up which pack
+        //     provides it via the pack store index and add that pack key.
+        // In both cases we skip adding if already listed in profile.packs.
+        let source_pack_key: Option<String> = if profile::is_registry_ref(profile_name) {
+            let key = profile_name
+                .split_once('@')
+                .map_or(profile_name.as_str(), |(p, _)| p)
+                .to_string();
+            Some(key)
+        } else {
+            profile::list_pack_store_profiles()
+                .into_iter()
+                .find(|(pname, _)| pname == profile_name)
+                .map(|(_, pack_ref)| pack_ref)
+        };
+        if let Some(key) = source_pack_key {
+            if !packs_to_verify.contains(&key) {
+                packs_to_verify.push(key);
+            }
         }
+
         verify_profile_packs(&packs_to_verify)?;
 
-        if !profile.packs.is_empty() && !options.hook_output_silent {
-            eprintln!("  Verified {} pack(s)", profile.packs.len());
+        if !packs_to_verify.is_empty() && !options.hook_output_silent {
+            eprintln!("  Verified {} pack(s)", packs_to_verify.len());
         }
 
         if options.install_hooks {

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -125,11 +125,18 @@ fn verify_profile_packs(packs: &[String]) -> crate::Result<()> {
 
         let bundle_path = install_dir.join(".nono-trust.bundle");
         if bundle_path.exists() {
-            verify_stored_bundles(&install_dir, &bundle_path, pack_ref)?;
+            let pinned_signer = locked
+                .and_then(|p| p.provenance.as_ref())
+                .map(|prov| prov.signer_identity.as_str());
+            verify_stored_bundles(&install_dir, &bundle_path, pack_ref, pinned_signer)?;
         }
     }
 
     Ok(())
+}
+
+fn canonical_signer(uri: &str) -> &str {
+    uri.rsplit_once('@').map_or(uri, |(prefix, _)| prefix)
 }
 
 /// Re-verify each artifact's Sigstore bundle from the stored trust bundle file.
@@ -137,6 +144,7 @@ fn verify_stored_bundles(
     install_dir: &Path,
     bundle_path: &Path,
     pack_ref: &str,
+    pinned_signer: Option<&str>,
 ) -> crate::Result<()> {
     let bundle_content = std::fs::read_to_string(bundle_path).map_err(|e| {
         nono::NonoError::PackageInstall(format!(
@@ -212,6 +220,40 @@ fn verify_stored_bundles(
                 artifact_name, pack_ref, e, pack_ref
             ))
         })?;
+
+        // Check the verified signer identity against the lockfile pin.
+        // All artifacts in a pack share the same signer, so we check on each
+        // entry and fail fast on any mismatch.
+        if let Some(pinned) = pinned_signer {
+            let identity =
+                nono::trust::extract_signer_identity(&bundle, Path::new(artifact_name))?;
+            let verified_uri = match &identity {
+                nono::trust::SignerIdentity::Keyless {
+                    repository,
+                    workflow,
+                    git_ref,
+                    ..
+                } => format!("https://github.com/{repository}/{workflow}@{git_ref}"),
+                nono::trust::SignerIdentity::Keyed { key_id } => {
+                    format!("keyed:{key_id}")
+                }
+            };
+            // Strip @<git_ref> for canonical comparison — we pin repo+workflow,
+            // not the specific tag that triggered each release.
+            if canonical_signer(verified_uri.as_str()) != canonical_signer(pinned) {
+                return Err(nono::NonoError::PackageVerification {
+                    package: pack_ref.to_string(),
+                    reason: format!(
+                        "signer identity mismatch for '{}': bundle was signed by '{}' \
+                         but lockfile pins '{}'. Reinstall with: nono pull {} --force",
+                        artifact_name,
+                        verified_uri,
+                        pinned,
+                        pack_ref
+                    ),
+                });
+            }
+        }
     }
 
     Ok(())
@@ -328,7 +370,16 @@ fn prepare_profile_with_options(
             Some(profile_name),
             options.hook_output_silent,
         )?;
-        verify_profile_packs(&profile.packs)?;
+        // If the profile was addressed by pack ref (e.g. --profile always-further/hermes),
+        // ensure that pack is verified even if the profile JSON doesn't list it in `packs`.
+        let mut packs_to_verify = profile.packs.clone();
+        let pack_key = profile_name
+            .split_once('@')
+            .map_or(profile_name.as_str(), |(p, _)| p);
+        if profile::is_registry_ref(profile_name) && !packs_to_verify.contains(&pack_key.to_string()) {
+            packs_to_verify.push(pack_key.to_string());
+        }
+        verify_profile_packs(&packs_to_verify)?;
 
         if !profile.packs.is_empty() && !options.hook_output_silent {
             eprintln!("  Verified {} pack(s)", profile.packs.len());


### PR DESCRIPTION
This change introduces new verification logic to ensure that installed packages were signed by the expected identity. It strengthens the security of package consumption by comparing the signer identity extracted from a package's Sigstore bundle against a pinned signer identity stored in the lockfile.

If a signer identity mismatch is detected, an error is returned, prompting the user to re-evaluate the package's provenance.

- Added `pinned_signer` to `verify_stored_bundles` to enable the comparison.
- Introduced `canonical_signer` to normalize signer URIs before comparison, focusing on repository/workflow rather than specific git refs.
- Ensured that if a profile is addressed directly by a package reference (e.g., `nono run some/pack`), that specific package is always included in the verification process, even if not explicitly listed in the profile's `packs` array.
- Made `is_registry_ref` public within the `nono-cli` crate to support the updated profile verification logic.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
