### PR TITLE
refactor(profile): extract opencode profile from built-ins

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -696,38 +696,6 @@
       },
       "interactive": false
     },
-    "opencode": {
-      "extends": "default",
-      "meta": {
-        "name": "opencode",
-        "version": "1.0.0",
-        "description": "OpenCode AI coding assistant",
-        "author": "always-further"
-      },
-      "groups": {
-        "include": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "linux_sysfs_read", "git_config", "unlink_protection"]
-      },
-      "security": {
-        "signal_mode": "isolated"
-      },
-      "filesystem": {
-        "allow": [
-          "$HOME/.opencode",
-          "$HOME/.config/opencode",
-          "$HOME/.cache/opencode",
-          "$HOME/.local/share/opencode",
-          "$HOME/.local/share/opentui",
-          "$HOME/.local/state/opencode",
-          "$TMPDIR"
-        ]
-      },
-      "network": { "block": false },
-      "workdir": { "access": "readwrite" },
-      "undo": {
-        "exclude_patterns": ["node_modules", ".next"]
-      },
-      "interactive": true
-    },
     "python-dev": {
       "extends": "default",
       "meta": {

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -67,6 +67,13 @@ const OFFICIAL_PACKS: &[OfficialPack] = &[
         description: Some("OpenAI Codex CLI sandbox profile + plugin"),
         installs_summary: Some("sandbox profile + Codex plugin (hooks, skill)"),
     },
+    OfficialPack {
+        profile_name: "opencode",
+        namespace: "always-further",
+        pack_name: "opencode",
+        description: Some("OpenCode AI coding assistant sandbox profile + plugin"),
+        installs_summary: Some("sandbox profile + OpenCode plugin (hooks, skill)"),
+    },
 ];
 
 struct OfficialPack {
@@ -327,6 +334,7 @@ mod tests {
         assert!(official_pack_for("claude").is_some());
         assert!(official_pack_for("claude-code").is_some());
         assert!(official_pack_for("codex").is_some());
+        assert!(official_pack_for("opencode").is_some());
         assert!(official_pack_for("definitely-not-real").is_none());
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -30,6 +30,13 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_no_longer_inbuilt() {
+        // Removed: opencode is now shipped via the registry pack
+        // `always-further/opencode`, not embedded in policy.json.
+        assert!(get_builtin("opencode").is_none());
+    }
+
+    #[test]
     fn test_get_builtin_default() {
         let profile = get_builtin("default").expect("Profile not found");
         assert_eq!(profile.meta.name, "default");
@@ -48,26 +55,6 @@ mod tests {
                 .filesystem
                 .allow
                 .contains(&"$HOME/.openclaw".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_builtin_opencode() {
-        let profile = get_builtin("opencode").expect("Profile not found");
-        assert_eq!(profile.meta.name, "opencode");
-        assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
-        assert!(profile.interactive);
-        assert!(
-            profile
-                .filesystem
-                .allow
-                .contains(&"$HOME/.opencode".to_string())
-        );
-        assert!(
-            profile
-                .filesystem
-                .allow
-                .contains(&"$HOME/.local/share/opentui".to_string())
         );
     }
 
@@ -126,22 +113,23 @@ mod tests {
         assert!(profiles.contains(&"default".to_string()));
         assert!(profiles.contains(&"linux-host-compat".to_string()));
         assert!(profiles.contains(&"openclaw".to_string()));
-        assert!(profiles.contains(&"opencode".to_string()));
         assert!(profiles.contains(&"swival".to_string()));
         // Profiles that ship via registry packs instead of as built-ins:
-        //   claude-code → always-further/claude (removed v0.43.0)
-        //   codex       → always-further/codex  (removed v0.43.0)
+        //   claude-code → always-further/claude   (removed v0.43.0)
+        //   codex       → always-further/codex    (removed v0.43.0)
+        //   opencode    → always-further/opencode (removed)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"claude-no-kc".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"opencode".to_string()));
     }
 
     #[test]
     fn test_profile_group_merging() {
-        // Use opencode as a representative inbuilt profile that extends
-        // `default` and adds its own groups (codex moved to a registry pack
-        // in v0.43.0 alongside claude-code).
-        let profile = get_builtin("opencode").expect("Profile not found");
+        // Use swival as a representative inbuilt profile that extends
+        // `default` and adds its own groups (opencode, codex, and claude-code
+        // moved to registry packs).
+        let profile = get_builtin("swival").expect("Profile not found");
         // Should have default profile groups (inherited via extends).
         assert!(
             profile
@@ -245,49 +233,27 @@ mod tests {
 
     #[test]
     fn test_linux_interactive_profiles_include_sysfs_but_not_runtime_state_or_temp() {
-        for name in ["opencode", "swival"] {
-            let profile = get_builtin(name).expect("Profile not found");
-            assert!(
-                !profile
-                    .groups
-                    .include
-                    .contains(&"linux_runtime_state".to_string()),
-                "{} should not include linux_runtime_state",
-                name
-            );
-            assert!(
-                profile
-                    .groups
-                    .include
-                    .contains(&"linux_sysfs_read".to_string()),
-                "{} should include linux_sysfs_read",
-                name
-            );
-            assert!(
-                !profile
-                    .groups
-                    .include
-                    .contains(&"linux_temp_read".to_string()),
-                "{} should not include linux_temp_read",
-                name
-            );
-        }
-    }
-
-    #[test]
-    fn test_opencode_profile_includes_tmpdir_and_state_dir() {
-        let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
-        let opencode = policy.profiles.get("opencode").expect("opencode profile");
+        let profile = get_builtin("swival").expect("Profile not found");
         assert!(
-            opencode.filesystem.allow.contains(&"$TMPDIR".to_string()),
-            "opencode profile should allow $TMPDIR for Bun TUI runtime extraction"
+            !profile
+                .groups
+                .include
+                .contains(&"linux_runtime_state".to_string()),
+            "swival should not include linux_runtime_state"
         );
         assert!(
-            opencode
-                .filesystem
-                .allow
-                .contains(&"$HOME/.local/state/opencode".to_string()),
-            "opencode profile should allow $HOME/.local/state/opencode"
+            profile
+                .groups
+                .include
+                .contains(&"linux_sysfs_read".to_string()),
+            "swival should include linux_sysfs_read"
+        );
+        assert!(
+            !profile
+                .groups
+                .include
+                .contains(&"linux_temp_read".to_string()),
+            "swival should not include linux_temp_read"
         );
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3204,8 +3204,8 @@ mod tests {
 
     #[test]
     fn test_load_builtin_profile() {
-        let profile = load_profile("opencode").expect("Failed to load profile");
-        assert_eq!(profile.meta.name, "opencode");
+        let profile = load_profile("openclaw").expect("Failed to load profile");
+        assert_eq!(profile.meta.name, "openclaw");
         assert!(!profile.network.block); // network allowed by default
     }
 
@@ -3262,11 +3262,14 @@ mod tests {
 
         let profiles = list_profiles();
         assert!(profiles.contains(&"openclaw".to_string()));
-        assert!(profiles.contains(&"opencode".to_string()));
-        // claude-code and codex were removed from the inbuilt profiles in
-        // v0.43.0; they ship via registry packs.
+        assert!(profiles.contains(&"swival".to_string()));
+        // These profiles were removed from built-ins; they ship via registry packs:
+        //   claude-code / claude → always-further/claude   (removed v0.43.0)
+        //   codex               → always-further/codex    (removed v0.43.0)
+        //   opencode            → always-further/opencode (removed)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"opencode".to_string()));
     }
 
     #[test]
@@ -5080,7 +5083,7 @@ mod tests {
         std::fs::write(
             &profile_path,
             r#"{
-                "extends": "opencode",
+                "extends": "openclaw",
                 "meta": { "name": "ext-test" },
                 "filesystem": { "allow": ["/tmp/ext-test"] }
             }"#,
@@ -5089,10 +5092,10 @@ mod tests {
 
         let profile = load_from_file(&profile_path).expect("load extended profile");
         assert_eq!(profile.meta.name, "ext-test");
-        // Should inherit codex's filesystem paths
+        // Should inherit openclaw's filesystem paths
         assert!(
             profile.filesystem.allow.len() > 1,
-            "Expected inherited paths from codex, got: {:?}",
+            "Expected inherited paths from openclaw, got: {:?}",
             profile.filesystem.allow
         );
         assert!(
@@ -5151,15 +5154,15 @@ mod tests {
 
     #[test]
     fn test_extends_chain_three_levels() {
-        // Test A -> B -> codex (built-in)
+        // Test A -> B -> openclaw (built-in)
         let dir = tempdir().expect("tmpdir");
 
-        // B extends codex
+        // B extends openclaw
         let b_path = dir.path().join("b.json");
         std::fs::write(
             &b_path,
             r#"{
-                "extends": "opencode",
+                "extends": "openclaw",
                 "meta": { "name": "b-profile" },
                 "filesystem": { "allow": ["/b/path"] }
             }"#,
@@ -5774,9 +5777,9 @@ mod tests {
 
     #[test]
     fn test_extends_duplicate_base_deduplicates() {
-        // extends: ["opencode", "opencode"] — duplicate is silently skipped
+        // extends: ["openclaw", "openclaw"] — duplicate is silently skipped
         let profile = Profile {
-            extends: Some(vec!["opencode".to_string(), "opencode".to_string()]),
+            extends: Some(vec!["openclaw".to_string(), "openclaw".to_string()]),
             ..Default::default()
         };
 
@@ -5822,7 +5825,7 @@ mod tests {
         std::fs::write(
             &profile_path,
             r#"{
-                "extends": ["opencode", "opencode"],
+                "extends": ["openclaw", "openclaw"],
                 "meta": { "name": "shared-base-test" }
             }"#,
         )
@@ -6047,12 +6050,12 @@ mod tests {
     #[test]
     fn test_extends_can_clear_inherited_network_profile_with_null() {
         let dir = tempfile::tempdir().expect("tmpdir");
-        let profile_path = dir.path().join("codex-netopen.json");
+        let profile_path = dir.path().join("openclaw-netopen.json");
         std::fs::write(
             &profile_path,
             r#"{
-                "meta": { "name": "codex-netopen" },
-                "extends": "opencode",
+                "meta": { "name": "openclaw-netopen" },
+                "extends": "openclaw",
                 "network": { "network_profile": null }
             }"#,
         )
@@ -6066,8 +6069,8 @@ mod tests {
                 .filesystem
                 .allow
                 .iter()
-                .any(|path| path == "$HOME/.opencode"),
-            "expected filesystem grants from opencode to still be inherited",
+                .any(|path| path == "$HOME/.openclaw"),
+            "expected filesystem grants from openclaw to still be inherited",
         );
     }
 

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -3291,9 +3291,9 @@ mod tests {
         let xdg_str = xdg.to_str().expect("utf8 xdg");
         let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
 
-        // `opencode` is a known built-in profile; init to the default path must be blocked.
+        // `openclaw` is a known built-in profile; init to the default path must be blocked.
         let result = cmd_init(ProfileInitArgs {
-            name: "opencode".to_string(),
+            name: "openclaw".to_string(),
             extends: None,
             groups: vec![],
             description: None,
@@ -3321,10 +3321,10 @@ mod tests {
         let xdg_str = xdg.to_str().expect("utf8 xdg");
         let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
 
-        let out = dir.path().join("opencode-draft.json");
+        let out = dir.path().join("openclaw-draft.json");
         // Shadow check applies even when --output points to a custom path.
         let result = cmd_init(ProfileInitArgs {
-            name: "opencode".to_string(),
+            name: "openclaw".to_string(),
             extends: None,
             groups: vec![],
             description: None,
@@ -3683,27 +3683,27 @@ mod tests {
             "expected 'default' in profiles"
         );
         assert!(
-            profiles.contains(&"opencode".to_string()),
-            "expected 'codex' in profiles"
+            profiles.contains(&"openclaw".to_string()),
+            "expected 'openclaw' in profiles"
         );
     }
 
     #[test]
     fn test_show_resolves_inheritance() {
-        let profile = profile::load_profile("opencode").expect("opencode profile should load");
+        let profile = profile::load_profile("openclaw").expect("openclaw profile should load");
         assert!(
             !profile.groups.include.is_empty(),
-            "opencode should have groups"
+            "openclaw should have groups"
         );
-        // opencode extends default, so it should have default's base groups
+        // openclaw extends default, so it should have default's base groups
         let has_deny = profile.groups.include.iter().any(|g| g.contains("deny"));
-        assert!(has_deny, "opencode should inherit deny groups");
+        assert!(has_deny, "openclaw should inherit deny groups");
     }
 
     #[test]
     fn test_diff_shows_differences() {
         let p1 = profile::load_profile("default").expect("default should load");
-        let p2 = profile::load_profile("opencode").expect("opencode should load");
+        let p2 = profile::load_profile("openclaw").expect("openclaw should load");
 
         let g1: BTreeSet<&str> = p1.groups.include.iter().map(|s| s.as_str()).collect();
         let g2: BTreeSet<&str> = p2.groups.include.iter().map(|s| s.as_str()).collect();
@@ -3711,7 +3711,7 @@ mod tests {
         let added: BTreeSet<&&str> = g2.difference(&g1).collect();
         assert!(
             !added.is_empty(),
-            "codex should have additional groups over default"
+            "openclaw should have additional groups over default"
         );
     }
 

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1418,7 +1418,7 @@ mod tests {
             ),
         ]);
 
-        assert_eq!(suggested_run_profile_name(None, "opencode"), None);
+        assert_eq!(suggested_run_profile_name(None, "openclaw"), None);
     }
 
     #[test]
@@ -1595,8 +1595,8 @@ mod tests {
             ),
         ]);
 
-        // `opencode` is a known built-in; writing to that user path would shadow it.
-        assert!(would_shadow_existing_profile("opencode"));
+        // `openclaw` is a known built-in; writing to that user path would shadow it.
+        assert!(would_shadow_existing_profile("openclaw"));
         // Names that don't exist as built-ins or pack profiles are fine.
         assert!(!would_shadow_existing_profile("my-unique-saved-profile"));
     }
@@ -1658,15 +1658,15 @@ mod tests {
 
         // Pre-create a user override of a built-in. A subsequent save to the
         // same name is an update, not a new shadow, and must be allowed.
-        let path = profile::get_user_profile_path("opencode").expect("profile path");
+        let path = profile::get_user_profile_path("openclaw").expect("profile path");
         std::fs::create_dir_all(path.parent().expect("dir")).expect("mkdir");
         std::fs::write(
             &path,
-            "{\"meta\":{\"name\":\"opencode\",\"version\":\"1.0.0\"}}\n",
+            "{\"meta\":{\"name\":\"openclaw\",\"version\":\"1.0.0\"}}\n",
         )
         .expect("write");
 
-        assert!(!would_shadow_existing_profile("opencode"));
+        assert!(!would_shadow_existing_profile("openclaw"));
     }
 
     #[test]


### PR DESCRIPTION
The `opencode` profile is no longer embedded directly within the application's policy.json. It has been moved to an official registry pack (`always-further/opencode`).

This change involves:
- Removing the `opencode` definition from `data/policy.json`.
- Adding an `OfficialPack` entry for `opencode` in the migration logic.
- Updating built-in profile lists and related tests to reflect `opencode`'s new status as a registry-distributed profile.
- Substituting `openclaw` or `swival` in various tests that previously used `opencode` as a representative built-in profile for inheritance or behavior checks.

## Linked Issue

Closes #788
