### PR TITLE
feat: annotate suppressed denials and style save prompt paths

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1270,6 +1270,10 @@ pub fn execute_supervised(
                     &default_redaction_policy
                 };
 
+                let canonical_denial_paths: Vec<std::path::PathBuf> = denials
+                    .iter()
+                    .map(|d| nono::try_canonicalize(&d.path))
+                    .collect();
                 let mut formatter = DiagnosticFormatter::new(config.caps)
                     .with_mode(mode)
                     .with_denials(&denials)
@@ -1280,7 +1284,8 @@ pub fn execute_supervised(
                     .with_current_dir(config.current_dir)
                     .with_session_id(diag_session_id)
                     .with_policy_explanations(policy_explanations)
-                    .with_suppressed_paths(config.ignored_denial_paths);
+                    .with_suppressed_paths(config.ignored_denial_paths)
+                    .with_canonical_denial_paths(canonical_denial_paths);
                 if let Some(program) = config.command.first() {
                     formatter = formatter.with_command(nono::diagnostic::CommandContext {
                         program: program.clone(),

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1279,7 +1279,8 @@ pub fn execute_supervised(
                     .with_error_observation(error_observation)
                     .with_current_dir(config.current_dir)
                     .with_session_id(diag_session_id)
-                    .with_policy_explanations(policy_explanations);
+                    .with_policy_explanations(policy_explanations)
+                    .with_suppressed_paths(config.ignored_denial_paths);
                 if let Some(program) = config.command.first() {
                     formatter = formatter.with_command(nono::diagnostic::CommandContext {
                         program: program.clone(),

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -619,7 +619,16 @@ fn render_diagnostic_line(idx: usize, line: &str, t: &theme::Theme) -> String {
     }
 
     if line.starts_with("  /") || line.starts_with("  ~/") {
-        return format!("  {}", fg(line.trim_start(), t.text).bold());
+        let content = line.trim_start();
+        return if let Some(idx) = content.find(" (") {
+            format!(
+                "  {} {}",
+                fg(&content[..idx], t.text).bold(),
+                &content[idx + 1..],
+            )
+        } else {
+            format!("  {}", fg(content, t.text).bold())
+        };
     }
 
     if line.starts_with("    + ") {

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -620,7 +620,7 @@ fn render_diagnostic_line(idx: usize, line: &str, t: &theme::Theme) -> String {
 
     if line.starts_with("  /") || line.starts_with("  ~/") {
         let content = line.trim_start();
-        return if let Some(idx) = content.find(" (") {
+        return if let Some(idx) = content.rfind(" (") {
             format!(
                 "  {} {}",
                 fg(&content[..idx], t.text).bold(),
@@ -926,6 +926,23 @@ mod tests {
         let footer = "nono diagnostic\n────────\nThe command failed.\n  Learn: nono learn";
         let rendered = render_diagnostic_footer(footer);
         assert_eq!(rendered.lines().count(), 4);
+    }
+
+    #[test]
+    fn render_diagnostic_footer_splits_path_on_last_paren_group() {
+        // Path contains " (" in the directory name — rfind ensures we split on
+        // the *last* parenthesised group (the access type), not the one
+        // embedded in the path.
+        let footer = "  /home/user/my (project)/file (read)";
+        let rendered = render_diagnostic_footer(footer);
+        assert!(
+            rendered.contains("/home/user/my (project)/file"),
+            "path with embedded parens should be preserved: {rendered}"
+        );
+        assert!(
+            rendered.contains("(read)"),
+            "access type should be preserved: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1,4 +1,5 @@
 use crate::command_display::format_command_line;
+use crate::theme;
 use crate::{profile, query_ext};
 use colored::Colorize;
 use nono::SandboxViolation;
@@ -559,14 +560,27 @@ pub(crate) fn print_patch_preview(patch: &profile::Profile) {
     }
 
     if has_entries {
-        prompt_println("[nono] Paths to be saved as grants:");
+        let t = theme::current();
+        prompt_println(&format!(
+            "{}",
+            theme::fg("[nono] Paths to be saved as grants:", t.brand).bold()
+        ));
         for (label, paths) in sections {
             for path in *paths {
                 let is_override = patch.filesystem.bypass_protection.contains(path);
                 if is_override {
-                    prompt_println(&format!("  {}  {} ({})", "⚠".red(), path, label));
+                    prompt_println(&format!(
+                        "  {}  {} ({})",
+                        "⚠".red(),
+                        theme::fg(path, t.text).bold(),
+                        label
+                    ));
                 } else {
-                    prompt_println(&format!("  {}  ({})", path, label));
+                    prompt_println(&format!(
+                        "  {}  ({})",
+                        theme::fg(path, t.text).bold(),
+                        label
+                    ));
                 }
             }
         }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -658,6 +658,11 @@ pub struct DiagnosticFormatter<'a> {
     /// denied paths with `[save skipped]` so the diagnostic footer is
     /// self-explanatory without requiring the user to cross-reference their profile.
     suppressed_paths: &'a [PathBuf],
+    /// Canonicalized forms of the denied paths, parallel to `denials`. When
+    /// provided, used in place of on-demand `try_canonicalize` calls inside the
+    /// render loop so filesystem I/O is done once (by the caller, after the
+    /// child exits) rather than once per denial per render method.
+    canonical_denial_paths: Vec<PathBuf>,
 }
 
 impl<'a> DiagnosticFormatter<'a> {
@@ -681,6 +686,7 @@ impl<'a> DiagnosticFormatter<'a> {
             session_id: None,
             policy_explanations: Vec::new(),
             suppressed_paths: &[],
+            canonical_denial_paths: Vec::new(),
         }
     }
 
@@ -699,14 +705,17 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 
     /// Set paths suppressed from the save-profile prompt.
-    ///
-    /// When set, denied paths that match an entry in `paths` are annotated with
-    /// `[save skipped]` in the diagnostic footer, making it clear why a blocked
-    /// path does not appear in the save prompt. The library applies no policy
-    /// from this list — it is used for display only.
     #[must_use]
     pub fn with_suppressed_paths(mut self, paths: &'a [PathBuf]) -> Self {
         self.suppressed_paths = paths;
+        self
+    }
+
+    /// Set pre-canonicalized forms of the denied paths to avoid repeated
+    /// calling of `try_canonicalize` at render time.
+    #[must_use]
+    pub fn with_canonical_denial_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.canonical_denial_paths = paths;
         self
     }
 
@@ -1532,9 +1541,20 @@ impl<'a> DiagnosticFormatter<'a> {
         }
     }
 
-    /// Return true when the denial cannot be fixed by a path flag alone —
-    /// i.e. the path is blocked by the sensitive-path policy and requires a
-    /// profile with `filesystem.bypass_protection`.
+    /// Return the canonical form of `denial.path`, using the pre-computed
+    /// parallel vec when available to avoid repeated filesystem I/O.
+    fn canonical_for_denial<'b>(&'b self, denial: &DenialRecord) -> std::borrow::Cow<'b, Path> {
+        if let Some(canonical) = self
+            .denials
+            .iter()
+            .position(|d| d.path == denial.path)
+            .and_then(|i| self.canonical_denial_paths.get(i))
+        {
+            return std::borrow::Cow::Borrowed(canonical.as_path());
+        }
+        std::borrow::Cow::Owned(crate::try_canonicalize(&denial.path))
+    }
+
     /// Return true when the denied path is in the caller-supplied suppression
     /// list (i.e. `suppress_save_prompt` entries). Such paths are still denied
     /// by the sandbox — this only controls whether they appear in the save
@@ -1543,12 +1563,15 @@ impl<'a> DiagnosticFormatter<'a> {
         if self.suppressed_paths.is_empty() {
             return false;
         }
-        let canonical = crate::try_canonicalize(&denial.path);
+        let canonical = self.canonical_for_denial(denial);
         self.suppressed_paths
             .iter()
-            .any(|suppressed| canonical == *suppressed || canonical.starts_with(suppressed))
+            .any(|suppressed| canonical.starts_with(suppressed))
     }
 
+    /// Return true when the denial cannot be fixed by a path flag alone —
+    /// i.e. the path is blocked by the sensitive-path policy and requires a
+    /// profile with `filesystem.bypass_protection`.
     fn is_denial_policy_blocked(&self, denial: &DenialRecord) -> bool {
         if let Some(expl) = self
             .policy_explanations
@@ -3802,6 +3825,36 @@ mod tests {
         assert!(
             line.contains("save skipped"),
             "expected 'save skipped' in: {line}"
+        );
+    }
+
+    #[test]
+    fn suppressed_denial_uses_precomputed_canonical_path() {
+        // Verify that when `with_canonical_denial_paths` is supplied the
+        // pre-computed value is used for suppression matching instead of the
+        // raw denial path. We supply a canonical path that differs from the
+        // raw path (simulating symlink resolution) and assert that suppression
+        // is triggered against the canonical form.
+        let caps = make_test_caps();
+        let raw_path = PathBuf::from("/tmp/link-to-suppressed");
+        let canonical_path = PathBuf::from("/tmp/real-suppressed-target");
+
+        let denials = vec![DenialRecord {
+            path: raw_path.clone(),
+            access: AccessMode::Read,
+            reason: DenialReason::RateLimited,
+        }];
+        // Suppress the canonical path, not the raw symlink path.
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials)
+            .with_suppressed_paths(std::slice::from_ref(&canonical_path))
+            .with_canonical_denial_paths(vec![canonical_path.clone()]);
+        let output = formatter.format_footer(1);
+
+        assert!(
+            output.contains("[save skipped]"),
+            "suppression via precomputed canonical path should annotate [save skipped]:\n{output}"
         );
     }
 }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -653,6 +653,11 @@ pub struct DiagnosticFormatter<'a> {
     session_id: Option<String>,
     /// Policy explanations for denied paths, resolved from `query_path`.
     policy_explanations: Vec<PolicyExplanation>,
+    /// Paths suppressed from the save-profile prompt (from `suppress_save_prompt`
+    /// profile field or `--suppress-save-prompt` CLI flag). Used to annotate
+    /// denied paths with `[save skipped]` so the diagnostic footer is
+    /// self-explanatory without requiring the user to cross-reference their profile.
+    suppressed_paths: &'a [PathBuf],
 }
 
 impl<'a> DiagnosticFormatter<'a> {
@@ -675,6 +680,7 @@ impl<'a> DiagnosticFormatter<'a> {
             current_dir: None,
             session_id: None,
             policy_explanations: Vec::new(),
+            suppressed_paths: &[],
         }
     }
 
@@ -689,6 +695,18 @@ impl<'a> DiagnosticFormatter<'a> {
     #[must_use]
     pub fn with_denials(mut self, denials: &'a [DenialRecord]) -> Self {
         self.denials = denials;
+        self
+    }
+
+    /// Set paths suppressed from the save-profile prompt.
+    ///
+    /// When set, denied paths that match an entry in `paths` are annotated with
+    /// `[save skipped]` in the diagnostic footer, making it clear why a blocked
+    /// path does not appear in the save prompt. The library applies no policy
+    /// from this list — it is used for display only.
+    #[must_use]
+    pub fn with_suppressed_paths(mut self, paths: &'a [PathBuf]) -> Self {
+        self.suppressed_paths = paths;
         self
     }
 
@@ -1436,10 +1454,17 @@ impl<'a> DiagnosticFormatter<'a> {
                 lines.push(format!("[nono]   … and {} more", total - idx));
                 break;
             }
-            let suffix = if self.is_denial_policy_blocked(denial) {
-                "  [permanently restricted]"
+            let mut labels: Vec<&str> = Vec::new();
+            if self.is_denial_policy_blocked(denial) {
+                labels.push("permanently restricted");
+            }
+            if self.is_denial_suppressed(denial) {
+                labels.push("save skipped");
+            }
+            let suffix = if labels.is_empty() {
+                String::new()
             } else {
-                ""
+                format!("  [{}]", labels.join(", "))
             };
             lines.push(format!(
                 "[nono]   {} ({}){}",
@@ -1510,6 +1535,20 @@ impl<'a> DiagnosticFormatter<'a> {
     /// Return true when the denial cannot be fixed by a path flag alone —
     /// i.e. the path is blocked by the sensitive-path policy and requires a
     /// profile with `filesystem.bypass_protection`.
+    /// Return true when the denied path is in the caller-supplied suppression
+    /// list (i.e. `suppress_save_prompt` entries). Such paths are still denied
+    /// by the sandbox — this only controls whether they appear in the save
+    /// prompt and how they are labelled in the diagnostic footer.
+    fn is_denial_suppressed(&self, denial: &DenialRecord) -> bool {
+        if self.suppressed_paths.is_empty() {
+            return false;
+        }
+        let canonical = crate::try_canonicalize(&denial.path);
+        self.suppressed_paths
+            .iter()
+            .any(|suppressed| canonical == *suppressed || canonical.starts_with(suppressed))
+    }
+
     fn is_denial_policy_blocked(&self, denial: &DenialRecord) -> bool {
         if let Some(expl) = self
             .policy_explanations
@@ -3661,5 +3700,108 @@ mod tests {
         let output = formatter.format_footer(42);
 
         assert!(output.contains("Command exited with code 42."));
+    }
+
+    #[test]
+    fn suppressed_denial_annotated_with_save_skipped() {
+        let caps = make_test_caps();
+        let denied = PathBuf::from("/tmp/suppressed-file");
+        let other = PathBuf::from("/tmp/other-file");
+        let suppressed = crate::try_canonicalize(&denied);
+
+        let denials = vec![
+            DenialRecord {
+                path: denied.clone(),
+                access: AccessMode::Read,
+                reason: DenialReason::RateLimited,
+            },
+            DenialRecord {
+                path: other.clone(),
+                access: AccessMode::Read,
+                reason: DenialReason::RateLimited,
+            },
+        ];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials)
+            .with_suppressed_paths(std::slice::from_ref(&suppressed));
+        let output = formatter.format_footer(1);
+
+        // The suppressed path gets the [save skipped] annotation.
+        assert!(
+            output.contains("[save skipped]"),
+            "expected [save skipped] in:\n{output}"
+        );
+        // The non-suppressed path does not.
+        let other_line = output
+            .lines()
+            .find(|l| l.contains("other-file"))
+            .unwrap_or("");
+        assert!(
+            !other_line.contains("[save skipped]"),
+            "non-suppressed path should not have [save skipped]: {other_line}"
+        );
+    }
+
+    #[test]
+    fn suppressed_denial_without_suppressed_paths_has_no_annotation() {
+        let caps = make_test_caps();
+        let denied = PathBuf::from("/tmp/some-file");
+        let denials = vec![DenialRecord {
+            path: denied,
+            access: AccessMode::Read,
+            reason: DenialReason::RateLimited,
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials);
+        let output = formatter.format_footer(1);
+
+        assert!(
+            !output.contains("[save skipped]"),
+            "no suppressed paths set — [save skipped] should not appear:\n{output}"
+        );
+    }
+
+    #[test]
+    fn permanently_restricted_and_suppressed_shows_both_labels() {
+        let caps = make_test_caps();
+        let denied = PathBuf::from("/tmp/restricted-and-suppressed");
+        let suppressed = crate::try_canonicalize(&denied);
+
+        // PolicyBlocked reason + a policy explanation with reason "sensitive_path"
+        // causes is_denial_policy_blocked() to return true.
+        let explanation = PolicyExplanation {
+            path: denied.clone(),
+            access: AccessMode::Read,
+            reason: "sensitive_path".to_string(),
+            details: None,
+            policy_source: None,
+            suggested_flag: None,
+        };
+        let denials = vec![DenialRecord {
+            path: denied,
+            access: AccessMode::Read,
+            reason: DenialReason::PolicyBlocked,
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_denials(&denials)
+            .with_policy_explanations(vec![explanation])
+            .with_suppressed_paths(std::slice::from_ref(&suppressed));
+        let output = formatter.format_footer(1);
+
+        let line = output
+            .lines()
+            .find(|l| l.contains("restricted-and-suppressed"))
+            .unwrap_or("");
+        assert!(
+            line.contains("permanently restricted"),
+            "expected 'permanently restricted' in: {line}"
+        );
+        assert!(
+            line.contains("save skipped"),
+            "expected 'save skipped' in: {line}"
+        );
     }
 }

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -341,7 +341,9 @@ to grant, but also do not want to see in the save-profile prompt on every run:
 }
 ```
 
-This does not grant access and does not hide diagnostics. It only suppresses
+This does not grant access and does not hide diagnostics. Suppressed denials
+still appear in the diagnostic footer annotated with `[save skipped]`, making
+it clear why they are absent from the save prompt. It only suppresses
 matching save-profile suggestions. `filesystem.ignore` is accepted as an alias,
 but the canonical name is deliberately explicit so it is not mistaken for
 allowing the denied path.

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -278,7 +278,8 @@ you do not want nono to keep offering it as a profile addition:
 
 `filesystem.suppress_save_prompt` only suppresses the save-profile suggestion
 for matching denials. The sandbox still denies the path, and the diagnostic
-footer can still show the denial if the run fails.
+footer still shows the denial annotated with `[save skipped]` so it is clear
+why the path does not appear in the save prompt.
 
 The interactive save prompt applies this to every listed path suggestion when
 you choose `suppress`; it does not create any allow/read/write grants.

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -278,7 +278,7 @@ you do not want nono to keep offering it as a profile addition:
 
 `filesystem.suppress_save_prompt` only suppresses the save-profile suggestion
 for matching denials. The sandbox still denies the path, and the diagnostic
-footer still shows the denial annotated with `[save skipped]` so it is clear
+footer still shows the denial, annotated with `[save skipped]` so it is clear
 why the path does not appear in the save prompt.
 
 The interactive save prompt applies this to every listed path suggestion when


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #984

## Summary

<!-- Briefly describe what this PR does and why. -->
This PR improve the output of the save prompt in the following way

  **1. `[save skipped]` annotation in the diagnostic footer**
Denied paths that are in the suppression list now show `[save skipped]` inline, so the blocked list is self-explanatory without cross-referencing the profile config. When a path is both permanently restricted and suppressed, both labels are combined: `[permanently restricted, save skipped]`.

  **2. Styled header and paths in the save prompt**
`[nono] Paths to be saved as grants:` now renders in `t.brand` bold. Each path beneath it renders in `t.text` bold, matching the visual weight of blocked paths in the diagnostic footer and making the actionable items immediately scannable.

To be consistent with the save prompt, denied path lines in the diagnostic footer now bold only the path, leaving the access type and labels in the terminal default colour.

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan
<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->
- [x] `diagnostic::tests::suppressed_denial_annotated_with_save_skipped` — suppressed path gets `[save skipped]
- [x] `diagnostic::tests::suppressed_denial_without_suppressed_paths_has_no_annotation` — no annotation when no suppressed paths set
- [x] `diagnostic::tests::permanently_restricted_and_suppressed_shows_both_labels` — path that is both permanently restricted and suppressed shows `[permanently restricted, save skipped]`
- [x] build with `cargo build -p nono-cli` and run with a profile containing `suppress_save_prompt` gives the expected output: 

<img width="780" height="180" alt="Pasted image 20260521003738" src="https://github.com/user-attachments/assets/3eb11e73-766b-4fad-a59d-40abffd5332f" />

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
