### PR TITLE
fix(pty): prevent keyboard mode reset in multiplexers

### DIFF
--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -102,8 +102,6 @@ const TERMINAL_RESTORE_AND_CLEAR_ESCAPE: &[u8] = concat!(
     "\x1b[?1005l\x1b[?1006l\x1b[?1015l", // disable mouse encodings
     "\x1b[?1004l", // disable focus events
     "\x1b[?2004l", // disable bracketed paste
-    "\x1b[?1l", // disable application cursor keys
-    "\x1b>",   // normal keypad mode
     "\x1b[?1049l", // exit alternate screen
     "\x1b[?25h", // show cursor
     "\x1b[2J\x1b[H", // clear screen + cursor home
@@ -1691,7 +1689,7 @@ fn leave_attach_screen(in_alt_screen: bool) {
         TERMINAL_RESTORE_NORMAL
     };
     let _ = write_all_fd(libc::STDOUT_FILENO, esc);
-    if !in_alt_screen && !is_inside_multiplexer() {
+    if !is_inside_multiplexer() {
         let _ = write_all_fd(libc::STDOUT_FILENO, KEYBOARD_MODE_RESET);
     }
     drain_terminal_output(libc::STDOUT_FILENO);
@@ -1709,7 +1707,7 @@ pub(crate) fn write_detach_terminal_reset(fd: RawFd, in_alt_screen: bool) {
         TERMINAL_RESTORE_NORMAL
     };
     let _ = write_all_fd(fd, esc);
-    if !in_alt_screen && !is_inside_multiplexer() {
+    if !is_inside_multiplexer() {
         let _ = write_all_fd(fd, KEYBOARD_MODE_RESET);
     }
 }
@@ -2418,7 +2416,8 @@ mod tests {
     use super::{
         ATTACH_HANDSHAKE_MAGIC, ATTACH_REQUEST_ATTACH, ATTACH_SCREEN_ENTER_ESCAPE,
         AltScreenTracker, AttachedClient, DEFAULT_DETACH_SEQUENCE, ERASE_NATIVE_SCROLLBACK,
-        KEYBOARD_MODE_RESET, PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_NORMAL,
+        KEYBOARD_MODE_RESET, PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_AND_CLEAR_ESCAPE,
+        TERMINAL_RESTORE_ESCAPE, TERMINAL_RESTORE_NORMAL,
         decode_attach_handshake, encode_attach_request_frame, read_fd_once,
         select_attach_replay_bytes, terminal_restore_escape, write_all_fd,
     };
@@ -2504,16 +2503,25 @@ mod tests {
     }
 
     #[test]
-    fn terminal_restore_normal_excludes_keyboard_mode_reset() {
-        let esc = std::str::from_utf8(TERMINAL_RESTORE_NORMAL).unwrap_or("");
-        assert!(
-            !esc.contains("\u{1b}[?1l"),
-            "TERMINAL_RESTORE_NORMAL must not contain DECCKM-off; use KEYBOARD_MODE_RESET separately"
-        );
-        assert!(
-            !esc.contains("\u{1b}>"),
-            "TERMINAL_RESTORE_NORMAL must not contain DECPNM; use KEYBOARD_MODE_RESET separately"
-        );
+    fn terminal_restore_constants_exclude_keyboard_mode_reset() {
+        for (name, bytes) in [
+            ("TERMINAL_RESTORE_NORMAL", TERMINAL_RESTORE_NORMAL),
+            (
+                "TERMINAL_RESTORE_AND_CLEAR_ESCAPE",
+                TERMINAL_RESTORE_AND_CLEAR_ESCAPE,
+            ),
+            ("TERMINAL_RESTORE_ESCAPE", TERMINAL_RESTORE_ESCAPE),
+        ] {
+            let esc = std::str::from_utf8(bytes).unwrap_or("");
+            assert!(
+                !esc.contains("\u{1b}[?1l"),
+                "{name} must not contain DECCKM-off; use KEYBOARD_MODE_RESET separately"
+            );
+            assert!(
+                !esc.contains("\u{1b}>"),
+                "{name} must not contain DECPNM; use KEYBOARD_MODE_RESET separately"
+            );
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -2416,8 +2416,8 @@ mod tests {
     use super::{
         ATTACH_HANDSHAKE_MAGIC, ATTACH_REQUEST_ATTACH, ATTACH_SCREEN_ENTER_ESCAPE,
         AltScreenTracker, AttachedClient, DEFAULT_DETACH_SEQUENCE, ERASE_NATIVE_SCROLLBACK,
-        KEYBOARD_MODE_RESET, PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_AND_CLEAR_ESCAPE,
-        TERMINAL_RESTORE_ESCAPE, TERMINAL_RESTORE_NORMAL,
+        KEYBOARD_MODE_RESET, PtyProxy, ReadFdOutcome, ScreenState,
+        TERMINAL_RESTORE_AND_CLEAR_ESCAPE, TERMINAL_RESTORE_ESCAPE, TERMINAL_RESTORE_NORMAL,
         decode_attach_handshake, encode_attach_request_frame, read_fd_once,
         select_attach_replay_bytes, terminal_restore_escape, write_all_fd,
     };

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -68,9 +68,18 @@ const TERMINAL_RESTORE_NORMAL: &[u8] = concat!(
     "\x1b[?1005l\x1b[?1006l\x1b[?1015l", // disable mouse encodings
     "\x1b[?1004l", // disable focus events
     "\x1b[?2004l", // disable bracketed paste
-    "\x1b[?1l", // disable application cursor keys
-    "\x1b>",   // normal keypad mode
     "\x1b[?25h", // show cursor
+)
+.as_bytes();
+
+// DECCKM off + DECPNM: kept separate from TERMINAL_RESTORE_NORMAL because
+// writing these to the outer PTY inside a terminal multiplexer (tmux, GNU
+// screen, Zellij) corrupts the multiplexer's keyboard-mode tracking and
+// breaks extended-key delivery (e.g. ESC via CSI-u) for the running
+// application. Emitted only when the outer terminal is not a multiplexer.
+const KEYBOARD_MODE_RESET: &[u8] = concat!(
+    "\x1b[?1l", // disable application cursor keys
+    "\x1b>",    // normal keypad mode
 )
 .as_bytes();
 
@@ -1669,6 +1678,12 @@ fn recv_attach_resize_socket(stream: &UnixStream) -> Result<Option<UnixDatagram>
     Ok(Some(socket))
 }
 
+fn is_inside_multiplexer() -> bool {
+    std::env::var_os("TMUX").is_some()
+        || std::env::var_os("STY").is_some()
+        || std::env::var_os("ZELLIJ").is_some()
+}
+
 fn leave_attach_screen(in_alt_screen: bool) {
     let esc = if in_alt_screen {
         terminal_restore_escape(false)
@@ -1676,6 +1691,9 @@ fn leave_attach_screen(in_alt_screen: bool) {
         TERMINAL_RESTORE_NORMAL
     };
     let _ = write_all_fd(libc::STDOUT_FILENO, esc);
+    if !in_alt_screen && !is_inside_multiplexer() {
+        let _ = write_all_fd(libc::STDOUT_FILENO, KEYBOARD_MODE_RESET);
+    }
     drain_terminal_output(libc::STDOUT_FILENO);
 }
 
@@ -1691,6 +1709,9 @@ pub(crate) fn write_detach_terminal_reset(fd: RawFd, in_alt_screen: bool) {
         TERMINAL_RESTORE_NORMAL
     };
     let _ = write_all_fd(fd, esc);
+    if !in_alt_screen && !is_inside_multiplexer() {
+        let _ = write_all_fd(fd, KEYBOARD_MODE_RESET);
+    }
 }
 
 pub(crate) fn write_detach_notice(fd: RawFd) {
@@ -2397,9 +2418,9 @@ mod tests {
     use super::{
         ATTACH_HANDSHAKE_MAGIC, ATTACH_REQUEST_ATTACH, ATTACH_SCREEN_ENTER_ESCAPE,
         AltScreenTracker, AttachedClient, DEFAULT_DETACH_SEQUENCE, ERASE_NATIVE_SCROLLBACK,
-        PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_NORMAL, decode_attach_handshake,
-        encode_attach_request_frame, read_fd_once, select_attach_replay_bytes,
-        terminal_restore_escape, write_all_fd,
+        KEYBOARD_MODE_RESET, PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_NORMAL,
+        decode_attach_handshake, encode_attach_request_frame, read_fd_once,
+        select_attach_replay_bytes, terminal_restore_escape, write_all_fd,
     };
     use nix::libc;
     use std::collections::VecDeque;
@@ -2480,6 +2501,32 @@ mod tests {
                 "normal-mode restore must still disable mouse mode {mode}"
             );
         }
+    }
+
+    #[test]
+    fn terminal_restore_normal_excludes_keyboard_mode_reset() {
+        let esc = std::str::from_utf8(TERMINAL_RESTORE_NORMAL).unwrap_or("");
+        assert!(
+            !esc.contains("\u{1b}[?1l"),
+            "TERMINAL_RESTORE_NORMAL must not contain DECCKM-off; use KEYBOARD_MODE_RESET separately"
+        );
+        assert!(
+            !esc.contains("\u{1b}>"),
+            "TERMINAL_RESTORE_NORMAL must not contain DECPNM; use KEYBOARD_MODE_RESET separately"
+        );
+    }
+
+    #[test]
+    fn keyboard_mode_reset_contains_decckm_and_decpnm() {
+        let esc = std::str::from_utf8(KEYBOARD_MODE_RESET).unwrap_or("");
+        assert!(
+            esc.contains("\u{1b}[?1l"),
+            "KEYBOARD_MODE_RESET must disable application cursor keys"
+        );
+        assert!(
+            esc.contains("\u{1b}>"),
+            "KEYBOARD_MODE_RESET must reset keypad to normal mode"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Previously, the `TERMINAL_RESTORE_NORMAL` sequence included `DECCKM off` (`\x1b[?1l`) and `DECPNM` (`\x1b>`), which disable application cursor keys and reset the keypad to normal mode.

Emitting these sequences directly to the outer PTY when running inside a terminal multiplexer (such as tmux, GNU screen, or Zellij) corrupts the multiplexer's internal keyboard-mode tracking. This issue leads to broken extended-key delivery for the running application (e.g., `ESC` via `CSI-u`).

To prevent this interference:

- The `DECCKM off` and `DECPNM` sequences have been moved into a new constant, `KEYBOARD_MODE_RESET`.
- A new `is_inside_multiplexer` function detects common terminal multiplexers by checking for environment variables like `TMUX`, `STY`, and `ZELLIJ`.
- The `KEYBOARD_MODE_RESET` sequences are now only emitted if the application is not in an alternative screen and is *not* detected as running inside a terminal multiplexer.

New unit tests confirm the correct separation and content of these terminal control sequence constants.

Fixes: #941
