### PR TITLE
feat(output): show blocked macos grants in capability summary

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -519,6 +519,10 @@ pub struct PreparedCaps {
     pub caps: CapabilitySet,
     pub needs_unlink_overrides: bool,
     pub deny_paths: Vec<PathBuf>,
+    /// User-granted paths (macOS) that a deny group silently blocks, paired
+    /// with the deny group that blocks each. Surfaced as a single folded line
+    /// in the capability summary; `(path, Some(group_name))`.
+    pub blocked_grants: Vec<(PathBuf, Option<String>)>,
 }
 
 /// Extension trait for CapabilitySet to add CLI-specific construction methods.
@@ -624,12 +628,13 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_blocked_command(cmd);
         }
 
-        finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
+        let blocked_grants = finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
 
         Ok(PreparedCaps {
             caps,
             needs_unlink_overrides: resolved.needs_unlink_overrides,
             deny_paths: resolved.deny_paths,
+            blocked_grants,
         })
     }
 
@@ -1062,7 +1067,7 @@ impl CapabilitySetExt for CapabilitySet {
             }
         }
 
-        finalize_caps(
+        let blocked_grants = finalize_caps(
             &mut caps,
             &mut resolved,
             &loaded_policy,
@@ -1074,6 +1079,7 @@ impl CapabilitySetExt for CapabilitySet {
             caps,
             needs_unlink_overrides: resolved.needs_unlink_overrides,
             deny_paths: resolved.deny_paths,
+            blocked_grants,
         })
     }
 }
@@ -1089,7 +1095,7 @@ fn finalize_caps(
     loaded_policy: &policy::Policy,
     args: &SandboxArgs,
     profile_bypass_protection: &[PathBuf],
-) -> Result<()> {
+) -> Result<Vec<(PathBuf, Option<String>)>> {
     // Apply profile-level deny overrides first, then CLI overrides.
     // Profile overrides come from `filesystem.bypass_protection` in the
     // profile JSON. CLI `--bypass-protection` flags are applied on top.
@@ -1104,22 +1110,16 @@ fn finalize_caps(
     // Validate deny/allow overlaps (hard-fail on Linux where Landlock cannot enforce denies)
     policy::validate_deny_overlaps(&resolved.deny_paths, caps)?;
 
-    // On macOS, warn when user-granted paths are silently blocked by deny rules.
-    // Seatbelt deny rules override earlier allow rules for content access, so the
-    // user's --allow/--read/--write has no effect without --bypass-protection.
-    if cfg!(target_os = "macos") {
-        for (path, group) in
-            policy::find_denied_user_grants(&resolved.deny_paths, caps, loaded_policy)
-        {
-            let source = group.as_deref().unwrap_or("a deny rule");
-            warn!(
-                "'{}' is blocked by '{}'; use --bypass-protection {} to allow access",
-                path.display(),
-                source,
-                path.display(),
-            );
-        }
-    }
+    // On macOS, collect user-granted paths that are silently blocked by deny
+    // rules so the caller can surface them as one folded line in the capability
+    // summary (rather than a wall of per-path warnings). Seatbelt deny rules
+    // override earlier allow rules for content access, so the user's
+    // --allow/--read/--write has no effect without --bypass-protection.
+    let blocked_grants = if cfg!(target_os = "macos") {
+        policy::find_denied_user_grants(&resolved.deny_paths, caps, loaded_policy)
+    } else {
+        Vec::new()
+    };
 
     // Keep broad keychain deny groups active, but allow explicit
     // keychain DB read grants (profile/CLI) on macOS.
@@ -1128,7 +1128,7 @@ fn finalize_caps(
     // Deduplicate capabilities
     caps.deduplicate();
 
-    Ok(())
+    Ok(blocked_grants)
 }
 
 fn apply_cli_network_mode(caps: &mut CapabilitySet, args: &SandboxArgs) {

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -52,7 +52,12 @@ pub fn print_banner(silent: bool) {
 /// When `verbose` is 0, only user-specified capabilities are shown (CLI flags
 /// and profile filesystem entries). System paths and group-resolved paths are
 /// hidden to reduce noise. Use `-v` to show all capabilities.
-pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
+pub fn print_capabilities(
+    caps: &CapabilitySet,
+    blocked_grants: &[(std::path::PathBuf, Option<String>)],
+    verbose: u8,
+    silent: bool,
+) {
     if silent {
         return;
     }
@@ -109,6 +114,11 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             );
         }
     }
+
+    // Protected paths kept blocked despite a user grant (macOS deny groups).
+    // Folded into one row by default so a broad grant (e.g. ~/Library) that
+    // overlaps several deny groups does not produce a wall of warnings.
+    print_blocked_grants(blocked_grants, verbose, t);
 
     // AF_UNIX socket capabilities (issue #685 / #696)
     let unix_caps = caps.unix_socket_capabilities();
@@ -216,6 +226,72 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
 }
 
 /// Format an access mode as a fixed-width colored badge
+/// Render the paths that a deny group keeps blocked despite a user grant.
+///
+/// Collapsed by default to a single row (a broad grant such as `~/Library`
+/// overlaps many deny groups and would otherwise emit one warning per path).
+/// `-v` expands to the full paths grouped by the deny rule that blocks them,
+/// with the `--bypass-protection` escape hatch shown once.
+fn print_blocked_grants(
+    blocked: &[(std::path::PathBuf, Option<String>)],
+    verbose: u8,
+    t: &theme::Theme,
+) {
+    if blocked.is_empty() {
+        return;
+    }
+
+    let badge = theme::badge("deny ", t.yellow, BADGE_FG_DARK);
+
+    if verbose == 0 {
+        let n = blocked.len();
+        let noun = if n == 1 { "path" } else { "paths" };
+        eprintln!(
+            "  {} {}",
+            badge,
+            theme::fg(
+                &format!("{n} sensitive {noun} kept blocked inside your grants (-v to show)"),
+                t.subtext,
+            ),
+        );
+        return;
+    }
+
+    eprintln!(
+        "  {} {}",
+        badge,
+        theme::fg("sensitive paths kept blocked despite your grants:", t.text),
+    );
+
+    // Group by the deny rule that blocks each path, preserving first-seen order.
+    let mut groups: Vec<(String, Vec<&std::path::Path>)> = Vec::new();
+    for (path, group) in blocked {
+        let label = group.as_deref().unwrap_or("a deny rule").to_string();
+        match groups.iter_mut().find(|(name, _)| *name == label) {
+            Some((_, paths)) => paths.push(path.as_path()),
+            None => groups.push((label, vec![path.as_path()])),
+        }
+    }
+
+    for (name, paths) in &groups {
+        eprintln!("       {}", theme::fg(name, t.subtext));
+        for path in paths {
+            eprintln!(
+                "         {}",
+                theme::fg(&path.display().to_string(), t.text),
+            );
+        }
+    }
+
+    eprintln!(
+        "       {}",
+        theme::fg(
+            "use --bypass-protection <path> to allow a specific path",
+            t.subtext,
+        ),
+    );
+}
+
 fn format_access_badge(access: &AccessMode) -> String {
     let t = theme::current();
     match access {
@@ -914,9 +990,11 @@ pub fn print_profile_hint(program: &str, profile: &str, silent: bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        dry_run_command_line, format_unix_socket_mode_badge, print_capabilities,
-        print_profile_hint, render_diagnostic_footer, render_terminal_block_for_tty,
+        dry_run_command_line, format_unix_socket_mode_badge, print_blocked_grants,
+        print_capabilities, print_profile_hint, render_diagnostic_footer,
+        render_terminal_block_for_tty,
     };
+    use super::theme;
     use nono::{CapabilitySet, UnixSocketMode};
     use std::ffi::{OsStr, OsString};
     use tempfile::tempdir;
@@ -1018,7 +1096,32 @@ mod tests {
             .allow_unix_socket_dir(dir.path(), UnixSocketMode::ConnectBind)
             .expect("bind dir grant");
 
-        print_capabilities(&caps, 0, true);
-        print_capabilities(&caps, 1, true);
+        print_capabilities(&caps, &[], 0, true);
+        print_capabilities(&caps, &[], 1, true);
+    }
+
+    #[test]
+    fn print_blocked_grants_collapsed_and_verbose_do_not_panic() {
+        // Blocked grants render as one folded row by default and expand under
+        // -v; both paths (and the empty case) must render without panicking.
+        let t = theme::current();
+        let blocked = vec![
+            (
+                std::path::PathBuf::from("/Users/x/Library/Application Support/Google/Chrome"),
+                Some("deny_browser_data_macos".to_string()),
+            ),
+            (
+                std::path::PathBuf::from("/Users/x/Library/Application Support/1Password"),
+                Some("deny_keychains_macos".to_string()),
+            ),
+            (
+                std::path::PathBuf::from("/Users/x/Library/Application Support/Unknown"),
+                None,
+            ),
+        ];
+
+        print_blocked_grants(&blocked, 0, t);
+        print_blocked_grants(&blocked, 1, t);
+        print_blocked_grants(&[], 0, t);
     }
 }

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -266,20 +266,17 @@ fn print_blocked_grants(
     // Group by the deny rule that blocks each path, preserving first-seen order.
     let mut groups: Vec<(String, Vec<&std::path::Path>)> = Vec::new();
     for (path, group) in blocked {
-        let label = group.as_deref().unwrap_or("a deny rule").to_string();
-        match groups.iter_mut().find(|(name, _)| *name == label) {
+        let group_name = group.as_deref().unwrap_or("a deny rule");
+        match groups.iter_mut().find(|(name, _)| name == group_name) {
             Some((_, paths)) => paths.push(path.as_path()),
-            None => groups.push((label, vec![path.as_path()])),
+            None => groups.push((group_name.to_string(), vec![path.as_path()])),
         }
     }
 
     for (name, paths) in &groups {
         eprintln!("       {}", theme::fg(name, t.subtext));
         for path in paths {
-            eprintln!(
-                "         {}",
-                theme::fg(&path.display().to_string(), t.text),
-            );
+            eprintln!("         {}", theme::fg(&path.to_string_lossy(), t.text));
         }
     }
 
@@ -989,12 +986,12 @@ pub fn print_profile_hint(program: &str, profile: &str, silent: bool) {
 
 #[cfg(test)]
 mod tests {
+    use super::theme;
     use super::{
         dry_run_command_line, format_unix_socket_mode_badge, print_blocked_grants,
         print_capabilities, print_profile_hint, render_diagnostic_footer,
         render_terminal_block_for_tty,
     };
-    use super::theme;
     use nono::{CapabilitySet, UnixSocketMode};
     use std::ffi::{OsStr, OsString};
     use tempfile::tempdir;

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -571,11 +571,12 @@ pub(crate) fn resolve_detached_cwd_prompt_response(
 
 fn finalize_prepared_sandbox(
     prepared: PreparedSandbox,
+    blocked_grants: &[(PathBuf, Option<String>)],
     args: &SandboxArgs,
     silent: bool,
 ) -> Result<PreparedSandbox> {
     output::print_skipped_requested_paths(&collect_missing_cli_requested_paths(args), silent);
-    output::print_capabilities(&prepared.caps, args.verbose, silent);
+    output::print_capabilities(&prepared.caps, blocked_grants, args.verbose, silent);
 
     if let Some(ref profile_name) = args.profile {
         crate::pack_update_hint::show_pack_update_hints(profile_name, silent);
@@ -1079,6 +1080,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 set_vars: None,
                 network_block_requested: args.block_net,
             },
+            &[],
             args,
             silent,
         );
@@ -1209,6 +1211,9 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     // re-run validate_deny_overlaps after CWD/pack grants are added below,
     // because Landlock cannot enforce a deny that lives under a later allow.
     let prepared_deny_paths = prepared.deny_paths;
+    // User grants silently blocked by deny groups (macOS); folded into the
+    // capability summary instead of emitting one warning per path.
+    let blocked_grants = prepared.blocked_grants;
 
     // Apply raw Seatbelt rules from the profile (macOS only).
     #[cfg(target_os = "macos")]
@@ -1392,6 +1397,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             set_vars: profile_set_vars,
             network_block_requested,
         },
+        &blocked_grants,
         args,
         silent,
     )

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -240,6 +240,10 @@ fn is_capability_summary_line(line: &str) -> bool {
         return true;
     }
 
+    if trimmed.starts_with("deny") && trimmed.contains("kept blocked") {
+        return true;
+    }
+
     if trimmed == "outbound allowed"
         || trimmed == "outbound blocked"
         || trimmed.starts_with("proxy localhost:")


### PR DESCRIPTION
Previously, macOS user-granted paths that were silently blocked by deny groups were logged as individual warnings. This could lead to a large number of warnings when a broad user grant (e.g., `~/Library`) overlapped with multiple deny groups.

This commit refactors the logic to collect these blocked grants and present them in the capability summary. The new display is collapsed into a single line by default, indicating the number of paths blocked. Using the `-v` (verbose) flag expands the summary to list each specific path and the deny rule that blocks it, along with a hint about how to use `--bypass-protection`. This significantly improves readability and user experience by folding multiple related warnings into a concise summary.

<img width="830" height="406" alt="image" src="https://github.com/user-attachments/assets/00c1592c-c8e6-488b-80a9-2e77f3de8d6d" />


## Linked Issue

Closes #1176


- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

