### PR TITLE
feat(profiles): expand shadowing checks to include pack profiles

### DIFF
--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -3,7 +3,8 @@ use crate::cli::LearnArgs;
 use crate::command_display::format_command_line;
 use crate::profile_save_runtime::{
     PreparedProfileSave, SaveAction, command_name, confirm, patch_has_policy_overrides,
-    print_patch_preview, print_profile_save, suggested_profile_name, write_profile,
+    print_patch_preview, print_profile_save, suggested_profile_name, would_shadow_existing_profile,
+    write_profile,
 };
 use crate::{learn, profile};
 use colored::Colorize;
@@ -222,14 +223,11 @@ fn offer_save_profile(
         return Ok(());
     }
 
-    if compared_profile
-        .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
-        .is_some_and(|name| name == profile_name)
-    {
+    if would_shadow_existing_profile(profile_name) {
         eprintln!(
             "{}",
             format!(
-                "Cannot save '{}' as a derived user profile because it would shadow the built-in profile it extends. Choose a different name.",
+                "Cannot save '{}' as a user profile because it would shadow an existing built-in or pack profile of the same name. Choose a different name.",
                 profile_name
             )
             .red()

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1895,6 +1895,32 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<(PathBuf, String)> {
     if !store.exists() {
         return None;
     }
+
+    // Fast path: if name is in `org/pack-name` format, look up the pack directly
+    // rather than scanning every pack's install_as values.
+    if is_registry_ref(name) {
+        return (|| {
+            let (ns, pack_name) = name.split_once('/')?;
+            let pack_path = store.join(ns).join(pack_name);
+            if !pack_path.is_dir() {
+                return None;
+            }
+            let manifest_str =
+                std::fs::read_to_string(pack_path.join("package.json")).ok()?;
+            let manifest: crate::package::PackageManifest =
+                serde_json::from_str(&manifest_str).ok()?;
+            manifest.artifacts.iter()
+                .filter(|a| a.artifact_type == crate::package::ArtifactType::Profile)
+                .find_map(|a| {
+                    let install_as = a.install_as.as_deref()?;
+                    let profile_file = pack_path
+                        .join("profiles")
+                        .join(format!("{install_as}.json"));
+                    profile_file.exists().then(|| (profile_file, name.to_owned()))
+                })
+        })();
+    }
+
     let mut matches: Vec<(String, PathBuf)> = Vec::new();
     let ns_entries = std::fs::read_dir(&store).ok()?;
     for ns_entry in ns_entries.flatten() {
@@ -2275,7 +2301,7 @@ fn load_base_profile_raw(
     context_dir: Option<&Path>,
     source_file: Option<&Path>,
 ) -> Result<ResolvedBase> {
-    if !is_valid_profile_name(name) {
+    if !is_valid_profile_name(name) && !is_registry_ref(name) {
         return Err(NonoError::ProfileInheritance(format!(
             "invalid base profile name '{}'",
             name

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1907,11 +1907,12 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<(PathBuf, String)> {
             if !pack_path.is_dir() {
                 return None;
             }
-            let manifest_str =
-                std::fs::read_to_string(pack_path.join("package.json")).ok()?;
+            let manifest_str = std::fs::read_to_string(pack_path.join("package.json")).ok()?;
             let manifest: crate::package::PackageManifest =
                 serde_json::from_str(&manifest_str).ok()?;
-            manifest.artifacts.iter()
+            manifest
+                .artifacts
+                .iter()
                 .filter(|a| a.artifact_type == crate::package::ArtifactType::Profile)
                 .find_map(|a| {
                     let install_as = a.install_as.as_deref()?;

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1896,12 +1896,14 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<(PathBuf, String)> {
         return None;
     }
 
-    // Fast path: if name is in `org/pack-name` format, look up the pack directly
-    // rather than scanning every pack's install_as values.
+    // Fast path: if name is in `org/pack-name[@version]` format, look up the
+    // pack directly rather than scanning every pack's install_as values.
+    // parse_package_ref strips the optional @version so we always look under
+    // the installed `packages/org/pack` directory, not `packages/org/pack@ver`.
     if is_registry_ref(name) {
         return (|| {
-            let (ns, pack_name) = name.split_once('/')?;
-            let pack_path = store.join(ns).join(pack_name);
+            let pkg = crate::package::parse_package_ref(name).ok()?;
+            let pack_path = store.join(&pkg.namespace).join(&pkg.name);
             if !pack_path.is_dir() {
                 return None;
             }
@@ -1916,7 +1918,7 @@ pub(crate) fn find_pack_store_profile(name: &str) -> Option<(PathBuf, String)> {
                     let profile_file = pack_path
                         .join("profiles")
                         .join(format!("{install_as}.json"));
-                    profile_file.exists().then(|| (profile_file, name.to_owned()))
+                    profile_file.exists().then(|| (profile_file, pkg.key()))
                 })
         })();
     }

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -59,7 +59,10 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
     // an installed pack before falling through to the generic name-validation
     // error — this gives the user actionable guidance.
     if profile::is_registry_ref(&args.name) {
-        let short_name = args.name.split_once('/').map_or(args.name.as_str(), |(_, n)| n);
+        let short_name = args
+            .name
+            .split_once('/')
+            .map_or(args.name.as_str(), |(_, n)| n);
         let suggested = format!("{}-local", short_name);
         let extends_target = args.extends.as_deref().unwrap_or(args.name.as_str());
         crate::output::print_warning(&format!(

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -55,6 +55,28 @@ pub fn run_profile(args: ProfileCmdArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn cmd_init(args: ProfileInitArgs) -> Result<()> {
+    // If the name looks like an org/pack reference, check whether it matches
+    // an installed pack before falling through to the generic name-validation
+    // error — this gives the user actionable guidance.
+    if profile::is_registry_ref(&args.name) {
+        let short_name = args.name.split_once('/').map_or(args.name.as_str(), |(_, n)| n);
+        let suggested = format!("{}-local", short_name);
+        let extends_target = args.extends.as_deref().unwrap_or(args.name.as_str());
+        crate::output::print_warning(&format!(
+            "'{}' is a pack reference, not a profile name. \
+             Choose a plain name for your profile.",
+            args.name
+        ));
+        let t = theme::current();
+        eprintln!(
+            "  {} nono profile init {} --extends {}",
+            theme::fg("Try:", t.green).bold(),
+            suggested,
+            extends_target
+        );
+        return Err(NonoError::Cancelled(String::new()));
+    }
+
     // Validate profile name
     if !profile::is_valid_profile_name(&args.name) {
         return Err(NonoError::ProfileParse(format!(
@@ -77,18 +99,25 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
         )));
     }
 
-    // When writing to the standard user profiles directory, block names that
-    // would shadow a built-in or installed pack profile. A user override of
-    // a pack profile intercepts all `"extends": "<name>"` chains and is
-    // almost never the intended outcome — use a derived name instead.
-    if args.output.is_none()
-        && crate::profile_save_runtime::would_shadow_existing_profile(&args.name)
+    // Block names that match an embedded built-in profile. Pack profiles use
+    // `org/name` keys (e.g. `always-further/hermes`), which are invalid as
+    // profile names, so a short name like `hermes` cannot shadow a pack.
     {
-        return Err(NonoError::ProfileParse(format!(
-            "Cannot create profile '{}': a built-in or pack profile with that name already \
-             exists. Choose a different name, or use --output to write to a custom path.",
-            args.name
-        )));
+        let pol = policy::load_embedded_policy()?;
+        if pol.profiles.contains_key(args.name.as_str()) {
+            crate::output::print_warning(&format!(
+                "Cannot create profile '{}': it conflicts with the built-in '{}' profile.",
+                args.name, args.name
+            ));
+            let t = theme::current();
+            eprintln!(
+                "  {} nono profile init {}-local --extends {}",
+                theme::fg("Try:", t.green).bold(),
+                args.name,
+                args.name
+            );
+            return Err(NonoError::Cancelled(String::new()));
+        }
     }
 
     // Validate --extends target exists in any of the three sources the
@@ -3272,13 +3301,13 @@ mod tests {
         assert!(result.is_err());
         let err = result.expect_err("error");
         assert!(
-            err.to_string().contains("already exists"),
-            "unexpected error: {err}"
+            matches!(err, nono::NonoError::Cancelled(_)),
+            "expected Cancelled (shadow block), got: {err}"
         );
     }
 
     #[test]
-    fn test_init_allowed_with_custom_output_bypasses_shadow_check() {
+    fn test_init_blocked_with_custom_output_when_shadowing_builtin() {
         let _guard = match crate::test_env::ENV_LOCK.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -3290,7 +3319,7 @@ mod tests {
         let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
 
         let out = dir.path().join("opencode-draft.json");
-        // Explicit --output to a custom path should bypass the shadow check.
+        // Shadow check applies even when --output points to a custom path.
         let result = cmd_init(ProfileInitArgs {
             name: "opencode".to_string(),
             extends: None,
@@ -3300,12 +3329,16 @@ mod tests {
             output: Some(out.clone()),
             force: false,
         });
-        assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-        assert!(out.exists());
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(
+            matches!(err, nono::NonoError::Cancelled(_)),
+            "expected Cancelled (shadow block), got: {err}"
+        );
     }
 
     #[test]
-    fn test_init_blocked_when_shadowing_pack_profile() {
+    fn test_init_allowed_when_pack_has_same_short_name() {
         let _guard = match crate::test_env::ENV_LOCK.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -3316,7 +3349,9 @@ mod tests {
         let xdg_str = xdg.to_str().expect("utf8 xdg");
         let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
 
-        // Set up a fake pack that provides a profile named "my-agent".
+        // Set up a fake pack that provides a profile with install_as "my-agent".
+        // Creating a user profile named "my-agent" must be allowed — packs are
+        // referenced by their full `org/name` key, not by `install_as`.
         let pack_dir = xdg
             .join("nono")
             .join("packages")
@@ -3337,6 +3372,9 @@ mod tests {
         )
         .expect("write pack profile");
 
+        let profiles_dir = xdg.join("nono").join("profiles");
+        std::fs::create_dir_all(&profiles_dir).expect("mkdir profiles");
+
         let result = cmd_init(ProfileInitArgs {
             name: "my-agent".to_string(),
             extends: None,
@@ -3346,12 +3384,7 @@ mod tests {
             output: None,
             force: false,
         });
-        assert!(result.is_err());
-        let err = result.expect_err("error");
-        assert!(
-            err.to_string().contains("already exists"),
-            "unexpected error: {err}"
-        );
+        assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -77,6 +77,20 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
         )));
     }
 
+    // When writing to the standard user profiles directory, block names that
+    // would shadow a built-in or installed pack profile. A user override of
+    // a pack profile intercepts all `"extends": "<name>"` chains and is
+    // almost never the intended outcome — use a derived name instead.
+    if args.output.is_none()
+        && crate::profile_save_runtime::would_shadow_existing_profile(&args.name)
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "Cannot create profile '{}': a built-in or pack profile with that name already \
+             exists. Choose a different name, or use --output to write to a custom path.",
+            args.name
+        )));
+    }
+
     // Validate --extends target exists in any of the three sources the
     // resolver knows about (user dir, pack store, built-in).
     if let Some(ref base) = args.extends
@@ -3231,6 +3245,113 @@ mod tests {
         assert!(result.is_err());
         let err = result.expect_err("error");
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_init_blocked_when_shadowing_builtin() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        // `opencode` is a known built-in profile; init to the default path must be blocked.
+        let result = cmd_init(ProfileInitArgs {
+            name: "opencode".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        });
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(
+            err.to_string().contains("already exists"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_init_allowed_with_custom_output_bypasses_shadow_check() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let out = dir.path().join("opencode-draft.json");
+        // Explicit --output to a custom path should bypass the shadow check.
+        let result = cmd_init(ProfileInitArgs {
+            name: "opencode".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: Some(out.clone()),
+            force: false,
+        });
+        assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
+        assert!(out.exists());
+    }
+
+    #[test]
+    fn test_init_blocked_when_shadowing_pack_profile() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        // Set up a fake pack that provides a profile named "my-agent".
+        let pack_dir = xdg
+            .join("nono")
+            .join("packages")
+            .join("test-ns")
+            .join("test-pack");
+        std::fs::create_dir_all(pack_dir.join("profiles")).expect("mkdir pack");
+        let manifest = r#"{
+            "schema_version": 1,
+            "name": "test-pack",
+            "artifacts": [
+                {"type": "profile", "path": "profiles/my-agent.json", "install_as": "my-agent"}
+            ]
+        }"#;
+        std::fs::write(pack_dir.join("package.json"), manifest).expect("write manifest");
+        std::fs::write(
+            pack_dir.join("profiles").join("my-agent.json"),
+            "{\"meta\":{\"name\":\"my-agent\",\"version\":\"1.0.0\"}}\n",
+        )
+        .expect("write pack profile");
+
+        let result = cmd_init(ProfileInitArgs {
+            name: "my-agent".to_string(),
+            extends: None,
+            groups: vec![],
+            description: None,
+            full: false,
+            output: None,
+            force: false,
+        });
+        assert!(result.is_err());
+        let err = result.expect_err("error");
+        assert!(
+            err.to_string().contains("already exists"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1455,11 +1455,11 @@ mod tests {
         )
         .expect("write pack profile");
 
-        // "hermes" matches a pack install_as but is not a built-in, so a
-        // "hermes-local" suggestion is valid.
+        // "hermes" matches a pack install_as but is not a built-in, so
+        // suggesting it directly as a profile name is valid.
         assert_eq!(
             suggested_run_profile_name(None, "hermes"),
-            Some("hermes-local".to_string())
+            Some("hermes".to_string())
         );
     }
 

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -398,16 +398,13 @@ pub(crate) fn would_shadow_existing_profile(profile_name: &str) -> bool {
     if profile::is_user_override(profile_name) {
         return false;
     }
-    // Check embedded built-in profiles. Treat load failure as fail-safe.
-    let is_builtin = crate::policy::load_embedded_policy()
+    // Only block names that match embedded built-ins. Pack profiles are
+    // referenced by their full `org/name` key (e.g. `always-further/hermes`),
+    // which is an invalid profile name, so a short user profile name like
+    // `hermes` cannot shadow a pack profile.
+    crate::policy::load_embedded_policy()
         .map(|policy| policy.profiles.contains_key(profile_name))
-        .unwrap_or(true);
-    if is_builtin {
-        return true;
-    }
-    // Check pack-store profiles. A user profile with the same name would
-    // shadow the pack profile and break any "extends": "<name>" chains.
-    profile::find_pack_store_profile(profile_name).is_some()
+        .unwrap_or(true)
 }
 
 pub(crate) fn write_profile(prepared: &PreparedProfileSave) -> Result<()> {
@@ -1424,7 +1421,7 @@ mod tests {
     }
 
     #[test]
-    fn suggested_run_profile_name_avoids_shadowing_pack_profile() {
+    fn suggested_run_profile_name_allows_short_name_matching_pack_install_as() {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let temp_home = TempDir::new().expect("temp home");
         let temp_config = TempDir::new().expect("temp config");
@@ -1458,9 +1455,12 @@ mod tests {
         )
         .expect("write pack profile");
 
-        // The command name "hermes" collides with the installed pack profile,
-        // so no suggestion should be offered.
-        assert_eq!(suggested_run_profile_name(None, "hermes"), None);
+        // "hermes" matches a pack install_as but is not a built-in, so a
+        // "hermes-local" suggestion is valid.
+        assert_eq!(
+            suggested_run_profile_name(None, "hermes"),
+            Some("hermes-local".to_string())
+        );
     }
 
     #[test]
@@ -1601,7 +1601,7 @@ mod tests {
     }
 
     #[test]
-    fn would_shadow_existing_profile_flags_installed_pack_profile() {
+    fn would_shadow_existing_profile_allows_short_name_matching_pack_install_as() {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let temp_home = TempDir::new().expect("temp home");
         let temp_config = TempDir::new().expect("temp config");
@@ -1622,7 +1622,6 @@ mod tests {
             .join("test-pack");
         std::fs::create_dir_all(pack_dir.join("profiles")).expect("mkdir pack");
 
-        // Write a minimal package.json that declares a profile artifact with install_as "hermes".
         let manifest = r#"{
             "schema_version": 1,
             "name": "test-pack",
@@ -1637,9 +1636,9 @@ mod tests {
         )
         .expect("write pack profile");
 
-        // Saving a user profile named "hermes" would shadow the pack profile.
-        assert!(would_shadow_existing_profile("hermes"));
-        // Unrelated names are still fine.
+        // Pack profiles are referenced by `org/name` (an invalid profile name),
+        // so a user profile named "hermes" does not shadow the pack.
+        assert!(!would_shadow_existing_profile("hermes"));
         assert!(!would_shadow_existing_profile("my-unique-saved-profile"));
     }
 

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -192,7 +192,21 @@ fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
 
         if candidate.is_empty() {
             if let Some(suggested_name) = suggested {
-                return Ok(Some(suggested_name.to_string()));
+                if !would_shadow_existing_profile(suggested_name) {
+                    return Ok(Some(suggested_name.to_string()));
+                }
+                // The suggestion itself would shadow an existing profile
+                // (possible if pack data changed since the suggestion was
+                // generated). Require the user to enter a different name.
+                prompt_println(&format!(
+                    "{}",
+                    format!(
+                        "The suggested name '{}' would shadow an existing built-in or pack profile. Enter a different name, or type 'skip' to cancel.",
+                        suggested_name
+                    )
+                    .red()
+                ));
+                continue;
             }
             prompt_println(&format!(
                 "{}",
@@ -314,9 +328,13 @@ pub(crate) fn confirm_typed_word(prompt: &str, expected: &str) -> Result<bool> {
 }
 
 pub(crate) fn suggested_profile_name(compared_profile: Option<&str>) -> Option<String> {
-    compared_profile
+    let candidate = compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && !profile::is_user_override(name))
-        .map(|name| format!("{}-local", name))
+        .map(|name| format!("{}-local", name))?;
+    if would_shadow_existing_profile(&candidate) {
+        return None;
+    }
+    Some(candidate)
 }
 
 fn suggested_run_profile_name(compared_profile: Option<&str>, cmd_name: &str) -> Option<String> {
@@ -380,16 +398,12 @@ pub(crate) fn would_shadow_existing_profile(profile_name: &str) -> bool {
     if profile::is_user_override(profile_name) {
         return false;
     }
-    // Check embedded built-in profiles first.
-    match crate::policy::load_embedded_policy() {
-        Ok(policy) => {
-            if policy.profiles.contains_key(profile_name) {
-                return true;
-            }
-        }
-        // Treat load failure as fail-safe: refuse to save rather than risk
-        // silently shadowing a built-in we couldn't enumerate.
-        Err(_) => return true,
+    // Check embedded built-in profiles. Treat load failure as fail-safe.
+    let is_builtin = crate::policy::load_embedded_policy()
+        .map(|policy| policy.profiles.contains_key(profile_name))
+        .unwrap_or(true);
+    if is_builtin {
+        return true;
     }
     // Check pack-store profiles. A user profile with the same name would
     // shadow the pack profile and break any "extends": "<name>" chains.

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -213,11 +213,11 @@ fn prompt_profile_name(suggested: Option<&str>) -> Result<Option<String>> {
             continue;
         }
 
-        if would_shadow_builtin(candidate) {
+        if would_shadow_existing_profile(candidate) {
             prompt_println(&format!(
                 "{}",
                 format!(
-                    "Cannot save '{}' as a user profile because it would shadow the built-in profile of the same name. Choose a different name.",
+                    "Cannot save '{}' as a user profile because it would shadow an existing built-in or pack profile of the same name. Choose a different name.",
                     candidate
                 )
                 .red()
@@ -325,7 +325,7 @@ fn suggested_run_profile_name(compared_profile: Option<&str>, cmd_name: &str) ->
     }
 
     let candidate = profile_name_from_command(cmd_name)?;
-    if would_shadow_builtin(&candidate) {
+    if would_shadow_existing_profile(&candidate) {
         return None;
     }
 
@@ -370,21 +370,30 @@ fn profile_name_from_command(cmd_name: &str) -> Option<String> {
 }
 
 /// Return true when writing `~/.config/nono/profiles/<name>.json` would shadow
-/// a built-in profile of the same name. User files are loaded in preference to
-/// built-ins, so saving under a built-in's name silently reroutes all future
-/// `--profile <name>` invocations to the user file.
-fn would_shadow_builtin(profile_name: &str) -> bool {
+/// a built-in or installed pack profile of the same name. User files are loaded
+/// in preference to built-ins and pack-store profiles, so saving under an
+/// existing profile's name silently reroutes all future `--profile <name>`
+/// invocations to the user file and intercepts any `"extends": "<name>"` chains.
+pub(crate) fn would_shadow_existing_profile(profile_name: &str) -> bool {
     // If a user file already exists at this name, the user has already chosen
     // to override it — writing there is an explicit update, not a new shadow.
     if profile::is_user_override(profile_name) {
         return false;
     }
+    // Check embedded built-in profiles first.
     match crate::policy::load_embedded_policy() {
-        Ok(policy) => policy.profiles.contains_key(profile_name),
+        Ok(policy) => {
+            if policy.profiles.contains_key(profile_name) {
+                return true;
+            }
+        }
         // Treat load failure as fail-safe: refuse to save rather than risk
         // silently shadowing a built-in we couldn't enumerate.
-        Err(_) => true,
+        Err(_) => return true,
     }
+    // Check pack-store profiles. A user profile with the same name would
+    // shadow the pack profile and break any "extends": "<name>" chains.
+    profile::find_pack_store_profile(profile_name).is_some()
 }
 
 pub(crate) fn write_profile(prepared: &PreparedProfileSave) -> Result<()> {
@@ -1401,6 +1410,46 @@ mod tests {
     }
 
     #[test]
+    fn suggested_run_profile_name_avoids_shadowing_pack_profile() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        // Set up a fake pack store with a profile named "hermes".
+        let pack_dir = temp_config
+            .path()
+            .join("nono")
+            .join("packages")
+            .join("test-ns")
+            .join("test-pack");
+        std::fs::create_dir_all(pack_dir.join("profiles")).expect("mkdir pack");
+        let manifest = r#"{
+            "schema_version": 1,
+            "name": "test-pack",
+            "artifacts": [
+                {"type": "profile", "path": "profiles/hermes.json", "install_as": "hermes"}
+            ]
+        }"#;
+        std::fs::write(pack_dir.join("package.json"), manifest).expect("write manifest");
+        std::fs::write(
+            pack_dir.join("profiles").join("hermes.json"),
+            "{\"meta\":{\"name\":\"hermes\",\"version\":\"1.0.0\"}}\n",
+        )
+        .expect("write pack profile");
+
+        // The command name "hermes" collides with the installed pack profile,
+        // so no suggestion should be offered.
+        assert_eq!(suggested_run_profile_name(None, "hermes"), None);
+    }
+
+    #[test]
     fn prompt_line_uses_crlf_for_terminal_layout() {
         assert_eq!(
             prompt_line("[nono] Paths to be saved as grants:"),
@@ -1519,7 +1568,7 @@ mod tests {
     }
 
     #[test]
-    fn would_shadow_builtin_flags_known_builtin_names() {
+    fn would_shadow_existing_profile_flags_known_builtin_names() {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let temp_home = TempDir::new().expect("temp home");
         let temp_config = TempDir::new().expect("temp config");
@@ -1531,15 +1580,57 @@ mod tests {
             ),
         ]);
 
-        // `codex` is a known built-in; writing to that user path would
-        // shadow it.
-        assert!(would_shadow_builtin("opencode"));
-        // Names that don't exist as built-ins are fine.
-        assert!(!would_shadow_builtin("my-unique-saved-profile"));
+        // `opencode` is a known built-in; writing to that user path would shadow it.
+        assert!(would_shadow_existing_profile("opencode"));
+        // Names that don't exist as built-ins or pack profiles are fine.
+        assert!(!would_shadow_existing_profile("my-unique-saved-profile"));
     }
 
     #[test]
-    fn would_shadow_builtin_allows_update_of_existing_user_override() {
+    fn would_shadow_existing_profile_flags_installed_pack_profile() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        // Set up a fake pack store: $XDG_CONFIG_HOME/nono/packages/test-ns/test-pack/
+        let pack_dir = temp_config
+            .path()
+            .join("nono")
+            .join("packages")
+            .join("test-ns")
+            .join("test-pack");
+        std::fs::create_dir_all(pack_dir.join("profiles")).expect("mkdir pack");
+
+        // Write a minimal package.json that declares a profile artifact with install_as "hermes".
+        let manifest = r#"{
+            "schema_version": 1,
+            "name": "test-pack",
+            "artifacts": [
+                {"type": "profile", "path": "profiles/hermes.json", "install_as": "hermes"}
+            ]
+        }"#;
+        std::fs::write(pack_dir.join("package.json"), manifest).expect("write manifest");
+        std::fs::write(
+            pack_dir.join("profiles").join("hermes.json"),
+            "{\"meta\":{\"name\":\"hermes\",\"version\":\"1.0.0\"}}\n",
+        )
+        .expect("write pack profile");
+
+        // Saving a user profile named "hermes" would shadow the pack profile.
+        assert!(would_shadow_existing_profile("hermes"));
+        // Unrelated names are still fine.
+        assert!(!would_shadow_existing_profile("my-unique-saved-profile"));
+    }
+
+    #[test]
+    fn would_shadow_existing_profile_allows_update_of_existing_user_override() {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let temp_home = TempDir::new().expect("temp home");
         let temp_config = TempDir::new().expect("temp config");
@@ -1557,11 +1648,11 @@ mod tests {
         std::fs::create_dir_all(path.parent().expect("dir")).expect("mkdir");
         std::fs::write(
             &path,
-            "{\"meta\":{\"name\":\"codex\",\"version\":\"1.0.0\"}}\n",
+            "{\"meta\":{\"name\":\"opencode\",\"version\":\"1.0.0\"}}\n",
         )
         .expect("write");
 
-        assert!(!would_shadow_builtin("opencode"));
+        assert!(!would_shadow_existing_profile("opencode"));
     }
 
     #[test]


### PR DESCRIPTION
The `would_shadow_builtin` function has been renamed to `would_shadow_existing_profile` and its logic expanded to prevent a user from saving a profile that would shadow an existing profile from an installed pack, in addition to built-in profiles.

This ensures that user-created profiles do not inadvertently override pack-provided profiles, which could lead to unexpected runtime behavior or break profile inheritance chains (`"extends"`).

- Updates profile name validation during save operations.
- Adjusts suggested profile name generation to avoid pack profile conflicts.
- Refines user-facing error messages to reflect the broader shadowing check.

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #958 


- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed