### PR TITLE
feat(wiring): support jsonc in wiring directives

### DIFF
--- a/crates/nono-cli/src/jsonc.rs
+++ b/crates/nono-cli/src/jsonc.rs
@@ -1,0 +1,13 @@
+use serde::de::DeserializeOwned;
+
+pub(crate) fn parse<T>(text: &str) -> std::result::Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    let parse_options = jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_trailing_commas: true,
+        ..Default::default()
+    };
+    jsonc_parser::parse_to_serde_value(text, &parse_options).map_err(|e| e.to_string())
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -25,6 +25,7 @@ mod execution_runtime;
 #[cfg(unix)]
 mod hook_runtime;
 mod instruction_deny;
+mod jsonc;
 mod launch_runtime;
 mod learn;
 mod learn_runtime;

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2239,14 +2239,7 @@ pub(crate) fn parse_profile_bytes(content: &[u8]) -> Result<Profile> {
     let text = std::str::from_utf8(content)
         .map_err(|e| NonoError::ProfileParse(format!("invalid UTF-8: {e}")))?;
 
-    let parse_options = jsonc_parser::ParseOptions {
-        allow_comments: true,
-        allow_trailing_commas: true,
-        ..Default::default()
-    };
-
-    let profile: Profile = jsonc_parser::parse_to_serde_value(text, &parse_options)
-        .map_err(|e| NonoError::ProfileParse(e.to_string()))?;
+    let profile: Profile = crate::jsonc::parse(text).map_err(NonoError::ProfileParse)?;
 
     // Validate custom credentials for security issues
     validate_profile_custom_credentials(&profile)?;

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -791,12 +791,7 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
 
 fn read_json(path: &Path) -> Result<Value> {
     let content = fs::read_to_string(path).map_err(NonoError::Io)?;
-    let parse_options = jsonc_parser::ParseOptions {
-        allow_comments: true,
-        allow_trailing_commas: true,
-        ..Default::default()
-    };
-    jsonc_parser::parse_to_serde_value(&content, &parse_options)
+    crate::jsonc::parse(&content)
         .map_err(|e| NonoError::PackageInstall(format!("invalid JSON in {}: {e}", path.display())))
 }
 

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -791,7 +791,12 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
 
 fn read_json(path: &Path) -> Result<Value> {
     let content = fs::read_to_string(path).map_err(NonoError::Io)?;
-    serde_json::from_str(&content)
+    let parse_options = jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_trailing_commas: true,
+        ..Default::default()
+    };
+    jsonc_parser::parse_to_serde_value(&content, &parse_options)
         .map_err(|e| NonoError::PackageInstall(format!("invalid JSON in {}: {e}", path.display())))
 }
 
@@ -1686,6 +1691,50 @@ mod tests {
     }
 
     #[test]
+    fn json_merge_accepts_jsonc_in_target_and_patch() {
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(
+                pack.join("patch.json"),
+                r#"{
+                    // Pack patches may carry comments too.
+                    "enabledPlugins": {
+                        "nono": true,
+                    },
+                }"#,
+            )
+            .expect("write patch");
+            let target = home.join("settings.json");
+            fs::write(
+                &target,
+                r#"{
+                    // User config comments must not break package wiring.
+                    "effortLevel": "xhigh",
+                }"#,
+            )
+            .expect("seed target");
+
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::JsonMerge {
+                file: "$HOME/settings.json".to_string(),
+                patch: "patch.json".to_string(),
+            }];
+            let report = exec(&directives, &ctx).expect("execute");
+            let v: Value =
+                serde_json::from_str(&fs::read_to_string(&target).expect("read")).expect("parse");
+            assert_eq!(v["effortLevel"], "xhigh", "preserve unrelated keys");
+            assert_eq!(v["enabledPlugins"]["nono"], true);
+
+            rev(&report.records);
+            let v2: Value =
+                serde_json::from_str(&fs::read_to_string(&target).expect("read")).expect("parse");
+            assert_eq!(v2["effortLevel"], "xhigh", "unrelated keys still present");
+            assert!(v2.get("enabledPlugins").is_none(), "merged keys gone");
+        });
+    }
+
+    #[test]
     fn json_array_append_dedups_by_key_field() {
         with_fake_home(|home| {
             let pack = home.join("pack");
@@ -1717,6 +1766,56 @@ mod tests {
             );
 
             rev(&r1.records);
+            let v2: Value =
+                serde_json::from_str(&fs::read_to_string(&target).expect("read")).expect("parse");
+            assert_eq!(
+                v2["hooks"]["PostToolUse"].as_array().expect("array").len(),
+                0
+            );
+        });
+    }
+
+    #[test]
+    fn json_array_append_accepts_jsonc_in_target_and_patch() {
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(
+                pack.join("entries.json"),
+                r#"[
+                    // Pack-provided append entries can be JSONC.
+                    { "name": "nono", "command": "x" },
+                ]"#,
+            )
+            .expect("write entries");
+
+            let target = home.join("hooks.json");
+            fs::write(
+                &target,
+                r#"{
+                    // Mirrors user-owned config files such as Copilot config.
+                    "hooks": {
+                        "PostToolUse": [],
+                    },
+                }"#,
+            )
+            .expect("seed target");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::JsonArrayAppend {
+                file: "$HOME/hooks.json".to_string(),
+                path: "hooks.PostToolUse".to_string(),
+                patch_entries: "entries.json".to_string(),
+                key_field: "name".to_string(),
+            }];
+            let report = exec(&directives, &ctx).expect("execute");
+
+            let v: Value =
+                serde_json::from_str(&fs::read_to_string(&target).expect("read")).expect("parse");
+            let entries = v["hooks"]["PostToolUse"].as_array().expect("array");
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0]["name"], "nono");
+
+            rev(&report.records);
             let v2: Value =
                 serde_json::from_str(&fs::read_to_string(&target).expect("read")).expect("parse");
             assert_eq!(


### PR DESCRIPTION
Wiring directives like `json_merge` and `json_array_append` now correctly parse JSON files that contain comments or trailing commas. This improves compatibility with user-edited configuration files and pack patch files, which often leverage these JSONC features.

## Linked Issue

Closes #1028
