### PR TITLE
feat(diagnostic): add profile option to suppress system service diagnostics

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -45,6 +45,10 @@
       "$ref": "#/$defs/NetworkConfig",
       "description": "Network access configuration including proxy settings, credential injection, and port allowlists."
     },
+    "diagnostics": {
+      "$ref": "#/$defs/DiagnosticsConfig",
+      "description": "Diagnostic output controls. These settings do not change sandbox enforcement."
+    },
     "linux": {
       "$ref": "#/$defs/LinuxConfig",
       "description": "Linux-specific hardening controls."
@@ -746,6 +750,18 @@
           "$ref": "#/$defs/WorkdirAccess",
           "description": "Access level for the current working directory.",
           "default": "none"
+        }
+      }
+    },
+    "DiagnosticsConfig": {
+      "type": "object",
+      "description": "Diagnostic output controls. Suppressions only affect nono's footer; the sandbox still denies the underlying operations.",
+      "additionalProperties": false,
+      "properties": {
+        "suppress_system_services": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Non-filesystem sandbox operation names to hide from diagnostic footers, such as forbidden-exec-sugid."
         }
       }
     },

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -210,6 +210,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             af_unix_mediation: prepared.af_unix_mediation,
             bypass_protection_paths: prepared.bypass_protection_paths,
             ignored_denial_paths: prepared.ignored_denial_paths,
+            suppressed_system_service_operations: prepared.suppressed_system_service_operations,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
             startup_timeout_secs: args.startup_timeout_secs,
@@ -293,6 +294,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             no_diagnostics,
             bypass_protection_paths: prepared.bypass_protection_paths,
             ignored_denial_paths: prepared.ignored_denial_paths,
+            suppressed_system_service_operations: prepared.suppressed_system_service_operations,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
             ..ExecutionFlags::defaults(silent)?

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -216,6 +216,8 @@ pub struct ExecConfig<'a> {
     pub profile_save_base: Option<&'a str>,
     /// Denied paths that should not be offered in the save-profile prompt.
     pub ignored_denial_paths: &'a [std::path::PathBuf],
+    /// Non-filesystem sandbox operations suppressed from diagnostic footers.
+    pub suppressed_system_service_operations: &'a [String],
     /// Optional startup timeout for known interactive CLIs that were launched
     /// without their recommended built-in profile.
     pub startup_timeout: Option<StartupTimeoutConfig<'a>>,
@@ -1255,12 +1257,16 @@ pub fn execute_supervised(
             };
             #[cfg(not(target_os = "macos"))]
             let sandbox_violations = Vec::new();
+            let visible_sandbox_violations = filter_suppressed_system_service_violations(
+                &sandbox_violations,
+                config.suppressed_system_service_operations,
+            );
 
             // Resolve policy explanations for denied paths so the diagnostic
             // can show group names and fix guidance inline. On macOS this is
             // also the source for the run-time profile save prompt.
             let policy_explanations =
-                build_policy_explanations(&denials, &sandbox_violations, config.caps);
+                build_policy_explanations(&denials, &visible_sandbox_violations, config.caps);
             let prompt_policy_explanations = policy_explanations.clone();
             let prompt_error_observation = error_observation.clone();
 
@@ -1270,7 +1276,7 @@ pub fn execute_supervised(
                     exit_code,
                     &denials,
                     &ipc_denials,
-                    &sandbox_violations,
+                    &visible_sandbox_violations,
                     &error_observation,
                 );
 
@@ -1308,6 +1314,9 @@ pub fn execute_supervised(
                     .with_session_id(diag_session_id)
                     .with_policy_explanations(policy_explanations)
                     .with_suppressed_paths(config.ignored_denial_paths)
+                    .with_suppressed_system_service_operations(
+                        config.suppressed_system_service_operations,
+                    )
                     .with_canonical_denial_paths(canonical_denial_paths);
                 if let Some(program) = config.command.first() {
                     formatter = formatter.with_command(nono::diagnostic::CommandContext {
@@ -1339,7 +1348,7 @@ pub fn execute_supervised(
                         caps: config.caps,
                         command: config.command,
                         compared_profile: config.profile_save_base,
-                        sandbox_violations: &sandbox_violations,
+                        sandbox_violations: &visible_sandbox_violations,
                         ignored_denial_paths: config.ignored_denial_paths,
                     },
                 )?;
@@ -1482,6 +1491,24 @@ fn should_print_diagnostic_footer(
             || !ipc_denials.is_empty()
             || !sandbox_violations.is_empty()
             || error_observation.has_findings())
+}
+
+fn filter_suppressed_system_service_violations(
+    sandbox_violations: &[nono::SandboxViolation],
+    suppressed_operations: &[String],
+) -> Vec<nono::SandboxViolation> {
+    if suppressed_operations.is_empty() {
+        return sandbox_violations.to_vec();
+    }
+
+    sandbox_violations
+        .iter()
+        .filter(|violation| {
+            nono::diagnostic::seatbelt_operation_to_access(&violation.operation).is_some()
+                || !suppressed_operations.contains(&violation.operation)
+        })
+        .cloned()
+        .collect()
 }
 
 fn should_offer_profile_save(

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1334,7 +1334,7 @@ pub fn execute_supervised(
                 exit_code,
                 &prompt_policy_explanations,
                 &prompt_error_observation,
-                &sandbox_violations,
+                &visible_sandbox_violations,
             ) {
                 // Clear the forwarding target before prompting. The child is
                 // already dead; keeping CHILD_PID set would cause forward_signal
@@ -3658,6 +3658,27 @@ mod tests {
             &explanations,
             &observation,
             &violations,
+        ));
+    }
+
+    #[test]
+    fn test_suppressed_system_service_violations_do_not_offer_profile_save() {
+        let explanations = Vec::new();
+        let observation = nono::diagnostic::ErrorObservation::default();
+        let violations = vec![nono::SandboxViolation {
+            operation: "forbidden-exec-sugid".to_string(),
+            target: None,
+        }];
+        let suppressed = vec!["forbidden-exec-sugid".to_string()];
+        let visible = filter_suppressed_system_service_violations(&violations, &suppressed);
+
+        assert!(visible.is_empty());
+        assert!(!should_offer_profile_save(
+            false,
+            0,
+            &explanations,
+            &observation,
+            &visible,
         ));
     }
 

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -384,6 +384,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             .as_deref()
             .or(recommended_profile),
         ignored_denial_paths: &flags.ignored_denial_paths,
+        suppressed_system_service_operations: &flags.suppressed_system_service_operations,
         startup_timeout: flags
             .startup_timeout_secs
             .filter(|&secs| secs > 0)

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -102,6 +102,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) af_unix_mediation: crate::profile::LinuxAfUnixMediation,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
     pub(crate) ignored_denial_paths: Vec<PathBuf>,
+    pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) session: SessionLaunchOptions,
     pub(crate) rollback: RollbackLaunchOptions,
     pub(crate) trust: TrustLaunchOptions,
@@ -128,6 +129,7 @@ impl ExecutionFlags {
             af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             bypass_protection_paths: Vec::new(),
             ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
             session: SessionLaunchOptions::default(),
             rollback: RollbackLaunchOptions::default(),
             trust: TrustLaunchOptions {
@@ -253,6 +255,7 @@ pub(crate) fn prepare_run_launch_plan(
             af_unix_mediation: prepared.af_unix_mediation,
             bypass_protection_paths: prepared.bypass_protection_paths,
             ignored_denial_paths: prepared.ignored_denial_paths,
+            suppressed_system_service_operations: prepared.suppressed_system_service_operations,
             session: SessionLaunchOptions {
                 detached_start: run_args.detached,
                 session_name: run_args.name,

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -284,6 +284,7 @@ mod tests {
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
             ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
         };
@@ -334,6 +335,7 @@ mod tests {
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
             ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
         };

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -163,6 +163,7 @@ impl ProfileDef {
             commands: self.commands.clone(),
             filesystem: self.filesystem.clone(),
             network: self.network.clone(),
+            diagnostics: profile::DiagnosticsConfig::default(),
             linux: profile::LinuxConfig::default(),
             env_credentials: self.env_credentials.clone(),
             environment: None,

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1339,6 +1339,19 @@ impl LinuxAfUnixMediation {
     }
 }
 
+/// Diagnostic output controls.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticsConfig {
+    /// Non-filesystem sandbox operations to suppress from diagnostic footers.
+    ///
+    /// This does not grant access and does not change sandbox enforcement. It
+    /// only hides recurring non-actionable system-service diagnostics, such as
+    /// `forbidden-exec-sugid`, from post-run output.
+    #[serde(default)]
+    pub suppress_system_services: Vec<String>,
+}
+
 /// Linux-specific profile controls.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1536,6 +1549,8 @@ pub struct Profile {
     #[serde(default)]
     pub network: NetworkConfig,
     #[serde(default)]
+    pub diagnostics: DiagnosticsConfig,
+    #[serde(default)]
     pub linux: LinuxConfig,
     /// ALIAS(canonical="env_credentials", introduced="v0.0.0", remove_by="indefinite", issue="#143")
     #[serde(default, alias = "secrets")]
@@ -1634,6 +1649,8 @@ struct ProfileDeserialize {
     #[serde(default)]
     network: NetworkConfig,
     #[serde(default)]
+    diagnostics: DiagnosticsConfig,
+    #[serde(default)]
     linux: LinuxConfig,
     /// ALIAS(canonical="env_credentials", introduced="v0.0.0", remove_by="indefinite", issue="#143")
     #[serde(default, alias = "secrets")]
@@ -1687,6 +1704,7 @@ impl From<ProfileDeserialize> for Profile {
             commands: raw.commands,
             filesystem: raw.filesystem,
             network: raw.network,
+            diagnostics: raw.diagnostics,
             linux: raw.linux,
             env_credentials: raw.env_credentials,
             environment: raw.environment,
@@ -2616,6 +2634,12 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 .linux
                 .af_unix_mediation
                 .or(base.linux.af_unix_mediation),
+        },
+        diagnostics: DiagnosticsConfig {
+            suppress_system_services: dedup_append(
+                &base.diagnostics.suppress_system_services,
+                &child.diagnostics.suppress_system_services,
+            ),
         },
         env_credentials: SecretsConfig {
             mappings: {
@@ -4609,6 +4633,7 @@ mod tests {
                 upstream_proxy: None,
                 upstream_bypass: Vec::new(),
             },
+            diagnostics: DiagnosticsConfig::default(),
             linux: LinuxConfig::default(),
             env_credentials: SecretsConfig {
                 mappings: {
@@ -4689,6 +4714,7 @@ mod tests {
                 upstream_proxy: None,
                 upstream_bypass: Vec::new(),
             },
+            diagnostics: DiagnosticsConfig::default(),
             linux: LinuxConfig::default(),
             env_credentials: SecretsConfig {
                 mappings: {
@@ -5645,6 +5671,29 @@ mod tests {
         let creds = merged.network.resolved_credentials();
         assert!(creds.contains(&"base_cred".to_string()));
         assert!(creds.contains(&"child_cred".to_string()));
+    }
+
+    #[test]
+    fn test_merge_profiles_diagnostics_suppressions_append() {
+        let mut base = base_profile();
+        base.diagnostics.suppress_system_services = vec![
+            "forbidden-exec-sugid".to_string(),
+            "mach-lookup".to_string(),
+        ];
+        let mut child = child_profile();
+        child.diagnostics.suppress_system_services =
+            vec!["forbidden-exec-sugid".to_string(), "signal".to_string()];
+
+        let merged = merge_profiles(base, child);
+
+        assert_eq!(
+            merged.diagnostics.suppress_system_services,
+            vec![
+                "forbidden-exec-sugid".to_string(),
+                "mach-lookup".to_string(),
+                "signal".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -28,6 +28,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) allow_parent_of_protected: bool,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
     pub(crate) ignored_denial_paths: Vec<PathBuf>,
+    pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -568,6 +569,10 @@ fn prepare_profile_with_options(
             &args.suppress_save_prompt,
             workdir,
         ),
+        suppressed_system_service_operations: loaded_profile
+            .as_ref()
+            .map(|profile| profile.diagnostics.suppress_system_services.clone())
+            .unwrap_or_default(),
         allowed_env_vars: loaded_profile.as_ref().and_then(|profile| {
             profile.environment.as_ref().map(|env_config| {
                 if let Some(err) = crate::exec_strategy::validate_env_var_patterns(

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -438,6 +438,7 @@ pub(crate) struct PreparedSandbox {
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
     pub(crate) ignored_denial_paths: Vec<PathBuf>,
+    pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -1066,6 +1067,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 open_url_allow_localhost: false,
                 bypass_protection_paths: Vec::new(),
                 ignored_denial_paths: Vec::new(),
+                suppressed_system_service_operations: Vec::new(),
                 allowed_env_vars: None,
                 denied_env_vars: None,
             },
@@ -1099,6 +1101,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allow_parent_of_protected: profile_allow_parent_of_protected,
         bypass_protection_paths,
         ignored_denial_paths,
+        suppressed_system_service_operations,
         allowed_env_vars: profile_allowed_env_vars,
         denied_env_vars: profile_denied_env_vars,
     } = prepared_profile;
@@ -1366,6 +1369,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             open_url_allow_localhost,
             bypass_protection_paths,
             ignored_denial_paths,
+            suppressed_system_service_operations,
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
         },

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -658,6 +658,9 @@ pub struct DiagnosticFormatter<'a> {
     /// denied paths with `[save skipped]` so the diagnostic footer is
     /// self-explanatory without requiring the user to cross-reference their profile.
     suppressed_paths: &'a [PathBuf],
+    /// Non-filesystem sandbox operations suppressed from the diagnostic footer.
+    /// The sandbox still denies these operations; this only controls reporting.
+    suppressed_system_service_operations: &'a [String],
     /// Canonicalized forms of the denied paths, parallel to `denials`. When
     /// provided, used in place of on-demand `try_canonicalize` calls inside the
     /// render loop so filesystem I/O is done once (by the caller, after the
@@ -686,6 +689,7 @@ impl<'a> DiagnosticFormatter<'a> {
             session_id: None,
             policy_explanations: Vec::new(),
             suppressed_paths: &[],
+            suppressed_system_service_operations: &[],
             canonical_denial_paths: Vec::new(),
         }
     }
@@ -708,6 +712,13 @@ impl<'a> DiagnosticFormatter<'a> {
     #[must_use]
     pub fn with_suppressed_paths(mut self, paths: &'a [PathBuf]) -> Self {
         self.suppressed_paths = paths;
+        self
+    }
+
+    /// Set non-filesystem sandbox operations suppressed from the diagnostic footer.
+    #[must_use]
+    pub fn with_suppressed_system_service_operations(mut self, operations: &'a [String]) -> Self {
+        self.suppressed_system_service_operations = operations;
         self
     }
 
@@ -1139,7 +1150,13 @@ impl<'a> DiagnosticFormatter<'a> {
 
         // Convert macOS Seatbelt violations (operation + target) into
         // DenialRecords so the same rendering logic handles both platforms.
-        let (violation_denials, non_fs_violations) = violations_to_denials(self.sandbox_violations);
+        let (violation_denials, mut non_fs_violations) =
+            violations_to_denials(self.sandbox_violations);
+        non_fs_violations.retain(|violation| {
+            !self
+                .suppressed_system_service_operations
+                .contains(&violation.operation)
+        });
 
         // Merge supervisor denials (Linux seccomp) with violation-derived
         // denials (macOS Seatbelt) into a single unified list.
@@ -3256,6 +3273,31 @@ mod tests {
         assert!(output.contains("not a path grant"));
         assert!(output.contains("does not save this automatically"));
         assert!(!output.contains("unsafe_macos_seatbelt_rules"));
+    }
+
+    #[test]
+    fn test_suppressed_system_service_violation_is_hidden_from_footer() {
+        let caps = make_test_caps();
+        let violations = vec![
+            SandboxViolation {
+                operation: "forbidden-exec-sugid".to_string(),
+                target: None,
+            },
+            SandboxViolation {
+                operation: "mach-lookup".to_string(),
+                target: Some("com.apple.logd".to_string()),
+            },
+        ];
+        let suppressed = vec!["forbidden-exec-sugid".to_string()];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations)
+            .with_suppressed_system_service_operations(&suppressed);
+        let output = formatter.format_footer(1);
+
+        assert!(!output.contains("forbidden-exec-sugid"));
+        assert!(!output.contains("Setuid/setgid executable blocked"));
+        assert!(output.contains("mach-lookup (com.apple.logd)"));
     }
 
     #[test]


### PR DESCRIPTION
Introduce `diagnostics.suppress_system_services` in the profile to filter out noisy, non-actionable system service denials from the diagnostic footer.

- This new profile field accepts an array of strings representing non-filesystem sandbox operation names (e.g., `forbidden-exec-sugid`, `mach-lookup`).
- Violations matching these operations will be hidden from the post-run diagnostic footer.
- This suppression *only* affects the diagnostic reporting; the sandbox still enforces the underlying denials.
- Suppressed violations will also be excluded from policy explanations and the profile save prompt.

## Linked Issue
#1058