### PR TITLE
feat(why): report explicit deny paths from sandbox policy

### DIFF
--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -337,6 +337,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let cap_file = write_capability_state_file(
         &caps,
         &flags.bypass_protection_paths,
+        &deny_paths,
         &allowed_domain_strs,
         &domain_endpoints,
         flags.silent,
@@ -790,13 +791,15 @@ fn validate_command_policy_execution_support() -> Result<()> {
 fn write_capability_state_file(
     caps: &CapabilitySet,
     bypass_protection_paths: &[std::path::PathBuf],
+    deny_paths: &[std::path::PathBuf],
     allowed_domains: &[String],
     domain_endpoints: &[sandbox_state::DomainEndpointState],
     silent: bool,
 ) -> Option<std::path::PathBuf> {
-    let state = sandbox_state::SandboxState::from_caps(
+    let state = sandbox_state::SandboxState::from_caps_with_denies(
         caps,
         bypass_protection_paths,
+        deny_paths,
         allowed_domains,
         domain_endpoints,
     );

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -33,6 +33,14 @@ pub struct SandboxState {
     /// ALIAS(canonical="bypass_protection_paths", introduced="v0.41.0", remove_by="v1.0.0", issue="#594")
     #[serde(default, alias = "override_deny_paths")]
     pub bypass_protection_paths: Vec<String>,
+    /// Resolved filesystem deny paths enforced by the active profile.
+    ///
+    /// These are not filesystem capabilities: on macOS they are explicit
+    /// Seatbelt deny rules which override covering allows. Persist them so
+    /// `nono why --self` reports the kernel policy rather than only the allow
+    /// side of the capability set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deny_paths: Vec<String>,
     /// Proxy domain allowlist at sandbox creation time
     #[serde(default)]
     pub allowed_domains: Vec<String>,
@@ -113,9 +121,27 @@ fn grant_time_inode(_cap: &nono::FsCapability) -> Option<(u64, u64)> {
 
 impl SandboxState {
     /// Create sandbox state from a CapabilitySet, bypass_protection paths, and domain allowlist
+    #[cfg(test)]
     pub fn from_caps(
         caps: &CapabilitySet,
         bypass_protection_paths: &[PathBuf],
+        allowed_domains: &[String],
+        domain_endpoints: &[DomainEndpointState],
+    ) -> Self {
+        Self::from_caps_with_denies(
+            caps,
+            bypass_protection_paths,
+            &[],
+            allowed_domains,
+            domain_endpoints,
+        )
+    }
+
+    /// Create sandbox state including explicit filesystem deny paths.
+    pub fn from_caps_with_denies(
+        caps: &CapabilitySet,
+        bypass_protection_paths: &[PathBuf],
+        deny_paths: &[PathBuf],
         allowed_domains: &[String],
         domain_endpoints: &[DomainEndpointState],
     ) -> Self {
@@ -147,6 +173,7 @@ impl SandboxState {
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect(),
+            deny_paths: deny_paths.iter().map(|p| p.display().to_string()).collect(),
             allowed_domains: allowed_domains.to_vec(),
             domain_endpoints: domain_endpoints.to_vec(),
             resource_limits: caps.resource_limits().copied(),
@@ -159,6 +186,11 @@ impl SandboxState {
             .iter()
             .map(PathBuf::from)
             .collect()
+    }
+
+    /// Get resolved filesystem deny paths for query use.
+    pub fn deny_paths_as_paths(&self) -> Vec<PathBuf> {
+        self.deny_paths.iter().map(PathBuf::from).collect()
     }
 
     /// Convert back to a CapabilitySet
@@ -620,6 +652,32 @@ mod tests {
     }
 
     #[test]
+    fn test_sandbox_state_roundtrip_preserves_deny_paths() {
+        let caps = CapabilitySet::new();
+        let deny_paths = vec![PathBuf::from("/workspace/blocked.txt")];
+        let state = SandboxState::from_caps_with_denies(&caps, &[], &deny_paths, &[], &[]);
+
+        let json = serde_json::to_string(&state).expect("serialize state");
+        let restored: SandboxState = serde_json::from_str(&json).expect("deserialize state");
+
+        assert_eq!(restored.deny_paths_as_paths(), deny_paths);
+    }
+
+    #[test]
+    fn test_legacy_sandbox_state_without_deny_paths_still_loads() {
+        let caps = CapabilitySet::new();
+        let state = SandboxState::from_caps(&caps, &[], &[], &[]);
+        let mut value = serde_json::to_value(&state).expect("serialize state");
+        value
+            .as_object_mut()
+            .expect("state object")
+            .remove("deny_paths");
+
+        let restored: SandboxState = serde_json::from_value(value).expect("legacy state loads");
+        assert!(restored.deny_paths.is_empty());
+    }
+
+    #[test]
     fn test_sandbox_state_write_and_read() {
         let dir = tempdir().expect("Failed to create temp dir");
         let file_path = dir.path().join("test_state.json");
@@ -811,6 +869,7 @@ mod tests {
             allowed_commands: vec![],
             blocked_commands: vec![],
             bypass_protection_paths: vec![],
+            deny_paths: vec![],
             allowed_domains: vec![],
             domain_endpoints: vec![],
             resource_limits: None,

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -288,7 +288,7 @@ fn matching_deny_path<'a>(
         .iter()
         .filter(|deny| {
             let resolved_deny = nono::try_canonicalize(deny);
-            resolved == resolved_deny || resolved.starts_with(&resolved_deny)
+            resolved.starts_with(&resolved_deny)
         })
         .max_by_key(|deny| deny.as_os_str().len())
 }

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -9,6 +9,7 @@ use nono::{AccessMode, CapabilitySet, NonoError, Result};
 
 struct WhyContext {
     caps: CapabilitySet,
+    deny_paths: Vec<std::path::PathBuf>,
     overridden_paths: Vec<std::path::PathBuf>,
     allowed_domains: Vec<String>,
     domain_endpoints: Vec<sandbox_state::DomainEndpointState>,
@@ -110,6 +111,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
                 let domain_endpoints = state.domain_endpoints.clone();
                 WhyContext {
                     caps: state.to_caps()?,
+                    deny_paths: state.deny_paths_as_paths(),
                     overridden_paths: paths,
                     allowed_domains: state.allowed_domains.clone(),
                     domain_endpoints,
@@ -174,6 +176,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
         }
         WhyContext {
             caps,
+            deny_paths: prepared.deny_paths,
             overridden_paths: override_paths,
             allowed_domains,
             domain_endpoints,
@@ -199,6 +202,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
         }
         WhyContext {
             caps,
+            deny_paths: prepared.deny_paths,
             overridden_paths: vec![],
             allowed_domains: vec![],
             domain_endpoints: vec![],
@@ -220,7 +224,20 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
             None => AccessMode::Read,
         };
-        let result = query_path(path, op, &ctx.caps, &ctx.overridden_paths)?;
+        let result = match matching_deny_path(path, &ctx.deny_paths) {
+            Some(deny_path) => QueryResult::Denied {
+                reason: "filesystem_deny".to_string(),
+                details: Some(format!(
+                    "Path is covered by filesystem.deny rule: {}",
+                    deny_path.display()
+                )),
+                policy_source: Some("filesystem.deny".to_string()),
+                matching_capability: None,
+                suggested_flag: None,
+                endpoint_rules: None,
+            },
+            None => query_path(path, op, &ctx.caps, &ctx.overridden_paths)?,
+        };
         apply_file_grant_staleness(
             result,
             path,
@@ -254,6 +271,26 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Return the most specific deny path that covers a query path.
+///
+/// Deny paths are retained separately from allow capabilities because macOS
+/// Seatbelt deny rules take precedence over a broader allow rule. Resolve the
+/// query through existing ancestors so missing leaf paths (the common
+/// create-file case) compare the same way as the rules installed at launch.
+fn matching_deny_path<'a>(
+    path: &std::path::Path,
+    deny_paths: &'a [std::path::PathBuf],
+) -> Option<&'a std::path::PathBuf> {
+    let resolved = nono::try_canonicalize(path);
+    deny_paths
+        .iter()
+        .filter(|deny| {
+            let resolved_deny = nono::try_canonicalize(deny);
+            resolved == resolved_deny || resolved.starts_with(&resolved_deny)
+        })
+        .max_by_key(|deny| deny.as_os_str().len())
 }
 
 /// A file-level grant whose Landlock rule no longer matches the file at the
@@ -705,6 +742,18 @@ mod tests {
     }
 
     #[test]
+    fn explicit_deny_covers_missing_leaf_under_denied_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let denied = dir.path().join("blocked");
+        let query = denied.join("future.txt");
+
+        assert_eq!(
+            matching_deny_path(&query, std::slice::from_ref(&denied)),
+            Some(&denied)
+        );
+    }
+
+    #[test]
     fn known_network_profile_contributes_hosts() {
         let profile = profile_from_json(r#"{"network":{"network_profile":"claude-code"}}"#);
         let domains = resolve_allowed_domains(&profile).expect("resolve allowlist");
@@ -725,6 +774,15 @@ mod tests {
             "169.254.169.254",
         );
         assert!(matches!(result, query_ext::QueryResult::Denied { .. }));
+    }
+
+    #[test]
+    fn explicit_deny_does_not_match_sibling_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let denied = dir.path().join("blocked");
+        let sibling = dir.path().join("blocked-backup");
+
+        assert!(matching_deny_path(&sibling, &[denied]).is_none());
     }
 
     fn gh_policy() -> CommandPoliciesConfig {

--- a/crates/nono-cli/tests/why_deny.rs
+++ b/crates/nono-cli/tests/why_deny.rs
@@ -1,0 +1,103 @@
+//! Regression coverage for explicit filesystem denies in `nono why`.
+//!
+//! macOS Seatbelt can enforce a child deny beneath an allowed parent. The
+//! query command must therefore consider deny rules before broad grants.
+
+#![cfg(target_os = "macos")]
+
+use std::fs;
+use std::process::Command;
+
+fn fixture() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let artifact_root = std::env::current_dir()
+        .expect("cwd")
+        .join("target")
+        .join("test-artifacts");
+    fs::create_dir_all(&artifact_root).expect("create artifact root");
+    let workspace = tempfile::tempdir_in(artifact_root).expect("temp workspace");
+    let blocked = workspace.path().join("blocked.txt");
+    let profile = workspace.path().join("policy.json");
+
+    fs::write(
+        &profile,
+        r#"{
+            "filesystem": {
+                "allow": ["$WORKDIR"],
+                "deny": ["$WORKDIR/blocked.txt"]
+            }
+        }"#,
+    )
+    .expect("write profile");
+
+    (workspace, blocked, profile)
+}
+
+#[test]
+fn why_reports_profile_deny_before_covering_allow() {
+    let (workspace, blocked, profile) = fixture();
+    let output = Command::new(env!("CARGO_BIN_EXE_nono"))
+        .args([
+            "why",
+            "--profile",
+            profile.to_str().expect("profile path"),
+            "--op",
+            "write",
+            "--path",
+            blocked.to_str().expect("blocked path"),
+        ])
+        .current_dir(workspace.path())
+        .output()
+        .expect("run nono why");
+
+    assert!(
+        output.status.success(),
+        "nono why failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("DENIED"), "expected denial, got:\n{stdout}");
+    assert!(
+        stdout.contains("Reason: filesystem_deny"),
+        "expected filesystem deny reason, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Policy: filesystem.deny"),
+        "expected deny policy source, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn why_self_reports_active_profile_deny_before_covering_allow() {
+    let (workspace, blocked, profile) = fixture();
+    let nono = env!("CARGO_BIN_EXE_nono");
+    let output = Command::new(nono)
+        .args([
+            "wrap",
+            "--silent",
+            "--profile",
+            profile.to_str().expect("profile path"),
+            "--",
+            nono,
+            "why",
+            "--self",
+            "--op",
+            "write",
+            "--path",
+            blocked.to_str().expect("blocked path"),
+        ])
+        .current_dir(workspace.path())
+        .output()
+        .expect("run sandboxed nono why --self");
+
+    assert!(
+        output.status.success(),
+        "sandboxed nono why --self failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("DENIED"), "expected denial, got:\n{stdout}");
+    assert!(
+        stdout.contains("Reason: filesystem_deny"),
+        "expected filesystem deny reason, got:\n{stdout}"
+    );
+}

--- a/tests/integration/test_bypass_protection.sh
+++ b/tests/integration/test_bypass_protection.sh
@@ -133,7 +133,7 @@ echo "--- nono why with bypass_protection ---"
 if [[ -d "$DOCKER_DIR" ]]; then
     # Without bypass, ~/.docker should be denied
     expect_output_contains "nono why reports .docker denied without bypass" \
-        "sensitive_path" \
+        "filesystem_deny" \
         "$NONO_BIN" --silent why --json --path "$DOCKER_DIR" --op read
 
     # With profile bypass_protection, ~/.docker should be allowed
@@ -218,7 +218,7 @@ echo "--- Bypass scope is targeted ---"
 if [[ -d "$DOCKER_DIR" ]] && [[ -d "$HOME/.ssh" ]]; then
     # Bypassing .docker must NOT also unlock .ssh
     expect_output_contains "bypass_protection for .docker does not bypass .ssh deny" \
-        "sensitive_path" \
+        "filesystem_deny" \
         "$NONO_BIN" --silent why --json --profile "$PROFILES_DIR/docker-bypass.json" \
             --path "$HOME/.ssh" --op read
 else

--- a/tests/integration/test_policy_queries.sh
+++ b/tests/integration/test_policy_queries.sh
@@ -26,7 +26,7 @@ echo ""
 
 echo "--- Path Policy Queries ---"
 
-expect_output_contains "sensitive path is denied" "\"reason\": \"sensitive_path\"" \
+expect_output_contains "sensitive path is denied" "\"reason\": \"filesystem_deny\"" \
     "$NONO_BIN" --silent why --json --path ~/.ssh --op read
 
 expect_output_contains "non-granted path is denied" "\"reason\": \"path_not_granted\"" \
@@ -57,7 +57,7 @@ expect_output_contains "human why output shows source on allow" "Source: user" \
     "$NONO_BIN" --silent why --path "$TMPDIR/write-target.txt" --op write --allow "$TMPDIR"
 
 if [[ -f ~/.zshrc ]]; then
-    expect_output_contains "read-file on sensitive path stays denied" "\"reason\": \"sensitive_path\"" \
+    expect_output_contains "read-file on sensitive path stays denied" "\"reason\": \"filesystem_deny\"" \
         "$NONO_BIN" --silent why --json --path ~/.zshrc --op read --read-file ~/.zshrc
 
     expect_output_contains "sensitive path reports policy source in human output" "Policy:" \


### PR DESCRIPTION
Introduce the concept of explicit filesystem deny paths into the sandbox state and ensure `nono why` accurately reports them.

- The `SandboxState` now includes a `deny_paths` field to store explicit filesystem deny rules.
- These `deny_paths` are populated during sandbox creation and persisted to the sandbox state file.
- `nono why` now checks against these `deny_paths` *before* checking allow capabilities. This is crucial for operating systems like macOS where Seatbelt deny rules take precedence over broader allow rules.
- This change ensures `nono why --self` can accurately report the complete kernel policy, including both allowed and explicitly denied filesystem paths.

## Linked Issue

Closes #1555

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates


