### PR TITLE
test(nono-cli): hermetic git test commit.gpgsign

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -3164,11 +3164,12 @@ mod tests {
 
         // git init + initial commit so worktree add works
         let main_repo_str = main_repo.to_str().expect("main_repo utf8");
-        std::process::Command::new("git")
+        let init = std::process::Command::new("git")
             .args(["init", main_repo_str])
-            .output()
+            .status()
             .expect("git init");
-        std::process::Command::new("git")
+        assert!(init.success(), "git init failed: {init}");
+        let commit = std::process::Command::new("git")
             .args([
                 "-C",
                 main_repo_str,
@@ -3181,16 +3182,21 @@ mod tests {
                 "-m",
                 "init",
             ])
-            .output()
+            .status()
             .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
 
         // git worktree add
         let wt = tmp.path().join("linked");
         let wt_str = wt.to_str().expect("wt utf8");
-        std::process::Command::new("git")
+        let worktree_add = std::process::Command::new("git")
             .args(["-C", main_repo_str, "worktree", "add", wt_str, "HEAD"])
-            .output()
+            .status()
             .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
 
         // Build a profile with @git:common-dir in filesystem.allow.
         // In a linked worktree, @git:common-dir resolves to the absolute path of the

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -3174,6 +3174,8 @@ mod tests {
                 "-C",
                 main_repo_str,
                 "-c",
+                "commit.gpgsign=false",
+                "-c",
                 "user.email=test@test.com",
                 "-c",
                 "user.name=Test",

--- a/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
+++ b/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
@@ -906,6 +906,8 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
         let commit = Command::new("git")
             .args([
                 "-c",
+                "commit.gpgsign=false",
+                "-c",
                 "user.email=t@t.com",
                 "-c",
                 "user.name=T",
@@ -991,6 +993,8 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .expect("git init");
         let commit = Command::new("git")
             .args([
+                "-c",
+                "commit.gpgsign=false",
                 "-c",
                 "user.email=t@t.com",
                 "-c",
@@ -1081,6 +1085,8 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .expect("git init");
         let commit = Command::new("git")
             .args([
+                "-c",
+                "commit.gpgsign=false",
                 "-c",
                 "user.email=t@t.com",
                 "-c",
@@ -1240,6 +1246,8 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .expect("git init");
         let commit = Command::new("git")
             .args([
+                "-c",
+                "commit.gpgsign=false",
                 "-c",
                 "user.email=t@t.com",
                 "-c",

--- a/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
+++ b/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
@@ -903,7 +903,7 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git init");
-        Command::new("git")
+        let commit = Command::new("git")
             .args([
                 "-c",
                 "user.email=t@t.com",
@@ -917,13 +917,18 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
 
         let wt = tmp.path().join("worktree");
-        Command::new("git")
+        let worktree_add = Command::new("git")
             .args(["worktree", "add", wt.to_str().expect("utf8")])
             .current_dir(&repo)
             .status()
             .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
 
         let result = git::read_common_dir_in(&wt).expect("read_common_dir in worktree");
         assert_eq!(result.len(), 1, "expected one entry, got {:?}", result);
@@ -984,7 +989,7 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git init");
-        Command::new("git")
+        let commit = Command::new("git")
             .args([
                 "-c",
                 "user.email=t@t.com",
@@ -998,13 +1003,18 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
 
         let wt = tmp.path().join("worktree");
-        Command::new("git")
+        let worktree_add = Command::new("git")
             .args(["worktree", "add", wt.to_str().expect("utf8")])
             .current_dir(&repo)
             .status()
             .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
 
         let result = git::read_main_worktree_in(&wt).expect("read_main_worktree in worktree");
         assert_eq!(result.len(), 1, "expected one entry, got {:?}", result);
@@ -1069,7 +1079,7 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git init");
-        Command::new("git")
+        let commit = Command::new("git")
             .args([
                 "-c",
                 "user.email=t@t.com",
@@ -1083,12 +1093,17 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
         let wt = tmp.path().join("worktree");
-        Command::new("git")
+        let worktree_add = Command::new("git")
             .args(["worktree", "add", wt.to_str().expect("utf8")])
             .current_dir(&repo)
             .status()
             .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
 
         // In a linked worktree, --show-toplevel returns the worktree dir, not the main repo.
         let result = git::read_toplevel_in(&wt).expect("read_toplevel in worktree");
@@ -1223,7 +1238,7 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git init");
-        Command::new("git")
+        let commit = Command::new("git")
             .args([
                 "-c",
                 "user.email=t@t.com",
@@ -1237,12 +1252,17 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             .current_dir(&repo)
             .status()
             .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
         let wt = tmp.path().join("worktree");
-        Command::new("git")
+        let worktree_add = Command::new("git")
             .args(["worktree", "add", wt.to_str().expect("utf8")])
             .current_dir(&repo)
             .status()
             .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
 
         let stub_dir = tmp.path().join("stub-bin");
         std::fs::create_dir(&stub_dir).expect("mkdir stub-bin");


### PR DESCRIPTION
## Linked Issue

Closes nolabs-ai/nono#1438

## Summary

* Updates `capability_ext` tests to explain git command failures
* Passes `commit.gpgsign=false` to git commands in `capability_ext` tests

## Test Plan

The tests have been updated. The reproduction steps from nolabs-ai/nono#1438 now work.

## Checklist

- [X] An issue exists and is linked above
- [X] All commits are signed-off, using [DCO](<https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin>)
- [X] All new code follows the project's coding standards ([CLAUDE.md](<CLAUDE.md>)) and is covered by tests
- [X] Public-facing changes are paired with documentation updates
- [X] Release note has been added to `CHANGELOG.md` if needed