### PR TITLE
refactor(pull_ui): remove sigstore provenance display

### DIFF
--- a/crates/nono-cli/src/pull_ui.rs
+++ b/crates/nono-cli/src/pull_ui.rs
@@ -1,8 +1,7 @@
 //! Sleek TUI for `nono pull`. Streams per-file download progress as it
-//! happens, then renders the Sigstore provenance and install summary as
-//! a coherent trust-chain block. Same output for the explicit
-//! `nono pull <ref>` command and the auto-pull path triggered by
-//! `--profile always-further/claude`.
+//! happens, then renders the install summary. Same output for the
+//! explicit `nono pull <ref>` command and the auto-pull path triggered
+//! by `--profile always-further/claude`.
 //!
 //! Design rules (do not relax without thinking):
 //!   - No spinners, no in-place line rewrites — output stays readable in
@@ -11,8 +10,6 @@
 //!     terminals don't wrap awkwardly.
 //!   - Color is decoration, not information: every line still parses
 //!     when ANSI is stripped (NO_COLOR, dumb terminals).
-//!   - The provenance block explains *what* was verified — users should
-//!     leave with a clear mental model of "artifact ↔ source code".
 
 use crate::package::{PackageRef, PullResponse};
 use colored::Colorize;
@@ -76,8 +73,8 @@ impl ProgressPrinter {
     }
 }
 
-/// Render the verified-and-installed summary. Called once after the
-/// install completes successfully.
+/// Render the install summary. Called once after the install
+/// completes successfully.
 ///
 /// `install_dir` is the absolute path of the installed pack inside the
 /// package store. `installed_artifacts` is the count from the install
@@ -100,44 +97,6 @@ pub fn render_summary(
     );
     let _ = writeln!(err);
 
-    let prov = &pull.provenance;
-    let label_w = "workflow".len();
-
-    let _ = writeln!(
-        err,
-        "     {label}  {body}",
-        label = "Verified".bold(),
-        body = "Sigstore cryptographic supply chain provenance binds all".normal(),
-    );
-    let _ = writeln!(
-        err,
-        "               release artifacts to the source of origin '{}'",
-        prov.repository,
-    );
-    let _ = writeln!(err);
-
-    write_field(&mut err, "repo", &prov.repository, label_w);
-    write_field(
-        &mut err,
-        ref_label(&prov.git_ref),
-        &strip_ref_prefix(&prov.git_ref),
-        label_w,
-    );
-    write_field(&mut err, "workflow", &prov.workflow, label_w);
-    if let Some(ts) = prov.signed_at {
-        write_field(
-            &mut err,
-            "signed",
-            &ts.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
-            label_w,
-        );
-    }
-    if let Some(idx) = prov.rekor_log_index {
-        let url = format!("https://search.sigstore.dev/?logIndex={idx}");
-        write_field(&mut err, "rekor", &url, label_w);
-    }
-
-    let _ = writeln!(err);
     let _ = writeln!(
         err,
         "     {label}  {body}",
@@ -158,46 +117,6 @@ pub fn render_summary(
         );
     }
     let _ = writeln!(err);
-}
-
-/// Field row in the provenance block. Two-space indent already applied
-/// upstream; the inner formatting matches the "Verified  …" header.
-fn write_field<W: Write>(out: &mut W, label: &str, value: &str, label_w: usize) {
-    let _ = writeln!(
-        out,
-        "               {label:<width$}   {value}",
-        label = label.dimmed(),
-        value = value,
-        width = label_w,
-    );
-}
-
-/// `refs/tags/foo` → `tag`, `refs/heads/foo` → `branch`, anything that
-/// looks like a SHA → `commit`, otherwise `ref`.
-fn ref_label(git_ref: &str) -> &'static str {
-    if git_ref.starts_with("refs/tags/") {
-        "tag"
-    } else if git_ref.starts_with("refs/heads/") {
-        "branch"
-    } else if is_sha_like(git_ref) {
-        "commit"
-    } else {
-        "ref"
-    }
-}
-
-fn strip_ref_prefix(git_ref: &str) -> String {
-    if let Some(rest) = git_ref.strip_prefix("refs/tags/") {
-        return rest.to_string();
-    }
-    if let Some(rest) = git_ref.strip_prefix("refs/heads/") {
-        return rest.to_string();
-    }
-    git_ref.to_string()
-}
-
-fn is_sha_like(s: &str) -> bool {
-    s.len() >= 7 && s.len() <= 40 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// "1.30 KB" / "412 B" / "2.10 MB" — three significant digits. Human
@@ -234,27 +153,5 @@ mod tests {
         assert_eq!(format_size(1500), "1.46 KB");
         assert_eq!(format_size(1024 * 1024), "1.00 MB");
         assert_eq!(format_size(1024 * 1024 * 1024), "1.00 GB");
-    }
-
-    #[test]
-    fn ref_label_classification() {
-        assert_eq!(ref_label("refs/tags/v0.0.1"), "tag");
-        assert_eq!(ref_label("refs/heads/main"), "branch");
-        assert_eq!(ref_label("a1b2c3d4e5f6"), "commit");
-        assert_eq!(
-            ref_label("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"),
-            "commit"
-        );
-        assert_eq!(ref_label("something-else"), "ref");
-    }
-
-    #[test]
-    fn strip_ref_prefix_strips_known_prefixes() {
-        assert_eq!(
-            strip_ref_prefix("refs/tags/claude-v0.0.11"),
-            "claude-v0.0.11"
-        );
-        assert_eq!(strip_ref_prefix("refs/heads/main"), "main");
-        assert_eq!(strip_ref_prefix("abc1234"), "abc1234");
     }
 }


### PR DESCRIPTION
The `nono pull` UI previously displayed detailed Sigstore provenance information after a successful pull. This information has been removed to simplify the user interface.

The provenance details were often complex and might not have provided clear value to the end user in this specific context, potentially causing confusion or visual clutter. Future iterations might integrate provenance in a different, more digestible way if needed.

This change removes:
- The "Verified Sigstore cryptographic supply chain provenance" block.
- Associated helper functions (`write_field`, `ref_label`, `strip_ref_prefix`, `is_sha_like`).
- Corresponding unit tests.
