### PR TITLE
feat(profile): allow registry refs in profile extends

### DIFF
--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1364,7 +1364,10 @@ pub(crate) fn prepare_profile_save_from_patch(
     let profile_path = profile::get_user_profile_path(profile_name)?;
     let mut new_profile = patch.clone();
     let extends = compared_profile
-        .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)
+        .filter(|name| {
+            (profile::is_valid_profile_name(name) || profile::is_registry_ref(name))
+                && *name != profile_name
+        })
         .map(|name| vec![name.to_string()]);
     let has_base = extends.is_some();
     let suppression_only = patch_is_suppression_only(patch);
@@ -2165,6 +2168,95 @@ mod tests {
             vec!["~/.copilot/settings.json"]
         );
         assert!(prepared.profile.filesystem.read_file.is_empty());
+    }
+
+    #[test]
+    fn prepare_profile_save_from_patch_preserves_registry_ref_as_extends() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        let patch = profile::Profile {
+            filesystem: profile::FilesystemConfig {
+                suppress_save_prompt: vec!["~/.copilot/settings.json".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let prepared = prepare_profile_save_from_patch(
+            &patch,
+            "claude",
+            "claude-test",
+            Some("always-further/claude"),
+        )
+        .expect("prepare");
+
+        assert!(matches!(prepared.action, SaveAction::Created));
+        assert_eq!(
+            prepared.profile.extends,
+            Some(vec!["always-further/claude".to_string()])
+        );
+    }
+
+    #[test]
+    fn prepare_profile_save_from_patch_preserves_versioned_registry_ref() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        let mut patch = profile::Profile::default();
+        patch.filesystem.read = vec!["~/workspace".to_string()];
+
+        let prepared = prepare_profile_save_from_patch(
+            &patch,
+            "claude",
+            "claude-test",
+            Some("always-further/claude@1.2.0"),
+        )
+        .expect("prepare");
+
+        assert_eq!(
+            prepared.profile.extends,
+            Some(vec!["always-further/claude@1.2.0".to_string()])
+        );
+    }
+
+    #[test]
+    fn prepare_profile_save_from_patch_still_avoids_self_reference() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_config = TempDir::new().expect("temp config");
+        let _env = EnvVarGuard::set_all(&[
+            ("HOME", temp_home.path().to_str().expect("home path")),
+            (
+                "XDG_CONFIG_HOME",
+                temp_config.path().to_str().expect("config path"),
+            ),
+        ]);
+
+        let mut patch = profile::Profile::default();
+        patch.filesystem.read = vec!["~/workspace".to_string()];
+
+        let prepared =
+            prepare_profile_save_from_patch(&patch, "claude", "my-profile", Some("my-profile"))
+                .expect("prepare");
+
+        assert!(prepared.profile.extends.is_none());
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -675,7 +675,6 @@ mod tests {
 mod cap_file_validation_tests {
     use super::*;
     use crate::test_env::{ENV_LOCK, EnvVarGuard};
-    use tempfile::tempdir;
 
     /// Write a valid `.nono-<hex>.json` capability file into `dir`.
     fn write_cap_file(dir: &Path) -> PathBuf {
@@ -718,7 +717,7 @@ mod cap_file_validation_tests {
 
     #[test]
     fn test_validate_accepts_file_in_tempdir() {
-        let dir = tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
         let path = write_cap_file(dir.path());
         let path_str = path.to_str().expect("utf8 path");
 
@@ -766,7 +765,7 @@ mod cap_file_validation_tests {
 
     #[test]
     fn test_validate_rejects_nonexistent_file() {
-        let dir = tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
         let missing = dir.path().join(".nono-0000000000000000.json");
         let err = validate_cap_file_path(missing.to_str().expect("utf8"))
             .expect_err("nonexistent file rejected");
@@ -791,7 +790,12 @@ mod cap_file_validation_tests {
 
     #[test]
     fn test_validate_rejects_wrong_filename_pattern() {
-        let dir = tempdir().expect("tempdir");
+        // Anchor under `/tmp` so the test is immune to parallel tests that
+        // modify `$TMPDIR` — a bare `tempdir()` would inherit the altered
+        // `$TMPDIR` and the backing directory may be deleted by the other
+        // test's TempDir drop, causing `canonicalize` to fail with ENOENT
+        // before the filename-pattern check is reached.
+        let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
         let caps = CapabilitySet::new().block_network();
         let state = SandboxState::from_caps(&caps, &[], &[], &[]);
         let path = dir.path().join("not-a-nono-file.json");
@@ -807,7 +811,7 @@ mod cap_file_validation_tests {
 
     #[test]
     fn test_validate_rejects_directory() {
-        let dir = tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
         let err = validate_cap_file_path(dir.path().to_str().expect("utf8"))
             .expect_err("directory rejected");
         // A directory in a temp root fails the filename-pattern check before the


### PR DESCRIPTION
When saving a profile that extends from a registry reference, the `extends` field was previously filtered out if it wasn't a local profile name. This change updates the `prepare_profile_save_from_patch` function to properly recognize and preserve registry references (e.g., "always-further/claude" or "always-further/claude@1.2.0").

New tests ensure that:
- Registry references are correctly preserved in the `extends` field.
- Versioned registry references are also preserved.
- Self-referencing profiles are still avoided.

## Linked Issue

Closes #1060