### PR TITLE
fix(undo): skip symlinks when walking snapshots

### DIFF
--- a/crates/nono-cli/src/rollback_preflight.rs
+++ b/crates/nono-cli/src/rollback_preflight.rs
@@ -115,6 +115,9 @@ pub(crate) fn run_preflight(
             .filter_entry(|e| !exclusion.is_excluded(e.path()))
             .filter_map(|e| e.ok())
         {
+            if entry.file_type().is_symlink() {
+                continue;
+            }
             if entry.path().is_file() {
                 file_count = file_count.saturating_add(1);
             }

--- a/crates/nono-cli/src/rollback_preflight.rs
+++ b/crates/nono-cli/src/rollback_preflight.rs
@@ -105,7 +105,7 @@ pub(crate) fn run_preflight(
     let mut capped = false;
 
     'outer: for tracked in tracked_paths {
-        if !tracked.exists() || tracked.is_file() {
+        if !tracked.exists() || tracked.is_file() || is_symlink(tracked) {
             continue;
         }
 
@@ -148,7 +148,7 @@ fn detect_heavy_dirs(
     let mut size_check_candidates = Vec::new();
 
     for tracked in tracked_paths {
-        if !tracked.exists() || tracked.is_file() {
+        if !tracked.exists() || tracked.is_file() || is_symlink(tracked) {
             continue;
         }
 
@@ -159,7 +159,7 @@ fn detect_heavy_dirs(
 
         for entry in entries.filter_map(|e| e.ok()) {
             let path = entry.path();
-            if !path.is_dir() {
+            if is_symlink(&path) || !path.is_dir() {
                 continue;
             }
 
@@ -203,7 +203,7 @@ fn detect_heavy_dirs(
         if size_check_start.elapsed() >= SIZE_CHECK_TOTAL_CAP {
             break;
         }
-        if exceeds_file_threshold(&path, exclusion) {
+        if exceeds_file_threshold(&path, exclusion, SIZE_THRESHOLD) {
             found.push(HeavyDir {
                 path,
                 name: name_str,
@@ -219,12 +219,17 @@ fn detect_heavy_dirs(
 }
 
 /// Check if a directory exceeds the file count threshold via bounded walk.
-/// Returns true if the directory contains more than `SIZE_THRESHOLD` files,
+/// Returns true if the directory contains more than `threshold` files,
 /// or if the time cap is hit before counting completes (assumes large).
 ///
-/// Applies the exclusion filter to skip already-excluded subtrees, ensuring
-/// the count reflects the effective snapshot scope.
-fn exceeds_file_threshold(path: &std::path::Path, exclusion: &ExclusionFilter) -> bool {
+/// Applies the exclusion filter to skip already-excluded subtrees, and skips
+/// symlinks the way the snapshot walk does, so the count reflects the
+/// effective snapshot scope.
+fn exceeds_file_threshold(
+    path: &std::path::Path,
+    exclusion: &ExclusionFilter,
+    threshold: usize,
+) -> bool {
     let start = Instant::now();
     let mut count: usize = 0;
 
@@ -234,19 +239,26 @@ fn exceeds_file_threshold(path: &std::path::Path, exclusion: &ExclusionFilter) -
         .filter_entry(|e| !exclusion.is_excluded(e.path()))
         .filter_map(|e| e.ok())
     {
-        if entry.path().is_file() {
+        if !entry.file_type().is_symlink() && entry.path().is_file() {
             count = count.saturating_add(1);
         }
-        if count > SIZE_THRESHOLD {
+        if count > threshold {
             return true;
         }
         if start.elapsed() >= SIZE_CHECK_TIME_CAP {
             // Time cap hit before we finished counting — treat as large
-            return count > SIZE_THRESHOLD / 2;
+            return count > threshold / 2;
         }
     }
 
     false
+}
+
+/// Whether `path` is a symlink, without following it.
+fn is_symlink(path: &std::path::Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 /// Print a one-line auto-exclude notice to stderr.
@@ -289,6 +301,68 @@ mod tests {
             force_include: Vec::new(),
         };
         ExclusionFilter::new(config, dir.path()).expect("filter")
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn heavy_dirs_ignores_symlinked_child() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let tracked = dir.path().join("project");
+        let elsewhere = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&tracked).expect("create tracked");
+        std::fs::create_dir_all(&elsewhere).expect("create elsewhere");
+        std::os::unix::fs::symlink(&elsewhere, tracked.join("node_modules")).expect("symlink");
+
+        let found = detect_heavy_dirs(&[tracked], &make_filter(vec![]), &[]);
+
+        let names: Vec<&str> = found.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            found.is_empty(),
+            "snapshotting skips symlinks, so none should be offered for exclusion: {names:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn heavy_dirs_ignores_symlinked_tracked_root() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let real = dir.path().join("real");
+        std::fs::create_dir_all(real.join("node_modules")).expect("create heavy dir");
+        let root_link = dir.path().join("linked-root");
+        std::os::unix::fs::symlink(&real, &root_link).expect("symlink");
+
+        let found = detect_heavy_dirs(&[root_link], &make_filter(vec![]), &[]);
+
+        assert!(
+            found.is_empty(),
+            "a symlinked tracked root is never walked at snapshot time"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn file_threshold_ignores_symlinks() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let target = dir.path().join("target.bin");
+        std::fs::write(&target, b"payload").expect("write target");
+        let links = dir.path().join("links");
+        std::fs::create_dir_all(&links).expect("create links dir");
+        for i in 0..5 {
+            std::os::unix::fs::symlink(&target, links.join(format!("link{i}"))).expect("symlink");
+        }
+
+        assert!(
+            !exceeds_file_threshold(&links, &make_filter(vec![]), 2),
+            "symlinks must not count toward the heavy-directory threshold"
+        );
+
+        for i in 0..5 {
+            std::fs::write(links.join(format!("real{i}.txt")), b"x").expect("write real file");
+        }
+        assert!(
+            exceeds_file_threshold(&links, &make_filter(vec![]), 2),
+            "real files still count"
+        );
     }
 
     #[test]

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -678,6 +678,14 @@ impl SnapshotManager {
                 continue;
             }
 
+            // Never follow a symlinked tracked root.
+            if fs::symlink_metadata(tracked)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
             let exclusion = self.filter_for_root(tracked);
 
             if tracked.is_file() {
@@ -721,6 +729,11 @@ impl SnapshotManager {
                 entries_visited = entries_visited.saturating_add(1);
                 self.check_budget(entries_visited, total_bytes)?;
                 let path = entry.path();
+                // Never follow symlinks at snapshot time. `WalkDir` already
+                // lstat'd this entry, so `is_symlink()` costs no extra syscall.
+                if entry.file_type().is_symlink() {
+                    continue;
+                }
                 if !path.is_file() {
                     continue;
                 }
@@ -770,6 +783,13 @@ impl SnapshotManager {
                 continue;
             }
 
+            if fs::symlink_metadata(tracked)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
             let exclusion = self.filter_for_root(tracked);
 
             if tracked.is_file() {
@@ -793,6 +813,10 @@ impl SnapshotManager {
                 entries_visited = entries_visited.saturating_add(1);
                 self.check_budget(entries_visited, total_bytes)?;
                 let path = entry.path();
+
+                if entry.file_type().is_symlink() {
+                    continue;
+                }
                 if !path.is_file() {
                     continue;
                 }

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -1718,6 +1718,35 @@ mod tests {
     }
 
     #[test]
+    fn symlink_to_large_file_not_counted_against_budget() {
+        let (dir, tracked) = setup_test_dir();
+        let session_dir = dir.path().join("session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let big = dir.path().join("big.bin");
+        fs::write(&big, vec![0u8; 64 * 1024]).expect("write big target");
+        let link = tracked.join("link-to-big");
+        std::os::unix::fs::symlink(&big, &link).expect("create symlink");
+
+        let mut manager = make_manager_with_budget(
+            &session_dir,
+            &tracked,
+            WalkBudget {
+                max_entries: 0,
+                max_bytes: 4096,
+            },
+        );
+
+        let manifest = manager.create_baseline().expect("baseline should succeed");
+        assert!(
+            !manifest.files.contains_key(&link),
+            "symlink should not be tracked as a file"
+        );
+        assert!(manifest.files.contains_key(&tracked.join("file1.txt")));
+        assert!(manifest.files.contains_key(&tracked.join("file2.txt")));
+    }
+
+    #[test]
     fn collect_atomic_temp_prunes_excluded_dirs() {
         let dir = TempDir::new().expect("tempdir");
         let tracked = dir.path().join("project");

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -1282,6 +1282,73 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn restore_removes_symlinks_created_during_session() {
+        let (dir, tracked) = setup_test_dir();
+        let session_dir = dir.path().join("session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let outside = dir.path().join("outside.txt");
+        fs::write(&outside, b"OUTSIDE").expect("write outside file");
+
+        let mut manager = make_manager(&session_dir, &tracked);
+        let baseline = manager.create_baseline().expect("baseline");
+
+        let planted = tracked.join("planted-link");
+        let dangling = tracked.join("dangling-link");
+        std::os::unix::fs::symlink(&outside, &planted).expect("create symlink");
+        std::os::unix::fs::symlink(dir.path().join("missing.txt"), &dangling)
+            .expect("create dangling symlink");
+
+        let applied = manager.restore_to(&baseline).expect("restore");
+
+        for link in [&planted, &dangling] {
+            assert!(
+                fs::symlink_metadata(link).is_err(),
+                "session symlink {} should be unlinked",
+                link.display()
+            );
+            let change = applied
+                .iter()
+                .find(|c| &c.path == link)
+                .expect("symlink removal should be reported");
+            assert_eq!(change.change_type, ChangeType::Deleted);
+        }
+
+        assert_eq!(
+            fs::read_to_string(&outside).expect("read outside file"),
+            "OUTSIDE"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn restore_diff_reports_session_symlink_as_deleted() {
+        let (dir, tracked) = setup_test_dir();
+        let session_dir = dir.path().join("session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let outside = dir.path().join("outside.txt");
+        fs::write(&outside, b"OUTSIDE").expect("write outside file");
+
+        let mut manager = make_manager(&session_dir, &tracked);
+        let baseline = manager.create_baseline().expect("baseline");
+
+        let planted = tracked.join("planted-link");
+        std::os::unix::fs::symlink(&outside, &planted).expect("create symlink");
+
+        let diff = manager
+            .compute_restore_diff(&baseline)
+            .expect("compute diff");
+        let change = diff
+            .iter()
+            .find(|c| c.path == planted)
+            .expect("diff should preview the symlink removal");
+        assert_eq!(change.change_type, ChangeType::Deleted);
+
+        // Dry run must not touch the filesystem.
+        assert!(fs::symlink_metadata(&planted).is_ok());
+    }
+
+    #[test]
     fn merkle_root_differs_between_snapshots() {
         let (dir, tracked) = setup_test_dir();
         let session_dir = dir.path().join("session");

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -41,6 +41,16 @@ impl Default for WalkBudget {
     }
 }
 
+/// What a walk over the tracked roots found.
+///
+/// Files and symlinks are kept apart because they are handled differently:
+/// files are hashed (and stored, for `walk_and_store`), while symlinks are
+/// only recorded by path.
+struct WalkResult {
+    files: HashMap<PathBuf, FileState>,
+    symlinks: HashSet<PathBuf>,
+}
+
 /// Manages snapshots for an undo session.
 ///
 /// Coordinates the object store, exclusion filter, and Merkle tree to
@@ -141,14 +151,15 @@ impl SnapshotManager {
     /// stores each file, builds the manifest with Merkle root, and writes
     /// it atomically to `snapshots/000.json`.
     pub fn create_baseline(&mut self) -> Result<SnapshotManifest> {
-        let files = self.walk_and_store()?;
-        let merkle = MerkleTree::from_manifest(&files)?;
+        let walked = self.walk_and_store()?;
+        let merkle = MerkleTree::from_manifest(&walked.files)?;
 
         let manifest = SnapshotManifest {
             number: 0,
             timestamp: now_epoch_secs(),
             parent: None,
-            files,
+            files: walked.files,
+            symlinks: walked.symlinks,
             merkle_root: *merkle.root(),
         };
 
@@ -166,16 +177,17 @@ impl SnapshotManager {
         &mut self,
         previous: &SnapshotManifest,
     ) -> Result<(SnapshotManifest, Vec<Change>)> {
-        let current_files = self.walk_and_store()?;
-        let changes = compute_changes(&previous.files, &current_files);
-        let merkle = MerkleTree::from_manifest(&current_files)?;
+        let walked = self.walk_and_store()?;
+        let changes = compute_changes(&previous.files, &walked.files);
+        let merkle = MerkleTree::from_manifest(&walked.files)?;
 
         let number = previous.number.saturating_add(1);
         let manifest = SnapshotManifest {
             number,
             timestamp: now_epoch_secs(),
             parent: Some(previous.number),
-            files: current_files,
+            files: walked.files,
+            symlinks: walked.symlinks,
             merkle_root: *merkle.root(),
         };
 
@@ -203,7 +215,8 @@ impl SnapshotManager {
     /// the list of changes that would be applied. Useful for dry-run previews.
     pub fn compute_restore_diff(&self, manifest: &SnapshotManifest) -> Result<Vec<Change>> {
         self.validate_manifest_paths(manifest)?;
-        let current_files = self.walk_current()?;
+        let current = self.walk_current()?;
+        let current_files = current.files;
         let mut changes = Vec::new();
 
         for (path, state) in &manifest.files {
@@ -241,21 +254,41 @@ impl SnapshotManager {
             }
         }
 
+        for path in &current.symlinks {
+            if Self::symlink_needs_cleanup(manifest, path) {
+                changes.push(Change {
+                    path: path.clone(),
+                    change_type: ChangeType::Deleted,
+                    size_delta: None,
+                    old_hash: None,
+                    new_hash: None,
+                });
+            }
+        }
+
         changes.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(changes)
+    }
+
+    /// Whether restore should unlink `path`, a symlink found on disk now.
+    fn symlink_needs_cleanup(manifest: &SnapshotManifest, path: &Path) -> bool {
+        !manifest.symlinks.contains(path) && !manifest.files.contains_key(path)
     }
 
     /// Restore filesystem to the state captured by the given manifest.
     ///
     /// For each file in the manifest: restores content from object store
     /// via atomic temp+rename. Deletes files that exist on disk but aren't
-    /// in the manifest. Returns the list of changes applied.
+    /// in the manifest, and unlinks symlinks the session created. Symlinks
+    /// recorded in the manifest are left in place; a link the session deleted
+    /// is not recreated, since manifests do not store link targets.
     ///
     /// All manifest paths are validated to be within tracked directories
     /// before any writes occur.
     pub fn restore_to(&self, manifest: &SnapshotManifest) -> Result<Vec<Change>> {
         self.validate_manifest_paths(manifest)?;
-        let current_files = self.walk_current()?;
+        let current = self.walk_current()?;
+        let current_files = current.files;
         let mut applied_changes = Vec::new();
 
         for (path, state) in &manifest.files {
@@ -329,6 +362,30 @@ impl SnapshotManager {
                         new_hash: None,
                     });
                 }
+            }
+        }
+
+        // Unlink symlinks the session created. `remove_file` unlinks the link
+        // itself and never follows it, so the target is untouched, but the
+        // path leading to it still has to be free of symlinked components.
+        for path in &current.symlinks {
+            if !Self::symlink_needs_cleanup(manifest, path) {
+                continue;
+            }
+            if let Err(e) = self.validate_restore_target(path) {
+                tracing::warn!("Skipping symlink cleanup for {}: {}", path.display(), e);
+                continue;
+            }
+            if let Err(e) = fs::remove_file(path) {
+                tracing::warn!("Failed to remove symlink {}: {}", path.display(), e);
+            } else {
+                applied_changes.push(Change {
+                    path: path.clone(),
+                    change_type: ChangeType::Deleted,
+                    size_delta: None,
+                    old_hash: None,
+                    new_hash: None,
+                });
             }
         }
 
@@ -438,9 +495,12 @@ impl SnapshotManager {
     /// file, and returns the Merkle root. This is useful for audit-only
     /// sessions that need a cryptographic commitment to filesystem state
     /// without the overhead of full snapshot storage.
+    ///
+    /// The commitment covers regular files only. Symlinks are not followed
+    /// and do not contribute to the root.
     pub fn compute_merkle_root(&self) -> Result<ContentHash> {
-        let files = self.walk_current()?;
-        let merkle = MerkleTree::from_manifest(&files)?;
+        let walked = self.walk_current()?;
+        let merkle = MerkleTree::from_manifest(&walked.files)?;
         Ok(*merkle.root())
     }
 
@@ -550,13 +610,14 @@ impl SnapshotManager {
         Ok(())
     }
 
-    /// Validate the live filesystem path that restore will write through.
+    /// Validate the live filesystem path that restore will write through or
+    /// unlink.
     ///
     /// Manifest validation is lexical: it proves stored paths are under tracked
     /// roots, but it cannot see symlinks created after the snapshot. Restore
     /// runs outside the sandbox, so every existing parent component at or below
     /// the tracked root must be a real directory before `create_dir_all`,
-    /// temp-file creation, rename, or chmod touches the path.
+    /// temp-file creation, rename, chmod, or unlink touches the path.
     fn validate_restore_target(&self, path: &Path) -> Result<()> {
         let tracked = self
             .tracked_paths
@@ -668,8 +729,9 @@ impl SnapshotManager {
         )
     }
 
-    fn walk_and_store(&self) -> Result<HashMap<PathBuf, FileState>> {
+    fn walk_and_store(&self) -> Result<WalkResult> {
         let mut files = HashMap::new();
+        let mut symlinks = HashSet::new();
         let mut entries_visited: usize = 0;
         let mut total_bytes: u64 = 0;
 
@@ -732,6 +794,7 @@ impl SnapshotManager {
                 // Never follow symlinks at snapshot time. `WalkDir` already
                 // lstat'd this entry, so `is_symlink()` costs no extra syscall.
                 if entry.file_type().is_symlink() {
+                    symlinks.insert(path.to_path_buf());
                     continue;
                 }
                 if !path.is_file() {
@@ -767,14 +830,15 @@ impl SnapshotManager {
             }
         }
 
-        Ok(files)
+        Ok(WalkResult { files, symlinks })
     }
 
     /// Walk tracked paths to get current file states without storing.
     ///
     /// Uses `filter_entry()` to prune excluded subtrees and enforces the walk budget.
-    fn walk_current(&self) -> Result<HashMap<PathBuf, FileState>> {
+    fn walk_current(&self) -> Result<WalkResult> {
         let mut files = HashMap::new();
+        let mut symlinks = HashSet::new();
         let mut entries_visited: usize = 0;
         let mut total_bytes: u64 = 0;
 
@@ -815,6 +879,7 @@ impl SnapshotManager {
                 let path = entry.path();
 
                 if entry.file_type().is_symlink() {
+                    symlinks.insert(path.to_path_buf());
                     continue;
                 }
                 if !path.is_file() {
@@ -829,7 +894,7 @@ impl SnapshotManager {
             }
         }
 
-        Ok(files)
+        Ok(WalkResult { files, symlinks })
     }
 
     /// Hash a file, store it in the object store, and return its FileState.
@@ -1322,6 +1387,36 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn restore_keeps_symlinks_present_at_baseline() {
+        let (dir, tracked) = setup_test_dir();
+        let session_dir = dir.path().join("session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let outside = dir.path().join("outside.txt");
+        fs::write(&outside, b"OUTSIDE").expect("write outside file");
+
+        let preexisting = tracked.join("preexisting-link");
+        std::os::unix::fs::symlink(&outside, &preexisting).expect("create symlink");
+
+        let mut manager = make_manager(&session_dir, &tracked);
+        let baseline = manager.create_baseline().expect("baseline");
+        assert!(
+            baseline.symlinks.contains(&preexisting),
+            "baseline should record the symlink path"
+        );
+        assert!(
+            !baseline.files.contains_key(&preexisting),
+            "symlink must not be tracked as a file"
+        );
+
+        fs::write(tracked.join("file1.txt"), b"modified").expect("modify");
+        manager.restore_to(&baseline).expect("restore");
+
+        let meta = fs::symlink_metadata(&preexisting).expect("baseline symlink should survive");
+        assert!(meta.file_type().is_symlink());
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn restore_diff_reports_session_symlink_as_deleted() {
         let (dir, tracked) = setup_test_dir();
         let session_dir = dir.path().join("session");
@@ -1346,6 +1441,38 @@ mod tests {
 
         // Dry run must not touch the filesystem.
         assert!(fs::symlink_metadata(&planted).is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn restore_never_removes_a_symlinked_tracked_root() {
+        let dir = TempDir::new().expect("tempdir");
+        let real = dir.path().join("real");
+        fs::create_dir_all(&real).expect("create real dir");
+        fs::write(real.join("file1.txt"), b"hello world").expect("write file1");
+        let root_link = dir.path().join("linked-root");
+        std::os::unix::fs::symlink(&real, &root_link).expect("create root symlink");
+
+        let session_dir = dir.path().join("session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let mut manager = make_manager(&session_dir, &root_link);
+        let baseline = manager.create_baseline().expect("baseline");
+        assert!(baseline.files.is_empty(), "symlinked root is not walked");
+        assert!(
+            baseline.symlinks.is_empty(),
+            "symlinked root is not tracked"
+        );
+
+        manager.restore_to(&baseline).expect("restore");
+
+        assert!(
+            fs::symlink_metadata(&root_link)
+                .expect("tracked root should survive")
+                .file_type()
+                .is_symlink()
+        );
+        assert!(real.join("file1.txt").exists());
     }
 
     #[test]
@@ -1607,6 +1734,7 @@ mod tests {
             number: 0,
             parent: None,
             files,
+            symlinks: HashSet::new(),
             merkle_root: ContentHash::from_bytes([0; 32]),
             timestamp: "2025-01-01T00:00:00Z".to_string(),
         };
@@ -1643,6 +1771,7 @@ mod tests {
             number: 0,
             parent: None,
             files,
+            symlinks: HashSet::new(),
             merkle_root: ContentHash::from_bytes([0; 32]),
             timestamp: "2025-01-01T00:00:00Z".to_string(),
         };

--- a/crates/nono/src/undo/types.rs
+++ b/crates/nono/src/undo/types.rs
@@ -4,7 +4,7 @@
 //! used by the object store and snapshot manager.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -478,6 +478,9 @@ pub struct SnapshotManifest {
     pub parent: Option<u32>,
     /// Map of file paths to their state at snapshot time
     pub files: HashMap<PathBuf, FileState>,
+    /// Symlinks present under the tracked roots at snapshot time.
+    #[serde(default)]
+    pub symlinks: HashSet<PathBuf>,
     /// Merkle root over all file hashes (cryptographic state commitment)
     pub merkle_root: ContentHash,
 }
@@ -549,6 +552,7 @@ mod tests {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             parent: None,
             files: HashMap::new(),
+            symlinks: HashSet::new(),
             merkle_root: ContentHash::from_bytes([0u8; 32]),
         };
         let json = serde_json::to_string(&manifest).expect("should serialize");
@@ -556,5 +560,19 @@ mod tests {
         assert_eq!(parsed.number, 0);
         assert!(parsed.parent.is_none());
         assert!(parsed.files.is_empty());
+        assert!(parsed.symlinks.is_empty());
+    }
+
+    #[test]
+    fn snapshot_manifest_loads_without_symlink_field() {
+        let json = r#"{
+            "number": 0,
+            "timestamp": "2025-01-01T00:00:00Z",
+            "parent": null,
+            "files": {},
+            "merkle_root": "0000000000000000000000000000000000000000000000000000000000000000"
+        }"#;
+        let parsed: SnapshotManifest = serde_json::from_str(json).expect("should deserialize");
+        assert!(parsed.symlinks.is_empty());
     }
 }


### PR DESCRIPTION
## Linked Issue
Closes #1480 

## Summary
Skips symlinks when walking snapshots to avoid including the size erroneously in budgets.

## Test Plan
Steps to reproduce

Red/green test added

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed
