### PR TITLE
test(integration-tests): use CARGO_TARGET_DIR in runner

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -33,8 +33,11 @@ if ! cargo build --release -p nono-cli --features test-trust-overrides 2>&1; the
     exit 1
 fi
 
-export NONO_BIN="$PROJECT_ROOT/target/release/nono"
-export PATH="$PROJECT_ROOT/target/release:$PATH"
+TARGET_DIR="${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}"
+RELEASE_DIR="$TARGET_DIR/release"
+
+export NONO_BIN="$RELEASE_DIR/nono"
+export PATH="$RELEASE_DIR:$PATH"
 
 # Verify binary exists
 if [[ ! -x "$NONO_BIN" ]]; then


### PR DESCRIPTION
The integration test runner previously hardcoded the path to the `nono` binary within `$PROJECT_ROOT/target/release`. This would cause issues if the user or CI environment set `CARGO_TARGET_DIR` to a different location.

This commit updates the script to respect the `CARGO_TARGET_DIR` environment variable, falling back to the default `$PROJECT_ROOT/target` if it's not set. This ensures the test runner always finds the correct binary, regardless of the build output directory.