### PR TITLE
fix(linux-gpu): handle gpu thread naming proc writes in supervisor

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -262,6 +262,11 @@ pub struct ExecConfig<'a> {
     /// and an additional Linux execute-only Landlock gate.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub tool_sandbox_runtime: Option<&'a crate::tool_sandbox::PreparedToolSandboxRuntime>,
+    /// Whether `--allow-gpu` is active for this session.
+    /// Used by the Linux supervisor to auto-approve writes to
+    /// `/proc/<tgid>/task/<tid>/comm` (CUDA thread naming).
+    #[cfg(target_os = "linux")]
+    pub allow_gpu_active: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -321,6 +326,10 @@ pub struct SupervisorConfig<'a> {
     /// Prepared tool-sandbox runtime listener for command-policy shim requests.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub tool_sandbox_runtime: Option<&'a crate::tool_sandbox::PreparedToolSandboxRuntime>,
+    /// Whether `--allow-gpu` is active. Enables the supervisor fast-path that
+    /// auto-approves writes to `/proc/<tgid>/task/<tid>/comm` for CUDA thread naming.
+    #[cfg(target_os = "linux")]
+    pub allow_gpu_active: bool,
 }
 
 #[cfg(target_os = "linux")]
@@ -4590,6 +4599,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         // Fork a child that closes its socket end and exits immediately.
@@ -4710,6 +4721,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         match unsafe { fork() } {
@@ -4796,6 +4809,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         // Allowed origin: validation passes
@@ -4839,6 +4854,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         let result = validate_url("file:///etc/passwd", &config);
@@ -4880,6 +4897,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
         let config_deny = SupervisorConfig {
             protected_roots: &[],
@@ -4903,6 +4922,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         // Localhost denied when not allowed
@@ -4949,6 +4970,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
@@ -5100,6 +5123,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         assert!(
@@ -5151,6 +5176,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         // The redirect_uri in query params should not affect origin validation.
@@ -5191,6 +5218,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         // The url crate's host_str() returns "::1" without brackets for IPv6.
@@ -5250,6 +5279,8 @@ mod tests {
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             tool_sandbox_runtime: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         };
 
         let result = validate_url("data:text/html,<script>alert(1)</script>", &config);

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -78,6 +78,24 @@ impl RateLimiter {
     }
 }
 
+/// Returns true if `path` is exactly `/proc/<N>/task/<M>/comm` where `<N>` equals
+/// `tgid`. Used by the GPU fast-path to allow CUDA thread naming without a broad
+/// Landlock write grant (Landlock resolves `/proc/self` to the startup PID, so
+/// grandchild processes would still be blocked even with a write rule on /proc/self/task).
+fn is_owned_proc_task_comm(path: &std::path::Path, tgid: u32) -> bool {
+    // Expected: ["", "proc", "<tgid>", "task", "<tid>", "comm"]
+    let mut it = path.components();
+    use std::path::Component::*;
+    let ok = matches!(it.next(), Some(RootDir))
+        && matches!(it.next(), Some(Normal(c)) if c == "proc")
+        && matches!(it.next(), Some(Normal(c)) if c.to_str().and_then(|s| s.parse::<u32>().ok()) == Some(tgid))
+        && matches!(it.next(), Some(Normal(c)) if c == "task")
+        && matches!(it.next(), Some(Normal(c)) if c.to_str().map_or(false, |s| s.parse::<u32>().is_ok()))
+        && matches!(it.next(), Some(Normal(c)) if c == "comm")
+        && it.next().is_none();
+    ok
+}
+
 /// Read the TGID (thread group ID / process ID) of a thread from /proc/<tid>/status.
 ///
 /// `seccomp_data.pid` is the TID of the requesting thread, not the TGID. `/proc/self`
@@ -283,6 +301,35 @@ pub(super) fn handle_seccomp_notification(
             },
         );
         let _ = deny_notif(notify_fd, notif.id);
+        return Ok(());
+    }
+
+    // 4.5. GPU fast-path: auto-approve opens of /proc/<tgid>/task/<tid>/comm
+    // when --allow-gpu is active. Landlock cannot cover grandchild PIDs because
+    // it resolves /proc/self to the startup PID at rule-setup time. The TGID
+    // check ensures a process can only name its own threads.
+    if config.allow_gpu_active && is_owned_proc_task_comm(&canonicalized, notifying_tgid) {
+        // If the notification is already stale there is no
+        // point opening the file and no notification to respond to.
+        if !notif_id_valid(notify_fd, notif.id)? {
+            return Ok(());
+        }
+        let open_result = std::fs::OpenOptions::new()
+            .read(matches!(access, AccessMode::Read | AccessMode::ReadWrite))
+            .write(matches!(access, AccessMode::Write | AccessMode::ReadWrite))
+            .open(&canonicalized);
+        match open_result {
+            Ok(file) => {
+                if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
+                    debug!("inject_fd failed for comm fast-path {}: {}", canonicalized.display(), e);
+                    let _ = deny_notif(notify_fd, notif.id);
+                }
+            }
+            Err(e) => {
+                let errno = e.raw_os_error().unwrap_or(libc::EACCES);
+                let _ = respond_notif_errno(notify_fd, notif.id, errno);
+            }
+        }
         return Ok(());
     }
 

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -326,7 +326,7 @@ pub(super) fn handle_seccomp_notification(
                 }
             }
             Err(e) => {
-                let errno = e.raw_os_error().unwrap_or(libc::EACCES);
+                let errno = e.raw_os_error().unwrap_or(libc::EIO);
                 let _ = respond_notif_errno(notify_fd, notif.id, errno);
             }
         }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -578,6 +578,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         set_vars: flags.set_vars.unwrap_or_default(),
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         tool_sandbox_runtime: tool_sandbox_runtime.as_ref(),
+        #[cfg(target_os = "linux")]
+        allow_gpu_active: flags.allow_gpu_active,
     };
 
     match strategy {

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -229,6 +229,8 @@ pub(crate) struct ExecutionFlags {
     pub(crate) set_vars: Option<Vec<(String, String)>>,
     pub(crate) startup_timeout_secs: Option<u64>,
     pub(crate) command_policies: Option<crate::command_policy::CommandPoliciesConfig>,
+    #[cfg(target_os = "linux")]
+    pub(crate) allow_gpu_active: bool,
 }
 
 impl ExecutionFlags {
@@ -265,6 +267,8 @@ impl ExecutionFlags {
             set_vars: None,
             startup_timeout_secs: None,
             command_policies: None,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: false,
         })
     }
 }
@@ -423,6 +427,8 @@ pub(crate) fn prepare_run_launch_plan(
             set_vars: prepared.set_vars,
             startup_timeout_secs,
             command_policies: prepared.command_policies,
+            #[cfg(target_os = "linux")]
+            allow_gpu_active: prepared.allow_gpu_active,
         },
     })
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1049,8 +1049,9 @@ pub(crate) fn print_allow_gpu_warning(silent: bool) {
         eprintln!(
             "  This grants read/write access to /dev/dri/renderD* and NVIDIA compute devices.\n  \
              On NVIDIA systems, additionally: read access to /proc/driver/nvidia,\n  \
-             /proc/driver/nvidia-uvm, and /proc/self; read/write access to\n  \
-             /proc/self/task (for CUDA thread-name initialisation)."
+             /proc/driver/nvidia-uvm, /proc/self, and /proc/self/task; writes to\n  \
+             /proc/<pid>/task/<tid>/comm (CUDA thread naming) are mediated by the\n  \
+             seccomp supervisor and restricted to the process's own threads."
         );
     }
 }
@@ -1465,6 +1466,13 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         .map(|profile| profile.credential_capture.clone())
         .unwrap_or_default();
     let loaded_secrets = load_env_credentials(args, &profile_secrets, silent)?;
+
+    // The GPU comm fast-path in the supervisor depends on seccomp-notify being
+    // active. Force capability_elevation on when --allow-gpu is in use so that
+    // the supervisor intercepts openat and can inject the fd for grandchild
+    // processes, regardless of whether the profile explicitly set the flag.
+    #[cfg(target_os = "linux")]
+    let capability_elevation = capability_elevation || allow_gpu_active;
 
     finalize_prepared_sandbox(
         PreparedSandbox {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -831,22 +831,6 @@ fn missing_cwd_prompt_must_fail(
 }
 
 /// Grant the procfs paths that the NVIDIA driver needs for CUDA initialisation.
-///
-/// Scoped narrowly to the NVIDIA stack — not called on pure DRM render-node,
-/// AMD ROCm, or WSL `/dev/dxg` setups.
-///
-/// - `/proc/driver/nvidia`, `/proc/driver/nvidia-uvm` (read, when present):
-///   CUDA's UVM subsystem reads these during init. We grant each individually
-///   rather than the parent `/proc/driver` to avoid exposing metadata about
-///   unrelated kernel drivers.
-/// - `/proc/self` (read): CUDA init reads `/proc/self/maps`, `/proc/self/status`
-///   and other per-process files.
-/// - `/proc/self/task` (read+write): NVIDIA driver 570+ writes to
-///   `/proc/self/task/<tid>/comm` during thread startup to set thread names.
-///   Without write access this returns EACCES and the driver treats it as a
-///   fatal OS error, surfacing as CUDA Error 304 (`cudaErrorOperatingSystem`).
-///   Narrowing write access to the `task` subtree keeps other per-process
-///   procfs entries read-only.
 #[cfg(target_os = "linux")]
 fn grant_nvidia_gpu_procfs(caps: &mut CapabilitySet) -> Result<()> {
     for name in ["nvidia", "nvidia-uvm"] {
@@ -857,17 +841,13 @@ fn grant_nvidia_gpu_procfs(caps: &mut CapabilitySet) -> Result<()> {
         }
     }
 
-    // /proc/self and /proc/self/task are guaranteed on Linux; propagate any
-    // error rather than silently skipping (fail-secure: if the kernel ever
-    // fails to present these, the sandbox should fail rather than grant
-    // less-than-intended access).
     caps.add_fs(FsCapability::new_dir(
         std::path::Path::new("/proc/self"),
         AccessMode::Read,
     )?);
     caps.add_fs(FsCapability::new_dir(
         std::path::Path::new("/proc/self/task"),
-        AccessMode::ReadWrite,
+        AccessMode::Read,
     )?);
 
     Ok(())
@@ -1557,8 +1537,11 @@ mod tests {
     #[test]
     fn grant_nvidia_gpu_procfs_scopes_proc_self_reads_with_task_writes() {
         // Regression test for the NVIDIA-scoped procfs grants:
-        //   /proc/self       Read        (CUDA init reads maps/status/etc.)
-        //   /proc/self/task  ReadWrite   (driver writes task/<tid>/comm)
+        //   /proc/self       Read  (CUDA init reads maps/status/etc.)
+        //   /proc/self/task  Read  (driver enumerates task entries)
+        // Writes to /proc/<tgid>/task/<tid>/comm are handled by the supervisor
+        // fast-path, not via a Landlock grant, because Landlock resolves
+        // /proc/self to the startup PID — grandchildren would still be blocked.
         // Plus any of /proc/driver/{nvidia,nvidia-uvm} that exist.
         //
         // /proc/self and /proc/self/task always exist on Linux, so those
@@ -1583,18 +1566,16 @@ mod tests {
         assert_eq!(
             proc_self.access,
             AccessMode::Read,
-            "/proc/self must be read-only (writes are scoped to /proc/self/task)"
+            "/proc/self must be read-only"
         );
         assert!(!proc_self.is_file);
 
-        let proc_self_task = find("/proc/self/task").expect(
-            "/proc/self/task must be granted read+write so the NVIDIA driver \
-             can write task/<tid>/comm (CUDA Error 304 root cause)",
-        );
+        let proc_self_task = find("/proc/self/task")
+            .expect("/proc/self/task must be granted read for task enumeration");
         assert_eq!(
             proc_self_task.access,
-            AccessMode::ReadWrite,
-            "/proc/self/task must be granted read+write"
+            AccessMode::Read,
+            "/proc/self/task must be read-only (comm writes go via supervisor fast-path)"
         );
         assert!(!proc_self_task.is_file);
 

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -288,6 +288,8 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         },
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         tool_sandbox_runtime: config.tool_sandbox_runtime,
+        #[cfg(target_os = "linux")]
+        allow_gpu_active: config.allow_gpu_active,
     };
 
     let exit_code = {


### PR DESCRIPTION
The NVIDIA driver 570+ writes to `/proc/<tgid>/task/<tid>/comm` during thread startup to set CUDA thread names. Previously, a Landlock `ReadWrite` grant on `/proc/self/task` was used for this.

This Landlock-based approach was insufficient because `/proc/self` resolves to the startup PID when rules are set up, not the PID of descendant processes. This could lead to `EACCES` and `cudaErrorOperatingSystem` (Error 304) when grandchild processes attempted to name their threads.

This commit refactors the handling of these specific writes:
- The Landlock grant for `/proc/self/task` is now `Read` only.
- When `--allow-gpu` is active, the Linux supervisor now includes a fast-path. This path intercepts `open` system calls to `/proc/<tgid>/task/<tid>/comm` and auto-approves them, provided the path corresponds to a thread within the current thread group.

This change ensures correct CUDA thread naming for all processes, including grandchildren, by using a supervisor-based approval mechanism that accurately reflects the calling process's TGID, rather than relying on Landlock's static `/proc/self` resolution.

We can close PR: #1001 if this lands. I simplied the approach and tested on a T4 machine with cuda drivers

Closes #924

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
