### PR TITLE
chore(docs): update README with curl installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ From here **fork the config**, tweak it, theme it, make it your own, and share i
 
 ## Quickstart
 
+#### curl
+
+```bash
+curl -fsSL https://nono.sh/install.sh | sh
+```
+
 #### macOS / Linux (Homebrew)
 ```bash
 brew install nono


### PR DESCRIPTION
Add installation instructions using curl. I was in two minds about doing this for a while, but so many users expect to install this way now, so we should make it simple for them. 

The script handles all operating systems and is here: https://github.com/always-further/nono-website/blob/main/public/install.sh
