### PR TITLE
feat(linux): implement af_unix pathname mediation

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -45,6 +45,10 @@
       "$ref": "#/$defs/NetworkConfig",
       "description": "Network access configuration including proxy settings, credential injection, and port allowlists."
     },
+    "linux": {
+      "$ref": "#/$defs/LinuxConfig",
+      "description": "Linux-specific hardening controls."
+    },
     "env_credentials": {
       "$ref": "#/$defs/SecretsConfig",
       "description": "Maps keystore account names (or op://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore at startup."
@@ -194,6 +198,25 @@
       "type": "string",
       "enum": ["error", "insecure_proxy"],
       "description": "WSL2 proxy fallback policy. 'error' (default) refuses to run if proxy-only mode cannot be kernel-enforced. 'insecure_proxy' allows degraded execution where the credential proxy injects credentials but the sandboxed process is not prevented from bypassing the proxy."
+    },
+    "LinuxConfig": {
+      "type": "object",
+      "description": "Linux-specific hardening controls.",
+      "additionalProperties": false,
+      "properties": {
+        "af_unix_mediation": {
+          "oneOf": [
+            { "$ref": "#/$defs/LinuxAfUnixMediation" },
+            { "type": "null" }
+          ],
+          "description": "Opt-in pathname AF_UNIX mediation. 'off' preserves compatibility. 'pathname' requires explicit filesystem.unix_socket* grants for pathname Unix socket connect/bind."
+        }
+      }
+    },
+    "LinuxAfUnixMediation": {
+      "type": "string",
+      "enum": ["off", "pathname"],
+      "description": "Linux pathname AF_UNIX mediation mode."
     },
     "ProfileSignalMode": {
       "type": "string",

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -144,6 +144,8 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             capability_elevation: prepared.capability_elevation,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: prepared.af_unix_mediation,
             bypass_protection_paths: prepared.bypass_protection_paths,
             ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
@@ -197,6 +199,15 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
         return Err(NonoError::ConfigParse(
             "nono wrap does not support proxy mode (activated by profile network settings). \
              Use `nono run` instead."
+                .to_string(),
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    if prepared.af_unix_mediation.is_pathname() {
+        return Err(NonoError::ConfigParse(
+            "nono wrap does not support linux.af_unix_mediation = \"pathname\" because direct \
+             exec cannot run the seccomp supervisor. Use `nono run` instead."
                 .to_string(),
         ));
     }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -841,44 +841,29 @@ pub fn execute_supervised(
                             msg.len(),
                         );
                     }
-                } else if install_network_notify {
-                    if let Some(fd) = child_sock_fd {
-                        let notify_result = if config.seccomp_proxy_fallback {
-                            let has_bind = match effective_caps.network_mode() {
-                                nono::NetworkMode::ProxyOnly { bind_ports, .. } => {
-                                    !bind_ports.is_empty()
-                                }
-                                _ => false,
-                            };
-                            nono::sandbox::install_seccomp_proxy_filter(has_bind)
-                        } else {
-                            nono::sandbox::install_seccomp_af_unix_filter()
-                        };
-
-                        match notify_result {
-                            Ok(proxy_notify_fd) => {
-                                if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
-                                    fd,
-                                    proxy_notify_fd.as_raw_fd(),
-                                ) {
-                                    let detail = format!(
-                                        "nono: failed to send proxy seccomp notify fd: {}\n",
-                                        e
-                                    );
-                                    let msg = detail.as_bytes();
-                                    unsafe {
-                                        libc::write(
-                                            libc::STDERR_FILENO,
-                                            msg.as_ptr().cast::<libc::c_void>(),
-                                            msg.len(),
-                                        );
-                                        libc::_exit(126);
-                                    }
-                                }
+                } else if install_network_notify && let Some(fd) = child_sock_fd {
+                    let notify_result = if config.seccomp_proxy_fallback {
+                        let has_bind = match effective_caps.network_mode() {
+                            nono::NetworkMode::ProxyOnly { bind_ports, .. } => {
+                                !bind_ports.is_empty()
                             }
-                            Err(e) => {
-                                let detail =
-                                    format!("nono: seccomp proxy filter not available: {}\n", e);
+                            _ => false,
+                        };
+                        nono::sandbox::install_seccomp_proxy_filter(has_bind)
+                    } else {
+                        nono::sandbox::install_seccomp_af_unix_filter()
+                    };
+
+                    match notify_result {
+                        Ok(proxy_notify_fd) => {
+                            if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
+                                fd,
+                                proxy_notify_fd.as_raw_fd(),
+                            ) {
+                                let detail = format!(
+                                    "nono: failed to send proxy seccomp notify fd: {}\n",
+                                    e
+                                );
                                 let msg = detail.as_bytes();
                                 unsafe {
                                     libc::write(
@@ -888,6 +873,19 @@ pub fn execute_supervised(
                                     );
                                     libc::_exit(126);
                                 }
+                            }
+                        }
+                        Err(e) => {
+                            let detail =
+                                format!("nono: seccomp proxy filter not available: {}\n", e);
+                            let msg = detail.as_bytes();
+                            unsafe {
+                                libc::write(
+                                    libc::STDERR_FILENO,
+                                    msg.as_ptr().cast::<libc::c_void>(),
+                                    msg.len(),
+                                );
+                                libc::_exit(126);
                             }
                         }
                     }
@@ -3843,10 +3841,19 @@ mod tests {
                     None, // no PTY relay
                 );
 
+                #[cfg(target_os = "linux")]
+                let (status, denials, ipc_denials) = result
+                    .map_err(|e| format!("supervisor loop: {e}"))
+                    .expect("supervisor loop failed");
+
+                #[cfg(not(target_os = "linux"))]
                 let (status, denials) = result
                     .map_err(|e| format!("supervisor loop: {e}"))
                     .expect("supervisor loop failed");
+
                 assert!(denials.is_empty(), "no denials expected");
+                #[cfg(target_os = "linux")]
+                assert!(ipc_denials.is_empty(), "no IPC denials expected");
 
                 // Child exited with code 42
                 match status {
@@ -3940,10 +3947,11 @@ mod tests {
                     None, // no PTY relay
                 );
 
-                let (status, denials) = result
+                let (status, denials, ipc_denials) = result
                     .map_err(|e| format!("supervisor loop: {e}"))
                     .expect("supervisor loop should not deadlock");
                 assert!(denials.is_empty());
+                assert!(ipc_denials.is_empty());
 
                 match status {
                     WaitStatus::Exited(_, code) => assert_eq!(code, 0),

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -232,6 +232,9 @@ pub struct ExecConfig<'a> {
     /// sends the notify fd; parent expects to receive it.
     #[cfg(target_os = "linux")]
     pub seccomp_proxy_fallback: bool,
+    /// Linux pathname AF_UNIX mediation requested by profile.
+    #[cfg(target_os = "linux")]
+    pub af_unix_mediation: crate::profile::LinuxAfUnixMediation,
     /// Allow-list of environment variable names. When set, only variables
     /// matching an exact name or prefix pattern (e.g. `"AWS_*"`) are
     /// passed to the child. Nono-injected credentials always bypass this.
@@ -274,6 +277,9 @@ pub struct SupervisorConfig<'a> {
     pub open_url_allow_localhost: bool,
     /// Optional append-only audit recorder for supervisor events.
     pub audit_recorder: Option<&'a Mutex<crate::audit_integrity::AuditRecorder>>,
+    /// Optional in-memory network/IPC audit events persisted into session metadata.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub network_audit_events: Option<&'a Mutex<Vec<nono::undo::NetworkAuditEvent>>>,
     /// Redaction policy for command context in diagnostics.
     pub redaction_policy: &'a nono::ScrubPolicy,
     /// Whether direct LaunchServices opening is enabled for this session.
@@ -288,6 +294,18 @@ pub struct SupervisorConfig<'a> {
     /// Pathname AF_UNIX socket grants allowed for seccomp proxy-only fallback.
     #[cfg(target_os = "linux")]
     pub unix_socket_allowlist: &'a [nono::UnixSocketCapability],
+    /// Linux connect/bind seccomp notify policy mode.
+    #[cfg(target_os = "linux")]
+    pub linux_network_notify_mode: LinuxNetworkNotifyMode,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxNetworkNotifyMode {
+    /// V<4 proxy fallback: mediate TCP proxy ports and AF_UNIX sockets.
+    ProxyOnly,
+    /// V4+ opt-in: mediate pathname AF_UNIX only; let TCP continue.
+    AfUnixOnly,
 }
 
 #[cfg(target_os = "macos")]
@@ -296,11 +314,8 @@ fn should_install_macos_open_shim(supervisor: Option<&SupervisorConfig<'_>>) -> 
 }
 
 #[cfg(target_os = "linux")]
-const fn linux_child_requires_dumpable(
-    capability_elevation: bool,
-    seccomp_proxy_fallback: bool,
-) -> bool {
-    capability_elevation || seccomp_proxy_fallback
+const fn linux_child_requires_dumpable(capability_elevation: bool, network_notify: bool) -> bool {
+    capability_elevation || network_notify
 }
 
 /// Execute a command using the Direct strategy (exec, nono disappears).
@@ -433,6 +448,7 @@ pub fn execute_supervised(
     let needs_child_ipc = supervisor.is_some()
         && (config.capability_elevation
             || config.seccomp_proxy_fallback
+            || config.af_unix_mediation.is_pathname()
             || trust_interceptor.is_some());
 
     #[cfg(not(target_os = "linux"))]
@@ -808,12 +824,15 @@ pub fn execute_supervised(
                     }
                 }
 
-                // If the parent determined that seccomp proxy fallback is needed
-                // (Landlock ABI lacks AccessNet + ProxyOnly mode), install the
-                // proxy filter and send its notify fd to the parent.
-                // On WSL2 this flag should already be false (guarded in main.rs),
-                // but check again to avoid EBUSY / _exit(126).
-                if config.seccomp_proxy_fallback && nono::sandbox::is_wsl2() {
+                // If the parent determined that network seccomp-notify is
+                // needed, install exactly one connect/bind notify filter and
+                // send its fd to the parent. Proxy fallback uses the stricter
+                // proxy filter; V4+ AF_UNIX mediation uses an AF_UNIX-only
+                // policy filter that lets non-AF_UNIX traffic continue to the
+                // existing Landlock/network policy.
+                let install_network_notify =
+                    config.seccomp_proxy_fallback || config.af_unix_mediation.is_pathname();
+                if install_network_notify && nono::sandbox::is_wsl2() {
                     let msg = b"nono: WSL2 detected, skipping seccomp proxy filter (proxy network filtering unavailable)\n";
                     unsafe {
                         libc::write(
@@ -822,13 +841,21 @@ pub fn execute_supervised(
                             msg.len(),
                         );
                     }
-                } else if config.seccomp_proxy_fallback {
-                    let has_bind = match effective_caps.network_mode() {
-                        nono::NetworkMode::ProxyOnly { bind_ports, .. } => !bind_ports.is_empty(),
-                        _ => false,
-                    };
+                } else if install_network_notify {
                     if let Some(fd) = child_sock_fd {
-                        match nono::sandbox::install_seccomp_proxy_filter(has_bind) {
+                        let notify_result = if config.seccomp_proxy_fallback {
+                            let has_bind = match effective_caps.network_mode() {
+                                nono::NetworkMode::ProxyOnly { bind_ports, .. } => {
+                                    !bind_ports.is_empty()
+                                }
+                                _ => false,
+                            };
+                            nono::sandbox::install_seccomp_proxy_filter(has_bind)
+                        } else {
+                            nono::sandbox::install_seccomp_af_unix_filter()
+                        };
+
+                        match notify_result {
                             Ok(proxy_notify_fd) => {
                                 if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
                                     fd,
@@ -868,7 +895,7 @@ pub fn execute_supervised(
 
                 if !linux_child_requires_dumpable(
                     config.capability_elevation,
-                    config.seccomp_proxy_fallback,
+                    config.seccomp_proxy_fallback || config.af_unix_mediation.is_pathname(),
                 ) {
                     use nix::sys::prctl;
 
@@ -1034,24 +1061,25 @@ pub fn execute_supervised(
             // receive the proxy notify fd from the child. Only attempt recv when
             // we know the child will send it (both sides use the same flag).
             #[cfg(target_os = "linux")]
-            let proxy_notify_fd: Option<OwnedFd> = if config.seccomp_proxy_fallback {
-                if let Some(ref sup_sock) = supervisor_sock {
-                    match sup_sock.recv_fd() {
-                        Ok(fd) => {
-                            debug!("Received proxy seccomp notify fd from child");
-                            Some(fd)
+            let proxy_notify_fd: Option<OwnedFd> =
+                if config.seccomp_proxy_fallback || config.af_unix_mediation.is_pathname() {
+                    if let Some(ref sup_sock) = supervisor_sock {
+                        match sup_sock.recv_fd() {
+                            Ok(fd) => {
+                                debug!("Received proxy seccomp notify fd from child");
+                                Some(fd)
+                            }
+                            Err(e) => {
+                                warn!("Failed to receive proxy seccomp notify fd: {}", e);
+                                None
+                            }
                         }
-                        Err(e) => {
-                            warn!("Failed to receive proxy seccomp notify fd: {}", e);
-                            None
-                        }
+                    } else {
+                        None
                     }
                 } else {
                     None
-                }
-            } else {
-                None
-            };
+                };
 
             // Set up signal forwarding.
             setup_signal_forwarding(child, pty_proxy.as_ref().map(|p| p.poll_fds().0));
@@ -1096,11 +1124,11 @@ pub fn execute_supervised(
                     .collect()
             };
 
-            let (status, denials) =
+            let (status, denials, ipc_denials) =
                 if let (Some(sup_cfg), Some(mut sup_sock)) = (supervisor, supervisor_sock) {
                     #[cfg(target_os = "linux")]
                     {
-                        run_supervisor_loop(
+                        let (status, denials, ipc_denials) = run_supervisor_loop(
                             child,
                             &mut sup_sock,
                             sup_cfg,
@@ -1110,23 +1138,25 @@ pub fn execute_supervised(
                             &initial_caps,
                             trust_interceptor,
                             pty_proxy.as_mut(),
-                        )?
+                        )?;
+                        (status, denials, ipc_denials)
                     }
                     #[cfg(not(target_os = "linux"))]
                     {
-                        run_supervisor_loop(
+                        let (status, denials) = run_supervisor_loop(
                             child,
                             &mut sup_sock,
                             sup_cfg,
                             config.startup_timeout,
                             trust_interceptor,
                             pty_proxy.as_mut(),
-                        )?
+                        )?;
+                        (status, denials, Vec::new())
                     }
                 } else {
                     let status =
                         wait_for_child_with_pty(child, pty_proxy.as_mut(), config.startup_timeout)?;
-                    (status, Vec::new())
+                    (status, Vec::new(), Vec::new())
                 };
 
             // Close the attach listener immediately so no new attach
@@ -1208,6 +1238,7 @@ pub fn execute_supervised(
                 config.no_diagnostics,
                 exit_code,
                 &denials,
+                &ipc_denials,
                 &sandbox_violations,
                 &error_observation,
             );
@@ -1234,6 +1265,7 @@ pub fn execute_supervised(
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
                     .with_denials(&denials)
+                    .with_ipc_denials(&ipc_denials)
                     .with_sandbox_violations(&sandbox_violations)
                     .with_protected_paths(config.protected_paths)
                     .with_error_observation(error_observation)
@@ -1403,12 +1435,14 @@ fn should_print_diagnostic_footer(
     no_diagnostics: bool,
     exit_code: i32,
     denials: &[nono::diagnostic::DenialRecord],
+    ipc_denials: &[nono::diagnostic::IpcDenialRecord],
     sandbox_violations: &[nono::SandboxViolation],
     error_observation: &nono::diagnostic::ErrorObservation,
 ) -> bool {
     !no_diagnostics
         && (exit_code != 0
             || !denials.is_empty()
+            || !ipc_denials.is_empty()
             || !sandbox_violations.is_empty()
             || error_observation.has_findings())
 }
@@ -2086,12 +2120,17 @@ fn run_supervisor_loop(
     initial_caps: &[supervisor_linux::InitialCapability],
     mut trust_interceptor: Option<crate::trust_intercept::TrustInterceptor>,
     mut pty: Option<&mut crate::pty_proxy::PtyProxy>,
-) -> Result<(WaitStatus, Vec<DenialRecord>)> {
+) -> Result<(
+    WaitStatus,
+    Vec<DenialRecord>,
+    Vec<nono::diagnostic::IpcDenialRecord>,
+)> {
     let sock_fd = sock.as_raw_fd();
     let notify_raw_fd = seccomp_fd.map(|fd| fd.as_raw_fd());
     let proxy_notify_raw_fd = proxy_seccomp_fd.map(|fd| fd.as_raw_fd());
     let mut rate_limiter = supervisor_linux::RateLimiter::new(10, 5);
     let mut denials = Vec::new();
+    let mut ipc_denials = Vec::new();
     let mut seen_request_ids = HashSet::new();
     let mut sock_fd_active = true;
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
@@ -2209,6 +2248,8 @@ fn run_supervisor_loop(
                         pfd,
                         config,
                         &mut rate_limiter,
+                        &mut denials,
+                        &mut ipc_denials,
                     )
                 {
                     debug!("Error handling proxy seccomp notification: {}", e);
@@ -2264,7 +2305,7 @@ fn run_supervisor_loop(
                         );
                         if terminate {
                             let _ = signal::kill(child, Signal::SIGTERM);
-                            return Ok((wait_for_child(child)?, denials));
+                            return Ok((wait_for_child(child)?, denials, ipc_denials));
                         }
                     }
                 }
@@ -2278,11 +2319,27 @@ fn run_supervisor_loop(
                 debug!("Child continued, keeping supervisor alive");
                 continue;
             }
-            Ok(status) => return Ok((status, denials)),
+            Ok(status) => {
+                drain_pending_network_notifications(
+                    proxy_notify_raw_fd,
+                    config,
+                    &mut rate_limiter,
+                    &mut denials,
+                    &mut ipc_denials,
+                );
+                return Ok((status, denials, ipc_denials));
+            }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(nix::errno::Errno::ECHILD) => {
                 warn!("Child already reaped in supervisor loop");
-                return Ok((WaitStatus::Exited(child, 1), denials));
+                drain_pending_network_notifications(
+                    proxy_notify_raw_fd,
+                    config,
+                    &mut rate_limiter,
+                    &mut denials,
+                    &mut ipc_denials,
+                );
+                return Ok((WaitStatus::Exited(child, 1), denials, ipc_denials));
             }
             Err(e) => {
                 return Err(NonoError::SandboxInit(format!(
@@ -2294,7 +2351,42 @@ fn run_supervisor_loop(
     }
 
     let status = wait_for_child(child)?;
-    Ok((status, denials))
+    Ok((status, denials, ipc_denials))
+}
+
+#[cfg(target_os = "linux")]
+fn drain_pending_network_notifications(
+    proxy_notify_raw_fd: Option<std::os::fd::RawFd>,
+    config: &SupervisorConfig<'_>,
+    rate_limiter: &mut supervisor_linux::RateLimiter,
+    denials: &mut Vec<DenialRecord>,
+    ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
+) {
+    let Some(fd) = proxy_notify_raw_fd else {
+        return;
+    };
+
+    loop {
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pfd, 1, 0) };
+        if ret <= 0 || pfd.revents & libc::POLLIN == 0 {
+            return;
+        }
+        if let Err(err) = supervisor_linux::handle_network_notification(
+            fd,
+            config,
+            rate_limiter,
+            denials,
+            ipc_denials,
+        ) {
+            debug!("Error draining pending proxy seccomp notification: {}", err);
+            return;
+        }
+    }
 }
 
 /// Handle a single supervisor IPC message.
@@ -3340,6 +3432,7 @@ mod tests {
             false,
             0,
             &denials,
+            &[],
             &violations,
             &observation,
         ));
@@ -3347,6 +3440,7 @@ mod tests {
             true,
             0,
             &denials,
+            &[],
             &violations,
             &observation,
         ));
@@ -3702,6 +3796,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3710,6 +3805,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         // Fork a child that closes its socket end and exits immediately.
@@ -3804,6 +3901,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3812,6 +3910,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         match unsafe { fork() } {
@@ -3882,6 +3982,7 @@ mod tests {
             open_url_origins: &origins,
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3890,6 +3991,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         // Allowed origin: validation passes
@@ -3920,6 +4023,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3928,6 +4032,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         let result = validate_url("file:///etc/passwd", &config);
@@ -3956,6 +4062,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: true,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3964,6 +4071,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
         let config_deny = SupervisorConfig {
             protected_roots: &[],
@@ -3974,6 +4083,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -3982,6 +4092,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         // Localhost denied when not allowed
@@ -4015,6 +4127,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
             #[cfg(target_os = "linux")]
@@ -4023,6 +4136,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
@@ -4159,6 +4274,7 @@ mod tests {
             open_url_origins: &[],
             open_url_allow_localhost: false,
             audit_recorder: None,
+            network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: true,
             #[cfg(target_os = "linux")]
@@ -4167,6 +4283,8 @@ mod tests {
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
+            #[cfg(target_os = "linux")]
+            linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
         };
 
         assert!(

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -931,29 +931,18 @@ fn ipc_denial_details(
             };
             let resolved = resolve_af_unix_sockaddr_path(child_pid, path)
                 .unwrap_or_else(|_| path.to_path_buf());
-            let display_path = match op {
-                UnixSocketOp::Connect => match resolved.canonicalize() {
-                    Ok(path) => path,
-                    Err(err) => {
-                        return (
-                            resolved.display().to_string(),
-                            format!("canonicalize failed: {err}"),
-                            None,
-                            None,
-                        );
-                    }
-                },
-                UnixSocketOp::Bind => match canonicalize_unix_socket_bind_path(&resolved) {
-                    Ok(path) => path,
-                    Err(err) => {
-                        return (
-                            resolved.display().to_string(),
-                            format!("canonicalize failed: {err}"),
-                            None,
-                            None,
-                        );
-                    }
-                },
+            let canonical = match op {
+                UnixSocketOp::Connect => resolved.canonicalize(),
+                UnixSocketOp::Bind => canonicalize_unix_socket_bind_path(&resolved),
+            };
+            let Ok(display_path) = canonical else {
+                return (
+                    resolved.display().to_string(),
+                    "no matching unix_socket capability; target could not be canonicalized"
+                        .to_string(),
+                    None,
+                    None,
+                );
             };
             let flag = match op {
                 UnixSocketOp::Connect => "--allow-unix-socket",
@@ -1071,10 +1060,26 @@ fn network_audit_denial_reason(sockaddr: &nono::sandbox::SockaddrInfo, syscall: 
 }
 
 fn current_unix_millis() -> u64 {
-    std::time::SystemTime::now()
+    static LAST: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    let wall_clock = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+
+    let mut previous = LAST.load(std::sync::atomic::Ordering::Relaxed);
+    loop {
+        let next = wall_clock.max(previous.saturating_add(1));
+        match LAST.compare_exchange_weak(
+            previous,
+            next,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        ) {
+            Ok(_) => return next,
+            Err(observed) => previous = observed,
+        }
+    }
 }
 
 /// Check if a path matches any capability in the initial set.
@@ -1311,7 +1316,9 @@ mod tests {
     // decided by TCP proxy ports.
 
     mod network_decision {
-        use super::super::{NetworkDecision, SupervisorConfig, decide_network_notification};
+        use super::super::{
+            LinuxNetworkNotifyMode, NetworkDecision, SupervisorConfig, decide_network_notification,
+        };
         use nix::libc;
         use nono::sandbox::{SYS_BIND, SYS_CONNECT, SockaddrInfo, UnixSocketKind};
         use nono::supervisor::{ApprovalDecision, CapabilityRequest};

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -538,8 +538,7 @@ pub(super) fn handle_seccomp_notification(
 /// `Allow` to `continue_notif(…)` and `Deny` to `respond_notif_errno(…, EACCES)`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum NetworkDecision {
-    /// Let the kernel proceed with the already-copied sockaddr
-    /// (`SECCOMP_USER_NOTIF_FLAG_CONTINUE`).
+    /// Allow the operation.
     Allow,
     /// Fail the syscall with `EACCES`.
     Deny,
@@ -599,6 +598,17 @@ pub(super) fn decide_network_notification(
                 return NetworkDecision::Deny;
             }
         }
+    }
+
+    if matches!(
+        config.linux_network_notify_mode,
+        LinuxNetworkNotifyMode::AfUnixOnly
+    ) {
+        debug!(
+            "AF_UNIX-only seccomp mediation: allowing non-AF_UNIX syscall family={} nr={}",
+            sockaddr.family, syscall
+        );
+        return NetworkDecision::Allow;
     }
 
     match syscall {
@@ -790,12 +800,16 @@ fn canonicalize_unix_socket_bind_path(
 /// the sockaddr from the child's memory and delegates the allow/deny
 /// decision to [`decide_network_notification`].
 ///
-/// Uses SECCOMP_USER_NOTIF_FLAG_CONTINUE on approval (safe for connect/bind
-/// because the kernel has already copied sockaddr into kernel memory).
+/// Denials return `EACCES` directly. Approvals currently use
+/// `SECCOMP_USER_NOTIF_FLAG_CONTINUE`, which preserves platform compatibility
+/// but carries the documented userspace-pointer TOCTOU limitation described
+/// by `read_notif_sockaddr`.
 pub(super) fn handle_network_notification(
     notify_fd: std::os::fd::RawFd,
     config: &SupervisorConfig<'_>,
     rate_limiter: &mut RateLimiter,
+    denials: &mut Vec<DenialRecord>,
+    ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
 ) -> nono::error::Result<()> {
     use nono::sandbox::{
         continue_notif, deny_notif, notif_id_valid, read_notif_sockaddr, recv_notif,
@@ -829,8 +843,6 @@ pub(super) fn handle_network_notification(
 
     match decide_network_notification(notif.pid, notif.data.nr, &sockaddr, config) {
         NetworkDecision::Allow => {
-            // SECCOMP_USER_NOTIF_FLAG_CONTINUE: let the kernel proceed with its
-            // already-copied sockaddr. Safe for connect/bind (move_addr_to_kernel).
             if let Err(e) = continue_notif(notify_fd, notif.id) {
                 debug!("continue_notif failed for network notification: {}", e);
                 // Must respond to avoid leaving the child blocked. Propagate if
@@ -839,11 +851,230 @@ pub(super) fn handle_network_notification(
             }
         }
         NetworkDecision::Deny => {
+            record_af_unix_ipc_denial(&sockaddr, notif.pid, notif.data.nr, denials, ipc_denials);
             respond_notif_errno(notify_fd, notif.id, libc::EACCES)?;
+            if let Err(err) = record_network_audit_denial(config, &sockaddr, notif.data.nr) {
+                warn!("Failed to record network denial audit event: {}", err);
+            }
         }
     }
 
     Ok(())
+}
+
+fn record_af_unix_ipc_denial(
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    child_pid: u32,
+    syscall: i32,
+    denials: &mut Vec<DenialRecord>,
+    ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
+) {
+    if sockaddr.family != libc::AF_UNIX as u16 {
+        return;
+    }
+
+    let op = unix_socket_op_for_syscall(syscall);
+    let operation = op
+        .map(|op| op.to_string())
+        .unwrap_or_else(|| format!("syscall {syscall}"));
+    let (target, reason, suggested_flag, path_record) = ipc_denial_details(sockaddr, child_pid, op);
+
+    ipc_denials.push(nono::diagnostic::IpcDenialRecord {
+        target,
+        operation,
+        reason,
+        suggested_flag,
+    });
+
+    let Some((display_path, op)) = path_record else {
+        return;
+    };
+    let access = match op {
+        UnixSocketOp::Connect => AccessMode::Read,
+        UnixSocketOp::Bind => AccessMode::ReadWrite,
+    };
+
+    record_denial(
+        denials,
+        DenialRecord {
+            path: display_path,
+            access,
+            reason: DenialReason::UnixSocketDenied,
+        },
+    );
+}
+
+type PathIpcDenial = Option<(std::path::PathBuf, UnixSocketOp)>;
+
+fn ipc_denial_details(
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    child_pid: u32,
+    op: Option<UnixSocketOp>,
+) -> (String, String, Option<String>, PathIpcDenial) {
+    match sockaddr.unix_kind {
+        Some(nono::sandbox::UnixSocketKind::Pathname) => {
+            let Some(path) = sockaddr.unix_path.as_deref() else {
+                return (
+                    "unix:<unparsed-pathname>".to_string(),
+                    "pathname not parsed".to_string(),
+                    None,
+                    None,
+                );
+            };
+            let Some(op) = op else {
+                return (
+                    path.display().to_string(),
+                    "unexpected syscall".to_string(),
+                    None,
+                    None,
+                );
+            };
+            let resolved = resolve_af_unix_sockaddr_path(child_pid, path)
+                .unwrap_or_else(|_| path.to_path_buf());
+            let display_path = match op {
+                UnixSocketOp::Connect => match resolved.canonicalize() {
+                    Ok(path) => path,
+                    Err(err) => {
+                        return (
+                            resolved.display().to_string(),
+                            format!("canonicalize failed: {err}"),
+                            None,
+                            None,
+                        );
+                    }
+                },
+                UnixSocketOp::Bind => match canonicalize_unix_socket_bind_path(&resolved) {
+                    Ok(path) => path,
+                    Err(err) => {
+                        return (
+                            resolved.display().to_string(),
+                            format!("canonicalize failed: {err}"),
+                            None,
+                            None,
+                        );
+                    }
+                },
+            };
+            let flag = match op {
+                UnixSocketOp::Connect => "--allow-unix-socket",
+                UnixSocketOp::Bind => "--allow-unix-socket-bind",
+            };
+            (
+                display_path.display().to_string(),
+                "no matching unix_socket capability".to_string(),
+                Some(format!("{flag} {}", display_path.display())),
+                Some((display_path, op)),
+            )
+        }
+        Some(nono::sandbox::UnixSocketKind::Abstract) => (
+            "unix:<abstract>".to_string(),
+            "abstract namespace is not covered by pathname capabilities".to_string(),
+            None,
+            None,
+        ),
+        Some(nono::sandbox::UnixSocketKind::Unnamed) | None => (
+            "unix:<unnamed>".to_string(),
+            "no pathname to authorize".to_string(),
+            None,
+            None,
+        ),
+    }
+}
+
+fn record_network_audit_denial(
+    config: &SupervisorConfig<'_>,
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    syscall: i32,
+) -> nono::Result<()> {
+    let target = network_audit_target(sockaddr);
+    let reason = network_audit_denial_reason(sockaddr, syscall);
+    let event = nono::undo::NetworkAuditEvent {
+        timestamp_unix_ms: current_unix_millis(),
+        mode: nono::undo::NetworkAuditMode::Connect,
+        decision: nono::undo::NetworkAuditDecision::Deny,
+        route_id: None,
+        auth_mechanism: None,
+        auth_outcome: None,
+        managed_credential_active: None,
+        injection_mode: None,
+        denial_category: Some(nono::undo::NetworkAuditDenialCategory::HostDenied),
+        target,
+        port: if sockaddr.port == 0 {
+            None
+        } else {
+            Some(sockaddr.port)
+        },
+        method: None,
+        path: None,
+        status: None,
+        reason: Some(reason),
+    };
+
+    if let Some(events_mutex) = config.network_audit_events {
+        let mut events = events_mutex
+            .lock()
+            .map_err(|_| NonoError::Snapshot("Network audit event lock poisoned".to_string()))?;
+        events.push(event.clone());
+    }
+
+    if let Some(recorder_mutex) = config.audit_recorder {
+        let mut recorder = recorder_mutex
+            .lock()
+            .map_err(|_| NonoError::Snapshot("Audit recorder lock poisoned".to_string()))?;
+        recorder.record_network_event(event)?;
+    }
+
+    Ok(())
+}
+
+fn network_audit_target(sockaddr: &nono::sandbox::SockaddrInfo) -> String {
+    if sockaddr.family == libc::AF_UNIX as u16 {
+        return match sockaddr.unix_kind {
+            Some(nono::sandbox::UnixSocketKind::Pathname) => sockaddr
+                .unix_path
+                .as_ref()
+                .map(|path| format!("unix:{}", path.display()))
+                .unwrap_or_else(|| "unix:<unparsed>".to_string()),
+            Some(nono::sandbox::UnixSocketKind::Abstract) => "unix:<abstract>".to_string(),
+            Some(nono::sandbox::UnixSocketKind::Unnamed) | None => "unix:<unnamed>".to_string(),
+        };
+    }
+
+    format!(
+        "family={} loopback={}",
+        sockaddr.family, sockaddr.is_loopback
+    )
+}
+
+fn network_audit_denial_reason(sockaddr: &nono::sandbox::SockaddrInfo, syscall: i32) -> String {
+    if sockaddr.family == libc::AF_UNIX as u16 {
+        let op = unix_socket_op_for_syscall(syscall)
+            .map(|op| op.to_string())
+            .unwrap_or_else(|| format!("syscall {syscall}"));
+        return match sockaddr.unix_kind {
+            Some(nono::sandbox::UnixSocketKind::Pathname) => {
+                format!("pathname AF_UNIX {op} denied: no matching unix_socket capability")
+            }
+            Some(nono::sandbox::UnixSocketKind::Abstract) => {
+                format!("abstract AF_UNIX {op} denied: not covered by pathname capabilities")
+            }
+            Some(nono::sandbox::UnixSocketKind::Unnamed) | None => {
+                format!("unnamed AF_UNIX {op} denied: no pathname to authorize")
+            }
+        };
+    }
+
+    format!(
+        "network syscall {syscall} denied for family={} port={}",
+        sockaddr.family, sockaddr.port
+    )
+}
+
+fn current_unix_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Check if a path matches any capability in the initial set.
@@ -1120,11 +1351,13 @@ mod tests {
                 open_url_origins: &[],
                 open_url_allow_localhost: false,
                 audit_recorder: None,
+                network_audit_events: None,
                 redaction_policy: &REDACTION_POLICY,
                 allow_launch_services_active: false,
                 proxy_port,
                 proxy_bind_ports,
                 unix_socket_allowlist,
+                linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             }
         }
 
@@ -1186,6 +1419,15 @@ mod tests {
 
         fn test_pid() -> u32 {
             std::process::id()
+        }
+
+        fn make_af_unix_only_config<'a>(
+            backend: &'a DenyAllBackend,
+            unix_socket_allowlist: &'a [UnixSocketCapability],
+        ) -> SupervisorConfig<'a> {
+            let mut config = make_config(backend, 0, Vec::new(), unix_socket_allowlist);
+            config.linux_network_notify_mode = LinuxNetworkNotifyMode::AfUnixOnly;
+            config
         }
 
         /// Pathname `bind(AF_UNIX, "/tmp/…")` is mediated by explicit
@@ -1376,6 +1618,20 @@ mod tests {
             assert_eq!(
                 decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(4000), &config),
                 NetworkDecision::Deny
+            );
+        }
+
+        #[test]
+        fn af_unix_only_mode_allows_non_af_unix_to_continue() {
+            let backend = DenyAllBackend;
+            let config = make_af_unix_only_config(&backend, &[]);
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_external(8080), &config),
+                NetworkDecision::Allow
+            );
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(4000), &config),
+                NetworkDecision::Allow
             );
         }
     }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -303,6 +303,16 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         }
     };
 
+    #[cfg(target_os = "linux")]
+    if flags.af_unix_mediation.is_pathname() && nono::sandbox::is_wsl2() {
+        return Err(NonoError::SandboxInit(
+            "WSL2: linux.af_unix_mediation = \"pathname\" requires seccomp user notification, \
+             but WSL2 reports EBUSY for seccomp notify listeners. Disable AF_UNIX mediation or \
+             run on native Linux."
+                .to_string(),
+        ));
+    }
+
     let config = exec_strategy::ExecConfig {
         command: &command,
         resolved_program: &resolved_program,
@@ -331,6 +341,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         capability_elevation: flags.capability_elevation,
         #[cfg(target_os = "linux")]
         seccomp_proxy_fallback,
+        #[cfg(target_os = "linux")]
+        af_unix_mediation: flags.af_unix_mediation,
         allowed_env_vars: flags.allowed_env_vars,
         denied_env_vars: flags.denied_env_vars,
     };

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -95,6 +95,8 @@ pub(crate) struct ExecutionFlags {
     pub(crate) capability_elevation: bool,
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy,
+    #[cfg(target_os = "linux")]
+    pub(crate) af_unix_mediation: crate::profile::LinuxAfUnixMediation,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
     pub(crate) ignored_denial_paths: Vec<PathBuf>,
     pub(crate) session: SessionLaunchOptions,
@@ -117,6 +119,8 @@ impl ExecutionFlags {
             capability_elevation: false,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             bypass_protection_paths: Vec::new(),
             ignored_denial_paths: Vec::new(),
             session: SessionLaunchOptions::default(),
@@ -237,6 +241,8 @@ pub(crate) fn prepare_run_launch_plan(
             capability_elevation: prepared.capability_elevation,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: prepared.af_unix_mediation,
             bypass_protection_paths: prepared.bypass_protection_paths,
             ignored_denial_paths: prepared.ignored_denial_paths,
             session: SessionLaunchOptions {

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -267,6 +267,8 @@ mod tests {
             capability_elevation: false,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             allow_launch_services_active: false,
             allow_gpu_active: false,
             open_url_origins: Vec::new(),
@@ -312,6 +314,8 @@ mod tests {
             capability_elevation: false,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             allow_launch_services_active: false,
             allow_gpu_active: false,
             open_url_origins: Vec::new(),

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -163,6 +163,7 @@ impl ProfileDef {
             commands: self.commands.clone(),
             filesystem: self.filesystem.clone(),
             network: self.network.clone(),
+            linux: profile::LinuxConfig::default(),
             env_credentials: self.env_credentials.clone(),
             environment: None,
             workdir: self.workdir.clone(),

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1232,6 +1232,40 @@ pub enum Wsl2ProxyPolicy {
     InsecureProxy,
 }
 
+/// Linux pathname AF_UNIX seccomp mediation mode.
+///
+/// When set to `pathname`, pathname Unix socket `connect(2)` and `bind(2)`
+/// calls are mediated by the supervisor and must match explicit
+/// `filesystem.unix_socket*` grants. The default `off` mode preserves
+/// compatibility: filesystem grants may still make pathname sockets reachable
+/// on Landlock V4+.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LinuxAfUnixMediation {
+    /// Do not install the V4+ AF_UNIX-only seccomp mediation filter.
+    #[default]
+    Off,
+    /// Mediate pathname AF_UNIX sockets through explicit socket grants.
+    Pathname,
+}
+
+impl LinuxAfUnixMediation {
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    #[must_use]
+    pub fn is_pathname(self) -> bool {
+        matches!(self, LinuxAfUnixMediation::Pathname)
+    }
+}
+
+/// Linux-specific profile controls.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LinuxConfig {
+    /// Opt-in pathname AF_UNIX mediation mode.
+    #[serde(default)]
+    pub af_unix_mediation: Option<LinuxAfUnixMediation>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkdirAccess {
@@ -1419,6 +1453,8 @@ pub struct Profile {
     pub filesystem: FilesystemConfig,
     #[serde(default)]
     pub network: NetworkConfig,
+    #[serde(default)]
+    pub linux: LinuxConfig,
     /// ALIAS(canonical="env_credentials", introduced="v0.0.0", remove_by="indefinite", issue="#143")
     #[serde(default, alias = "secrets")]
     pub env_credentials: SecretsConfig,
@@ -1505,6 +1541,8 @@ struct ProfileDeserialize {
     policy: crate::deprecated_schema::LegacyPolicyPatch,
     #[serde(default)]
     network: NetworkConfig,
+    #[serde(default)]
+    linux: LinuxConfig,
     /// ALIAS(canonical="env_credentials", introduced="v0.0.0", remove_by="indefinite", issue="#143")
     #[serde(default, alias = "secrets")]
     env_credentials: SecretsConfig,
@@ -1553,6 +1591,7 @@ impl From<ProfileDeserialize> for Profile {
             commands: raw.commands,
             filesystem: raw.filesystem,
             network: raw.network,
+            linux: raw.linux,
             env_credentials: raw.env_credentials,
             environment: raw.environment,
             workdir: raw.workdir,
@@ -2409,6 +2448,12 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.network.upstream_bypass,
                 &child.network.upstream_bypass,
             ),
+        },
+        linux: LinuxConfig {
+            af_unix_mediation: child
+                .linux
+                .af_unix_mediation
+                .or(base.linux.af_unix_mediation),
         },
         env_credentials: SecretsConfig {
             mappings: {
@@ -4258,6 +4303,7 @@ mod tests {
                 upstream_proxy: None,
                 upstream_bypass: Vec::new(),
             },
+            linux: LinuxConfig::default(),
             env_credentials: SecretsConfig {
                 mappings: {
                     let mut m = HashMap::new();
@@ -4335,6 +4381,7 @@ mod tests {
                 upstream_proxy: None,
                 upstream_bypass: Vec::new(),
             },
+            linux: LinuxConfig::default(),
             env_credentials: SecretsConfig {
                 mappings: {
                     let mut m = HashMap::new();
@@ -4389,6 +4436,30 @@ mod tests {
         let merged = merge_profiles(base_profile(), child_profile());
         // base has [3000], child has [3000, 5000] — merged should dedup to [3000, 5000]
         assert_eq!(merged.network.open_port, vec![3000, 5000]);
+    }
+
+    #[test]
+    fn test_profile_parses_linux_af_unix_mediation() {
+        let json = r#"{
+            "meta": {"name": "linux-ipc", "version": "1.0"},
+            "linux": {"af_unix_mediation": "pathname"}
+        }"#;
+        let profile: Profile = serde_json::from_str(json).expect("parse profile");
+        assert_eq!(
+            profile.linux.af_unix_mediation,
+            Some(LinuxAfUnixMediation::Pathname)
+        );
+    }
+
+    #[test]
+    fn test_merge_profiles_inherits_linux_af_unix_mediation() {
+        let mut base = base_profile();
+        base.linux.af_unix_mediation = Some(LinuxAfUnixMediation::Pathname);
+        let merged = merge_profiles(base, child_profile());
+        assert_eq!(
+            merged.linux.af_unix_mediation,
+            Some(LinuxAfUnixMediation::Pathname)
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -923,6 +923,13 @@ pub(crate) fn cmd_show(args: ProfileShowArgs) -> Result<()> {
             theme::fg(&format!("{policy:?}"), t.text)
         );
     }
+    if let Some(mode) = profile.linux.af_unix_mediation {
+        println!(
+            "  {} {}",
+            theme::fg("Linux AF_UNIX mediation:", t.subtext),
+            theme::fg(&format!("{mode:?}"), t.text)
+        );
+    }
 
     // Filesystem
     let fs = &profile.filesystem;
@@ -1159,6 +1166,9 @@ fn profile_to_json(
         security.insert("wsl2_proxy_policy".into(), serde_json::json!(v));
     }
     val["security"] = serde_json::Value::Object(security);
+    if let Some(v) = profile.linux.af_unix_mediation {
+        val["linux"] = serde_json::json!({ "af_unix_mediation": v });
+    }
 
     // Filesystem (canonical schema — `allow`/`read`/`write`/`*_file`/`deny`/
     // `bypass_protection`). Legacy keys deserialize into these fields via
@@ -1387,6 +1397,12 @@ pub(crate) fn cmd_diff(args: ProfileDiffArgs) -> Result<()> {
         "wsl2_proxy_policy",
         &p1.security.wsl2_proxy_policy.map(|v| format!("{v:?}")),
         &p2.security.wsl2_proxy_policy.map(|v| format!("{v:?}")),
+        t,
+    );
+    any_diff |= diff_scalar_option(
+        "linux.af_unix_mediation",
+        &p1.linux.af_unix_mediation.map(|v| format!("{v:?}")),
+        &p2.linux.af_unix_mediation.map(|v| format!("{v:?}")),
         t,
     );
     any_diff |= diff_scalar_option(
@@ -1899,6 +1915,13 @@ fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_j
             "profile1": p1.security.wsl2_proxy_policy,
             "profile2": p2.security.wsl2_proxy_policy,
             "changed": p1.security.wsl2_proxy_policy != p2.security.wsl2_proxy_policy,
+        },
+        "linux": {
+            "af_unix_mediation": {
+                "profile1": p1.linux.af_unix_mediation,
+                "profile2": p2.linux.af_unix_mediation,
+                "changed": p1.linux.af_unix_mediation != p2.linux.af_unix_mediation,
+            }
         },
         "filesystem": diff_fs_json(&p1.filesystem, &p2.filesystem),
         "workdir": {

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -9,6 +9,8 @@ pub(crate) struct PreparedProfile {
     pub(crate) capability_elevation: bool,
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: profile::Wsl2ProxyPolicy,
+    #[cfg(target_os = "linux")]
+    pub(crate) af_unix_mediation: profile::LinuxAfUnixMediation,
     pub(crate) workdir_access: Option<profile::WorkdirAccess>,
     pub(crate) rollback_exclude_patterns: Vec<String>,
     pub(crate) rollback_exclude_globs: Vec<String>,
@@ -351,6 +353,11 @@ fn prepare_profile_with_options(
         wsl2_proxy_policy: loaded_profile
             .as_ref()
             .and_then(|profile| profile.security.wsl2_proxy_policy)
+            .unwrap_or_default(),
+        #[cfg(target_os = "linux")]
+        af_unix_mediation: loaded_profile
+            .as_ref()
+            .and_then(|profile| profile.linux.af_unix_mediation)
             .unwrap_or_default(),
         workdir_access: loaded_profile
             .as_ref()

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -36,6 +36,8 @@ pub(crate) struct RollbackExitContext<'a> {
     pub(crate) audit_snapshot_state: Option<AuditSnapshotState>,
     pub(crate) audit_tracked_paths: Vec<PathBuf>,
     pub(crate) audit_recorder: Option<&'a Mutex<AuditRecorder>>,
+    pub(crate) supervisor_network_audit_events:
+        Option<&'a Mutex<Vec<nono::undo::NetworkAuditEvent>>>,
     pub(crate) audit_integrity_enabled: bool,
     pub(crate) proxy_handle: Option<&'a nono_proxy::server::ProxyHandle>,
     pub(crate) executable_identity: Option<&'a ExecutableIdentity>,
@@ -460,6 +462,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         audit_snapshot_state,
         audit_tracked_paths,
         audit_recorder,
+        supervisor_network_audit_events,
         audit_integrity_enabled,
         proxy_handle,
         executable_identity,
@@ -477,6 +480,12 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         Vec::new,
         nono_proxy::server::ProxyHandle::drain_audit_events,
     );
+    if let Some(events_mutex) = supervisor_network_audit_events {
+        let mut supervisor_events = events_mutex.lock().map_err(|_| {
+            nono::NonoError::Snapshot("Network audit event lock poisoned".to_string())
+        })?;
+        network_events.extend(supervisor_events.drain(..));
+    }
     let (audit_event_count, audit_integrity) = if let Some(recorder_mutex) = audit_recorder {
         let mut recorder = recorder_mutex
             .lock()

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -429,6 +429,8 @@ pub(crate) struct PreparedSandbox {
     pub(crate) capability_elevation: bool,
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy,
+    #[cfg(target_os = "linux")]
+    pub(crate) af_unix_mediation: crate::profile::LinuxAfUnixMediation,
     pub(crate) allow_launch_services_active: bool,
     pub(crate) allow_gpu_active: bool,
     pub(crate) open_url_origins: Vec<String>,
@@ -1015,6 +1017,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 capability_elevation: false,
                 #[cfg(target_os = "linux")]
                 wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::default(),
+                #[cfg(target_os = "linux")]
+                af_unix_mediation: crate::profile::LinuxAfUnixMediation::default(),
                 allow_launch_services_active: false,
                 allow_gpu_active: false,
                 open_url_origins: Vec::new(),
@@ -1035,6 +1039,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         capability_elevation,
         #[cfg(target_os = "linux")]
         wsl2_proxy_policy,
+        #[cfg(target_os = "linux")]
+        af_unix_mediation,
         workdir_access: profile_workdir_access,
         rollback_exclude_patterns: profile_rollback_patterns,
         rollback_exclude_globs: profile_rollback_globs,
@@ -1284,6 +1290,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             capability_elevation,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation,
             allow_launch_services_active,
             allow_gpu_active,
             open_url_origins,

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -201,6 +201,13 @@ impl SetupRunner {
             );
         }
 
+        println!("  * Linux AF_UNIX mediation: off by default");
+        println!("    - For stricter IPC isolation, set linux.af_unix_mediation = \"pathname\"");
+        println!("    - Then grant required pathname sockets with filesystem.unix_socket entries");
+        println!(
+            "    - In public-facing or privacy-sensitive deployments that keep it off, run nono inside a stronger outer boundary such as a MicroVM"
+        );
+
         println!("  * Filesystem ruleset creation verified");
 
         // WSL2 environment detection and feature matrix

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -213,6 +213,9 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     } else {
         None
     };
+    let supervisor_network_audit_events = audit_state
+        .as_ref()
+        .map(|_| std::sync::Mutex::new(Vec::new()));
     if let Some(recorder_mutex) = audit_recorder.as_ref() {
         let mut recorder = recorder_mutex
             .lock()
@@ -232,6 +235,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         open_url_origins: &proxy.open_url_origins,
         open_url_allow_localhost: proxy.open_url_allow_localhost,
         audit_recorder: audit_recorder.as_ref(),
+        network_audit_events: supervisor_network_audit_events.as_ref(),
         redaction_policy,
         allow_launch_services_active: proxy.allow_launch_services_active,
         #[cfg(target_os = "linux")]
@@ -246,6 +250,12 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         },
         #[cfg(target_os = "linux")]
         unix_socket_allowlist: caps.unix_socket_capabilities(),
+        #[cfg(target_os = "linux")]
+        linux_network_notify_mode: if config.seccomp_proxy_fallback {
+            exec_strategy::LinuxNetworkNotifyMode::ProxyOnly
+        } else {
+            exec_strategy::LinuxNetworkNotifyMode::AfUnixOnly
+        },
     };
 
     let exit_code = {
@@ -273,6 +283,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         audit_snapshot_state,
         audit_tracked_paths,
         audit_recorder: audit_recorder.as_ref(),
+        supervisor_network_audit_events: supervisor_network_audit_events.as_ref(),
         audit_integrity_enabled: !rollback.no_audit_integrity,
         proxy_handle,
         executable_identity,

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -34,6 +34,23 @@ fn test_schema_has_canonical_top_level_commands() {
 }
 
 #[test]
+fn test_schema_has_linux_af_unix_mediation() {
+    let schema = load_schema();
+    assert!(
+        schema.pointer("/properties/linux").is_some(),
+        "schema is missing canonical /properties/linux"
+    );
+    let props = schema
+        .pointer("/$defs/LinuxConfig/properties")
+        .and_then(Value::as_object)
+        .expect("LinuxConfig.properties is an object");
+    assert!(
+        props.contains_key("af_unix_mediation"),
+        "LinuxConfig.af_unix_mediation missing from canonical schema"
+    );
+}
+
+#[test]
 fn test_schema_groups_has_include_and_exclude() {
     let schema = load_schema();
     let props = schema

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -31,6 +31,8 @@ pub enum DenialReason {
     RateLimited,
     /// Approval backend returned an error
     BackendError,
+    /// Pathname Unix socket was denied by IPC mediation
+    UnixSocketDenied,
 }
 
 /// Record of a denied access attempt during a supervised session.
@@ -42,6 +44,19 @@ pub struct DenialRecord {
     pub access: AccessMode,
     /// Why it was denied
     pub reason: DenialReason,
+}
+
+/// Record of a denied IPC attempt during a supervised session.
+#[derive(Debug, Clone)]
+pub struct IpcDenialRecord {
+    /// IPC resource that was denied, e.g. `/run/user/1000/bus` or `unix:<abstract>`.
+    pub target: String,
+    /// Operation attempted, e.g. `connect` or `bind`.
+    pub operation: String,
+    /// Why it was denied.
+    pub reason: String,
+    /// Suggested CLI flag when this denial can be fixed by an explicit grant.
+    pub suggested_flag: Option<String>,
 }
 
 /// Best-effort sandbox violation recovered from OS-native logging.
@@ -616,6 +631,7 @@ pub struct DiagnosticFormatter<'a> {
     caps: &'a CapabilitySet,
     mode: DiagnosticMode,
     denials: &'a [DenialRecord],
+    ipc_denials: &'a [IpcDenialRecord],
     sandbox_violations: &'a [SandboxViolation],
     /// Paths that are write-protected due to trust verification
     protected_paths: &'a [PathBuf],
@@ -647,6 +663,7 @@ impl<'a> DiagnosticFormatter<'a> {
             caps,
             mode: DiagnosticMode::Standard,
             denials: &[],
+            ipc_denials: &[],
             sandbox_violations: &[],
             protected_paths: &[],
             primary_verdict: None,
@@ -672,6 +689,13 @@ impl<'a> DiagnosticFormatter<'a> {
     #[must_use]
     pub fn with_denials(mut self, denials: &'a [DenialRecord]) -> Self {
         self.denials = denials;
+        self
+    }
+
+    /// Add IPC denial records from a supervised session.
+    #[must_use]
+    pub fn with_ipc_denials(mut self, denials: &'a [IpcDenialRecord]) -> Self {
+        self.ipc_denials = denials;
         self
     }
 
@@ -1069,14 +1093,17 @@ impl<'a> DiagnosticFormatter<'a> {
         let primary_verdict = self.primary_observation_verdict();
         let has_observation = self.has_error_observation();
 
+        let has_ipc_denials = !self.ipc_denials.is_empty();
+
         if self.denials.is_empty()
+            && !has_ipc_denials
             && matches!(
                 primary_verdict.as_ref(),
                 Some(ErrorVerdict::MissingPath(_)) | Some(ErrorVerdict::NonSandboxFailure(_))
             )
         {
             lines.push(format_command_failed_not_sandbox_line(exit_code));
-        } else if exit_code == 0 && has_observation && self.denials.is_empty() {
+        } else if exit_code == 0 && has_observation && self.denials.is_empty() && !has_ipc_denials {
             lines.push(format_command_succeeded_with_stderr_line());
         } else {
             lines.extend(self.format_exit_explanation(exit_code));
@@ -1097,7 +1124,14 @@ impl<'a> DiagnosticFormatter<'a> {
             .collect();
         all_denials.extend(self.observed_denials_matching_logged_paths(&all_denials));
 
-        if all_denials.is_empty() {
+        if !self.ipc_denials.is_empty() {
+            self.format_ipc_denial_guidance(&mut lines);
+            if !all_denials.is_empty() || !non_fs_violations.is_empty() {
+                lines.push("[nono]".to_string());
+            }
+        }
+
+        if all_denials.is_empty() && self.ipc_denials.is_empty() {
             // No denials from either source.
             if !non_fs_violations.is_empty() {
                 // Non-filesystem violations (mach-lookup, signal, etc.) —
@@ -1121,7 +1155,7 @@ impl<'a> DiagnosticFormatter<'a> {
             self.format_grant_help(&mut lines);
             lines.push("[nono]".to_string());
             self.format_follow_up_guidance(&mut lines, None);
-        } else {
+        } else if !all_denials.is_empty() {
             // Deduplicate by path, merging access modes. Classification into
             // actionable vs. policy-blocked is done by the consolidated
             // formatter using policy_explanations when available.
@@ -1350,11 +1384,40 @@ impl<'a> DiagnosticFormatter<'a> {
     ) {
         const MAX_INLINE_LIST: usize = 10;
 
-        let total = denials.len();
+        let (unix_socket_denials, path_denials): (Vec<&DenialRecord>, Vec<&DenialRecord>) = denials
+            .iter()
+            .partition(|denial| denial.reason == DenialReason::UnixSocketDenied);
+
+        if !unix_socket_denials.is_empty() {
+            let total = unix_socket_denials.len();
+            let plural_s = if total == 1 { "" } else { "s" };
+            lines.push(format!(
+                "[nono] IPC denial: {} pathname Unix socket{} blocked.",
+                total, plural_s
+            ));
+            for (idx, denial) in unix_socket_denials.iter().enumerate() {
+                if idx >= MAX_INLINE_LIST {
+                    lines.push(format!("[nono]   ... and {} more", total - idx));
+                    break;
+                }
+                lines.push(format!("[nono]   {}", denial.path.display()));
+            }
+            let flags: Vec<String> = unix_socket_denials
+                .iter()
+                .map(|d| self.suggested_flag_for_denial(d))
+                .collect();
+            lines.push(format!("[nono] Fix: {}", flags.join(" ")));
+        }
+
+        if path_denials.is_empty() {
+            return;
+        }
+
+        let total = path_denials.len();
         let mut actionable: Vec<&DenialRecord> = Vec::new();
         let mut policy_blocked: Vec<&DenialRecord> = Vec::new();
 
-        for denial in denials {
+        for denial in &path_denials {
             if self.is_denial_policy_blocked(denial) {
                 policy_blocked.push(denial);
             } else {
@@ -1368,7 +1431,7 @@ impl<'a> DiagnosticFormatter<'a> {
             total, plural_s
         ));
 
-        for (idx, denial) in denials.iter().enumerate() {
+        for (idx, denial) in path_denials.iter().enumerate() {
             if idx >= MAX_INLINE_LIST {
                 lines.push(format!("[nono]   … and {} more", total - idx));
                 break;
@@ -1414,6 +1477,36 @@ impl<'a> DiagnosticFormatter<'a> {
         }
     }
 
+    fn format_ipc_denial_guidance(&self, lines: &mut Vec<String>) {
+        const MAX_INLINE_LIST: usize = 10;
+
+        let total = self.ipc_denials.len();
+        let plural_s = if total == 1 { "" } else { "s" };
+        lines.push(format!(
+            "[nono] IPC denial: {} Unix socket operation{} blocked.",
+            total, plural_s
+        ));
+        for (idx, denial) in self.ipc_denials.iter().enumerate() {
+            if idx >= MAX_INLINE_LIST {
+                lines.push(format!("[nono]   ... and {} more", total - idx));
+                break;
+            }
+            lines.push(format!(
+                "[nono]   {} {} ({})",
+                denial.operation, denial.target, denial.reason
+            ));
+        }
+
+        let flags: Vec<&str> = self
+            .ipc_denials
+            .iter()
+            .filter_map(|denial| denial.suggested_flag.as_deref())
+            .collect();
+        if !flags.is_empty() {
+            lines.push(format!("[nono] Fix: {}", flags.join(" ")));
+        }
+    }
+
     /// Return true when the denial cannot be fixed by a path flag alone —
     /// i.e. the path is blocked by the sensitive-path policy and requires a
     /// profile with `filesystem.bypass_protection`.
@@ -1434,6 +1527,15 @@ impl<'a> DiagnosticFormatter<'a> {
     /// explanation's `suggested_flag` (which knows about parent-directory
     /// canonicalization) and falls back to a local computation otherwise.
     fn suggested_flag_for_denial(&self, denial: &DenialRecord) -> String {
+        if denial.reason == DenialReason::UnixSocketDenied {
+            let flag = if denial.access.contains(AccessMode::Write) {
+                "--allow-unix-socket-bind"
+            } else {
+                "--allow-unix-socket"
+            };
+            return format!("{} {}", flag, denial.path.display());
+        }
+
         if let Some(flag) = self
             .policy_explanations
             .iter()
@@ -1971,6 +2073,7 @@ fn stricter_reason(a: DenialReason, b: DenialReason) -> DenialReason {
     fn rank(r: &DenialReason) -> u8 {
         match r {
             DenialReason::PolicyBlocked => 5,
+            DenialReason::UnixSocketDenied => 5,
             DenialReason::InsufficientAccess => 4,
             DenialReason::UserDenied => 3,
             DenialReason::RateLimited => 2,
@@ -3111,6 +3214,26 @@ mod tests {
         // Policy-blocked paths cannot be fixed with a path flag.
         assert!(!output.contains("Fix: --read /etc/shadow"));
         assert!(!output.contains("--allow <path>"));
+    }
+
+    #[test]
+    fn test_supervised_unix_socket_denial_uses_ipc_guidance() {
+        let caps = make_test_caps();
+        let denials = vec![DenialRecord {
+            path: PathBuf::from("/run/user/1000/bus"),
+            access: AccessMode::Read,
+            reason: DenialReason::UnixSocketDenied,
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials);
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains("IPC denial: 1 pathname Unix socket blocked."));
+        assert!(output.contains("/run/user/1000/bus"));
+        assert!(output.contains("Fix: --allow-unix-socket /run/user/1000/bus"));
+        assert!(!output.contains("No path denials were observed"));
+        assert!(!output.contains("--read /run/user/1000/bus"));
     }
 
     #[test]

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -68,7 +68,7 @@ pub use capability::{
 };
 pub use diagnostic::{
     CommandContext, DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode,
-    SandboxViolation,
+    IpcDenialRecord, SandboxViolation,
 };
 pub use error::{NonoError, Result};
 pub use keystore::{

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -1557,8 +1557,9 @@ pub fn respond_notif_errno(notify_fd: std::os::fd::RawFd, notif_id: u64, errno: 
 
 /// Continue a seccomp notification, letting the child's original syscall run.
 ///
-/// This preserves the original syscall semantics exactly. It is safe only when
-/// the syscall is already authorized by the sandbox's allow-list.
+/// This resumes the original syscall with its original userspace arguments.
+/// Do not use it after making an authorization decision from child-controlled
+/// pointer memory unless the policy accepts the resulting TOCTOU window.
 pub fn continue_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
     let resp = SeccompNotifResp {
         id: notif_id,
@@ -1929,6 +1930,55 @@ fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
     ]
 }
 
+/// Build a BPF filter for opt-in pathname AF_UNIX mediation.
+///
+/// The filter routes `connect()` and `bind()` to the supervisor so it can
+/// inspect `sockaddr_un` paths. Everything else is allowed by this filter:
+/// TCP policy remains Landlock's job on V4+ kernels.
+///
+/// Instruction layout:
+/// ```text
+///  0: ld  [nr]
+///  1: jeq SYS_CONNECT jt=+2 (-> 4: notify)
+///  2: jeq SYS_BIND    jt=+1 (-> 4: notify)
+///  3: ret ALLOW
+///  4: ret USER_NOTIF
+/// ```
+fn build_seccomp_af_unix_filter() -> Vec<SockFilterInsn> {
+    vec![
+        SockFilterInsn {
+            code: BPF_LD | BPF_W | BPF_ABS,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_DATA_NR_OFFSET,
+        },
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 2,
+            jf: 0,
+            k: SYS_CONNECT as u32,
+        },
+        SockFilterInsn {
+            code: BPF_JMP | BPF_JEQ | BPF_K,
+            jt: 1,
+            jf: 0,
+            k: SYS_BIND as u32,
+        },
+        SockFilterInsn {
+            code: BPF_RET | BPF_K,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_ALLOW,
+        },
+        SockFilterInsn {
+            code: BPF_RET | BPF_K,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_USER_NOTIF,
+        },
+    ]
+}
+
 /// Install a seccomp-notify BPF filter for proxy-only network mode.
 ///
 /// Returns the notify fd that the supervisor must poll for connect/bind
@@ -1941,9 +1991,23 @@ fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
 ///
 /// Returns an error if the seccomp syscall fails.
 pub fn install_seccomp_proxy_filter(has_bind_ports: bool) -> Result<std::os::fd::OwnedFd> {
-    use std::os::fd::FromRawFd;
+    install_seccomp_notify_filter(&build_seccomp_proxy_filter(has_bind_ports), "proxy filter")
+}
 
-    let filter = build_seccomp_proxy_filter(has_bind_ports);
+/// Install a seccomp-notify BPF filter for pathname AF_UNIX mediation.
+///
+/// # Errors
+///
+/// Returns an error if the seccomp syscall fails.
+pub fn install_seccomp_af_unix_filter() -> Result<std::os::fd::OwnedFd> {
+    install_seccomp_notify_filter(&build_seccomp_af_unix_filter(), "AF_UNIX mediation filter")
+}
+
+fn install_seccomp_notify_filter(
+    filter: &[SockFilterInsn],
+    label: &str,
+) -> Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
 
     let prog = SockFprog {
         len: filter.len() as u16,
@@ -1990,8 +2054,9 @@ pub fn install_seccomp_proxy_filter(has_bind_ports: bool) -> Result<std::os::fd:
 
         if ret < 0 {
             return Err(NonoError::SandboxInit(format!(
-                "seccomp(SECCOMP_SET_MODE_FILTER) for proxy filter failed: {}. \
+                "seccomp(SECCOMP_SET_MODE_FILTER) for {} failed: {}. \
                  Requires kernel >= 5.0 with SECCOMP_FILTER_FLAG_NEW_LISTENER.",
+                label,
                 std::io::Error::last_os_error()
             )));
         }
@@ -2012,12 +2077,11 @@ pub fn install_seccomp_proxy_filter(has_bind_ports: bool) -> Result<std::os::fd:
 ///
 /// # TOCTOU Warning
 ///
-/// For connect/bind, the kernel copies sockaddr into kernel memory via
-/// `move_addr_to_kernel()` before the seccomp filter runs. The userspace
-/// copy we read here may differ from what the kernel uses, but we use
-/// `SECCOMP_USER_NOTIF_FLAG_CONTINUE` which lets the kernel proceed with
-/// its already-copied data. The userspace read is only used for the
-/// allow/deny decision.
+/// Seccomp notification happens at syscall entry, before `connect(2)` or
+/// `bind(2)` copies the sockaddr into kernel memory. The userspace memory
+/// read here is therefore child-controlled and can race with another thread.
+/// Callers must not use `SECCOMP_USER_NOTIF_FLAG_CONTINUE` after authorizing
+/// pointer-derived data unless that TOCTOU window is explicitly acceptable.
 ///
 /// Always call `notif_id_valid()` after reading to verify the notification
 /// is still pending.
@@ -3233,6 +3297,18 @@ mod tests {
             "bind must route to USER_NOTIF regardless of has_bind_ports so \
              the supervisor can permit AF_UNIX pathname bind (#685)"
         );
+    }
+
+    #[test]
+    fn test_build_seccomp_af_unix_filter_notifies_connect_bind_only() {
+        let filter = build_seccomp_af_unix_filter();
+        assert_eq!(filter.len(), 5);
+        assert_eq!(filter[0].code, BPF_LD | BPF_W | BPF_ABS);
+        assert_eq!(filter[0].k, SECCOMP_DATA_NR_OFFSET);
+        assert_eq!(filter[1].k, SYS_CONNECT as u32);
+        assert_eq!(filter[2].k, SYS_BIND as u32);
+        assert_eq!(filter[3].k, SECCOMP_RET_ALLOW);
+        assert_eq!(filter[4].k, SECCOMP_RET_USER_NOTIF);
     }
 
     #[test]

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -31,9 +31,10 @@ pub use linux::is_wsl2;
 pub use linux::{
     OpenHow, SYS_BIND, SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2, SeccompData, SeccompNetFallback,
     SeccompNotif, SockaddrInfo, UnixSocketKind, classify_access_from_flags, classify_af_unix,
-    continue_notif, deny_notif, inject_fd, install_seccomp_notify, install_seccomp_proxy_filter,
-    notif_id_valid, probe_seccomp_block_network_support, read_notif_path, read_notif_sockaddr,
-    read_open_how, recv_notif, resolve_notif_path, respond_notif_errno, validate_openat2_size,
+    continue_notif, deny_notif, inject_fd, install_seccomp_af_unix_filter, install_seccomp_notify,
+    install_seccomp_proxy_filter, notif_id_valid, probe_seccomp_block_network_support,
+    read_notif_path, read_notif_sockaddr, read_open_how, recv_notif, resolve_notif_path,
+    respond_notif_errno, validate_openat2_size,
 };
 
 /// Information about sandbox support on this platform

--- a/docs/cli/internals/landlock.mdx
+++ b/docs/cli/internals/landlock.mdx
@@ -130,6 +130,55 @@ nono why --scope signal --profile claude-code
 nono why --scope abstract-unix-socket --profile claude-code
 ```
 
+## Pathname Unix Socket Mediation
+
+Landlock filesystem rules and pathname Unix socket IPC are separate security
+surfaces. On Linux, a process that can reach a filesystem-backed Unix socket
+path may be able to communicate with a user-session service through that
+socket unless nono separately mediates AF_UNIX `connect(2)` and `bind(2)`.
+
+For compatibility, this mediation is off by default on Landlock V4+ kernels.
+Profiles that need stricter IPC isolation can opt in:
+
+```json
+{
+  "linux": {
+    "af_unix_mediation": "pathname"
+  },
+  "filesystem": {
+    "unix_socket": ["$XDG_RUNTIME_DIR/bus"],
+    "unix_socket_dir_bind": ["$TMPDIR/my-tool"]
+  }
+}
+```
+
+When enabled, pathname AF_UNIX sockets are default-deny and must match explicit
+`filesystem.unix_socket*` grants. Broad filesystem read/write grants no longer
+imply permission to talk to every socket under those paths.
+
+Allowed pathname sockets are resumed through Linux seccomp user notification.
+Because seccomp receives the syscall before the kernel copies `sockaddr_un`
+from userspace, a multi-threaded sandboxed process can race an allowed
+`connect(2)` or `bind(2)` by mutating that userspace address before the kernel
+continues the syscall. Denied sockets do not have this race because nono returns
+`EACCES` directly and the kernel never runs the original syscall. Treat this
+mode as a strong default-deny IPC hardening layer; avoid broad socket grants for
+untrusted multi-threaded workloads.
+
+High-risk socket categories include user service managers, session buses,
+keyring and credential agents, SSH/GPG agents, container runtimes, and package
+manager daemons. Hardened profiles should grant only the specific sockets they
+need.
+
+<Warning>
+  If you run with `linux.af_unix_mediation` off in a public-facing,
+  multi-tenant, privacy-sensitive, or otherwise high-risk deployment, run nono
+  inside a stronger outer isolation boundary such as a MicroVM. Firecracker
+  style MicroVMs are a good fit for service deployments where the VM boundary
+  can isolate host user-session services and credentials from the sandboxed
+  agent.
+</Warning>
+
 ## Enforcement Status
 
 nono reports the enforcement status after applying the sandbox:


### PR DESCRIPTION
Introduce the `linux.af_unix_mediation` profile option, allowing stricter isolation for filesystem-backed AF_UNIX sockets on Linux.

When `af_unix_mediation` is set to "pathname":
- A seccomp-notify filter is installed to mediate `connect(2)` and `bind(2)` calls for pathname AF_UNIX sockets.
- This requires explicit `filesystem.unix_socket` or `filesystem.unix_socket_dir_bind` grants for allowed socket paths.
- Other network traffic (e.g., TCP/UDP) bypasses this specific filter and continues to be managed by Landlock or existing network policies.

The default mode "off" preserves compatibility by not enabling this seccomp mediation.

This feature is not supported in "pathname" mode by:
- `nono wrap` due to supervisor requirements.
- WSL2 environments due to seccomp-notify limitations.

Updates include:
- Schema definition for `LinuxConfig` and `LinuxAfUnixMediation`.
- Runtime integration across CLI components to process and enforce the policy.
- Supervisor logic to manage seccomp filters and network decisions.
- Comprehensive documentation in `docs/cli/internals/landlock.mdx`.
-   Introduce `IpcDenialRecord` to capture specific details about denied Unix socket operations (e.g., target, operation, reason, suggested flag).
-   Update the diagnostic formatter to clearly distinguish between file access denials and IPC denials.
-   Provide specific guidance and suggested CLI flags (`--allow-unix-socket`, `--allow-unix-socket-bind`) for Unix socket denials.
-   Add a new in-memory buffer, `network_audit_events`, to `SupervisorConfig` for collecting detailed network audit events during a supervised session (Linux-only).
-   Integrate these `network_audit_events` with the existing audit recorder and ensure they are persisted into session metadata upon exit.
-   Refactor the Linux supervisor loop to return `IpcDenialRecord` instances separately from `DenialRecord` instances, allowing for more granular processing and display.

Issue: #527

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
