### PR TITLE
fix(session): route attach socket through symlink

### DIFF
--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -352,7 +352,8 @@ impl PtyProxy {
     ) -> Result<Self> {
         let attach_path = crate::session::session_socket_path(session_id)?;
         remove_stale_attach_socket(&attach_path)?;
-        let attach_listener = bind_attach_listener(&attach_path)?;
+        let bind_path = crate::session::session_socket_bind_path(session_id)?;
+        let attach_listener = bind_attach_listener(&bind_path, &attach_path)?;
         attach_listener.set_nonblocking(true).map_err(|e| {
             NonoError::SandboxInit(format!("Failed to set attach socket nonblocking: {}", e))
         })?;
@@ -1486,7 +1487,7 @@ fn remove_stale_attach_socket(attach_path: &Path) -> Result<()> {
     })
 }
 
-fn bind_attach_listener(attach_path: &Path) -> Result<UnixListener> {
+fn bind_attach_listener(bind_path: &Path, canonical_path: &Path) -> Result<UnixListener> {
     struct UmaskGuard(libc::mode_t);
 
     impl Drop for UmaskGuard {
@@ -1498,16 +1499,17 @@ fn bind_attach_listener(attach_path: &Path) -> Result<UnixListener> {
     }
 
     let _umask_guard = UmaskGuard(unsafe { libc::umask(0o177) });
-    let listener = UnixListener::bind(attach_path).map_err(|e| NonoError::ConfigWrite {
-        path: attach_path.to_path_buf(),
+    // Bind through the short symlinked `bind_path` (keeps `sun_path` in-bounds),
+    let listener = UnixListener::bind(bind_path).map_err(|e| NonoError::ConfigWrite {
+        path: canonical_path.to_path_buf(),
         source: e,
     })?;
 
     #[cfg(unix)]
     {
         let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(attach_path, perms).map_err(|e| NonoError::ConfigWrite {
-            path: attach_path.to_path_buf(),
+        std::fs::set_permissions(canonical_path, perms).map_err(|e| NonoError::ConfigWrite {
+            path: canonical_path.to_path_buf(),
             source: e,
         })?;
     }
@@ -1992,7 +1994,9 @@ pub fn connect_to_session(session_id: &str) -> Result<UnixStream> {
         return Err(NonoError::SessionGone);
     }
 
-    let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+    // Connect through the short symlinked path so `sun_path` stays in bounds
+    let bind_path = crate::session::session_socket_bind_path(session_id)?;
+    let mut stream = UnixStream::connect(&bind_path).map_err(|e| {
         if is_socket_disconnect(&e)
             || matches!(
                 e.kind(),
@@ -2018,7 +2022,9 @@ pub fn request_session_detach(session_id: &str) -> Result<()> {
         return Err(NonoError::SessionGone);
     }
 
-    let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+    // Connect through the short symlinked path so `sun_path` stays in bounds
+    let bind_path = crate::session::session_socket_bind_path(session_id)?;
+    let mut stream = UnixStream::connect(&bind_path).map_err(|e| {
         if is_socket_disconnect(&e)
             || matches!(
                 e.kind(),
@@ -3308,5 +3314,74 @@ mod tests {
         assert!(forwarded.is_empty());
         assert!(!proxy.take_suspension_request());
         assert!(proxy.take_detach_request());
+    }
+
+    #[test]
+    fn attach_socket_binds_and_connects_over_sun_path_limit() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        // Usable `sockaddr_un.sun_path` bytes (sizeof - 1, for the NUL):
+        // macOS caps sun_path at 104, Linux/most others at 108.
+        let sun_path_max: usize = if cfg!(target_os = "macos") { 103 } else { 107 };
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("the system clock is set after the UNIX epoch")
+            .as_nanos();
+        let pid = std::process::id();
+
+        // A deep sessions directory whose "<dir>/<id>.sock" overflows sun_path
+        let root = std::env::temp_dir().join(format!("nono-sunpath-deep-{pid}-{nanos}"));
+        let mut deep = root.clone();
+        while deep.join("0123456789abcdef.sock").as_os_str().len() <= sun_path_max {
+            deep = deep.join("deeeeeeeeeeeeeeeeep");
+        }
+        std::fs::create_dir_all(&deep).expect("a unique deep dir tree under TMPDIR is creatable");
+        let canonical = deep.join("0123456789abcdef.sock");
+        assert!(
+            canonical.as_os_str().len() > sun_path_max,
+            "test setup: canonical socket path must exceed the sun_path limit"
+        );
+
+        assert!(
+            UnixListener::bind(&canonical).is_err(),
+            "precondition: over-long path must reject a direct bind"
+        );
+
+        // Address the socket through a short directory symlink pointing
+        // at the deep directory.
+        let link =
+            std::path::PathBuf::from("/tmp").join(format!("nono-sunpath-link-{pid}-{nanos}"));
+        std::os::unix::fs::symlink(&deep, &link).expect("short dir symlink is creatable");
+        let bind_path = link.join("0123456789abcdef.sock");
+        assert!(
+            bind_path.as_os_str().len() <= sun_path_max,
+            "the symlinked bind path must stay within sun_path"
+        );
+
+        // Binding through the short symlink succeeds and the socket inode lands at
+        // its canonical location.
+        let listener = UnixListener::bind(&bind_path)
+            .expect("binding through the short symlink keeps the address within sun_path");
+        assert!(
+            canonical.exists(),
+            "socket must exist at the canonical deep path, so stat/chmod/cleanup still work there"
+        );
+
+        // The client side (`nono attach`) connects through the same short path and
+        // reaches the listener.
+        assert!(
+            UnixStream::connect(&canonical).is_err(),
+            "precondition: over-long path must reject a direct connect"
+        );
+        let _client =
+            UnixStream::connect(&bind_path).expect("the short-path connect reaches the listener");
+        listener
+            .accept()
+            .expect("a client connection is pending, so accept returns it");
+
+        drop(listener);
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/nono-cli/src/session.rs
+++ b/crates/nono-cli/src/session.rs
@@ -605,6 +605,143 @@ pub(crate) fn session_socket_path(session_id: &str) -> Result<PathBuf> {
     Ok(ensure_sessions_dir()?.join(format!("{session_id}.sock")))
 }
 
+/// Usable bytes in an AF_UNIX `sockaddr_un.sun_path`, i.e. `sizeof(sun_path) - 1`
+///
+/// `std`'s socket-address builder rejects any `bind(2)`/`connect(2)` path whose length is `>=
+/// sizeof(sun_path)`. See `man 4 unix` (macOS) / `man 7 unix` (Linux).
+#[cfg(target_os = "macos")]
+pub(crate) const SUN_PATH_MAX: usize = 103;
+#[cfg(not(target_os = "macos"))]
+pub(crate) const SUN_PATH_MAX: usize = 107;
+
+/// Path used to `bind(2)`/`connect(2)` a session's attach socket.
+///
+/// The socket itself always lives at [`session_socket_path`]
+/// (`$XDG_STATE_HOME/nono/sessions/<id>.sock`), but that absolute path can exceed
+/// [`SUN_PATH_MAX`] when `$XDG_STATE_HOME` is too long, which makes `bind`/`connect`
+/// fail with `ENAMETOOLONG`. There is no `bindat`/`connectat` to anchor a
+/// relative address, so instead we route through a short, per-user directory
+/// symlink (`<short-base>/nono-<uid>` → the sessions directory). Addressing the
+/// socket as `<link>/<id>.sock` keeps the `sun_path` the kernel sees within the
+/// limit while it resolves to the same socket inode.
+#[cfg(unix)]
+pub(crate) fn session_socket_bind_path(session_id: &str) -> Result<PathBuf> {
+    validate_session_id(session_id)?;
+    let sessions = ensure_sessions_dir()?;
+    let leaf = format!("{session_id}.sock");
+    let uid = nix::unistd::geteuid().as_raw();
+    let link = ensure_socket_link(&sessions, uid, leaf.len())?;
+    let bind_path = link.join(&leaf);
+    if bind_path.as_os_str().len() > SUN_PATH_MAX {
+        return Err(NonoError::ConfigParse(format!(
+            "Session socket path {} exceeds the {}-byte sun_path limit even via the short link",
+            bind_path.display(),
+            SUN_PATH_MAX
+        )));
+    }
+    Ok(bind_path)
+}
+
+/// Short, per-user base directory that holds the session-socket symlink.
+///
+/// The base must itself be short, so we prefer a private `$XDG_RUNTIME_DIR` (i.e.
+/// `/run/user/<uid>`) and fall back to `/tmp`.
+#[cfg(unix)]
+fn socket_link_base(link_name: &str, leaf_len: usize) -> PathBuf {
+    let fits = |base: &Path| {
+        base.as_os_str()
+            .len()
+            .saturating_add(1)
+            .saturating_add(link_name.len())
+            .saturating_add(1)
+            .saturating_add(leaf_len)
+            <= SUN_PATH_MAX
+    };
+    if let Ok(raw) = std::env::var("XDG_RUNTIME_DIR") {
+        let base = PathBuf::from(&raw);
+        if base.is_absolute() && fits(&base) {
+            return base;
+        }
+    }
+    PathBuf::from("/tmp")
+}
+
+/// Create (or reuse) the short directory symlink pointing at `sessions`, and
+/// return its path.
+///
+/// The link is keyed by both `uid` and a short hash of the target.
+#[cfg(unix)]
+fn ensure_socket_link(sessions: &Path, uid: u32, leaf_len: usize) -> Result<PathBuf> {
+    use std::hash::{Hash, Hasher};
+
+    let target_canon = std::fs::canonicalize(sessions).map_err(|e| NonoError::ConfigWrite {
+        path: sessions.to_path_buf(),
+        source: e,
+    })?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    target_canon.as_os_str().hash(&mut hasher);
+    let tag = hasher.finish() as u32;
+    let link_name = format!("nono-{uid}-{tag:08x}");
+    let link = socket_link_base(&link_name, leaf_len).join(&link_name);
+    create_socket_link(&link, &target_canon, uid)?;
+    Ok(link)
+}
+
+/// Establish `link` as a symlink to `target`.
+#[cfg(unix)]
+fn create_socket_link(link: &Path, target: &Path, uid: u32) -> Result<()> {
+    let target_canon = std::fs::canonicalize(target).map_err(|e| NonoError::ConfigWrite {
+        path: target.to_path_buf(),
+        source: e,
+    })?;
+
+    for _ in 0..8 {
+        match std::os::unix::fs::symlink(target, link) {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let meta = std::fs::symlink_metadata(link).map_err(|e| NonoError::ConfigWrite {
+                    path: link.to_path_buf(),
+                    source: e,
+                })?;
+                if !meta.file_type().is_symlink() {
+                    return Err(NonoError::ConfigParse(format!(
+                        "Refusing to use session socket link {}: not a symlink",
+                        link.display()
+                    )));
+                }
+                if meta.uid() != uid {
+                    return Err(NonoError::ConfigParse(format!(
+                        "Refusing to use session socket link {} owned by uid {}, expected {}",
+                        link.display(),
+                        meta.uid(),
+                        uid
+                    )));
+                }
+                match std::fs::canonicalize(link) {
+                    Ok(current) if current == target_canon => return Ok(()),
+                    _ => {
+                        std::fs::remove_file(link).map_err(|e| NonoError::ConfigWrite {
+                            path: link.to_path_buf(),
+                            source: e,
+                        })?;
+                        continue;
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(NonoError::ConfigWrite {
+                    path: link.to_path_buf(),
+                    source: e,
+                });
+            }
+        }
+    }
+    Err(NonoError::ConfigParse(format!(
+        "Failed to establish session socket link {} after repeated races",
+        link.display()
+    )))
+}
+
 pub(crate) fn session_events_path(session_id: &str) -> Result<PathBuf> {
     validate_session_id(session_id)?;
     Ok(sessions_dir()?.join(format!("{session_id}.events.ndjson")))
@@ -782,6 +919,94 @@ mod tests {
     fn make_private_dir(path: &Path) {
         let perms = std::fs::Permissions::from_mode(0o700);
         std::fs::set_permissions(path, perms).expect("chmod 700");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_socket_link_creates_symlink_to_target() {
+        let base = tempdir().expect("tempdir");
+        let target = tempdir().expect("tempdir");
+        let uid = nix::unistd::geteuid().as_raw();
+        let link = base.path().join("nono-link");
+
+        create_socket_link(&link, target.path(), uid).expect("link is created");
+
+        let meta = std::fs::symlink_metadata(&link).expect("link exists");
+        assert!(meta.file_type().is_symlink(), "entry must be a symlink");
+        assert_eq!(
+            std::fs::canonicalize(&link).expect("resolves"),
+            std::fs::canonicalize(target.path()).expect("resolves"),
+            "link must resolve to the target sessions dir"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_socket_link_reuses_matching_link() {
+        let base = tempdir().expect("tempdir");
+        let target = tempdir().expect("tempdir");
+        let uid = nix::unistd::geteuid().as_raw();
+        let link = base.path().join("nono-link");
+
+        create_socket_link(&link, target.path(), uid).expect("first create");
+
+        create_socket_link(&link, target.path(), uid).expect("reuse existing link");
+        assert_eq!(
+            std::fs::canonicalize(&link).expect("resolves"),
+            std::fs::canonicalize(target.path()).expect("resolves"),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_socket_link_replaces_stale_target() {
+        let base = tempdir().expect("tempdir");
+        let old_target = tempdir().expect("tempdir");
+        let new_target = tempdir().expect("tempdir");
+        let uid = nix::unistd::geteuid().as_raw();
+        let link = base.path().join("nono-link");
+
+        // A link we own that points at a since-abandoned dir (e.g. after
+        // `$XDG_STATE_HOME` changed) is repointed at the current target.
+        std::os::unix::fs::symlink(old_target.path(), &link).expect("seed stale link");
+        create_socket_link(&link, new_target.path(), uid).expect("stale link is replaced");
+        assert_eq!(
+            std::fs::canonicalize(&link).expect("resolves"),
+            std::fs::canonicalize(new_target.path()).expect("resolves"),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_socket_link_refuses_non_symlink() {
+        let base = tempdir().expect("tempdir");
+        let target = tempdir().expect("tempdir");
+        let uid = nix::unistd::geteuid().as_raw();
+        let link = base.path().join("nono-link");
+
+        // A plain file where the link should be is refused, not removed.
+        std::fs::write(&link, b"not a symlink").expect("seed regular file");
+        let err =
+            create_socket_link(&link, target.path(), uid).expect_err("must refuse non-symlink");
+        assert!(
+            matches!(err, NonoError::ConfigParse(_)),
+            "expected a refusal, got {err:?}"
+        );
+        assert!(link.exists(), "the refused entry must be left untouched");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_socket_link_refuses_foreign_owner() {
+        let base = tempdir().expect("tempdir");
+        let target = tempdir().expect("tempdir");
+        let link = base.path().join("nono-link");
+        std::os::unix::fs::symlink(target.path(), &link).expect("seed our link");
+
+        let foreign = nix::unistd::geteuid().as_raw().wrapping_add(1);
+        let err = create_socket_link(&link, target.path(), foreign)
+            .expect_err("must refuse a link owned by another uid");
+        assert!(matches!(err, NonoError::ConfigParse(_)), "got {err:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes nolabs-ai/nono#1465

## Summary

Routes attach sockets through a symlink to avoid paths which are too long (i.e. >SUN_LEN)

## Test Plan

```
export XDG_STATE_HOME="$HOME/$(printf '-%.0s' {1..80})"
mkdir -p "XDG_STATE_HOME"
nono run --detached -- yes
```

## Checklist

- [X] An issue exists and is linked above
- [X] All commits are signed-off, using [DCO](<https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin>)
- [X] All new code follows the project's coding standards ([CLAUDE.md](<CLAUDE.md>)) and is covered by tests
- [X] Public-facing changes are paired with documentation updates
- [X] Release note has been added to `CHANGELOG.md` if needed