### PR TITLE
refactor(pack-hints): refresh in detached process to avoid threads

### DIFF
--- a/crates/nono-cli/src/app_runtime.rs
+++ b/crates/nono-cli/src/app_runtime.rs
@@ -118,6 +118,7 @@ fn dispatch_command(
             run_command_with_update(update_handle, silent, || package_cmd::run_outdated(args))
         }
         Commands::OpenUrlHelper(args) => run_open_url_helper(args),
+        Commands::PackUpdateHintHelper(args) => crate::pack_update_hint::run_refresh_helper(args),
         Commands::Completions(args) => run_completions(args),
     }
 }

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -657,6 +657,10 @@ IN-BAND DETACH:
     /// Internal: open a URL via supervisor IPC
     #[command(hide = true)]
     OpenUrlHelper(OpenUrlHelperArgs),
+
+    /// Internal: refresh cached pack update hints out of process
+    #[command(hide = true)]
+    PackUpdateHintHelper(PackUpdateHintHelperArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -828,6 +832,17 @@ pub struct OutdatedArgs {
 pub struct OpenUrlHelperArgs {
     /// The URL to open
     pub url: String,
+}
+
+/// Arguments for the hidden pack-update-hint-helper subcommand.
+///
+/// Invoked by `nono run` to refresh stale pack update hint cache entries in a
+/// child process, so the supervised parent does not gain an extra thread before
+/// fork.
+#[derive(Parser, Debug, Clone)]
+pub struct PackUpdateHintHelperArgs {
+    /// Alternating package reference and installed version values.
+    pub packs: Vec<String>,
 }
 
 /// Shell variant for completion generation.

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -180,6 +180,7 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         | Commands::Unpin(_)
         | Commands::Outdated(_)
         | Commands::OpenUrlHelper(_)
+        | Commands::PackUpdateHintHelper(_)
         | Commands::Completions(_) => 0,
     }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -427,6 +427,17 @@ mod tests {
     }
 
     #[test]
+    fn test_pre_exec_update_check_disabled_for_pack_update_hint_helper() {
+        let helper = Cli::parse_from([
+            "nono",
+            "pack-update-hint-helper",
+            "always-further/claude",
+            "1.0.0",
+        ]);
+        assert!(!allows_pre_exec_update_check(&helper.command));
+    }
+
+    #[test]
     fn test_pre_exec_update_check_enabled_for_non_exec_commands() {
         let why = Cli::parse_from(["nono", "why", "--path", "/tmp", "--op", "read"]);
         assert!(allows_pre_exec_update_check(&why.command));

--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -111,6 +111,7 @@ pub fn show_pack_update_hints(profile_name: &str, silent: bool) {
 /// Refresh stale hint cache entries for the hidden helper subcommand.
 pub fn run_refresh_helper(args: crate::cli::PackUpdateHintHelperArgs) -> crate::Result<()> {
     let Some(stale) = parse_refresh_helper_args(args.packs) else {
+        tracing::debug!("pack update hint helper received malformed pack/version arguments");
         return Ok(());
     };
     if stale.is_empty() || is_opted_out() {
@@ -280,7 +281,13 @@ fn save_state(state: &PackHintsState) {
         let _ = std::fs::create_dir_all(parent);
     }
     if let Ok(json) = serde_json::to_string_pretty(state) {
-        let _ = std::fs::write(&path, json);
+        let tmp_path =
+            path.with_file_name(format!(".{HINTS_STATE_FILE}.{}.tmp", std::process::id()));
+        let write_result = std::fs::write(&tmp_path, format!("{json}\n"))
+            .and_then(|()| std::fs::rename(&tmp_path, &path));
+        if write_result.is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+        }
     }
 }
 

--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -2,21 +2,22 @@
 //!
 //! After the capabilities block, checks whether any pack-provided profile in
 //! the active extends chain has a newer version available, and prints a one-line
-//! hint if so. Results are cached per pack for 24 hours in the state directory
-//! so the registry check never blocks startup. A background thread refreshes
-//! stale entries for the next run.
+//! hint if so. Results are cached per pack for 24 hours in the state directory.
+//! Stale entries are refreshed by a detached helper process so `nono run` does
+//! not add a thread before supervised mode forks.
 //!
-//! Respects the same opt-out as the CLI update check: `NONO_NO_UPDATE_CHECK=1`
-//! or `[updates] check = false` in `~/.config/nono/config.toml`.
+//! Respects `NONO_NO_PACK_UPDATE_HINTS=1`, plus the same opt-out as the CLI
+//! update check: `NONO_NO_UPDATE_CHECK=1` or `[updates] check = false` in
+//! `~/.config/nono/config.toml`.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
-use std::thread;
+use std::process::{Command, Stdio};
 
 const HINTS_STATE_FILE: &str = "pack-update-hints.json";
 const CHECK_INTERVAL_SECS: i64 = 86400;
+const NO_PACK_UPDATE_HINTS_ENV: &str = "NONO_NO_PACK_UPDATE_HINTS";
 
 /// Per-pack cache entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,8 +44,8 @@ struct PackHintsState {
 /// Print update hints for every pack-provided profile in the active extends
 /// chain, reading from a 24-hour local cache.
 ///
-/// Silently no-ops on any error (network, I/O, parse). A background thread
-/// refreshes stale cache entries without blocking the current run.
+/// Silently no-ops on any error (network, I/O, parse). Stale cache entries are
+/// refreshed out of process without blocking the current run.
 pub fn show_pack_update_hints(profile_name: &str, silent: bool) {
     if silent || is_opted_out() {
         return;
@@ -97,14 +98,29 @@ pub fn show_pack_update_hints(profile_name: &str, silent: bool) {
                 }
             }
         } else {
-            // Cache exists but some entries are stale — refresh in background
-            // so startup latency is unaffected.
-            let shared = Arc::new(Mutex::new(state));
-            refresh_in_background(stale, shared);
+            // Cache exists but some entries are stale — refresh in a detached
+            // process so startup latency is unaffected and the supervised
+            // parent does not gain a thread before fork.
+            refresh_in_background_process(&stale);
         }
     }
 
     print_hints(&hints);
+}
+
+/// Refresh stale hint cache entries for the hidden helper subcommand.
+pub fn run_refresh_helper(args: crate::cli::PackUpdateHintHelperArgs) -> crate::Result<()> {
+    let Some(stale) = parse_refresh_helper_args(args.packs) else {
+        return Ok(());
+    };
+    if stale.is_empty() || is_opted_out() {
+        return Ok(());
+    }
+
+    let mut state = load_state();
+    refresh_synchronous(&stale, &mut state);
+    save_state(&state);
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -178,39 +194,38 @@ fn refresh_synchronous(packs: &[(String, String)], state: &mut PackHintsState) {
     }
 }
 
-fn refresh_in_background(stale: Vec<(String, String)>, state: Arc<Mutex<PackHintsState>>) {
-    let registry_url = crate::registry_client::resolve_registry_url(None);
-    let _ = thread::spawn(move || {
-        let client = crate::registry_client::RegistryClient::new(registry_url);
-        let mut changed = false;
+fn refresh_in_background_process(stale: &[(String, String)]) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
 
-        for (pack_ref, installed) in stale {
-            let pkg_ref = match crate::package::parse_package_ref(&pack_ref) {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            let latest = client
-                .fetch_package_status(&pkg_ref, Some(&installed))
-                .ok()
-                .and_then(|s| s.latest);
+    let mut child = Command::new(exe);
+    child.arg("pack-update-hint-helper");
+    child.args(refresh_helper_args(stale));
+    child.stdin(Stdio::null());
+    child.stdout(Stdio::null());
+    child.stderr(Stdio::null());
+    let _ = child.spawn();
+}
 
-            if let Ok(mut guard) = state.lock() {
-                guard.entries.insert(
-                    pack_ref,
-                    PackHintEntry {
-                        last_check: Utc::now(),
-                        installed_at_check: installed,
-                        latest,
-                    },
-                );
-                changed = true;
-            }
-        }
+fn refresh_helper_args(stale: &[(String, String)]) -> Vec<String> {
+    stale
+        .iter()
+        .flat_map(|(pack_ref, installed)| [pack_ref.clone(), installed.clone()])
+        .collect()
+}
 
-        if changed && let Ok(guard) = state.lock() {
-            save_state(&guard);
-        }
-    });
+fn parse_refresh_helper_args(args: Vec<String>) -> Option<Vec<(String, String)>> {
+    let mut chunks = args.chunks_exact(2);
+    let stale = chunks
+        .by_ref()
+        .map(|chunk| (chunk[0].clone(), chunk[1].clone()))
+        .collect();
+    if chunks.remainder().is_empty() {
+        Some(stale)
+    } else {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +289,9 @@ fn save_state(state: &PackHintsState) {
 // ---------------------------------------------------------------------------
 
 fn is_opted_out() -> bool {
+    if std::env::var(NO_PACK_UPDATE_HINTS_ENV).is_ok() {
+        return true;
+    }
     if std::env::var("NONO_NO_UPDATE_CHECK").is_ok() {
         return true;
     }
@@ -296,5 +314,38 @@ fn is_newer(installed: &str, latest: &str) -> bool {
         (Some(i), Some(l)) => l > i,
         (None, Some(_)) => true, // legacy non-semver installed, new semver release available
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_helper_args_round_trip() {
+        let stale = vec![
+            ("always-further/claude".to_string(), "1.0.0".to_string()),
+            ("always-further/codex".to_string(), "2.3.4".to_string()),
+        ];
+
+        let args = refresh_helper_args(&stale);
+
+        assert_eq!(parse_refresh_helper_args(args), Some(stale));
+    }
+
+    #[test]
+    fn refresh_helper_args_reject_odd_values() {
+        assert!(parse_refresh_helper_args(vec!["always-further/claude".to_string()]).is_none());
+    }
+
+    #[test]
+    fn pack_hint_env_var_opts_out() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let _env = crate::test_env::EnvVarGuard::set_all(&[(NO_PACK_UPDATE_HINTS_ENV, "1")]);
+
+        assert!(is_opted_out());
     }
 }

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -15,7 +15,11 @@ use std::process::{Child, Command, Stdio};
 pub(crate) fn allows_pre_exec_update_check(command: &Commands) -> bool {
     !matches!(
         command,
-        Commands::Run(_) | Commands::Shell(_) | Commands::Wrap(_) | Commands::Completions(_)
+        Commands::Run(_)
+            | Commands::Shell(_)
+            | Commands::Wrap(_)
+            | Commands::Completions(_)
+            | Commands::PackUpdateHintHelper(_)
     )
 }
 

--- a/docs/cli/features/managing-packs.mdx
+++ b/docs/cli/features/managing-packs.mdx
@@ -62,7 +62,7 @@ When you run `nono run --profile <name>`, nono checks whether any pack in the ac
   update available  always-further/claude  0.0.12 → 0.0.13   run: nono update
 ```
 
-Results are cached for 24 hours so the check never blocks startup. A background thread refreshes stale entries for the next run. The hint respects the same opt-out as the CLI update check: set `NONO_NO_UPDATE_CHECK=1` or `[updates] check = false` in `~/.config/nono/config.toml` to suppress it.
+Results are cached for 24 hours so the check never blocks startup. Stale entries refresh in a detached helper process for the next run. To suppress only pack update hints, set `NONO_NO_PACK_UPDATE_HINTS=1`. The hint also respects the global CLI update-check opt-out: set `NONO_NO_UPDATE_CHECK=1` or `[updates] check = false` in `~/.config/nono/config.toml`.
 
 ## Checking for Updates
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -1466,6 +1466,7 @@ nono run -- cargo build
 | Variable | Description |
 |----------|-------------|
 | `NONO_NO_UPDATE_CHECK` | Disable automatic update checks |
+| `NONO_NO_PACK_UPDATE_HINTS` | Disable pack update hints during `nono run` |
 | `NONO_UPDATE_URL` | Custom update service URL |
 
 ## Examples


### PR DESCRIPTION
The pack update hint refresh mechanism now uses a detached child process instead of a background thread. This ensures that the `nono run` command, when operating in supervised mode, does not create an additional thread in the parent process before forking the supervisor.

- Introduce `pack-update-hint-helper` subcommand for out-of-process refresh.
- Add `NONO_NO_PACK_UPDATE_HINTS` environment variable to specifically disable pack update hints, distinct from the general update check opt-out.
- Disable pre-execution update checks for the new helper command to prevent recursion.
- Update relevant documentation to reflect these changes.

Fixes: #1004

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
