### PR TITLE
refactor(credentials): require explicit activation for custom credentials

### DIFF
--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -137,7 +137,10 @@ impl ProxyLaunchOptions {
     pub(crate) fn is_active(&self) -> bool {
         self.domain_filter.is_some()
             || self.endpoint_filter.is_some()
-            || self.credentials.is_some()
+            || self
+                .credentials
+                .as_ref()
+                .is_some_and(|credentials| !credentials.credentials.is_empty())
             || self.upstream_proxy.is_some()
     }
 }

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -184,10 +184,10 @@ pub fn resolve_credentials(
     service_names: &[String],
     custom_credentials: &HashMap<String, CustomCredentialDef>,
 ) -> Result<Vec<RouteConfig>> {
-    // Build the full set of names to resolve: explicitly requested names
-    // (from `credentials`) plus all custom_credentials keys. custom_credentials
-    // entries are always activated — they don't need to be listed in `credentials`.
-    let mut all_names: Vec<String> = custom_credentials.keys().cloned().collect();
+    // Build the full set of names to resolve from explicitly requested
+    // credentials. `custom_credentials` defines route templates, but does not
+    // enable them on its own.
+    let mut all_names: Vec<String> = Vec::new();
     for name in service_names {
         if !all_names.contains(name) {
             all_names.push(name.clone());
@@ -1298,10 +1298,10 @@ mod tests {
     }
 
     /// A profile with `custom_credentials` but no `credentials` list passes an
-    /// empty `service_names` slice.  `resolve_credentials` should still return
-    /// a route for each entry in `custom_credentials`.
+    /// empty `service_names` slice. `resolve_credentials` should not activate
+    /// route definitions unless they are explicitly named.
     #[test]
-    fn test_resolve_credentials_custom_credentials_without_service_names() {
+    fn test_resolve_credentials_custom_credentials_without_service_names_returns_no_routes() {
         use crate::profile::CustomCredentialDef;
 
         let json = embedded_network_policy_json();
@@ -1331,25 +1331,17 @@ mod tests {
         );
 
         let routes = resolve_credentials(&policy, &[], &custom).unwrap();
-        assert_eq!(
-            routes.len(),
-            1,
-            "expected one route for the custom credential, got {}",
+        assert!(
+            routes.is_empty(),
+            "custom credential definitions should remain disabled until explicitly requested, got {} route(s)",
             routes.len()
-        );
-        assert_eq!(routes[0].prefix, "mockhttp");
-        assert_eq!(routes[0].upstream, "https://mockhttp.org");
-        assert_eq!(
-            routes[0].env_var,
-            Some("MOCK_API_KEY".to_string()),
-            "env_var must be propagated from CustomCredentialDef"
         );
     }
 
     /// When `service_names` is empty but multiple `custom_credentials` are
-    /// defined, `resolve_credentials` should return a route for every entry.
+    /// defined, `resolve_credentials` should leave them all disabled.
     #[test]
-    fn test_resolve_credentials_all_custom_credentials_without_service_names() {
+    fn test_resolve_credentials_all_custom_credentials_without_service_names_returns_no_routes() {
         use crate::profile::CustomCredentialDef;
 
         let json = embedded_network_policy_json();
@@ -1401,23 +1393,10 @@ mod tests {
 
         let routes = resolve_credentials(&policy, &[], &custom).unwrap();
 
-        assert_eq!(
-            routes.len(),
-            2,
-            "expected one route per custom credential, got {}",
+        assert!(
+            routes.is_empty(),
+            "custom credential definitions should remain disabled until explicitly requested, got {} route(s)",
             routes.len()
-        );
-
-        let prefixes: Vec<&str> = routes.iter().map(|r| r.prefix.as_str()).collect();
-        assert!(
-            prefixes.contains(&"svc_a"),
-            "route for svc_a must be present; got: {:?}",
-            prefixes
-        );
-        assert!(
-            prefixes.contains(&"svc_b"),
-            "route for svc_b must be present; got: {:?}",
-            prefixes
         );
     }
 }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -105,7 +105,7 @@ pub(crate) fn prepare_proxy_launch_options(
         None
     };
 
-    let credentials_intent = if has_credentials {
+    let credentials_intent = if has_credentials || !prepared.custom_credentials.is_empty() {
         Some(CredentialProxyIntent {
             credentials,
             custom_credentials: prepared.custom_credentials.clone(),
@@ -788,6 +788,10 @@ mod tests {
         assert!(
             !opts.is_active(),
             "proxy must stay inactive when only custom credential definitions are present"
+        );
+        assert!(
+            opts.credentials.is_some(),
+            "custom credential definitions should still be carried for network profile overrides"
         );
     }
 }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -54,9 +54,8 @@ pub(crate) fn prepare_proxy_launch_options(
         bypass
     };
 
-    let has_custom_credentials = !prepared.custom_credentials.is_empty();
     let has_domain_filter = network_profile.is_some() || !allow_domain.is_empty();
-    let has_credentials = !credentials.is_empty() || has_custom_credentials;
+    let has_credentials = !credentials.is_empty();
     let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
 
     if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
@@ -716,11 +715,12 @@ mod tests {
         assert!(endpoint.iter().any(|e| matches!(e, AllowDomainEntry::WithEndpoints { domain, .. } if domain == "filtered.example.com")));
     }
 
-    /// A profile with only `custom_credentials` set (no built-in `credentials`,
-    /// no `network_profile`, no `allow_domain`, no upstream proxy) should still
-    /// activate the proxy so that credential injection works.
+    /// A profile with only `custom_credentials` set (no enabled `credentials`,
+    /// no `network_profile`, no `allow_domain`, no upstream proxy) should not
+    /// activate the proxy. Custom credential entries are route definitions, not
+    /// enabled routes.
     #[test]
-    fn test_proxy_is_active_when_only_custom_credentials_are_set() {
+    fn test_proxy_is_inactive_when_only_custom_credentials_are_set() {
         use crate::profile::CustomCredentialDef;
         use crate::sandbox_prepare::PreparedSandbox;
         use nono::CapabilitySet;
@@ -786,8 +786,8 @@ mod tests {
             .expect("prepare_proxy_launch_options");
 
         assert!(
-            opts.is_active(),
-            "proxy must be active when custom_credentials is non-empty"
+            !opts.is_active(),
+            "proxy must stay inactive when only custom credential definitions are present"
         );
     }
 }


### PR DESCRIPTION
defining custom credentials in a profile would cause them to be automatically activated, leading to the creation of routes and the proxy becoming active even if no services explicitly requested credentials.

This change modifies the behavior of `resolve_credentials` and `prepare_proxy_launch_options` to treat custom credentials as definitions or templates. They must now be explicitly listed in the `credentials` section of a policy to be enabled. This aligns their behavior with other credential types, ensuring that the proxy and routes are only activated when genuinely needed.

- Custom credential definitions no longer implicitly activate routes.
- The proxy will not activate solely due to the presence of custom credential definitions.

Fixes: #1214
Fixes #1209 

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
