### PR TITLE
ci(release): enable github attesations workflow for releases (current and future)

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -1,0 +1,41 @@
+name: Attest Existing Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attest (e.g., v0.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    if: github.repository == 'always-further/nono'
+    name: Attest Release Artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          mkdir -p artifacts
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "*.tar.gz" \
+            --pattern "*.deb" \
+            --dir artifacts
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            artifacts/*.tar.gz
+            artifacts/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,31 @@ jobs:
           name: nono-${{ matrix.target }}
           path: artifact_staging
 
+  attest:
+    name: Attest Release Artifacts
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            artifacts/**/*.tar.gz
+            artifacts/**/*.deb
+
   release:
     name: Create Release
-    needs: build
+    needs: attest
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -152,28 +174,6 @@ jobs:
             artifacts/*.tar.gz
             artifacts/*.deb
             artifacts/SHA256SUMS.txt
-
-  attest:
-    name: Attest Release Artifacts
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
-        with:
-          subject-path: |
-            artifacts/**/*.tar.gz
-            artifacts/**/*.deb
 
   publish-crates:
     name: Publish to crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,28 @@ jobs:
             artifacts/*.deb
             artifacts/SHA256SUMS.txt
 
+  attest:
+    name: Attest Release Artifacts
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            artifacts/**/*.tar.gz
+            artifacts/**/*.deb
+
   publish-crates:
     name: Publish to crates.io
     needs: release


### PR DESCRIPTION
The release workflow to handle future releases; with a manual workflow that backfills attestations for an existing GitHub Release