### PR TITLE
fix: allow non-UTF-8 command line arguments

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -5,6 +5,7 @@
 
 use clap::builder::styling::{Style, Styles};
 use clap::{Parser, Subcommand, ValueEnum};
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 const STYLES: Styles = Styles::plain().header(Style::new().bold());
@@ -2102,7 +2103,7 @@ pub struct RunArgs {
 
     /// Command to run inside the sandbox (optional if profile specifies `binary`)
     #[arg(hide = true)]
-    pub command: Vec<String>,
+    pub command: Vec<OsString>,
 
     /// Print help
     #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
@@ -2150,7 +2151,7 @@ pub struct WrapArgs {
 
     /// Command to run inside the sandbox
     #[arg(required = true, hide = true)]
-    pub command: Vec<String>,
+    pub command: Vec<OsString>,
 
     /// Print help
     #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
@@ -2194,7 +2195,7 @@ pub struct WhyArgs {
 
     /// Arguments for --command after `--`
     #[arg(last = true, value_name = "ARGS", help_heading = "QUERY")]
-    pub command_args: Vec<String>,
+    pub command_args: Vec<OsString>,
 
     /// Path to check
     #[arg(long, help_heading = "QUERY")]
@@ -2318,7 +2319,7 @@ pub struct LearnArgs {
 
     /// Command to trace
     #[arg(required = true, hide = true)]
-    pub command: Vec<String>,
+    pub command: Vec<OsString>,
 
     /// Print help
     #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -17,9 +17,17 @@ pub(crate) fn normalize_legacy_flag_env_vars() {
     copy_legacy_env_var("NONO_EXTERNAL_PROXY_BYPASS", "NONO_UPSTREAM_BYPASS");
 }
 
-pub(crate) fn collect_legacy_network_warnings() -> Vec<String> {
+/// Collect deprecation warnings for legacy network flags and env vars.
+///
+/// Every legacy flag below is ASCII, so comparing lossily can only fail to
+/// match an argument that was never a legacy flag to begin with.
+pub(crate) fn collect_legacy_network_warnings(args: &[std::ffi::OsString]) -> Vec<String> {
     let mut warnings = Vec::new();
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<std::borrow::Cow<'_, str>> = args
+        .iter()
+        .skip(1)
+        .map(|arg| arg.to_string_lossy())
+        .collect();
 
     // (legacy, replacement, remove_by)
     for (legacy, replacement, remove_by) in [
@@ -44,7 +52,7 @@ pub(crate) fn collect_legacy_network_warnings() -> Vec<String> {
     ] {
         if args
             .iter()
-            .any(|arg| arg == legacy || arg.starts_with(&format!("{legacy}=")))
+            .any(|arg| arg.as_ref() == legacy || arg.starts_with(&format!("{legacy}=")))
         {
             let mut message = if let Some(replacement) = replacement {
                 format!("Warning: `{legacy}` is deprecated; use `{replacement}` instead.")
@@ -291,9 +299,58 @@ impl Write for SharedFileWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::SharedFileMakeWriter;
+    use super::{SharedFileMakeWriter, collect_legacy_network_warnings};
+    use std::ffi::{OsStr, OsString};
     use std::io::{Read, Write};
+    use std::os::unix::ffi::OsStrExt;
     use tracing_subscriber::fmt::writer::MakeWriter;
+
+    /// Issue #1504: this scan runs before clap, so reading argv as `String`
+    /// aborted the process before any diagnostic could be printed.
+    #[test]
+    fn legacy_network_warnings_tolerate_non_utf8_args() {
+        let args = vec![
+            OsString::from("nono"),
+            OsString::from("run"),
+            OsStr::from_bytes(b"\xff").to_os_string(),
+        ];
+
+        assert!(collect_legacy_network_warnings(&args).is_empty());
+    }
+
+    /// A non-UTF-8 element elsewhere in argv must not stop the scan from
+    /// recognising a legacy flag that really is present.
+    #[test]
+    fn legacy_network_warnings_still_match_alongside_non_utf8_args() {
+        let args = vec![
+            OsString::from("nono"),
+            OsString::from("run"),
+            OsString::from("--allow-net"),
+            OsStr::from_bytes(b"\xff").to_os_string(),
+        ];
+
+        let warnings = collect_legacy_network_warnings(&args);
+
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("`--allow-net` is deprecated"),
+            "warnings: {warnings:?}"
+        );
+    }
+
+    /// The scan starts at argv[1] because argv[0] holds the program, which a
+    /// caller may set to anything. The same string warns when passed as a flag
+    /// and must not warn when it is the program.
+    #[test]
+    fn legacy_network_warnings_ignore_the_program_slot() {
+        let flag = OsString::from("--allow-net");
+
+        let as_program = vec![flag.clone()];
+        assert!(collect_legacy_network_warnings(&as_program).is_empty());
+
+        let as_flag = vec![OsString::from("/usr/local/bin/nono"), flag];
+        assert_eq!(collect_legacy_network_warnings(&as_flag).len(), 1);
+    }
 
     #[test]
     fn shared_file_make_writer_appends_output() {

--- a/crates/nono-cli/src/command_display.rs
+++ b/crates/nono-cli/src/command_display.rs
@@ -1,20 +1,26 @@
 //! Helpers for rendering user-supplied commands for display.
 //!
-//! Commands passed to `nono` (e.g. after `--`) preserve each argument as a
-//! separate `String`. When we echo those commands back to the user — in the
-//! `nono learn` "Run with:" hint, the dry-run banner, `nono ps` details,
-//! audit/rollback listings — we want the rendered line to round-trip: a user
-//! copy-pasting it into a shell must execute the exact same argv that was
-//! learned or recorded.
+//! Commands passed to `nono` (e.g. after `--`) preserve each argument
+//! separately, as an `OsString` on the execution path. When we echo those
+//! commands back to the user — in the `nono learn` "Run with:" hint, the dry-run
+//! banner, `nono ps` details, audit/rollback listings — we want the rendered
+//! line to round-trip: a user copy-pasting it into a shell must execute the
+//! exact same argv that was learned or recorded.
 //!
 //! A naive `command.join(" ")` breaks that contract as soon as any argument
 //! contains whitespace, quotes, `$`, backslashes, etc. `echo 'foo bar' baz`
 //! becomes `echo foo bar baz` (three args instead of two). See issue #660.
 //!
+//! Round-tripping holds only for arguments that are valid UTF-8. Rendering is
+//! infallible by design, so invalid bytes become U+FFFD and no longer name what
+//! the child received; word boundaries survive, the bytes do not. Nothing here
+//! may feed an execution path — see `exec_strategy::build_execve_argv`.
+//!
 //! This module centralises shell-quoting via [`shlex::try_quote`] so all
 //! display sites stay consistent.
 
 use std::borrow::Cow;
+use std::ffi::OsStr;
 
 /// Quote a single argument for POSIX shell display.
 ///
@@ -36,10 +42,10 @@ fn quote_arg(arg: &str) -> Cow<'_, str> {
 ///
 /// Each element is quoted independently with [`shlex::try_quote`] and joined
 /// with spaces. Empty `command` returns an empty string.
-pub(crate) fn format_command_line(command: &[String]) -> String {
+pub(crate) fn format_command_line<S: AsRef<OsStr>>(command: &[S]) -> String {
     command
         .iter()
-        .map(|a| quote_arg(a))
+        .map(|a| quote_arg(&a.as_ref().to_string_lossy()).into_owned())
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -78,7 +84,7 @@ pub(crate) fn truncate_chars(s: &str, max_len: usize) -> String {
 ///
 /// Thin wrapper over [`truncate_chars`]; see that function for truncation
 /// semantics.
-pub(crate) fn truncate_command(command: &[String], max_len: usize) -> String {
+pub(crate) fn truncate_command<S: AsRef<OsStr>>(command: &[S], max_len: usize) -> String {
     truncate_chars(&format_command_line(command), max_len)
 }
 
@@ -134,7 +140,7 @@ mod tests {
 
     #[test]
     fn empty_command_returns_empty_string() {
-        assert_eq!(format_command_line(&[]), "");
+        assert_eq!(format_command_line::<&str>(&[]), "");
     }
 
     #[test]
@@ -168,6 +174,31 @@ mod tests {
         // Char-aware: keep `max_len - 3 = 2` chars (`'é`), append "...".
         assert_eq!(result, "'é...");
         assert!(result.chars().count() <= 5);
+    }
+
+    /// Issue #1504: argv reaching this module may contain bytes that are not
+    /// valid UTF-8. Rendering must stay infallible and must not panic; losing
+    /// the exact bytes is expected here, since this output is for humans.
+    #[test]
+    fn non_utf8_args_render_lossily_without_panicking() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let cmd = vec![
+            OsString::from("echo"),
+            OsStr::from_bytes(b"pre\xffpost").to_os_string(),
+        ];
+
+        let out = format_command_line(&cmd);
+
+        assert!(out.starts_with("echo "), "out: {out}");
+        assert!(
+            out.contains('\u{FFFD}'),
+            "invalid bytes should surface as U+FFFD, out: {out}"
+        );
+        // Still a single shell word, so the rendered line remains parseable.
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed.len(), 2, "reparsed: {reparsed:?}");
     }
 
     #[test]

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -128,7 +128,7 @@ pub(crate) fn strip_untrusted_unsafe_seatbelt_rules(
 /// (and is a user profile), use it. If the CLI also provides a trailing
 /// command, warn that the profile binary takes precedence.
 fn resolve_program_from_profile_or_cli(
-    cli_command: &[String],
+    cli_command: &[OsString],
     loaded_profile: Option<(&str, &profile::Profile)>,
     silent: bool,
 ) -> Result<(OsString, Vec<OsString>)> {
@@ -140,16 +140,13 @@ fn resolve_program_from_profile_or_cli(
             crate::output::print_warning(&format!(
                 "Profile specifies binary '{}'; ignoring trailing command '{}'",
                 binary,
-                cli_command.join(" ")
+                crate::command_display::format_command_line(cli_command)
             ));
         }
         let program = OsString::from(&binary);
         Ok((program, Vec::new()))
-    } else if !cli_command.is_empty() {
-        let mut iter = cli_command.iter();
-        let program = OsString::from(iter.next().ok_or(NonoError::NoCommand)?);
-        let cmd_args: Vec<OsString> = iter.map(OsString::from).collect();
-        Ok((program, cmd_args))
+    } else if let Some((program, cmd_args)) = cli_command.split_first() {
+        Ok((program.clone(), cmd_args.to_vec()))
     } else {
         Err(NonoError::NoCommand)
     }
@@ -337,13 +334,11 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
     let command = wrap_args.command;
     let no_diagnostics = wrap_args.no_diagnostics;
 
-    if command.is_empty() {
+    let Some((program, cmd_args)) = command.split_first() else {
         return Err(NonoError::NoCommand);
-    }
-
-    let mut command_iter = command.into_iter();
-    let program = OsString::from(command_iter.next().ok_or(NonoError::NoCommand)?);
-    let cmd_args: Vec<OsString> = command_iter.map(OsString::from).collect();
+    };
+    let program = program.clone();
+    let cmd_args = cmd_args.to_vec();
 
     if args.dry_run {
         let prepared = prepare_sandbox(&args, silent)?;

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -53,13 +53,34 @@ pub(crate) use env_sanitization::validate_set_vars;
 ///
 /// # Errors
 /// Returns an error if the program cannot be found in PATH or as a valid path.
-pub fn resolve_program(program: &str) -> Result<PathBuf> {
+pub fn resolve_program(program: &OsStr) -> Result<PathBuf> {
     which::which(program).map_err(|e| {
+        // Escaped only when the name is not valid UTF-8: this message names the
+        // program that could not be found, so those bytes must stay legible,
+        // but escaping the ordinary case would just add quotes to every miss.
+        let shown = program
+            .to_str()
+            .map_or_else(|| format!("{program:?}"), str::to_owned);
         NonoError::CommandExecution(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            format!("{}: {}", program, e),
+            format!("{shown}: {e}"),
         ))
     })
+}
+
+/// Build the `argv` vector handed to `execve`: the resolved program followed by
+/// each argument.
+///
+/// Rejects an embedded NUL, which cannot be represented in argv at all.
+fn build_execve_argv(program_c: &CString, cmd_args: &[std::ffi::OsString]) -> Result<Vec<CString>> {
+    let mut argv_c: Vec<CString> = Vec::with_capacity(1 + cmd_args.len());
+    argv_c.push(program_c.clone());
+    for arg in cmd_args {
+        argv_c.push(CString::new(arg.as_bytes()).map_err(|_| {
+            NonoError::SandboxInit(format!("Argument contains null byte: {arg:?}"))
+        })?);
+    }
+    Ok(argv_c)
 }
 
 /// Maximum threads allowed when keyring backend is active.
@@ -83,7 +104,7 @@ pub(crate) struct ProfileSaveOffer<'a> {
     pub(crate) policy_explanations: &'a [crate::diagnostic::PolicyExplanation],
     pub(crate) error_observation: &'a crate::diagnostic::ErrorObservation,
     pub(crate) caps: &'a CapabilitySet,
-    pub(crate) command: &'a [String],
+    pub(crate) command: &'a [std::ffi::OsString],
     pub(crate) compared_profile: Option<&'a str>,
     pub(crate) sandbox_violations: &'a [nono::SandboxViolation],
     pub(crate) ignored_denial_paths: &'a [std::path::PathBuf],
@@ -226,7 +247,7 @@ impl SeccompPolicy {
 /// Configuration for command execution.
 pub struct ExecConfig<'a> {
     /// The command to execute (program + args).
-    pub command: &'a [String],
+    pub command: &'a [std::ffi::OsString],
     /// Pre-resolved absolute path to the program.
     /// This is resolved BEFORE the sandbox is applied to ensure the program
     /// can be found even if its directory is not in the sandbox's allowed paths.
@@ -508,25 +529,17 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
     let program = &config.command[0];
     let cmd_args = &config.command[1..];
 
-    info!("Executing (supervised): {} {:?}", program, cmd_args);
+    info!("Executing (supervised): {:?} {:?}", program, cmd_args);
 
     // Use pre-resolved program path (resolved before fork)
     let program_path = config.resolved_program;
 
-    // Convert program path to CString for execve
-    let program_c = CString::new(program_path.to_string_lossy().as_bytes())
+    let program_c = CString::new(program_path.as_os_str().as_bytes())
         .map_err(|_| NonoError::SandboxInit("Program path contains null byte".to_string()))?;
     let current_dir_c = CString::new(config.current_dir.as_os_str().as_bytes())
         .map_err(|_| NonoError::SandboxInit("Working directory contains null byte".to_string()))?;
 
-    // Build argv: [program, args..., NULL]
-    let mut argv_c: Vec<CString> = Vec::with_capacity(1 + cmd_args.len());
-    argv_c.push(program_c.clone());
-    for arg in cmd_args {
-        argv_c.push(CString::new(arg.as_bytes()).map_err(|_| {
-            NonoError::SandboxInit(format!("Argument contains null byte: {}", arg))
-        })?);
-    }
+    let argv_c = build_execve_argv(&program_c, cmd_args)?;
 
     // Create supervisor socket pair only when the exec'd child actually needs
     // to talk back to the unsandboxed parent. The supervised parent/session
@@ -1718,11 +1731,16 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
                     )
                     .with_canonical_denial_paths(canonical_denial_paths);
                 if let Some(program) = config.command.first() {
+                    let argv_display: Vec<String> = config
+                        .command
+                        .iter()
+                        .map(|arg| arg.to_string_lossy().into_owned())
+                        .collect();
                     base_formatter =
                         base_formatter.with_command(crate::diagnostic::CommandContext {
-                            program: program.clone(),
+                            program: program.to_string_lossy().into_owned(),
                             resolved_path: config.resolved_program.to_path_buf(),
-                            args: nono::scrub_argv_with_policy(config.command, redaction_policy),
+                            args: nono::scrub_argv_with_policy(&argv_display, redaction_policy),
                         });
                 }
 
@@ -4380,6 +4398,49 @@ mod tests {
             .iter()
             .map(|c| c.to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// Issue #1504: argv elements are byte strings on Unix, so an argument that
+    /// is not valid UTF-8 must reach `execve` unchanged rather than being
+    /// lossily rewritten to U+FFFD.
+    #[test]
+    fn build_execve_argv_preserves_non_utf8_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let program_c = CString::new("/bin/echo").expect("program cstring");
+        let raw = OsStr::from_bytes(b"pre\xffpost").to_os_string();
+        let args = vec![OsString::from("plain"), raw];
+
+        let argv = build_execve_argv(&program_c, &args).expect("build argv");
+
+        assert_eq!(argv.len(), 3, "program plus both arguments");
+        assert_eq!(argv[0].as_bytes(), b"/bin/echo");
+        assert_eq!(argv[1].as_bytes(), b"plain");
+        assert_eq!(
+            argv[2].as_bytes(),
+            b"pre\xffpost",
+            "non-UTF-8 argument must survive byte-for-byte"
+        );
+        assert!(
+            !argv[2]
+                .as_bytes()
+                .windows(3)
+                .any(|w| w == [0xef, 0xbf, 0xbd]),
+            "argument must not contain the U+FFFD replacement character"
+        );
+    }
+
+    /// An embedded NUL cannot be represented in argv, so it is the one input
+    /// that must be rejected rather than forwarded.
+    #[test]
+    fn build_execve_argv_rejects_embedded_nul() {
+        use std::ffi::OsString;
+
+        let program_c = CString::new("/bin/echo").expect("program cstring");
+        let args = vec![OsString::from("bad\0arg")];
+
+        assert!(build_execve_argv(&program_c, &args).is_err());
     }
 
     #[test]

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -184,12 +184,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         });
     }
 
-    let command: Vec<String> = std::iter::once(program.to_string_lossy().into_owned())
-        .chain(
-            cmd_args
-                .iter()
-                .map(|arg| arg.to_string_lossy().into_owned()),
-        )
+    let command: Vec<std::ffi::OsString> = std::iter::once(program.clone())
+        .chain(cmd_args.iter().cloned())
         .collect();
 
     if command.is_empty() {
@@ -197,6 +193,11 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     }
 
     let resolved_program = exec_strategy::resolve_program(&command[0])?;
+
+    // Lossy is sound for the policy lookups below because every key they match
+    // against comes from JSON, so it is valid UTF-8.
+    let program_display = command[0].to_string_lossy().into_owned();
+
     let known_builtin_profile = recommended_builtin_profile(&resolved_program);
     let recommended_profile = if flags.session.profile_name.is_none() {
         known_builtin_profile
@@ -207,7 +208,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let recommended_program_name = resolved_program
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or(&command[0]);
+        .unwrap_or(&program_display);
 
     if let Some(profile) = recommended_profile {
         output::print_profile_hint(recommended_program_name, profile, flags.silent);
@@ -407,7 +408,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let tool_sandbox_initial_shim = tool_sandbox_runtime
         .as_ref()
-        .and_then(|runtime| runtime.shim_for_initial_command(&command[0]))
+        .and_then(|runtime| runtime.shim_for_initial_command(&program_display))
         .map(std::path::Path::to_path_buf);
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let exec_resolved_program = tool_sandbox_initial_shim
@@ -418,7 +419,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     if let Some(runtime) = tool_sandbox_runtime.as_ref()
-        && let Some(err) = runtime.validate_initial_exec(&command[0], &resolved_program)?
+        && let Some(err) = runtime.validate_initial_exec(&program_display, &resolved_program)?
     {
         return Err(err);
     }
@@ -660,10 +661,14 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             unreachable!("execute_direct only returns on error");
         }
         exec_strategy::ExecStrategy::Supervised => {
+            let command_display: Vec<String> = command
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect();
             let exit_result = execute_supervised_runtime(SupervisedRuntimeContext {
                 config: &config,
                 caps: &caps,
-                command: &command,
+                command: &command_display,
                 session,
                 rollback,
                 trust,

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -491,7 +491,7 @@ pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
 /// nettop runs in CSV logging mode (`-L 0`) polling at 1-second intervals.
 #[cfg(target_os = "macos")]
 fn run_fs_usage_and_nettop(
-    command: &[String],
+    command: &[std::ffi::OsString],
     timeout: Option<u64>,
 ) -> Result<(Vec<FileAccess>, Vec<NetworkAccess>)> {
     use std::time::Duration;
@@ -1177,7 +1177,7 @@ enum TracedAccess {
 /// Run strace on the command and collect file accesses, network accesses, and DNS queries
 #[cfg(target_os = "linux")]
 fn run_strace(
-    command: &[String],
+    command: &[std::ffi::OsString],
     timeout: Option<u64>,
 ) -> Result<(Vec<FileAccess>, Vec<NetworkAccess>, Vec<String>)> {
     use std::time::{Duration, Instant};
@@ -1186,16 +1186,18 @@ fn run_strace(
         return Err(NonoError::NoCommand);
     }
 
-    let mut strace_args = vec![
-        "-f".to_string(),  // Follow forks
-        "-s".to_string(),  // Increase max string size for DNS packet capture
-        "256".to_string(),
-        "-e".to_string(),  // Trace these syscalls
+    // OsString, not String: everything after `--` is the traced command's own
+    // argv and must reach it byte-for-byte.
+    let mut strace_args: Vec<std::ffi::OsString> = vec![
+        "-f".into(),  // Follow forks
+        "-s".into(),  // Increase max string size for DNS packet capture
+        "256".into(),
+        "-e".into(),  // Trace these syscalls
         "openat,open,access,stat,lstat,readlink,execve,creat,mkdir,rename,unlink,connect,bind,sendto,sendmsg"
-            .to_string(),
-        "-o".to_string(),
-        "/dev/stderr".to_string(), // Output to stderr so we can capture it
-        "--".to_string(),
+            .into(),
+        "-o".into(),
+        "/dev/stderr".into(), // Output to stderr so we can capture it
+        "--".into(),
     ];
     strace_args.extend(command.iter().cloned());
 

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -2,7 +2,7 @@ use crate::cli::LearnArgs;
 #[cfg(target_os = "macos")]
 use crate::command_display::format_command_line;
 use crate::profile_save_runtime::{
-    PreparedProfileSave, SaveAction, command_name, confirm, patch_has_policy_overrides,
+    PreparedProfileSave, SaveAction, confirm, offer_command_name, patch_has_policy_overrides,
     print_patch_preview, print_profile_save, suggested_profile_name, would_shadow_existing_profile,
     write_profile,
 };
@@ -157,10 +157,12 @@ fn print_macos_run_guidance(args: &LearnArgs, silent: bool) -> Result<()> {
 
 fn offer_save_profile(
     result: &learn::LearnResult,
-    command: &[String],
+    command: &[std::ffi::OsString],
     compared_profile: Option<&str>,
 ) -> Result<()> {
-    let cmd_name = command_name(command)?;
+    let Some(cmd_name) = offer_command_name(command) else {
+        return Ok(());
+    };
 
     // Compute the patch early so we can preview it before asking any questions.
     let patch = result.to_profile_patch()?;

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -117,12 +117,13 @@ fn main() {
     }
     tool_sandbox::record_main_start();
 
-    let legacy_network_warnings = collect_legacy_network_warnings();
+    let os_args: Vec<_> = std::env::args_os().collect();
+
+    let legacy_network_warnings = collect_legacy_network_warnings(&os_args);
     normalize_legacy_flag_env_vars();
     // Emit one deprecation warning per distinct legacy long flag before clap
     // parses. clap's `alias` rebinds `--override-deny` to `--bypass-protection`
     // silently; without this scan the user would never see a removal notice.
-    let os_args: Vec<_> = std::env::args_os().collect();
     deprecated_schema::warn_for_deprecated_flags(&os_args);
     let cli = Cli::parse();
     init_tracing(&cli);

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -254,7 +254,9 @@ pub(crate) fn offer_save_run_profile(offer: &ProfileSaveOffer<'_>) -> Result<()>
         merge_profile_patch(&mut patch, &url_patch);
     }
 
-    let cmd_name = command_name(offer.command)?;
+    let Some(cmd_name) = offer_command_name(offer.command) else {
+        return Ok(());
+    };
 
     // Try the interactive selector first; fall back to the text prompt when
     // raw mode is unavailable (e.g. a dumb terminal or a redirected TTY).
@@ -277,7 +279,7 @@ pub(crate) fn offer_save_run_profile(offer: &ProfileSaveOffer<'_>) -> Result<()>
 /// Offer profile save when only URL denials exist (no filesystem patch).
 fn offer_url_only_save(
     url_denials: &[UrlDenialRecord],
-    command: &[String],
+    command: &[std::ffi::OsString],
     compared_profile: Option<&str>,
 ) -> Result<()> {
     if url_denials.is_empty() {
@@ -288,7 +290,9 @@ fn offer_url_only_save(
         return Ok(());
     };
 
-    let cmd_name = command_name(command)?;
+    let Some(cmd_name) = offer_command_name(command) else {
+        return Ok(());
+    };
 
     match interactive_denial_selector(&url_patch)? {
         Some(items) => {
@@ -304,7 +308,7 @@ fn offer_url_only_save(
 fn offer_save_with_patch(
     patch: &profile::Profile,
     cmd_name: &str,
-    command: &[String],
+    command: &[std::ffi::OsString],
     compared_profile: Option<&str>,
 ) -> Result<()> {
     let has_overrides = patch_has_policy_overrides(patch);
@@ -351,7 +355,7 @@ fn offer_save_with_patch(
 fn offer_save_text_prompt(
     patch: &profile::Profile,
     cmd_name: &str,
-    command: &[String],
+    command: &[std::ffi::OsString],
     compared_profile: Option<&str>,
 ) -> Result<()> {
     let has_overrides = patch_has_policy_overrides(patch);
@@ -566,13 +570,32 @@ fn parse_profile_save_choice(input: &str, can_suppress: bool) -> Option<ProfileS
     }
 }
 
-pub(crate) fn command_name(command: &[String]) -> Result<String> {
+fn command_name<S: AsRef<std::ffi::OsStr>>(command: &[S]) -> Result<String> {
     command
         .first()
-        .and_then(|command| std::path::Path::new(command).file_name())
+        .and_then(|command| std::path::Path::new(command.as_ref()).file_name())
         .and_then(|name| name.to_str())
         .map(ToOwned::to_owned)
         .ok_or_else(|| NonoError::LearnError("Cannot derive profile name from command".to_string()))
+}
+
+/// Derive the profile name for a save *offer*, warning and returning `None`
+/// when it cannot be derived.
+///
+/// Every caller runs after the traced or sandboxed child has already finished,
+/// so an undeliverable offer must not become the run's result: propagating here
+/// would replace the child's exit status with an error about profile naming.
+pub(crate) fn offer_command_name<S: AsRef<std::ffi::OsStr>>(command: &[S]) -> Option<String> {
+    match command_name(command) {
+        Ok(name) => Some(name),
+        Err(_) => {
+            crate::output::print_warning(
+                "Skipping profile save: cannot derive a profile name from the command \
+                 (a profile name must be valid UTF-8).",
+            );
+            None
+        }
+    }
 }
 
 pub(crate) fn confirm(prompt: &str, default_yes: bool) -> Result<bool> {
@@ -750,7 +773,7 @@ fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[String]) {
+pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[std::ffi::OsString]) {
     let status = match prepared.action {
         SaveAction::Created => "Profile saved:",
         SaveAction::Updated => "Profile updated:",
@@ -2231,6 +2254,26 @@ mod tests {
         assert_eq!(
             suggested_run_profile_name(Some("claude-code"), "copilot"),
             Some("claude-code-local".to_string())
+        );
+    }
+
+    /// Issue #1504: a profile name becomes a filename and a JSON key, so a
+    /// non-UTF-8 program name cannot yield one. The offer is skipped rather than
+    /// failed, because the child whose exit status we still owe has already run.
+    #[test]
+    fn offer_command_name_skips_non_utf8_program_without_erroring() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStrExt;
+
+        assert_eq!(
+            offer_command_name(&[OsString::from("/usr/bin/claude")]),
+            Some("claude".to_string())
+        );
+        assert_eq!(
+            offer_command_name(
+                &[std::ffi::OsStr::from_bytes(b"/usr/bin/cl\xffude").to_os_string()]
+            ),
+            None
         );
     }
 

--- a/crates/nono-cli/src/tool-sandbox/url_shim.rs
+++ b/crates/nono-cli/src/tool-sandbox/url_shim.rs
@@ -52,8 +52,10 @@ pub(crate) fn run_url_open_shim() -> Result<()> {
             )
         })?;
 
-    let url = std::env::args()
+    // A non-UTF-8 argument cannot be an http(s) URL
+    let url = std::env::args_os()
         .skip(1)
+        .filter_map(|arg| arg.into_string().ok())
         .find(|arg| arg.starts_with("http://") || arg.starts_with("https://"))
         .ok_or_else(|| {
             NonoError::SandboxInit(

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -416,7 +416,7 @@ fn apply_file_grant_staleness(
 fn query_command_policy(
     command: &str,
     caller: &str,
-    command_args: &[String],
+    command_args: &[std::ffi::OsString],
     policies: Option<&CommandPoliciesConfig>,
 ) -> query_ext::QueryResult {
     let Some(policies) = policies else {
@@ -490,6 +490,7 @@ fn query_command_policy(
         };
     };
 
+    use std::os::unix::ffi::OsStrExt;
     let mut argv = Vec::with_capacity(command_args.len() + 1);
     argv.push(command.as_bytes().to_vec());
     argv.extend(command_args.iter().map(|arg| arg.as_bytes().to_vec()));
@@ -511,7 +512,7 @@ fn query_command_policy(
             reason,
             details: Some(format!(
                 "Command '{command}' from '{caller}' with argv [{}] is denied by invocation_policy. This is an Tool Sandbox  command/argument policy denial, not a filesystem path denial.{endpoint_note}",
-                command_args.join(" ")
+                crate::command_display::format_command_line(command_args)
             )),
             policy_source: Some(format!(
                 "command_policies.commands.{command}.from.{caller}.invocation_policy"
@@ -529,7 +530,7 @@ fn query_command_policy(
             reason: reason.unwrap_or_else(|| "invocation_policy approval required".to_string()),
             details: Some(format!(
                 "Command '{command}' from '{caller}' with argv [{}] matches {rule_label}. Backend: {}. Timeout: {}.{endpoint_note}",
-                command_args.join(" "),
+                crate::command_display::format_command_line(command_args),
                 backend.unwrap_or_else(|| "<default>".to_string()),
                 timeout_secs
                     .map(|secs| format!("{secs}s"))
@@ -692,9 +693,9 @@ mod tests {
     fn command_policy_query_reports_argv_deny_reason() {
         let policies = gh_policy();
         let args = vec![
-            "issue".to_string(),
-            "comment".to_string(),
-            "1052".to_string(),
+            std::ffi::OsString::from("issue"),
+            std::ffi::OsString::from("comment"),
+            std::ffi::OsString::from("1052"),
         ];
 
         let result = query_command_policy("gh", "session", &args, Some(&policies));
@@ -907,7 +908,11 @@ mod tests {
     #[test]
     fn command_policy_query_reports_argv_allow() {
         let policies = gh_policy();
-        let args = vec!["issue".to_string(), "view".to_string(), "1052".to_string()];
+        let args = vec![
+            std::ffi::OsString::from("issue"),
+            std::ffi::OsString::from("view"),
+            std::ffi::OsString::from("1052"),
+        ];
 
         let result = query_command_policy("gh", "session", &args, Some(&policies));
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1504

## Summary

Read CLI arguments as `OsString` so they can be passed to child programs directly.

## Test Plan
Steps to reproduce fixed

Tests added

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
