### PR TITLE
fix(proxy): add redeem_phantoms for by-value nonce redemption

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1050,7 +1050,7 @@
     },
     "CustomCredentialDef": {
       "type": "object",
-      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. credential_key, auth, aws_auth, and spiffe are mutually exclusive — at most one may be set.",
+      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must set at least one of: credential_key, auth, aws_auth, spiffe, or redeem_phantoms. credential_key/auth/aws_auth/spiffe are mutually exclusive with each other. redeem_phantoms may stand alone OR combine with credential_key/auth (but not aws_auth/spiffe).",
       "additionalProperties": false,
       "required": ["upstream"],
       "anyOf": [
@@ -1119,7 +1119,13 @@
             { "type": "string" },
             { "type": "null" }
           ],
-          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, env:// URI (e.g., \"env://MY_TOKEN\"), or cmd:// URI backed by credential_capture. Mutually exclusive with auth and aws_auth."
+          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, env:// URI (e.g., \"env://MY_TOKEN\"), or cmd:// URI backed by credential_capture. Mutually exclusive with auth and aws_auth; may combine with redeem_phantoms."
+        },
+        "redeem_phantoms": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Broker credential names this route resolves from caller-presented phantoms (including JWT-shaped) found in request headers. By-value / proof-of-possession auth, gated route-side: a process that captured the token presents the phantom (possession), and the route authorizes which credential(s) it will resolve (a presented phantom resolves only if its credential name is in this list). A non-empty list forces interception even without credential_key. Composes with a managed credential_key/auth (managed value injected into inject_header; caller phantoms resolved on the other headers) or stands alone. Cannot combine with aws_auth or spiffe, which use dedicated intercept handlers that do not resolve caller phantoms."
         },
         "auth": {
           "oneOf": [

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1038,7 +1038,7 @@
     },
     "CustomCredentialDef": {
       "type": "object",
-      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. credential_key, auth, aws_auth, and spiffe are mutually exclusive — at most one may be set.",
+      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must set at least one of: credential_key, auth, aws_auth, spiffe, or redeem_phantoms. credential_key/auth/aws_auth/spiffe are mutually exclusive with each other. redeem_phantoms may stand alone OR combine with credential_key/auth (but not aws_auth/spiffe).",
       "additionalProperties": false,
       "required": ["upstream"],
       "anyOf": [
@@ -1107,7 +1107,13 @@
             { "type": "string" },
             { "type": "null" }
           ],
-          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, env:// URI (e.g., \"env://MY_TOKEN\"), or cmd:// URI backed by credential_capture. Mutually exclusive with auth and aws_auth."
+          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, env:// URI (e.g., \"env://MY_TOKEN\"), or cmd:// URI backed by credential_capture. Mutually exclusive with auth and aws_auth; may combine with redeem_phantoms."
+        },
+        "redeem_phantoms": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Broker credential names this route resolves from caller-presented phantoms (including JWT-shaped) found in request headers. By-value / proof-of-possession auth, gated route-side: a process that captured the token presents the phantom (possession), and the route authorizes which credential(s) it will resolve (a presented phantom resolves only if its credential name is in this list). A non-empty list forces interception even without credential_key. Composes with a managed credential_key/auth (managed value injected into inject_header; caller phantoms resolved on the other headers) or stands alone. Cannot combine with aws_auth or spiffe, which use dedicated intercept handlers that do not resolve caller phantoms."
         },
         "auth": {
           "oneOf": [

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -237,6 +237,7 @@ pub fn resolve_credentials(
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: cred.credential_key.clone(),
+                redeem_phantoms: cred.redeem_phantoms.clone(),
                 inject_mode: cred.inject_mode.clone(),
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -291,6 +292,7 @@ pub fn resolve_credentials(
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: Some(key),
+                redeem_phantoms: Vec::new(),
                 inject_mode: InjectMode::Header,
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -454,6 +456,7 @@ pub fn partition_allow_domain(
                         prefix,
                         upstream: format!("{}://{}", scheme, domain),
                         credential_key: None,
+                        redeem_phantoms: Vec::new(),
                         inject_mode: InjectMode::default(),
                         inject_header: "Authorization".to_string(),
                         credential_format: None,
@@ -610,6 +613,7 @@ mod tests {
         custom.insert(
             "telegram".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: Some("telegram_bot_token".to_string()),
                 auth: None,
@@ -654,6 +658,7 @@ mod tests {
         custom.insert(
             "openai".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://my-proxy.example.com/openai".to_string(),
                 credential_key: Some("my_openai_key".to_string()),
                 auth: None,
@@ -694,6 +699,7 @@ mod tests {
         custom.insert(
             "telegram".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: Some("telegram_bot_token".to_string()),
                 auth: None,
@@ -744,6 +750,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://localhost:8080/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -834,6 +841,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://127.1.2.3:8080/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -871,6 +879,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://0.0.0.0:3000/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -908,6 +917,7 @@ mod tests {
         custom.insert(
             "test".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("api_key".to_string()),
                 auth: None,
@@ -950,6 +960,7 @@ mod tests {
         custom.insert(
             "openai".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("op://Development/OpenAI/credential".to_string()),
                 auth: None,
@@ -1086,6 +1097,7 @@ mod tests {
         custom.insert(
             "evil".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("safe_key".to_string()),
                 auth: None,
@@ -1173,6 +1185,7 @@ mod tests {
         custom.insert(
             "my_api".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: None,
                 auth: Some(OAuth2Config {
@@ -1232,6 +1245,7 @@ mod tests {
         custom.insert(
             "standard".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("my_key".to_string()),
                 auth: None,
@@ -1390,6 +1404,7 @@ mod tests {
         custom.insert(
             "mockhttp".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://mockhttp.org".to_string(),
                 credential_key: Some("env://MOCK_API_KEY".to_string()),
                 auth: None,
@@ -1433,6 +1448,7 @@ mod tests {
         custom.insert(
             "svc_a".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://svc-a.example.com".to_string(),
                 credential_key: Some("env://SVC_A_KEY".to_string()),
                 auth: None,
@@ -1457,6 +1473,7 @@ mod tests {
         custom.insert(
             "svc_b".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://svc-b.example.com".to_string(),
                 credential_key: Some("env://SVC_B_KEY".to_string()),
                 auth: None,

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -237,6 +237,7 @@ pub fn resolve_credentials(
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: cred.credential_key.clone(),
+                redeem_phantoms: cred.redeem_phantoms.clone(),
                 inject_mode: cred.inject_mode.clone(),
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -291,6 +292,7 @@ pub fn resolve_credentials(
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
                 credential_key: Some(key),
+                redeem_phantoms: Vec::new(),
                 inject_mode: InjectMode::Header,
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -453,6 +455,7 @@ pub fn partition_allow_domain(
                         prefix,
                         upstream: format!("{}://{}", scheme, domain),
                         credential_key: None,
+                        redeem_phantoms: Vec::new(),
                         inject_mode: InjectMode::default(),
                         inject_header: "Authorization".to_string(),
                         credential_format: None,
@@ -616,6 +619,7 @@ mod tests {
         custom.insert(
             "telegram".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: Some("telegram_bot_token".to_string()),
                 auth: None,
@@ -660,6 +664,7 @@ mod tests {
         custom.insert(
             "openai".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://my-proxy.example.com/openai".to_string(),
                 credential_key: Some("my_openai_key".to_string()),
                 auth: None,
@@ -700,6 +705,7 @@ mod tests {
         custom.insert(
             "telegram".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.telegram.org".to_string(),
                 credential_key: Some("telegram_bot_token".to_string()),
                 auth: None,
@@ -750,6 +756,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://localhost:8080/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -840,6 +847,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://127.1.2.3:8080/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -877,6 +885,7 @@ mod tests {
         custom.insert(
             "local".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "http://0.0.0.0:3000/api".to_string(),
                 credential_key: Some("local_api_key".to_string()),
                 auth: None,
@@ -914,6 +923,7 @@ mod tests {
         custom.insert(
             "test".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("api_key".to_string()),
                 auth: None,
@@ -956,6 +966,7 @@ mod tests {
         custom.insert(
             "openai".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("op://Development/OpenAI/credential".to_string()),
                 auth: None,
@@ -1092,6 +1103,7 @@ mod tests {
         custom.insert(
             "evil".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("safe_key".to_string()),
                 auth: None,
@@ -1179,6 +1191,7 @@ mod tests {
         custom.insert(
             "my_api".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: None,
                 auth: Some(OAuth2Config {
@@ -1238,6 +1251,7 @@ mod tests {
         custom.insert(
             "standard".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("my_key".to_string()),
                 auth: None,
@@ -1396,6 +1410,7 @@ mod tests {
         custom.insert(
             "mockhttp".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://mockhttp.org".to_string(),
                 credential_key: Some("env://MOCK_API_KEY".to_string()),
                 auth: None,
@@ -1439,6 +1454,7 @@ mod tests {
         custom.insert(
             "svc_a".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://svc-a.example.com".to_string(),
                 credential_key: Some("env://SVC_A_KEY".to_string()),
                 auth: None,
@@ -1463,6 +1479,7 @@ mod tests {
         custom.insert(
             "svc_b".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://svc-b.example.com".to_string(),
                 credential_key: Some("env://SVC_B_KEY".to_string()),
                 auth: None,

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -268,6 +268,10 @@ pub struct CustomCredentialDef {
     /// Mutually exclusive with `auth` — use one or the other.
     #[serde(default)]
     pub credential_key: Option<String>,
+    /// Broker credential names this route redeems from a caller-presented phantom.
+    /// Not honored with `aws_auth`/`spiffe`, whose handlers skip phantom resolution.
+    #[serde(default)]
+    pub redeem_phantoms: Vec<String>,
     /// Optional OAuth2 client_credentials configuration.
     /// When present, the proxy handles token exchange automatically.
     /// Mutually exclusive with `credential_key` — use one or the other.
@@ -625,17 +629,43 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
         )));
     }
 
+    // aws_auth/spiffe branch to dedicated handlers that never run the
+    // phantom-resolution loop, so redeem_phantoms would be silently ignored.
+    if !cred.redeem_phantoms.is_empty() && (cred.aws_auth.is_some() || cred.spiffe.is_some()) {
+        return Err(NonoError::ProfileParse(format!(
+            "custom credential '{}' sets 'redeem_phantoms' together with 'aws_auth' or \
+             'spiffe'; those use dedicated intercept handlers that do not resolve caller phantoms, \
+             so redeem_phantoms could not be honored — remove one",
+            name
+        )));
+    }
+
     // At least one auth mechanism must be set
     if cred.credential_key.is_none()
         && cred.auth.is_none()
         && cred.aws_auth.is_none()
         && cred.spiffe.is_none()
+        && cred.redeem_phantoms.is_empty()
     {
         return Err(NonoError::ProfileParse(format!(
             "custom credential '{}' must have either 'credential_key', 'auth', 'aws_auth', \
-             or 'spiffe' set",
+             'spiffe', or 'redeem_phantoms' set",
             name
         )));
+    }
+
+    for cred_name in &cred.redeem_phantoms {
+        if cred_name.is_empty()
+            || !cred_name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'+' | b'-'))
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "custom credential '{}' has an invalid 'redeem_phantoms' entry '{}'; \
+                 names must be non-empty and contain only [A-Za-z0-9._+-]",
+                name, cred_name
+            )));
+        }
     }
 
     // Validate inject_header for SPIFFE routes (credential_key has its own validate_header_mode()).
@@ -5416,6 +5446,7 @@ mod tests {
 
     fn header_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("api_key".to_string()),
             auth: None,
@@ -5580,6 +5611,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_spiffe_only_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "http://127.0.0.1:8080".to_string(),
             credential_key: None,
             auth: None,
@@ -5610,6 +5642,65 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_redeem_phantoms_composes_with_credential_key() {
+        // A route may both inject a managed credential (credential_key) and
+        // resolve caller-presented phantoms (redeem_phantoms): the managed
+        // value goes into inject_header, caller phantoms resolve on other headers.
+        let mut cred = header_cred_builder();
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    /// `redeem_phantoms` alone satisfies the at-least-one-auth-mechanism rule.
+    #[test]
+    fn test_validate_redeem_phantoms_alone_is_sufficient_auth() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_with_aws_auth_rejected() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        cred.aws_auth = Some(nono_proxy::config::AwsAuthConfig::default());
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("redeem_phantoms + aws_auth must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_rejects_empty_name() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["".to_string()];
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("empty redeem_phantoms name must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_with_spiffe_rejected() {
+        // spiffe branches to its own intercept handler that never resolves
+        // caller phantoms, so redeem_phantoms could not be honored — reject.
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        cred.spiffe = Some(nono_proxy::config::SpiffeAuthConfig::Jwt {
+            workload_api_socket: "/run/spire/agent/api.sock".to_string(),
+            audience: vec!["test-audience".to_string()],
+            inject_header: "Authorization".to_string(),
+            credential_format: None,
+            svid_hint: None,
+        });
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("redeem_phantoms + spiffe must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
     fn test_validate_custom_credential_spiffe_with_credential_key_rejected() {
         let mut cred = header_cred_builder();
         cred.spiffe = Some(nono_proxy::config::SpiffeAuthConfig::Jwt {
@@ -5636,6 +5727,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5662,6 +5754,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_missing_pattern() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5690,6 +5783,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_pattern_without_placeholder() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5718,6 +5812,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_with_replacement() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5744,6 +5839,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_replacement_without_placeholder() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5772,6 +5868,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5798,6 +5895,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_missing_param_name() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5826,6 +5924,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_empty_param_name() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5854,6 +5953,7 @@ mod tests {
     #[test]
     fn test_validate_basic_auth_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("example_basic_auth".to_string()),
             auth: None,
@@ -6054,6 +6154,7 @@ mod tests {
 
     fn oauth2_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: None,
             auth: Some(OAuth2Config {
@@ -6782,6 +6883,7 @@ mod tests {
         base.network.custom_credentials.insert(
             "svc_a".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://a.example.com".to_string(),
                 credential_key: Some("key_a".to_string()),
                 auth: None,
@@ -6808,6 +6910,7 @@ mod tests {
         child.network.custom_credentials.insert(
             "svc_b".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://b.example.com".to_string(),
                 credential_key: Some("key_b".to_string()),
                 auth: None,
@@ -6952,6 +7055,7 @@ mod tests {
         base.network.custom_credentials.insert(
             "svc_shared".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://base.example.com".to_string(),
                 credential_key: Some("key_base".to_string()),
                 auth: None,
@@ -6978,6 +7082,7 @@ mod tests {
         child.network.custom_credentials.insert(
             "svc_shared".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://child.example.com".to_string(),
                 credential_key: Some("key_child".to_string()),
                 auth: None,
@@ -8759,6 +8864,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_accepted() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/api-token".to_string()),
             auth: None,
@@ -8788,6 +8894,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_requires_env_var() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/api-token".to_string()),
             auth: None,
@@ -8820,6 +8927,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_invalid_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file://relative/path".to_string()),
             auth: None,
@@ -8852,6 +8960,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_traversal_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/../../../etc/shadow".to_string()),
             auth: None,
@@ -8916,6 +9025,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_env_uri_accepted() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://MY_API_TOKEN".to_string()),
             auth: None,
@@ -9326,6 +9436,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_env_uri_dangerous_var_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://LD_PRELOAD".to_string()),
             auth: None,
@@ -10179,6 +10290,7 @@ mod tests {
 
     fn aws_auth_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
             credential_key: None,
             auth: None,

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -269,6 +269,10 @@ pub struct CustomCredentialDef {
     /// Mutually exclusive with `auth` — use one or the other.
     #[serde(default)]
     pub credential_key: Option<String>,
+    /// Broker credential names this route redeems from a caller-presented phantom.
+    /// Not honored with `aws_auth`/`spiffe`, whose handlers skip phantom resolution.
+    #[serde(default)]
+    pub redeem_phantoms: Vec<String>,
     /// Optional OAuth2 client_credentials configuration.
     /// When present, the proxy handles token exchange automatically.
     /// Mutually exclusive with `credential_key` — use one or the other.
@@ -626,17 +630,43 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
         )));
     }
 
+    // aws_auth/spiffe branch to dedicated handlers that never run the
+    // phantom-resolution loop, so redeem_phantoms would be silently ignored.
+    if !cred.redeem_phantoms.is_empty() && (cred.aws_auth.is_some() || cred.spiffe.is_some()) {
+        return Err(NonoError::ProfileParse(format!(
+            "custom credential '{}' sets 'redeem_phantoms' together with 'aws_auth' or \
+             'spiffe'; those use dedicated intercept handlers that do not resolve caller phantoms, \
+             so redeem_phantoms could not be honored — remove one",
+            name
+        )));
+    }
+
     // At least one auth mechanism must be set
     if cred.credential_key.is_none()
         && cred.auth.is_none()
         && cred.aws_auth.is_none()
         && cred.spiffe.is_none()
+        && cred.redeem_phantoms.is_empty()
     {
         return Err(NonoError::ProfileParse(format!(
             "custom credential '{}' must have either 'credential_key', 'auth', 'aws_auth', \
-             or 'spiffe' set",
+             'spiffe', or 'redeem_phantoms' set",
             name
         )));
+    }
+
+    for cred_name in &cred.redeem_phantoms {
+        if cred_name.is_empty()
+            || !cred_name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'+' | b'-'))
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "custom credential '{}' has an invalid 'redeem_phantoms' entry '{}'; \
+                 names must be non-empty and contain only [A-Za-z0-9._+-]",
+                name, cred_name
+            )));
+        }
     }
 
     // Validate inject_header for SPIFFE routes (credential_key has its own validate_header_mode()).
@@ -5451,6 +5481,7 @@ mod tests {
 
     fn header_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("api_key".to_string()),
             auth: None,
@@ -5615,6 +5646,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_spiffe_only_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "http://127.0.0.1:8080".to_string(),
             credential_key: None,
             auth: None,
@@ -5645,6 +5677,65 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_redeem_phantoms_composes_with_credential_key() {
+        // A route may both inject a managed credential (credential_key) and
+        // resolve caller-presented phantoms (redeem_phantoms): the managed
+        // value goes into inject_header, caller phantoms resolve on other headers.
+        let mut cred = header_cred_builder();
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    /// `redeem_phantoms` alone satisfies the at-least-one-auth-mechanism rule.
+    #[test]
+    fn test_validate_redeem_phantoms_alone_is_sufficient_auth() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_with_aws_auth_rejected() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        cred.aws_auth = Some(nono_proxy::config::AwsAuthConfig::default());
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("redeem_phantoms + aws_auth must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_rejects_empty_name() {
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["".to_string()];
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("empty redeem_phantoms name must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
+    fn test_validate_redeem_phantoms_with_spiffe_rejected() {
+        // spiffe branches to its own intercept handler that never resolves
+        // caller phantoms, so redeem_phantoms could not be honored — reject.
+        let mut cred = header_cred_builder();
+        cred.credential_key = None;
+        cred.redeem_phantoms = vec!["partner-token".to_string()];
+        cred.spiffe = Some(nono_proxy::config::SpiffeAuthConfig::Jwt {
+            workload_api_socket: "/run/spire/agent/api.sock".to_string(),
+            audience: vec!["test-audience".to_string()],
+            inject_header: "Authorization".to_string(),
+            credential_format: None,
+            svid_hint: None,
+        });
+        let err = validate_custom_credential("test", &cred)
+            .expect_err("redeem_phantoms + spiffe must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[test]
     fn test_validate_custom_credential_spiffe_with_credential_key_rejected() {
         let mut cred = header_cred_builder();
         cred.spiffe = Some(nono_proxy::config::SpiffeAuthConfig::Jwt {
@@ -5671,6 +5762,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5697,6 +5789,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_missing_pattern() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5725,6 +5818,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_pattern_without_placeholder() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5753,6 +5847,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_with_replacement() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5779,6 +5874,7 @@ mod tests {
     #[test]
     fn test_validate_url_path_mode_replacement_without_placeholder() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.telegram.org".to_string(),
             credential_key: Some("telegram_token".to_string()),
             auth: None,
@@ -5807,6 +5903,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5833,6 +5930,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_missing_param_name() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5861,6 +5959,7 @@ mod tests {
     #[test]
     fn test_validate_query_param_mode_empty_param_name() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://maps.googleapis.com".to_string(),
             credential_key: Some("google_maps_key".to_string()),
             auth: None,
@@ -5889,6 +5988,7 @@ mod tests {
     #[test]
     fn test_validate_basic_auth_mode_valid() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("example_basic_auth".to_string()),
             auth: None,
@@ -6089,6 +6189,7 @@ mod tests {
 
     fn oauth2_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: None,
             auth: Some(OAuth2Config {
@@ -6896,6 +6997,7 @@ mod tests {
         base.network.custom_credentials.insert(
             "svc_a".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://a.example.com".to_string(),
                 credential_key: Some("key_a".to_string()),
                 auth: None,
@@ -6922,6 +7024,7 @@ mod tests {
         child.network.custom_credentials.insert(
             "svc_b".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://b.example.com".to_string(),
                 credential_key: Some("key_b".to_string()),
                 auth: None,
@@ -7066,6 +7169,7 @@ mod tests {
         base.network.custom_credentials.insert(
             "svc_shared".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://base.example.com".to_string(),
                 credential_key: Some("key_base".to_string()),
                 auth: None,
@@ -7092,6 +7196,7 @@ mod tests {
         child.network.custom_credentials.insert(
             "svc_shared".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://child.example.com".to_string(),
                 credential_key: Some("key_child".to_string()),
                 auth: None,
@@ -8913,6 +9018,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_accepted() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/api-token".to_string()),
             auth: None,
@@ -8942,6 +9048,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_requires_env_var() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/api-token".to_string()),
             auth: None,
@@ -8974,6 +9081,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_invalid_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file://relative/path".to_string()),
             auth: None,
@@ -9006,6 +9114,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_file_uri_traversal_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("file:///run/secrets/../../../etc/shadow".to_string()),
             auth: None,
@@ -9070,6 +9179,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_env_uri_accepted() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://MY_API_TOKEN".to_string()),
             auth: None,
@@ -9480,6 +9590,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_env_uri_dangerous_var_rejected() {
         let cred = CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://LD_PRELOAD".to_string()),
             auth: None,
@@ -10333,6 +10444,7 @@ mod tests {
 
     fn aws_auth_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
             credential_key: None,
             auth: None,

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1874,6 +1874,7 @@ fn collect_tool_sandbox_proxy_grants(
         };
 
         let route = crate::profile::CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream,
             credential_key,
             auth: None,
@@ -2525,6 +2526,7 @@ fn synthesize_credential_provider_proxy_config(
                 })
                 .collect();
             proxy_config.routes.push(nono_proxy::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: prefix.clone(),
                 upstream: api_host.clone(),
                 credential_key: None,
@@ -2730,6 +2732,17 @@ struct TokenBrokerNonceResolver(crate::tool_sandbox::token_broker::SharedBroker)
 impl nono_proxy::NonceResolver for TokenBrokerNonceResolver {
     fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>> {
         self.0.lock().ok()?.resolve_nonce(nonce, consumer)
+    }
+
+    fn resolve_for_credentials(
+        &self,
+        nonce: &str,
+        allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        self.0
+            .lock()
+            .ok()?
+            .resolve_phantom_for_credentials(nonce, allowed_credentials)
     }
 }
 
@@ -3554,6 +3567,7 @@ mod tests {
         custom_credentials.insert(
             "mockhttp".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://mockhttp.org".to_string(),
                 credential_key: Some("env://MOCK_API_KEY".to_string()),
                 auth: None,
@@ -4048,6 +4062,7 @@ mod tests {
 
         let mut proxy_config = nono_proxy::config::ProxyConfig::default();
         proxy_config.routes.push(nono_proxy::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "github-api".to_string(),
             upstream: "https://api.github.com".to_string(),
             credential_key: Some("github-token".to_string()),

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1873,6 +1873,7 @@ fn collect_tool_sandbox_proxy_grants(
         };
 
         let route = crate::profile::CustomCredentialDef {
+            redeem_phantoms: Vec::new(),
             upstream,
             credential_key,
             auth: None,
@@ -2523,6 +2524,7 @@ fn synthesize_credential_provider_proxy_config(
                 })
                 .collect();
             proxy_config.routes.push(nono_proxy::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: prefix.clone(),
                 upstream: api_host.clone(),
                 credential_key: None,
@@ -2728,6 +2730,17 @@ struct TokenBrokerNonceResolver(crate::tool_sandbox::token_broker::SharedBroker)
 impl nono_proxy::NonceResolver for TokenBrokerNonceResolver {
     fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>> {
         self.0.lock().ok()?.resolve_nonce(nonce, consumer)
+    }
+
+    fn resolve_for_credentials(
+        &self,
+        nonce: &str,
+        allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        self.0
+            .lock()
+            .ok()?
+            .resolve_phantom_for_credentials(nonce, allowed_credentials)
     }
 }
 
@@ -3516,6 +3529,7 @@ mod tests {
         custom_credentials.insert(
             "mockhttp".to_string(),
             CustomCredentialDef {
+                redeem_phantoms: Vec::new(),
                 upstream: "https://mockhttp.org".to_string(),
                 credential_key: Some("env://MOCK_API_KEY".to_string()),
                 auth: None,
@@ -4004,6 +4018,7 @@ mod tests {
 
         let mut proxy_config = nono_proxy::config::ProxyConfig::default();
         proxy_config.routes.push(nono_proxy::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "github-api".to_string(),
             upstream: "https://api.github.com".to_string(),
             credential_key: Some("github-token".to_string()),

--- a/crates/nono-cli/src/tool-sandbox/token_broker.rs
+++ b/crates/nono-cli/src/tool-sandbox/token_broker.rs
@@ -69,6 +69,9 @@ impl GrantSet {
 pub(crate) struct TokenBroker {
     map: std::collections::HashMap<String, (Zeroizing<Vec<u8>>, GrantSet)>,
     named: std::collections::HashMap<String, (Zeroizing<Vec<u8>>, GrantSet)>,
+    /// Phantom → credential name (named credentials only). Gate by name, not
+    /// value: one name (e.g. `partner-token`) holds different per-audience values.
+    phantom_names: std::collections::HashMap<String, String>,
 }
 
 impl TokenBroker {
@@ -76,6 +79,7 @@ impl TokenBroker {
         Self {
             map: std::collections::HashMap::new(),
             named: std::collections::HashMap::new(),
+            phantom_names: std::collections::HashMap::new(),
         }
     }
 
@@ -109,8 +113,11 @@ impl TokenBroker {
     /// `grants` scopes which consumers may redeem nonces issued for this credential.
     pub(crate) fn store_named(&mut self, name: String, value: Vec<u8>, grants: GrantSet) -> String {
         let zeroized = Zeroizing::new(value);
-        self.named.insert(name, (zeroized.clone(), grants.clone()));
-        self.issue_granted(zeroized, grants)
+        self.named
+            .insert(name.clone(), (zeroized.clone(), grants.clone()));
+        let nonce = self.issue_granted(zeroized, grants);
+        self.phantom_names.insert(nonce.clone(), name);
+        nonce
     }
 
     /// Issue a fresh nonce for a previously stored named supervisor credential.
@@ -121,7 +128,9 @@ impl TokenBroker {
         let (value, grants) = self.named.get(name)?;
         let value = value.clone();
         let grants = grants.clone();
-        Some(self.issue_granted(value, grants))
+        let nonce = self.issue_granted(value, grants);
+        self.phantom_names.insert(nonce.clone(), name.to_string());
+        Some(nonce)
     }
 
     /// If `env_entry` has the form `NAME=nono_<64hex>` and the nonce is known to
@@ -162,6 +171,24 @@ impl TokenBroker {
         Some(real.clone())
     }
 
+    /// Resolve a phantom iff its credential name is in `allowed_credentials`; the
+    /// route's `redeem_phantoms` is the authority, so the grant set is not consulted.
+    pub(crate) fn resolve_phantom_for_credentials(
+        &self,
+        nonce: &str,
+        allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        if !is_nonce(nonce) {
+            return None;
+        }
+        let name = self.phantom_names.get(nonce)?;
+        if !allowed_credentials.iter().any(|a| a == name) {
+            return None;
+        }
+        let (real, _grants) = self.map.get(nonce)?;
+        Some(real.clone())
+    }
+
     /// Scan `input` for broker nonces or broker-held values and issue fresh
     /// nonces for each one found, returning the substituted buffer.
     ///
@@ -196,8 +223,12 @@ impl TokenBroker {
                     && is_nonce(s)
                     && let Some((real, grants)) = self.map.get(s).cloned()
                 {
-                    // Re-issue a fresh nonce for the real value, inheriting grants
+                    // Inherit the credential name so redeem_phantoms still resolves the reissue.
+                    let name = self.phantom_names.get(s).cloned();
                     let new_nonce = self.issue_granted(real, grants);
+                    if let Some(name) = name {
+                        self.phantom_names.insert(new_nonce.clone(), name);
+                    }
                     out.extend_from_slice(new_nonce.as_bytes());
                     i += NONCE_LEN;
                     continue;
@@ -206,7 +237,13 @@ impl TokenBroker {
 
             if let Some((real, grants)) = self.longest_secret_value_at(&input[i..]) {
                 let len = real.len();
+                // Preserve the credential name so a redacted raw value stays
+                // redeemable by redeem_phantoms, like the phantom path above.
+                let name = self.credential_name_for_value(&real);
                 let new_nonce = self.issue_granted(real, grants);
+                if let Some(name) = name {
+                    self.phantom_names.insert(new_nonce.clone(), name);
+                }
                 out.extend_from_slice(new_nonce.as_bytes());
                 i += len;
                 continue;
@@ -216,6 +253,18 @@ impl TokenBroker {
             i = i.saturating_add(1);
         }
         out
+    }
+
+    /// Credential name for a raw `value`. Searches `phantom_names` rather than `named`
+    /// so a value overwritten by a later capture still relabels to its own name.
+    fn credential_name_for_value(&self, value: &[u8]) -> Option<String> {
+        self.map.iter().find_map(|(nonce, (v, _))| {
+            if v.as_slice() == value {
+                self.phantom_names.get(nonce).cloned()
+            } else {
+                None
+            }
+        })
     }
 
     fn longest_secret_value_at(&self, input: &[u8]) -> Option<(Zeroizing<Vec<u8>>, GrantSet)> {
@@ -470,5 +519,134 @@ mod tests {
             .expect("stored gitlab credential should be available");
         assert!(broker.resolve_nonce(&n2, "cmd.glab").is_some());
         assert!(broker.resolve_nonce(&n2, "cmd.curl").is_none());
+    }
+
+    #[test]
+    fn resolve_phantom_for_credentials_gates_by_name() {
+        let mut broker = TokenBroker::new();
+        // GrantSet::All: the name allow-list, not the grant set, is the gate.
+        let partner = broker.store_named(
+            "partner-token".to_string(),
+            b"real-partner-jwt".to_vec(),
+            GrantSet::All,
+        );
+        let other = broker.store_named(
+            "orgstore".to_string(),
+            b"other-secret".to_vec(),
+            GrantSet::All,
+        );
+
+        // Listed credential resolves.
+        let allowed = vec!["partner-token".to_string()];
+        let resolved = broker
+            .resolve_phantom_for_credentials(&partner, &allowed)
+            .expect("listed credential must resolve");
+        assert_eq!(resolved.as_slice(), b"real-partner-jwt");
+        // A phantom for a credential the route does not list fails closed.
+        assert!(
+            broker
+                .resolve_phantom_for_credentials(&other, &allowed)
+                .is_none()
+        );
+        // Empty allow-list never resolves.
+        assert!(
+            broker
+                .resolve_phantom_for_credentials(&partner, &[])
+                .is_none()
+        );
+        // Input that is not a phantom fails closed.
+        assert!(
+            broker
+                .resolve_phantom_for_credentials("not-a-phantom", &allowed)
+                .is_none()
+        );
+        // An anonymous phantom (no credential name) never resolves route-side.
+        let anon = broker.issue(Zeroizing::new(b"anon".to_vec()));
+        assert!(
+            broker
+                .resolve_phantom_for_credentials(&anon, &allowed)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolve_phantom_for_credentials_gates_by_name_not_value() {
+        // An earlier phantom must resolve to its own value even after a later
+        // store_named overwrites the name's value.
+        let mut broker = TokenBroker::new();
+        let allowed = vec!["partner-token".to_string()];
+        let first = broker.store_named(
+            "partner-token".to_string(),
+            b"audience-A".to_vec(),
+            GrantSet::All,
+        );
+        // A later capture under the same name with a different value.
+        let second = broker.store_named(
+            "partner-token".to_string(),
+            b"audience-B".to_vec(),
+            GrantSet::All,
+        );
+
+        let r1 = broker
+            .resolve_phantom_for_credentials(&first, &allowed)
+            .expect("first phantom resolves by name");
+        let r2 = broker
+            .resolve_phantom_for_credentials(&second, &allowed)
+            .expect("second phantom resolves by name");
+        assert_eq!(r1.as_slice(), b"audience-A");
+        assert_eq!(r2.as_slice(), b"audience-B");
+    }
+
+    #[test]
+    fn reissued_phantom_keeps_credential_name() {
+        let mut broker = TokenBroker::new();
+        let allowed = vec!["partner-token".to_string()];
+        let original = broker.store_named(
+            "partner-token".to_string(),
+            b"jwt-value".to_vec(),
+            GrantSet::All,
+        );
+        let reissued_buf = broker.scan_and_reissue(original.as_bytes());
+        let reissued = std::str::from_utf8(&reissued_buf).expect("utf8 phantom");
+        assert_ne!(reissued, original, "reissue mints a fresh phantom");
+        let resolved = broker
+            .resolve_phantom_for_credentials(reissued, &allowed)
+            .expect("reissued phantom resolves by inherited name");
+        assert_eq!(resolved.as_slice(), b"jwt-value");
+    }
+
+    #[test]
+    fn reissued_raw_value_keeps_credential_name() {
+        // A raw credential value in captured stdout is redacted to a fresh
+        // phantom that stays redeemable by name — even for a historical value
+        // after store_named overwrote the name's current value.
+        let mut broker = TokenBroker::new();
+        let allowed = vec!["partner-token".to_string()];
+        broker.store_named(
+            "partner-token".to_string(),
+            b"audience-A".to_vec(),
+            GrantSet::All,
+        );
+        // Overwrite the name's current value with a newer audience.
+        broker.store_named(
+            "partner-token".to_string(),
+            b"audience-B".to_vec(),
+            GrantSet::All,
+        );
+
+        let reissued_buf = broker.scan_and_reissue(b"prefix audience-A suffix");
+        let reissued = std::str::from_utf8(&reissued_buf).expect("utf8");
+        assert!(
+            !reissued.contains("audience-A"),
+            "historical raw value must be redacted"
+        );
+        let nonce = reissued
+            .split_whitespace()
+            .find(|w| is_nonce(w))
+            .expect("a phantom replaced the raw value");
+        let resolved = broker
+            .resolve_phantom_for_credentials(nonce, &allowed)
+            .expect("historical raw value resolves by inherited name");
+        assert_eq!(resolved.as_slice(), b"audience-A");
     }
 }

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -497,6 +497,7 @@ fn test_schema_custom_credential_def_matches_rust_model() {
             "tls_client_cert",
             "tls_client_key",
             "rate_limit",
+            "redeem_phantoms",
         ],
     );
 }

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -722,6 +722,11 @@ pub struct RouteConfig {
     /// If `None`, no credential is injected.
     pub credential_key: Option<String>,
 
+    /// Broker credential names this route redeems from a caller-presented phantom.
+    /// Non-empty forces `requires_intercept`; not honored with `aws_auth`/`spiffe`.
+    #[serde(default)]
+    pub redeem_phantoms: Vec<String>,
+
     /// Injection mode (default: "header")
     #[serde(default)]
     pub inject_mode: InjectMode,

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -708,6 +708,11 @@ pub struct RouteConfig {
     /// If `None`, no credential is injected.
     pub credential_key: Option<String>,
 
+    /// Broker credential names this route redeems from a caller-presented phantom.
+    /// Non-empty forces `requires_intercept`; not honored with `aws_auth`/`spiffe`.
+    #[serde(default)]
+    pub redeem_phantoms: Vec<String>,
+
     /// Injection mode (default: "header")
     #[serde(default)]
     pub inject_mode: InjectMode,

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -961,6 +961,7 @@ mod tests {
         use crate::config::OAuth2Config;
 
         RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: "https://api.example.com".to_string(),
             credential_key: None,
@@ -996,6 +997,7 @@ mod tests {
     async fn test_load_missing_env_credential_records_credential_not_found() {
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "preview-missing".to_string(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://NONO_PROXY_TEST_MISSING_CRED".to_string()),
@@ -1118,6 +1120,7 @@ mod tests {
     async fn test_load_no_credential_routes() {
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "/test".to_string(),
             upstream: "https://example.com".to_string(),
             credential_key: None,
@@ -1162,6 +1165,7 @@ mod tests {
     async fn test_load_cmd_uri_registers_lazy_route() {
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "/github".to_string(),
             upstream: "https://api.github.com".to_string(),
             credential_key: Some("cmd://github".to_string()),
@@ -1268,6 +1272,7 @@ mod tests {
         };
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "litellm".to_string(),
             upstream: "https://litellm".to_string(),
             credential_key: Some("env://NONO_PROXY_TEST_LITELLM_TOKEN".to_string()),
@@ -1307,6 +1312,7 @@ mod tests {
         };
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "api".to_string(),
             upstream: "https://api.example.com".to_string(),
             credential_key: Some("env://NONO_PROXY_TEST_API_KEY".to_string()),
@@ -1350,6 +1356,7 @@ mod tests {
         };
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "my-api".to_string(),
             upstream: "https://api.example.com".to_string(),
             credential_key: None,

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -97,6 +97,8 @@ pub struct LoadedRoute {
     /// route is unlimited. Shared behind an `Arc` because the limiter carries
     /// interior-mutable token-bucket state consulted on every request.
     pub rate_limiter: Option<std::sync::Arc<crate::rate_limit::RouteRateLimiter>>,
+    /// See [`crate::config::RouteConfig::redeem_phantoms`].
+    pub redeem_phantoms: Vec<String>,
 }
 
 impl std::fmt::Debug for LoadedRoute {
@@ -115,7 +117,8 @@ impl std::fmt::Debug for LoadedRoute {
             )
             .field("managed_auth_mechanism", &self.managed_auth_mechanism)
             .field("managed_injection_mode", &self.managed_injection_mode)
-            .field("has_rate_limiter", &self.rate_limiter.is_some());
+            .field("has_rate_limiter", &self.rate_limiter.is_some())
+            .field("redeem_phantoms", &self.redeem_phantoms);
         let managed_auth_type = self.managed_auth.as_ref().map(|a| match a.as_ref() {
             crate::auth::ManagedUpstreamAuth::SpiffeJwt(_) => "spiffe_jwt",
         });
@@ -275,6 +278,18 @@ impl RouteStore {
                 )));
             }
 
+            // `aws_auth` and `spiffe` replace the auth header wholesale instead
+            // of running the phantom-resolution loop, so a caller-presented
+            // phantom would be dropped rather than redeemed.
+            if !route.redeem_phantoms.is_empty()
+                && (route.aws_auth.is_some() || route.spiffe.is_some())
+            {
+                return Err(ProxyError::Config(format!(
+                    "route '{}': `redeem_phantoms` cannot combine with `aws_auth` or `spiffe`",
+                    normalized_prefix
+                )));
+            }
+
             // Connect to the SPIRE Workload API for SPIFFE routes. This blocks
             // startup (fail-closed) if the socket is unreachable within the
             // initial_sync_timeout configured on the source builder.
@@ -314,6 +329,7 @@ impl RouteStore {
                 || route.aws_auth.is_some()
                 || route.spiffe.is_some();
             let requires_intercept = requires_managed_credential
+                || !route.redeem_phantoms.is_empty()
                 || !endpoint_policy.allows_all_without_l7()
                 || !upgrade_rules.is_empty();
             let managed_auth_mechanism = auth_mechanism_for_route(route);
@@ -345,6 +361,7 @@ impl RouteStore {
                     managed_injection_mode,
                     managed_auth,
                     rate_limiter,
+                    redeem_phantoms: route.redeem_phantoms.clone(),
                 },
             );
         }
@@ -944,6 +961,7 @@ mod tests {
     async fn test_load_routes_without_credentials() {
         // Routes without credential_key should still be loaded into RouteStore
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "/openai".to_string(),
             upstream: "https://api.openai.com".to_string(),
             credential_key: None,
@@ -997,6 +1015,7 @@ mod tests {
     #[tokio::test]
     async fn test_load_routes_normalises_prefix() {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "/anthropic/".to_string(),
             upstream: "https://api.anthropic.com".to_string(),
             credential_key: None,
@@ -1028,6 +1047,7 @@ mod tests {
     #[tokio::test]
     async fn test_is_route_upstream() {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "openai".to_string(),
             upstream: "https://api.openai.com".to_string(),
             credential_key: None,
@@ -1060,6 +1080,7 @@ mod tests {
     async fn test_route_upstream_hosts() {
         let routes = vec![
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
@@ -1083,6 +1104,7 @@ mod tests {
                 rate_limit: None,
             },
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: None,
@@ -1169,6 +1191,7 @@ mod tests {
     #[tokio::test]
     async fn test_route_store_matches_bracketed_ipv6_authority() -> Result<()> {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "local".to_string(),
             upstream: "http://[::1]:8080/v1".to_string(),
             credential_key: Some("local".to_string()),
@@ -1214,6 +1237,7 @@ mod tests {
             "https://api.openai.com:notaport",
         ] {
             let routes = vec![RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "bad".to_string(),
                 upstream: upstream.to_string(),
                 credential_key: None,
@@ -1271,6 +1295,7 @@ mod tests {
     #[test]
     fn test_loaded_route_debug() {
         let route = LoadedRoute {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.openai.com".to_string(),
             upstream_host_port: Some("api.openai.com:443".to_string()),
             endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
@@ -1298,6 +1323,7 @@ mod tests {
     #[tokio::test]
     async fn test_requires_intercept_credential_only() {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "openai".to_string(),
             upstream: "https://api.openai.com".to_string(),
             credential_key: Some("openai_api_key".to_string()),
@@ -1338,6 +1364,7 @@ mod tests {
     #[tokio::test]
     async fn test_requires_intercept_wildcard_credential_upstream() {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "internal_api".to_string(),
             upstream: "https://*.dev.example.net".to_string(),
             credential_key: Some("cmd://internal_api".to_string()),
@@ -1383,6 +1410,7 @@ mod tests {
         // L7-only route (no credential): rules alone are enough to require
         // interception.
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "internal".to_string(),
             upstream: "https://internal.example.com".to_string(),
             credential_key: None,
@@ -1421,6 +1449,7 @@ mod tests {
         // No credential, no rules — purely declarative route. CONNECT to
         // this upstream still gets the existing 403 (not intercepted).
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "alias".to_string(),
             upstream: "https://aliased.example.com".to_string(),
             credential_key: None,
@@ -1449,8 +1478,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_redeem_phantoms_forces_intercept_without_credential() {
+        // redeem_phantoms alone must force intercept and not trip the
+        // managed-credential-unavailable gate.
+        let routes = vec![RouteConfig {
+            redeem_phantoms: vec!["partner-token".to_string()],
+            prefix: "partner-api".to_string(),
+            upstream: "https://api.partner.example.com".to_string(),
+            credential_key: None,
+            inject_mode: Default::default(),
+            inject_header: "Authorization".to_string(),
+            credential_format: None,
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            proxy: None,
+            env_var: None,
+            endpoint_rules: vec![],
+            endpoint_policy: None,
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+            oauth2: None,
+            aws_auth: None,
+            spiffe: None,
+            rate_limit: None,
+            upgrades: vec![],
+        }];
+        let store = RouteStore::load(&routes).await.unwrap();
+        assert!(store.has_intercept_route("api.partner.example.com:443"));
+        let hit = store
+            .lookup_by_upstream("api.partner.example.com:443")
+            .unwrap();
+        assert!(!hit.1.requires_managed_credential);
+        assert!(!hit.1.missing_managed_credential(false, false, false, false));
+    }
+
+    /// The CLI profile layer rejects this too, but the proxy must not depend on
+    /// it: a direct config would otherwise silently drop caller phantoms.
+    #[tokio::test]
+    async fn test_redeem_phantoms_rejected_with_aws_auth() {
+        let route = RouteConfig {
+            redeem_phantoms: vec!["partner-token".to_string()],
+            aws_auth: Some(crate::config::AwsAuthConfig::default()),
+            prefix: "partner-api".to_string(),
+            upstream: "https://api.partner.example.com".to_string(),
+            credential_key: None,
+            inject_mode: Default::default(),
+            inject_header: "Authorization".to_string(),
+            credential_format: None,
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            proxy: None,
+            env_var: None,
+            endpoint_rules: vec![],
+            endpoint_policy: None,
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+            oauth2: None,
+            spiffe: None,
+            rate_limit: None,
+            upgrades: vec![],
+        };
+        let err = RouteStore::load(&[route])
+            .await
+            .expect_err("redeem_phantoms + aws_auth must be rejected");
+        assert!(err.to_string().contains("redeem_phantoms"));
+    }
+
+    #[tokio::test]
     async fn test_missing_managed_credential_policy() {
         let managed = LoadedRoute {
+            redeem_phantoms: Vec::new(),
             upstream: "https://api.openai.com".to_string(),
             upstream_host_port: Some("api.openai.com:443".to_string()),
             endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
@@ -1473,6 +1574,7 @@ mod tests {
         assert!(!managed.missing_managed_credential(false, false, false, true));
 
         let l7_only = LoadedRoute {
+            redeem_phantoms: Vec::new(),
             upstream: "https://internal.example.com".to_string(),
             upstream_host_port: Some("internal.example.com:443".to_string()),
             endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
@@ -1494,6 +1596,7 @@ mod tests {
     #[tokio::test]
     async fn test_lookup_by_upstream_returns_prefix() {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "openai".to_string(),
             upstream: "https://api.openai.com".to_string(),
             credential_key: Some("openai_api_key".to_string()),
@@ -1528,6 +1631,7 @@ mod tests {
     async fn test_lookup_all_by_upstream_returns_multiple_routes() {
         let routes = vec![
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "github_org_a".to_string(),
                 upstream: "https://github.com".to_string(),
                 credential_key: Some("env://GH_TOKEN_A".to_string()),
@@ -1554,6 +1658,7 @@ mod tests {
                 rate_limit: None,
             },
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "github_org_b".to_string(),
                 upstream: "https://github.com".to_string(),
                 credential_key: Some("env://GH_TOKEN_B".to_string()),
@@ -1634,6 +1739,7 @@ mod tests {
         // Helper to build a route with the given prefix and endpoint path.
         fn gh_route(prefix: &str, env: &str, path: &str) -> RouteConfig {
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: prefix.to_string(),
                 upstream: "https://github.com".to_string(),
                 credential_key: Some(format!("env://{env}")),
@@ -2050,6 +2156,7 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         std::fs::write(&key_path, TEST_CLIENT_KEY_PEM).unwrap();
 
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "k8s".to_string(),
             upstream: "https://192.168.64.1:6443".to_string(),
             credential_key: None,

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -178,15 +178,39 @@ fn strip_proxy_headers(header_bytes: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Like [`strip_proxy_headers`], but also redeems any `nono_…` phantom nonce
-/// via `resolver`/`consumer`, fail-open per [`tls_intercept::handle::resolve_nonce_in_header_value`].
+/// Credential names every route on `host_port` redeems. The absolute-form path
+/// has only the target host to go on, so when several routes share an upstream it
+/// must not grant one route's phantoms to another: intersect instead.
 ///
-/// Returns the rewritten headers and whether a real credential was swapped in,
-/// so the audit event can distinguish an injected credential from a bare route
-/// match (no credential configured, or a nonce that failed to redeem).
+/// `None` means the routes declared by-value redemption but agree on nothing —
+/// no header may be redeemed at all, not even via the grant set.
+fn shared_redeem_phantoms(
+    store: &crate::route::RouteStore,
+    host_port: &str,
+) -> Option<Vec<String>> {
+    let candidates = store.lookup_all_by_upstream(host_port);
+    let any_declared = candidates
+        .iter()
+        .any(|(_, route)| !route.redeem_phantoms.is_empty());
+    let mut routes = candidates.into_iter();
+    let (_, first) = routes.next()?;
+    let mut shared = first.redeem_phantoms.clone();
+    for (_, route) in routes {
+        shared.retain(|name| route.redeem_phantoms.contains(name));
+    }
+    if any_declared && shared.is_empty() {
+        return None;
+    }
+    Some(shared)
+}
+
+/// Like [`strip_proxy_headers`], but also redeems any phantom via
+/// `resolver`. The returned flag lets the audit event distinguish an injected
+/// credential from a bare route match.
 fn strip_and_redeem_proxy_headers(
     header_bytes: &[u8],
     consumer: &str,
+    allowed_credentials: &[String],
     resolver: &dyn crate::token::NonceResolver,
 ) -> (Vec<u8>, bool) {
     let header_str = match std::str::from_utf8(header_bytes) {
@@ -210,8 +234,12 @@ fn strip_and_redeem_proxy_headers(
             Some(v) => (v, "\r\n"),
             None => (rest, ""),
         };
-        match tls_intercept::handle::resolve_nonce_in_header_value(value.trim(), consumer, resolver)
-        {
+        match tls_intercept::handle::resolve_nonce_in_header_value(
+            value.trim(),
+            consumer,
+            allowed_credentials,
+            resolver,
+        ) {
             Some(resolved) => {
                 redeemed = true;
                 out.extend_from_slice(name.as_bytes());
@@ -924,6 +952,17 @@ impl crate::token::NonceResolver for CompositeNonceResolver {
             .as_ref()
             .and_then(|resolver| resolver.resolve(nonce, consumer))
             .or_else(|| self.oauth.resolve(nonce, consumer))
+    }
+
+    fn resolve_for_credentials(
+        &self,
+        nonce: &str,
+        allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        // Only the broker tracks credential names; OAuth-capture has none.
+        self.external
+            .as_ref()
+            .and_then(|resolver| resolver.resolve_for_credentials(nonce, allowed_credentials))
     }
 }
 
@@ -2015,16 +2054,22 @@ async fn handle_forward_http(
         .route_store
         .lookup_by_upstream(&host_port)
         .map(|(prefix, _)| prefix.to_string());
+    let redeemable = matched_route.as_ref().and_then(|prefix| {
+        Some((
+            prefix,
+            shared_redeem_phantoms(&state.route_store, &host_port)?,
+        ))
+    });
     let (filtered_headers, credential_redeemed) =
-        match (&matched_route, state.nonce_resolver.as_deref()) {
-            (Some(prefix), Some(resolver)) => {
+        match (&redeemable, state.nonce_resolver.as_deref()) {
+            (Some((prefix, redeem_phantoms)), Some(resolver)) => {
                 debug!(
                     "forward-http: absolute-form target {} matches route '{}' upstream; \
                  redeeming phantom headers before forwarding",
                     host_port, prefix
                 );
                 let consumer = format!("proxy.{prefix}");
-                strip_and_redeem_proxy_headers(header_bytes, &consumer, resolver)
+                strip_and_redeem_proxy_headers(header_bytes, &consumer, redeem_phantoms, resolver)
             }
             _ => (strip_proxy_headers(header_bytes), false),
         };
@@ -2189,6 +2234,7 @@ mod tests {
     #[tokio::test]
     async fn normalize_authority_matches_ipv6_route_upstreams() -> Result<()> {
         let routes = vec![crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "local".to_string(),
             upstream: "http://[::1]:8080/v1".to_string(),
             credential_key: Some("local".to_string()),
@@ -2291,6 +2337,7 @@ mod tests {
     /// moved back inside the guard.
     fn declarative_route(upstream: &str) -> crate::config::RouteConfig {
         crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "svc".to_string(),
             upstream: upstream.to_string(),
             credential_key: None,
@@ -2784,6 +2831,7 @@ mod tests {
         {
             let config = ProxyConfig {
                 routes: vec![crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -2863,6 +2911,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "alias".to_string(),
                 upstream: "https://aliased.example.com".to_string(),
                 credential_key: None,
@@ -2949,6 +2998,7 @@ mod tests {
             .join("intercept");
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -3000,6 +3050,7 @@ mod tests {
         let config = ProxyConfig {
             routes: vec![
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3023,6 +3074,7 @@ mod tests {
                     rate_limit: None,
                 },
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "alias".to_string(),
                     upstream: "https://aliased.example.com".to_string(),
                     credential_key: None,
@@ -3086,6 +3138,7 @@ mod tests {
             routes: vec![
                 // Credential catch-all route (no endpoint rules).
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github_api".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3110,6 +3163,7 @@ mod tests {
                 },
                 // Synthetic endpoint-authorization route for the same upstream.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "_ep_api.github.com".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: None,
@@ -3173,6 +3227,7 @@ mod tests {
             routes: vec![
                 // Wildcard credential route.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github_raw".to_string(),
                     upstream: "https://*.githubusercontent.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3197,6 +3252,7 @@ mod tests {
                 },
                 // `_ep_` route on a concrete subdomain covered by the wildcard.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "_ep_raw.githubusercontent.com".to_string(),
                     upstream: "https://raw.githubusercontent.com".to_string(),
                     credential_key: None,
@@ -3250,6 +3306,7 @@ mod tests {
     async fn test_route_diagnostics_omits_unreachable_upstream() {
         let dir = tempfile::tempdir().unwrap();
         let route = |prefix: &str, upstream: &str| crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: upstream.to_string(),
             credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3301,6 +3358,7 @@ mod tests {
     async fn test_route_diagnostics_respects_wildcard_allowlist() {
         let dir = tempfile::tempdir().unwrap();
         let route = |prefix: &str, upstream: &str| crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: upstream.to_string(),
             credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3417,6 +3475,7 @@ mod tests {
     async fn test_proxy_credential_env_vars() {
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
@@ -3472,6 +3531,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("openai_api_key".to_string()),
@@ -3536,6 +3596,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("op://Development/OpenAI/credential".to_string()),
@@ -3606,6 +3667,7 @@ mod tests {
         let config = ProxyConfig {
             routes: vec![
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("openai_api_key".to_string()),
@@ -3629,6 +3691,7 @@ mod tests {
                     rate_limit: None,
                 },
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: Some("env://GITHUB_TOKEN".to_string()),
@@ -3695,6 +3758,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "myapi".to_string(),
                 upstream: "https://api.internal.corp".to_string(),
                 credential_key: None,
@@ -3759,6 +3823,7 @@ mod tests {
         // Test leading slash
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "/anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: None,
@@ -3798,6 +3863,7 @@ mod tests {
         // Test trailing slash
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai/".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
@@ -3859,6 +3925,7 @@ mod tests {
         };
         let config_no_env_var = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: None,
@@ -3909,6 +3976,7 @@ mod tests {
         };
         let config_fixed = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: Some("ANTHROPIC_API_KEY".to_string()),
@@ -4185,6 +4253,7 @@ mod tests {
             allowed_hosts: vec!["api.openai.com".to_string()],
             direct_connect_ports: vec![443],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4231,6 +4300,7 @@ mod tests {
             allowed_hosts: vec!["openai.com".to_string()],
             direct_connect_ports: vec![443],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4301,6 +4371,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4341,6 +4412,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "local".to_string(),
                 upstream: "http://[::1]:8080/v1".to_string(),
                 credential_key: Some("local".to_string()),
@@ -4383,6 +4455,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "internal".to_string(),
                 upstream: "https://*.dev.example.net".to_string(),
                 credential_key: Some("internal".to_string()),
@@ -4582,6 +4655,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -4804,11 +4878,24 @@ mod tests {
         nonce: String,
         real: Vec<u8>,
         admitted_consumer: String,
+        credential_name: String,
     }
 
     impl crate::token::NonceResolver for TestResolver {
         fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>> {
             if nonce == self.nonce && consumer == self.admitted_consumer {
+                Some(Zeroizing::new(self.real.clone()))
+            } else {
+                None
+            }
+        }
+
+        fn resolve_for_credentials(
+            &self,
+            nonce: &str,
+            allowed: &[String],
+        ) -> Option<Zeroizing<Vec<u8>>> {
+            if nonce == self.nonce && allowed.iter().any(|a| a == &self.credential_name) {
                 Some(Zeroizing::new(self.real.clone()))
             } else {
                 None
@@ -4827,12 +4914,13 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.headroom".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = format!(
             "Host: 127.0.0.1:8787\r\nAuthorization: Bearer {nonce}\r\nProxy-Authorization: Basic abc\r\n"
         );
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &[], &resolver);
         assert!(swapped, "a real credential was swapped in");
         let s = String::from_utf8(redeemed).unwrap();
         assert!(
@@ -4857,10 +4945,11 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.other-route".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = format!("Authorization: Bearer {nonce}\r\n");
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &[], &resolver);
         assert!(
             !swapped,
             "no credential was swapped in for an unadmitted nonce"
@@ -4872,18 +4961,112 @@ mod tests {
         );
     }
 
+    /// Two routes sharing an upstream are indistinguishable on the absolute-form
+    /// path, so only credentials both routes redeem may be honored.
+    #[tokio::test]
+    async fn shared_redeem_phantoms_intersects_routes_on_one_upstream() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        a.redeem_phantoms = vec!["shared-token".to_string(), "a-only".to_string()];
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+        b.redeem_phantoms = vec!["shared-token".to_string(), "b-only".to_string()];
+        let mut solo = declarative_route("https://other.example.com");
+        solo.prefix = "svc-solo".to_string();
+        solo.redeem_phantoms = vec!["solo-token".to_string()];
+
+        let store = crate::route::RouteStore::load(&[a, b, solo]).await.unwrap();
+        assert_eq!(
+            shared_redeem_phantoms(&store, "api.example.com:443"),
+            Some(vec!["shared-token".to_string()])
+        );
+        assert_eq!(
+            shared_redeem_phantoms(&store, "other.example.com:443"),
+            Some(vec!["solo-token".to_string()])
+        );
+        assert_eq!(
+            shared_redeem_phantoms(&store, "unrelated.example.com:443"),
+            None
+        );
+    }
+
+    /// Disjoint lists must deny outright, not fall back to grant-set auth — an
+    /// empty allow-list is the grant-set sentinel, so it cannot mean "deny".
+    #[tokio::test]
+    async fn shared_redeem_phantoms_denies_when_routes_agree_on_nothing() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        a.redeem_phantoms = vec!["a-only".to_string()];
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+        b.redeem_phantoms = vec!["b-only".to_string()];
+
+        let store = crate::route::RouteStore::load(&[a, b]).await.unwrap();
+        assert_eq!(shared_redeem_phantoms(&store, "api.example.com:443"), None);
+    }
+
+    /// Routes that declare nothing keep the pre-existing grant-set path.
+    #[tokio::test]
+    async fn shared_redeem_phantoms_empty_when_no_route_declares_any() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+
+        let store = crate::route::RouteStore::load(&[a, b]).await.unwrap();
+        assert_eq!(
+            shared_redeem_phantoms(&store, "api.example.com:443"),
+            Some(Vec::new())
+        );
+    }
+
     #[test]
     fn strip_and_redeem_proxy_headers_leaves_headers_without_nonce_unchanged() {
         let resolver = TestResolver {
             nonce: make_nonce(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.headroom".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = b"Host: 127.0.0.1:8787\r\nAccept: */*\r\n";
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers, "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers, "proxy.headroom", &[], &resolver);
         assert!(!swapped);
         assert_eq!(redeemed, headers);
+    }
+
+    /// A route declaring `redeem_phantoms` redeems by credential name, so the
+    /// absolute-form path must admit a phantom the consumer grant set would not.
+    #[test]
+    fn strip_and_redeem_proxy_headers_redeems_by_value_for_declared_route() {
+        let nonce = make_nonce();
+        let resolver = TestResolver {
+            nonce: nonce.clone(),
+            real: b"real-secret".to_vec(),
+            admitted_consumer: "proxy.other-route".to_string(),
+            credential_name: "partner-token".to_string(),
+        };
+        let headers = format!("Authorization: Bearer {nonce}\r\n");
+        let allowed = vec!["partner-token".to_string()];
+        let (redeemed, swapped) = strip_and_redeem_proxy_headers(
+            headers.as_bytes(),
+            "proxy.headroom",
+            &allowed,
+            &resolver,
+        );
+        assert!(
+            swapped,
+            "declared redeem_phantoms admits the phantom by value"
+        );
+        let s = String::from_utf8(redeemed).unwrap();
+        assert!(
+            s.contains("Authorization: Bearer real-secret"),
+            "got: {s:?}"
+        );
+        assert!(
+            !s.contains(&nonce),
+            "phantom nonce must not reach upstream: {s:?}"
+        );
     }
 
     /// Spawn a one-shot local HTTP/1.1 origin server that echoes the received
@@ -5011,6 +5194,7 @@ mod tests {
         let config = ProxyConfig {
             allowed_hosts: vec!["127.0.0.1".to_string()],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "svc".to_string(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -5120,6 +5304,7 @@ mod tests {
                 aws_auth: None,
                 spiffe: None,
                 rate_limit: None,
+                redeem_phantoms: Vec::new(),
                 upgrades: vec![],
             }],
             ..ProxyConfig::default()
@@ -5128,6 +5313,7 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.local".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let handle = start_with_nonce_resolver(config, None, None, Some(Arc::new(resolver)))
             .await
@@ -5217,6 +5403,7 @@ mod tests {
                 aws_auth: None,
                 spiffe: None,
                 rate_limit: None,
+                redeem_phantoms: Vec::new(),
                 upgrades: vec![],
             }],
             ..ProxyConfig::default()
@@ -5225,6 +5412,7 @@ mod tests {
             nonce: make_nonce(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.local".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let handle = start_with_nonce_resolver(config, None, None, Some(Arc::new(resolver)))
             .await
@@ -5402,6 +5590,7 @@ mod tests {
         // reverse handler at all, not the forward path.
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -178,15 +178,39 @@ fn strip_proxy_headers(header_bytes: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Like [`strip_proxy_headers`], but also redeems any `nono_…` phantom nonce
-/// via `resolver`/`consumer`, fail-open per [`tls_intercept::handle::resolve_nonce_in_header_value`].
+/// Credential names every route on `host_port` redeems. The absolute-form path
+/// has only the target host to go on, so when several routes share an upstream it
+/// must not grant one route's phantoms to another: intersect instead.
 ///
-/// Returns the rewritten headers and whether a real credential was swapped in,
-/// so the audit event can distinguish an injected credential from a bare route
-/// match (no credential configured, or a nonce that failed to redeem).
+/// `None` means the routes declared by-value redemption but agree on nothing —
+/// no header may be redeemed at all, not even via the grant set.
+fn shared_redeem_phantoms(
+    store: &crate::route::RouteStore,
+    host_port: &str,
+) -> Option<Vec<String>> {
+    let candidates = store.lookup_all_by_upstream(host_port);
+    let any_declared = candidates
+        .iter()
+        .any(|(_, route)| !route.redeem_phantoms.is_empty());
+    let mut routes = candidates.into_iter();
+    let (_, first) = routes.next()?;
+    let mut shared = first.redeem_phantoms.clone();
+    for (_, route) in routes {
+        shared.retain(|name| route.redeem_phantoms.contains(name));
+    }
+    if any_declared && shared.is_empty() {
+        return None;
+    }
+    Some(shared)
+}
+
+/// Like [`strip_proxy_headers`], but also redeems any phantom via
+/// `resolver`. The returned flag lets the audit event distinguish an injected
+/// credential from a bare route match.
 fn strip_and_redeem_proxy_headers(
     header_bytes: &[u8],
     consumer: &str,
+    allowed_credentials: &[String],
     resolver: &dyn crate::token::NonceResolver,
 ) -> (Vec<u8>, bool) {
     let header_str = match std::str::from_utf8(header_bytes) {
@@ -210,8 +234,12 @@ fn strip_and_redeem_proxy_headers(
             Some(v) => (v, "\r\n"),
             None => (rest, ""),
         };
-        match tls_intercept::handle::resolve_nonce_in_header_value(value.trim(), consumer, resolver)
-        {
+        match tls_intercept::handle::resolve_nonce_in_header_value(
+            value.trim(),
+            consumer,
+            allowed_credentials,
+            resolver,
+        ) {
             Some(resolved) => {
                 redeemed = true;
                 out.extend_from_slice(name.as_bytes());
@@ -912,6 +940,17 @@ impl crate::token::NonceResolver for CompositeNonceResolver {
             .as_ref()
             .and_then(|resolver| resolver.resolve(nonce, consumer))
             .or_else(|| self.oauth.resolve(nonce, consumer))
+    }
+
+    fn resolve_for_credentials(
+        &self,
+        nonce: &str,
+        allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        // Only the broker tracks credential names; OAuth-capture has none.
+        self.external
+            .as_ref()
+            .and_then(|resolver| resolver.resolve_for_credentials(nonce, allowed_credentials))
     }
 }
 
@@ -1999,16 +2038,22 @@ async fn handle_forward_http(
         .route_store
         .lookup_by_upstream(&host_port)
         .map(|(prefix, _)| prefix.to_string());
+    let redeemable = matched_route.as_ref().and_then(|prefix| {
+        Some((
+            prefix,
+            shared_redeem_phantoms(&state.route_store, &host_port)?,
+        ))
+    });
     let (filtered_headers, credential_redeemed) =
-        match (&matched_route, state.nonce_resolver.as_deref()) {
-            (Some(prefix), Some(resolver)) => {
+        match (&redeemable, state.nonce_resolver.as_deref()) {
+            (Some((prefix, redeem_phantoms)), Some(resolver)) => {
                 debug!(
                     "forward-http: absolute-form target {} matches route '{}' upstream; \
                  redeeming phantom headers before forwarding",
                     host_port, prefix
                 );
                 let consumer = format!("proxy.{prefix}");
-                strip_and_redeem_proxy_headers(header_bytes, &consumer, resolver)
+                strip_and_redeem_proxy_headers(header_bytes, &consumer, redeem_phantoms, resolver)
             }
             _ => (strip_proxy_headers(header_bytes), false),
         };
@@ -2173,6 +2218,7 @@ mod tests {
     #[tokio::test]
     async fn normalize_authority_matches_ipv6_route_upstreams() -> Result<()> {
         let routes = vec![crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "local".to_string(),
             upstream: "http://[::1]:8080/v1".to_string(),
             credential_key: Some("local".to_string()),
@@ -2275,6 +2321,7 @@ mod tests {
     /// moved back inside the guard.
     fn declarative_route(upstream: &str) -> crate::config::RouteConfig {
         crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "svc".to_string(),
             upstream: upstream.to_string(),
             credential_key: None,
@@ -2729,6 +2776,7 @@ mod tests {
         {
             let config = ProxyConfig {
                 routes: vec![crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -2808,6 +2856,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "alias".to_string(),
                 upstream: "https://aliased.example.com".to_string(),
                 credential_key: None,
@@ -2894,6 +2943,7 @@ mod tests {
             .join("intercept");
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -2945,6 +2995,7 @@ mod tests {
         let config = ProxyConfig {
             routes: vec![
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -2968,6 +3019,7 @@ mod tests {
                     rate_limit: None,
                 },
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "alias".to_string(),
                     upstream: "https://aliased.example.com".to_string(),
                     credential_key: None,
@@ -3031,6 +3083,7 @@ mod tests {
             routes: vec![
                 // Credential catch-all route (no endpoint rules).
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github_api".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3055,6 +3108,7 @@ mod tests {
                 },
                 // Synthetic endpoint-authorization route for the same upstream.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "_ep_api.github.com".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: None,
@@ -3118,6 +3172,7 @@ mod tests {
             routes: vec![
                 // Wildcard credential route.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github_raw".to_string(),
                     upstream: "https://*.githubusercontent.com".to_string(),
                     credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3142,6 +3197,7 @@ mod tests {
                 },
                 // `_ep_` route on a concrete subdomain covered by the wildcard.
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "_ep_raw.githubusercontent.com".to_string(),
                     upstream: "https://raw.githubusercontent.com".to_string(),
                     credential_key: None,
@@ -3195,6 +3251,7 @@ mod tests {
     async fn test_route_diagnostics_omits_unreachable_upstream() {
         let dir = tempfile::tempdir().unwrap();
         let route = |prefix: &str, upstream: &str| crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: upstream.to_string(),
             credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3246,6 +3303,7 @@ mod tests {
     async fn test_route_diagnostics_respects_wildcard_allowlist() {
         let dir = tempfile::tempdir().unwrap();
         let route = |prefix: &str, upstream: &str| crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: upstream.to_string(),
             credential_key: Some("env://NONO_TEST_MISSING".to_string()),
@@ -3362,6 +3420,7 @@ mod tests {
     async fn test_proxy_credential_env_vars() {
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
@@ -3417,6 +3476,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("openai_api_key".to_string()),
@@ -3481,6 +3541,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("op://Development/OpenAI/credential".to_string()),
@@ -3551,6 +3612,7 @@ mod tests {
         let config = ProxyConfig {
             routes: vec![
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "openai".to_string(),
                     upstream: "https://api.openai.com".to_string(),
                     credential_key: Some("openai_api_key".to_string()),
@@ -3574,6 +3636,7 @@ mod tests {
                     rate_limit: None,
                 },
                 crate::config::RouteConfig {
+                    redeem_phantoms: Vec::new(),
                     prefix: "github".to_string(),
                     upstream: "https://api.github.com".to_string(),
                     credential_key: Some("env://GITHUB_TOKEN".to_string()),
@@ -3640,6 +3703,7 @@ mod tests {
         };
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "myapi".to_string(),
                 upstream: "https://api.internal.corp".to_string(),
                 credential_key: None,
@@ -3704,6 +3768,7 @@ mod tests {
         // Test leading slash
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "/anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: None,
@@ -3743,6 +3808,7 @@ mod tests {
         // Test trailing slash
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai/".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: None,
@@ -3804,6 +3870,7 @@ mod tests {
         };
         let config_no_env_var = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: None,
@@ -3854,6 +3921,7 @@ mod tests {
         };
         let config_fixed = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "anthropic".to_string(),
                 upstream: "https://api.anthropic.com".to_string(),
                 credential_key: Some("ANTHROPIC_API_KEY".to_string()),
@@ -4130,6 +4198,7 @@ mod tests {
             allowed_hosts: vec!["api.openai.com".to_string()],
             direct_connect_ports: vec![443],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4176,6 +4245,7 @@ mod tests {
             allowed_hosts: vec!["openai.com".to_string()],
             direct_connect_ports: vec![443],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4246,6 +4316,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com/v1".to_string(),
                 credential_key: Some("openai".to_string()),
@@ -4286,6 +4357,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "local".to_string(),
                 upstream: "http://[::1]:8080/v1".to_string(),
                 credential_key: Some("local".to_string()),
@@ -4328,6 +4400,7 @@ mod tests {
                 "redis".to_string(),
             ],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "internal".to_string(),
                 upstream: "https://*.dev.example.net".to_string(),
                 credential_key: Some("internal".to_string()),
@@ -4527,6 +4600,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -4749,11 +4823,24 @@ mod tests {
         nonce: String,
         real: Vec<u8>,
         admitted_consumer: String,
+        credential_name: String,
     }
 
     impl crate::token::NonceResolver for TestResolver {
         fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>> {
             if nonce == self.nonce && consumer == self.admitted_consumer {
+                Some(Zeroizing::new(self.real.clone()))
+            } else {
+                None
+            }
+        }
+
+        fn resolve_for_credentials(
+            &self,
+            nonce: &str,
+            allowed: &[String],
+        ) -> Option<Zeroizing<Vec<u8>>> {
+            if nonce == self.nonce && allowed.iter().any(|a| a == &self.credential_name) {
                 Some(Zeroizing::new(self.real.clone()))
             } else {
                 None
@@ -4772,12 +4859,13 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.headroom".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = format!(
             "Host: 127.0.0.1:8787\r\nAuthorization: Bearer {nonce}\r\nProxy-Authorization: Basic abc\r\n"
         );
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &[], &resolver);
         assert!(swapped, "a real credential was swapped in");
         let s = String::from_utf8(redeemed).unwrap();
         assert!(
@@ -4802,10 +4890,11 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.other-route".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = format!("Authorization: Bearer {nonce}\r\n");
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers.as_bytes(), "proxy.headroom", &[], &resolver);
         assert!(
             !swapped,
             "no credential was swapped in for an unadmitted nonce"
@@ -4817,18 +4906,112 @@ mod tests {
         );
     }
 
+    /// Two routes sharing an upstream are indistinguishable on the absolute-form
+    /// path, so only credentials both routes redeem may be honored.
+    #[tokio::test]
+    async fn shared_redeem_phantoms_intersects_routes_on_one_upstream() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        a.redeem_phantoms = vec!["shared-token".to_string(), "a-only".to_string()];
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+        b.redeem_phantoms = vec!["shared-token".to_string(), "b-only".to_string()];
+        let mut solo = declarative_route("https://other.example.com");
+        solo.prefix = "svc-solo".to_string();
+        solo.redeem_phantoms = vec!["solo-token".to_string()];
+
+        let store = crate::route::RouteStore::load(&[a, b, solo]).await.unwrap();
+        assert_eq!(
+            shared_redeem_phantoms(&store, "api.example.com:443"),
+            Some(vec!["shared-token".to_string()])
+        );
+        assert_eq!(
+            shared_redeem_phantoms(&store, "other.example.com:443"),
+            Some(vec!["solo-token".to_string()])
+        );
+        assert_eq!(
+            shared_redeem_phantoms(&store, "unrelated.example.com:443"),
+            None
+        );
+    }
+
+    /// Disjoint lists must deny outright, not fall back to grant-set auth — an
+    /// empty allow-list is the grant-set sentinel, so it cannot mean "deny".
+    #[tokio::test]
+    async fn shared_redeem_phantoms_denies_when_routes_agree_on_nothing() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        a.redeem_phantoms = vec!["a-only".to_string()];
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+        b.redeem_phantoms = vec!["b-only".to_string()];
+
+        let store = crate::route::RouteStore::load(&[a, b]).await.unwrap();
+        assert_eq!(shared_redeem_phantoms(&store, "api.example.com:443"), None);
+    }
+
+    /// Routes that declare nothing keep the pre-existing grant-set path.
+    #[tokio::test]
+    async fn shared_redeem_phantoms_empty_when_no_route_declares_any() {
+        let mut a = declarative_route("https://api.example.com");
+        a.prefix = "svc-a".to_string();
+        let mut b = declarative_route("https://api.example.com");
+        b.prefix = "svc-b".to_string();
+
+        let store = crate::route::RouteStore::load(&[a, b]).await.unwrap();
+        assert_eq!(
+            shared_redeem_phantoms(&store, "api.example.com:443"),
+            Some(Vec::new())
+        );
+    }
+
     #[test]
     fn strip_and_redeem_proxy_headers_leaves_headers_without_nonce_unchanged() {
         let resolver = TestResolver {
             nonce: make_nonce(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.headroom".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let headers = b"Host: 127.0.0.1:8787\r\nAccept: */*\r\n";
         let (redeemed, swapped) =
-            strip_and_redeem_proxy_headers(headers, "proxy.headroom", &resolver);
+            strip_and_redeem_proxy_headers(headers, "proxy.headroom", &[], &resolver);
         assert!(!swapped);
         assert_eq!(redeemed, headers);
+    }
+
+    /// A route declaring `redeem_phantoms` redeems by credential name, so the
+    /// absolute-form path must admit a phantom the consumer grant set would not.
+    #[test]
+    fn strip_and_redeem_proxy_headers_redeems_by_value_for_declared_route() {
+        let nonce = make_nonce();
+        let resolver = TestResolver {
+            nonce: nonce.clone(),
+            real: b"real-secret".to_vec(),
+            admitted_consumer: "proxy.other-route".to_string(),
+            credential_name: "partner-token".to_string(),
+        };
+        let headers = format!("Authorization: Bearer {nonce}\r\n");
+        let allowed = vec!["partner-token".to_string()];
+        let (redeemed, swapped) = strip_and_redeem_proxy_headers(
+            headers.as_bytes(),
+            "proxy.headroom",
+            &allowed,
+            &resolver,
+        );
+        assert!(
+            swapped,
+            "declared redeem_phantoms admits the phantom by value"
+        );
+        let s = String::from_utf8(redeemed).unwrap();
+        assert!(
+            s.contains("Authorization: Bearer real-secret"),
+            "got: {s:?}"
+        );
+        assert!(
+            !s.contains(&nonce),
+            "phantom nonce must not reach upstream: {s:?}"
+        );
     }
 
     /// Spawn a one-shot local HTTP/1.1 origin server that echoes the received
@@ -4956,6 +5139,7 @@ mod tests {
         let config = ProxyConfig {
             allowed_hosts: vec!["127.0.0.1".to_string()],
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "svc".to_string(),
                 upstream: "https://api.example.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
@@ -5065,6 +5249,7 @@ mod tests {
                 aws_auth: None,
                 spiffe: None,
                 rate_limit: None,
+                redeem_phantoms: Vec::new(),
                 upgrades: vec![],
             }],
             ..ProxyConfig::default()
@@ -5073,6 +5258,7 @@ mod tests {
             nonce: nonce.clone(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.local".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let handle = start_with_nonce_resolver(config, None, None, Some(Arc::new(resolver)))
             .await
@@ -5162,6 +5348,7 @@ mod tests {
                 aws_auth: None,
                 spiffe: None,
                 rate_limit: None,
+                redeem_phantoms: Vec::new(),
                 upgrades: vec![],
             }],
             ..ProxyConfig::default()
@@ -5170,6 +5357,7 @@ mod tests {
             nonce: make_nonce(),
             real: b"real-secret".to_vec(),
             admitted_consumer: "proxy.local".to_string(),
+            credential_name: "partner-token".to_string(),
         };
         let handle = start_with_nonce_resolver(config, None, None, Some(Arc::new(resolver)))
             .await
@@ -5347,6 +5535,7 @@ mod tests {
         // reverse handler at all, not the forward path.
         let config = ProxyConfig {
             routes: vec![crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "openai".to_string(),
                 upstream: "https://api.openai.com".to_string(),
                 credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),

--- a/crates/nono-proxy/src/tls_intercept/h2_forward.rs
+++ b/crates/nono-proxy/src/tls_intercept/h2_forward.rs
@@ -376,6 +376,7 @@ async fn handle_h2_stream(
     // carries a broker nonce in a header would forward the raw nonce upstream
     // instead of the resolved credential.
     let nonce_consumer = service.map(|s| format!("proxy.{s}"));
+    let redeem_phantoms: &[String] = route.map_or(&[], |r| r.redeem_phantoms.as_slice());
     let mut upstream_headers = HeaderMap::new();
     for (name, value) in request.headers() {
         let name_lower = name.as_str().to_lowercase();
@@ -420,7 +421,12 @@ async fn handle_h2_stream(
             .and_then(|v| {
                 nonce_consumer.as_deref().and_then(|consumer| {
                     ctx.nonce_resolver.as_deref().and_then(|resolver| {
-                        handle::resolve_nonce_in_header_value(v, consumer, resolver)
+                        handle::resolve_nonce_in_header_value(
+                            v,
+                            consumer,
+                            redeem_phantoms,
+                            resolver,
+                        )
                     })
                 })
             })
@@ -761,6 +767,7 @@ mod tests {
         tls_connector: &tokio_rustls::TlsConnector,
     ) -> (RouteStore, CredentialStore) {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "cmd-svc".to_string(),
             upstream: format!("https://{}:{}", host, port),
             credential_key: Some("cmd://my-cmd-cred".to_string()),
@@ -843,6 +850,7 @@ mod tests {
     /// Build a RouteStore with a single route pointing at `host:port`.
     async fn make_route_store(host: &str, port: u16, rules: Vec<EndpointRule>) -> RouteStore {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "test-svc".to_string(),
             upstream: format!("https://{}:{}", host, port),
             credential_key: None,
@@ -1647,6 +1655,7 @@ mod tests {
 
         // Route configured for AWS SigV4 (h2 signing not yet implemented).
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "aws-svc".to_string(),
             upstream: format!("https://localhost:{}", upstream_port),
             credential_key: None,
@@ -2038,6 +2047,7 @@ mod tests {
 
         let routes = vec![
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "svc-a".to_string(),
                 upstream: format!("https://localhost:{}", upstream_port),
                 credential_key: None,
@@ -2064,6 +2074,7 @@ mod tests {
                 rate_limit: None,
             },
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "svc-b".to_string(),
                 upstream: format!("https://localhost:{}", upstream_port),
                 credential_key: None,
@@ -2245,6 +2256,7 @@ mod tests {
         rules: Vec<EndpointRule>,
     ) -> RouteStore {
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "_ep_test".to_string(),
             upstream: format!("https://{}:{}", host, port),
             credential_key: None,
@@ -2373,6 +2385,7 @@ mod tests {
         // No legacy endpoint_rules — so the legacy path would treat this as a
         // catch-all and forward the request.
         let routes = vec![RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: "_ep_policy".to_string(),
             upstream: format!("https://localhost:{}", upstream_port),
             credential_key: None,
@@ -2580,6 +2593,7 @@ mod tests {
         let routes = vec![
             // Credential catch-all (no endpoint_rules)
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "github-cred".to_string(),
                 upstream: format!("https://localhost:{}", upstream_port),
                 credential_key: Some("gh-token".to_string()),
@@ -2604,6 +2618,7 @@ mod tests {
             },
             // Endpoint-only restriction (_ep_ route)
             RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: "_ep_localhost".to_string(),
                 upstream: format!("https://localhost:{}", upstream_port),
                 credential_key: None,

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1259,6 +1259,7 @@ where
     }
     let injected_header_names = reverse::injected_credential_header_names(cred);
     let nonce_consumer = service.map(|s| format!("proxy.{s}"));
+    let redeem_phantoms: &[String] = route.map_or(&[], |r| r.redeem_phantoms.as_slice());
     for (name, value) in &filtered_headers {
         if injected_header_names
             .iter()
@@ -1269,9 +1270,9 @@ where
         let resolved_value = nonce_consumer
             .as_deref()
             .and_then(|consumer| {
-                ctx.nonce_resolver
-                    .as_deref()
-                    .and_then(|resolver| resolve_nonce_in_header_value(value, consumer, resolver))
+                ctx.nonce_resolver.as_deref().and_then(|resolver| {
+                    resolve_nonce_in_header_value(value, consumer, redeem_phantoms, resolver)
+                })
             })
             .unwrap_or_else(|| value.clone());
         request.push_str(&format!("{}: {}\r\n", name, resolved_value));
@@ -1594,18 +1595,13 @@ where
     Ok(())
 }
 
-/// Scan a header value for a tool-sandbox broker nonce (`nono_<64hex>`) and,
-/// if one is found and `resolver` admits `consumer`, return the header value
-/// with the nonce replaced by the real credential bytes (UTF-8).
-///
-/// Only the first nonce found is substituted. Non-UTF-8 real values are
-/// forwarded verbatim (fail-open for the substitution, not the request).
-/// If no nonce is found, or the resolver returns `None`, the original value
-/// is returned unchanged (fail-closed: the upstream sees the raw nonce and
-/// will reject the request, not a silently wrong credential).
+/// Replace a broker phantom in a header value with the real credential. Empty
+/// `allowed_credentials` authorizes by grant set, non-empty by credential name.
+/// Fail-closed: an unauthorized phantom is left raw so the upstream 401s.
 pub(crate) fn resolve_nonce_in_header_value(
     value: &str,
     consumer: &str,
+    allowed_credentials: &[String],
     resolver: &dyn crate::token::NonceResolver,
 ) -> Option<String> {
     const NONCE_PREFIX: &str = "nono_";
@@ -1623,7 +1619,11 @@ pub(crate) fn resolve_nonce_in_header_value(
     {
         return None;
     }
-    let real = resolver.resolve(nonce, consumer)?;
+    let real = if allowed_credentials.is_empty() {
+        resolver.resolve(nonce, consumer)?
+    } else {
+        resolver.resolve_for_credentials(nonce, allowed_credentials)?
+    };
     let real_str = std::str::from_utf8(&real).ok()?;
     // Resolved values are interpolated directly into a raw "name: value\r\n"
     // request line at every call site. A resolved secret containing CR, LF,
@@ -1633,6 +1633,24 @@ pub(crate) fn resolve_nonce_in_header_value(
     if real_str.bytes().any(|b| matches!(b, b'\r' | b'\n' | 0)) {
         return None;
     }
+
+    // Replace the whole shaped token, or a JWT real value splices into the
+    // signature segment and yields 5 segments. Anchored at the phantom already
+    // parsed at `start` so a re-search can't match a different occurrence.
+    if let Ok(shaped) = crate::jwt_phantom::jwt_shaped_phantom(nonce)
+        && let Some(shaped_prefix) = shaped.strip_suffix(nonce)
+        && let Some(shaped_start) = start.checked_sub(shaped_prefix.len())
+        // `.get` (not indexing): shaped_start may fall mid-UTF-8 on a crafted header.
+        && value.get(shaped_start..start) == Some(shaped_prefix)
+    {
+        return Some(format!(
+            "{}{}{}",
+            &value[..shaped_start],
+            real_str,
+            &value[end..]
+        ));
+    }
+
     Some(format!("{}{}{}", &value[..start], real_str, &value[end..]))
 }
 
@@ -1877,6 +1895,7 @@ where
         &upstream_authority,
         cred,
         service,
+        route.map_or(&[], |r| r.redeem_phantoms.as_slice()),
         ctx.nonce_resolver.as_deref(),
     ) {
         Ok(request) => request,
@@ -2121,6 +2140,7 @@ fn build_websocket_upstream_request(
     upstream_authority: &str,
     cred: Option<&crate::credential::LoadedCredential>,
     service: Option<&str>,
+    redeem_phantoms: &[String],
     nonce_resolver: Option<&dyn crate::token::NonceResolver>,
 ) -> Result<Zeroizing<String>> {
     let injected_header_names = reverse::injected_credential_header_names(cred);
@@ -2142,11 +2162,13 @@ fn build_websocket_upstream_request(
             let resolver = nonce_resolver.ok_or_else(|| {
                 ProxyError::Credential("phantom nonce resolver is unavailable".to_string())
             })?;
-            resolve_nonce_in_header_value(&field.value, consumer, resolver).ok_or_else(|| {
-                ProxyError::Credential(
-                    "phantom nonce is invalid, expired, or not admitted for this route".to_string(),
-                )
-            })?
+            resolve_nonce_in_header_value(&field.value, consumer, redeem_phantoms, resolver)
+                .ok_or_else(|| {
+                    ProxyError::Credential(
+                        "phantom nonce is invalid, expired, or not admitted for this route"
+                            .to_string(),
+                    )
+                })?
         } else {
             field.value
         };
@@ -2525,6 +2547,7 @@ mod tests {
         tls_ca: Option<&str>,
     ) -> crate::config::RouteConfig {
         crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: format!("https://{}:{}", host, port),
             credential_key: Some(format!("env://{}_TOKEN", prefix.to_uppercase())),
@@ -2561,6 +2584,7 @@ mod tests {
     async fn select_intercept_route_disjoint_credential_routes_do_not_cross_deny() {
         fn cred_route(prefix: &str, path: &str) -> crate::config::RouteConfig {
             crate::config::RouteConfig {
+                redeem_phantoms: Vec::new(),
                 prefix: prefix.to_string(),
                 upstream: "https://example.com".to_string(),
                 credential_key: Some(format!("env://{}_TOKEN", prefix.to_uppercase())),
@@ -2640,6 +2664,67 @@ mod tests {
         }
     }
 
+    /// On the intercept path route selection is authoritative: each request
+    /// resolves phantoms against the list of the one route selected for it, so a
+    /// sibling route sharing the upstream neither widens nor narrows the gate.
+    /// (The absolute-form path has no selection and intersects instead — see
+    /// `server::shared_redeem_phantoms`.)
+    #[tokio::test]
+    async fn select_intercept_route_uses_only_the_selected_routes_redeem_phantoms() {
+        fn route(prefix: &str, path: &str, redeem: &[&str]) -> crate::config::RouteConfig {
+            crate::config::RouteConfig {
+                redeem_phantoms: redeem.iter().map(|s| (*s).to_string()).collect(),
+                prefix: prefix.to_string(),
+                upstream: "https://example.com".to_string(),
+                credential_key: None,
+                inject_mode: crate::config::InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: None,
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: None,
+                endpoint_rules: vec![crate::config::EndpointRule {
+                    method: "GET".to_string(),
+                    path: path.to_string(),
+                }],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+                aws_auth: None,
+                endpoint_policy: None,
+                spiffe: None,
+                upgrades: vec![],
+                rate_limit: None,
+            }
+        }
+
+        let routes = vec![
+            route("gated", "/gated", &["partner-token"]),
+            route("open", "/open", &[]),
+        ];
+        let store = RouteStore::load(&routes).await.unwrap();
+
+        for (path, expected) in [
+            ("/gated", vec!["partner-token".to_string()]),
+            ("/open", Vec::new()),
+        ] {
+            let request = InterceptRouteRequest {
+                method: "GET",
+                path,
+                websocket_path: None,
+            };
+            match select_intercept_route(&store, "example.com", 443, request, None, None).await {
+                RouteSelection::Selected(Some(selected)) => {
+                    assert_eq!(selected.route.redeem_phantoms, expected, "for {path}");
+                }
+                _ => panic!("{path} must select its own route"),
+            }
+        }
+    }
+
     /// A selected route whose `RouteRateLimiter` has exhausted its burst and has
     /// no delay budget must reject the request with HTTP 429. The first request
     /// consumes the single burst token and is selected; the second overshoots
@@ -2678,6 +2763,7 @@ mod tests {
                 burst: 1,
                 max_delay_secs: 0,
             }),
+            redeem_phantoms: vec![],
         };
 
         let store = RouteStore::load(&[route]).await.unwrap();
@@ -2744,6 +2830,7 @@ mod tests {
     /// `GET /gated` through an approval backend and denies everything else.
     fn approval_gated_route(prefix: &str) -> crate::config::RouteConfig {
         crate::config::RouteConfig {
+            redeem_phantoms: Vec::new(),
             prefix: prefix.to_string(),
             upstream: "https://example.com".to_string(),
             credential_key: Some(format!("env://{}_TOKEN", prefix.to_uppercase())),
@@ -2952,12 +3039,28 @@ mod tests {
     struct TestResolver {
         nonce: String,
         real: Vec<u8>,
+        /// Admitted for the consumer/grant-set path (`resolve`).
         admitted_consumer: String,
+        /// Broker credential name for the route-authoritative path
+        /// (`resolve_for_credentials`).
+        credential_name: String,
     }
 
     impl crate::token::NonceResolver for TestResolver {
         fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>> {
             if nonce == self.nonce && consumer == self.admitted_consumer {
+                Some(Zeroizing::new(self.real.clone()))
+            } else {
+                None
+            }
+        }
+
+        fn resolve_for_credentials(
+            &self,
+            nonce: &str,
+            allowed: &[String],
+        ) -> Option<Zeroizing<Vec<u8>>> {
+            if nonce == self.nonce && allowed.iter().any(|a| a == &self.credential_name) {
                 Some(Zeroizing::new(self.real.clone()))
             } else {
                 None
@@ -2969,41 +3072,46 @@ mod tests {
         format!("nono_{}", "a".repeat(64))
     }
 
+    fn test_resolver(nonce: &str, real: &[u8]) -> TestResolver {
+        TestResolver {
+            nonce: nonce.to_string(),
+            real: real.to_vec(),
+            admitted_consumer: "proxy.anthropic".to_string(),
+            credential_name: "partner-token".to_string(),
+        }
+    }
+
+    // Empty allow-list selects the consumer/grant-set resolution path.
+    const CONSUMER_PATH: &[String] = &[];
+
     #[test]
     fn resolves_bearer_nonce() {
         let nonce = make_nonce();
-        let resolver = TestResolver {
-            nonce: nonce.clone(),
-            real: b"sk-ant-real".to_vec(),
-            admitted_consumer: "proxy.anthropic".to_string(),
-        };
+        let resolver = test_resolver(&nonce, b"sk-ant-real");
         let value = format!("Bearer {nonce}");
-        let result = resolve_nonce_in_header_value(&value, "proxy.anthropic", &resolver);
+        let result =
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", CONSUMER_PATH, &resolver);
         assert_eq!(result, Some("Bearer sk-ant-real".to_string()));
     }
 
     #[test]
     fn returns_none_for_unadmitted_consumer() {
         let nonce = make_nonce();
-        let resolver = TestResolver {
-            nonce: nonce.clone(),
-            real: b"sk-ant-real".to_vec(),
-            admitted_consumer: "proxy.anthropic".to_string(),
-        };
+        let resolver = test_resolver(&nonce, b"sk-ant-real");
         let value = format!("Bearer {nonce}");
-        let result = resolve_nonce_in_header_value(&value, "proxy.other", &resolver);
+        let result = resolve_nonce_in_header_value(&value, "proxy.other", CONSUMER_PATH, &resolver);
         assert!(result.is_none(), "unadmitted consumer must not resolve");
     }
 
     #[test]
     fn returns_none_when_no_nonce_present() {
-        let resolver = TestResolver {
-            nonce: make_nonce(),
-            real: b"secret".to_vec(),
-            admitted_consumer: "proxy.anthropic".to_string(),
-        };
-        let result =
-            resolve_nonce_in_header_value("Bearer plain-token", "proxy.anthropic", &resolver);
+        let resolver = test_resolver(&make_nonce(), b"secret");
+        let result = resolve_nonce_in_header_value(
+            "Bearer plain-token",
+            "proxy.anthropic",
+            CONSUMER_PATH,
+            &resolver,
+        );
         assert!(result.is_none());
     }
 
@@ -3016,52 +3124,149 @@ mod tests {
     #[test]
     fn rejects_resolved_value_containing_crlf() {
         let nonce = make_nonce();
-        let resolver = TestResolver {
-            nonce: nonce.clone(),
-            real: b"evil\r\nX-Injected: yes".to_vec(),
-            admitted_consumer: "proxy.svc".to_string(),
-        };
+        let resolver = test_resolver(&nonce, b"evil\r\nX-Injected: yes");
         let value = format!("Bearer {nonce}");
-        let result = resolve_nonce_in_header_value(&value, "proxy.svc", &resolver);
         assert!(
-            result.is_none(),
-            "CRLF in resolved value must not substitute"
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", CONSUMER_PATH, &resolver)
+                .is_none(),
+            "CRLF in resolved value must not substitute (grant-set path)"
+        );
+        let allowed = vec!["partner-token".to_string()];
+        assert!(
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", &allowed, &resolver).is_none(),
+            "CRLF in resolved value must not substitute (by-value path)"
         );
     }
 
     #[test]
     fn rejects_resolved_value_containing_nul() {
         let nonce = make_nonce();
-        let resolver = TestResolver {
-            nonce: nonce.clone(),
-            real: b"evil\0byte".to_vec(),
-            admitted_consumer: "proxy.svc".to_string(),
-        };
+        let resolver = test_resolver(&nonce, b"evil\0byte");
         let value = format!("Bearer {nonce}");
-        let result = resolve_nonce_in_header_value(&value, "proxy.svc", &resolver);
         assert!(
-            result.is_none(),
-            "NUL in resolved value must not substitute"
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", CONSUMER_PATH, &resolver)
+                .is_none(),
+            "NUL in resolved value must not substitute (grant-set path)"
+        );
+        let allowed = vec!["partner-token".to_string()];
+        assert!(
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", &allowed, &resolver).is_none(),
+            "NUL in resolved value must not substitute (by-value path)"
         );
     }
 
     #[test]
     fn preserves_prefix_and_suffix_around_nonce() {
         let nonce = make_nonce();
-        let resolver = TestResolver {
-            nonce: nonce.clone(),
-            real: b"REAL".to_vec(),
-            admitted_consumer: "proxy.svc".to_string(),
-        };
+        let mut resolver = test_resolver(&nonce, b"REAL");
+        resolver.admitted_consumer = "proxy.svc".to_string();
         let value = format!("prefix-{nonce}-suffix");
-        let result = resolve_nonce_in_header_value(&value, "proxy.svc", &resolver);
+        let result = resolve_nonce_in_header_value(&value, "proxy.svc", CONSUMER_PATH, &resolver);
         assert_eq!(result, Some("prefix-REAL-suffix".to_string()));
+    }
+
+    const REAL_JWT: &str = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJyYXBpZCJ9.c2lnbmF0dXJlLWJ5dGVz";
+
+    #[test]
+    fn jwt_shaped_phantom_resolves_to_clean_real_jwt() {
+        // The real value is a JWT: a substring splice would mangle it to 5 segments.
+        let nonce = make_nonce();
+        let shaped = crate::jwt_phantom::jwt_shaped_phantom(&nonce).expect("shape");
+        let resolver = test_resolver(&nonce, REAL_JWT.as_bytes());
+        let allowed = vec!["partner-token".to_string()];
+        let value = format!("Bearer {shaped}");
+        let result =
+            resolve_nonce_in_header_value(&value, "proxy.partner-api", &allowed, &resolver)
+                .expect("resolves");
+        assert_eq!(result, format!("Bearer {REAL_JWT}"));
+        let token = result.strip_prefix("Bearer ").expect("bearer prefix");
+        assert_eq!(
+            token.matches('.').count(),
+            2,
+            "expected exactly 3 JWT segments"
+        );
+    }
+
+    #[test]
+    fn opaque_phantom_uses_substring_replacement() {
+        let nonce = make_nonce();
+        let mut resolver = test_resolver(&nonce, b"opaque-secret");
+        resolver.admitted_consumer = "proxy.svc".to_string();
+        let value = format!("token={nonce}&scope=all");
+        let result = resolve_nonce_in_header_value(&value, "proxy.svc", CONSUMER_PATH, &resolver);
+        assert_eq!(result, Some("token=opaque-secret&scope=all".to_string()));
+    }
+
+    #[test]
+    fn multibyte_before_phantom_does_not_panic() {
+        // A multibyte char positioned so the shaped-prefix anchor offset lands
+        // mid-codepoint must not panic (crafted-header DoS); falls to opaque.
+        let nonce = make_nonce();
+        let shaped = crate::jwt_phantom::jwt_shaped_phantom(&nonce).expect("shape");
+        let prefix_len = shaped.len() - nonce.len();
+        // 'é' is 2 bytes; start = prefix_len + 1, so shaped_start = 1 (inside 'é').
+        let filler = "a".repeat(prefix_len - 1);
+        let value = format!("é{filler}{nonce}");
+        let resolver = test_resolver(&nonce, b"REAL");
+        let result =
+            resolve_nonce_in_header_value(&value, "proxy.anthropic", CONSUMER_PATH, &resolver);
+        assert_eq!(result, Some(format!("é{filler}REAL")));
+    }
+
+    #[test]
+    fn route_resolves_only_listed_credential() {
+        // Route-authoritative gate: the phantom resolves because the route lists
+        // its credential name, regardless of consumer/grant-set.
+        let nonce = make_nonce();
+        let resolver = test_resolver(&nonce, b"real-partner-jwt");
+        let allowed = vec!["partner-token".to_string()];
+        let value = format!("Bearer {nonce}");
+        let result =
+            resolve_nonce_in_header_value(&value, "proxy.partner-api", &allowed, &resolver);
+        assert_eq!(result, Some("Bearer real-partner-jwt".to_string()));
+    }
+
+    #[test]
+    fn route_fails_closed_for_unlisted_credential() {
+        // The presented phantom is for `partner-token`, but the route only
+        // resolves `some-other-token`, so it must not resolve (fail-closed).
+        let nonce = make_nonce();
+        let resolver = test_resolver(&nonce, REAL_JWT.as_bytes());
+        let allowed = vec!["some-other-token".to_string()];
+        let value = format!("Bearer {nonce}");
+        let result =
+            resolve_nonce_in_header_value(&value, "proxy.partner-api", &allowed, &resolver);
+        assert!(
+            result.is_none(),
+            "route must not resolve a credential it does not list"
+        );
+    }
+
+    #[test]
+    fn short_phantom_marker_never_resolves() {
+        // A `nono_` marker shorter than the fixed phantom length fails closed.
+        let resolver = test_resolver(&make_nonce(), REAL_JWT.as_bytes());
+        let allowed = vec!["partner-token".to_string()];
+        assert!(
+            resolve_nonce_in_header_value("Bearer nono_deadbeef", "proxy.svc", &allowed, &resolver)
+                .is_none()
+        );
+        assert!(
+            resolve_nonce_in_header_value(
+                "Bearer nono_deadbeef",
+                "proxy.svc",
+                CONSUMER_PATH,
+                &resolver
+            )
+            .is_none()
+        );
     }
 
     #[test]
     fn websocket_request_rejects_nonce_for_wrong_consumer() {
         let nonce = make_nonce();
         let resolver = TestResolver {
+            credential_name: "partner-token".to_string(),
             nonce: nonce.clone(),
             real: b"REAL".to_vec(),
             admitted_consumer: "proxy.chat".to_string(),
@@ -3082,6 +3287,7 @@ mod tests {
                 "chat.example",
                 None,
                 Some("other"),
+                &[],
                 Some(&resolver),
             )
             .is_err()
@@ -3092,6 +3298,7 @@ mod tests {
     fn websocket_request_resolves_admitted_nonce_before_forwarding() {
         let nonce = make_nonce();
         let resolver = TestResolver {
+            credential_name: "partner-token".to_string(),
             nonce: nonce.clone(),
             real: b"REAL".to_vec(),
             admitted_consumer: "proxy.chat".to_string(),
@@ -3111,6 +3318,7 @@ mod tests {
             "chat.example",
             None,
             Some("chat"),
+            &[],
             Some(&resolver),
         )
         .unwrap();

--- a/crates/nono-proxy/src/token.rs
+++ b/crates/nono-proxy/src/token.rs
@@ -30,6 +30,17 @@ pub trait NonceResolver: Send + Sync {
     /// Returns the real credential bytes if the nonce is known and admitted
     /// for `consumer` (`"proxy.<route_id>"`), or `None` otherwise (fail-closed).
     fn resolve(&self, nonce: &str, consumer: &str) -> Option<Zeroizing<Vec<u8>>>;
+
+    /// Resolve the phantom `nonce` iff its credential name is in `allowed_credentials`
+    /// (route-authoritative; ignores the grant set). Default `None` for
+    /// resolvers that don't track credential names (e.g. OAuth-capture store).
+    fn resolve_for_credentials(
+        &self,
+        _nonce: &str,
+        _allowed_credentials: &[String],
+    ) -> Option<Zeroizing<Vec<u8>>> {
+        None
+    }
 }
 
 /// Length of the random token in bytes (256 bits of entropy).

--- a/crates/nono-proxy/tests/spiffe_integration.rs
+++ b/crates/nono-proxy/tests/spiffe_integration.rs
@@ -12,6 +12,7 @@ use nono_proxy::spiffe::SpiffeJwtSource;
 
 fn make_jwt_route(socket: &str) -> RouteConfig {
     RouteConfig {
+        redeem_phantoms: Vec::new(),
         prefix: "testapi".to_string(),
         upstream: "http://127.0.0.1:1".to_string(),
         credential_key: None,
@@ -151,6 +152,7 @@ async fn test_spiffe_jwt_live_proxy_startup() {
     let audience = live_audience();
 
     let route = RouteConfig {
+        redeem_phantoms: Vec::new(),
         prefix: "testapi".to_string(),
         upstream: "http://127.0.0.1:1".to_string(),
         credential_key: None,


### PR DESCRIPTION
## Linked Issue

Closes #1468

## Summary

Adds `redeem_phantoms` to a `custom_credentials` route — a list of broker
credential names the route resolves from a caller-presented phantom in a request
header (by-value / proof-of-possession). A non-empty list forces interception for
the route's host; resolution is gated by credential name (not value); it composes
with a managed `credential_key`/`auth` or stands alone. JWT-shaped phantoms are
whole-token replaced (anchored to the parsed nonce) so a real JWT stays 3 segments.
The broker gains a name-gated `resolve_nonce_for_credentials` (per-nonce name map)
and the `NonceResolver` trait gains a `resolve_for_credentials` method (default `None`).

**Stacked — do not merge until #1443 lands in `main`:**
- **#1443** (WebSocket tunnelling) — needed by the `build_websocket_upstream_request` call site.

## Test Plan

`make ci` clean. New unit tests: shape-aware JWT resolution (3-segment result),
opaque substring replacement, route-authoritative name gate + fail-closed,
name-vs-value across per-audience overwrites, raw-value reissue relabel, a
multibyte-boundary panic regression, and profile validation (composes with
`credential_key`; rejected with `aws_auth`/`spiffe`; empty-name rejected).

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Disclosure

Generated by an AI agent. Reuses the existing `NonceResolver` and CONNECT intercept
dispatch; no new resolver trait, URI scheme, or consumer class. Files changed:
`crates/nono-proxy/src/{config,route,server,token,tls_intercept/{handle,h2_forward}}.rs`,
`crates/nono-cli/src/{network_policy,profile/mod,proxy_runtime,tool-sandbox/token_broker}.rs`,
`crates/nono-cli/data/nono-profile.schema.json`.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1468)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
