### PR TITLE
fix(audit): propogate errors after unparseable ledger

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -135,6 +135,7 @@ pub(crate) fn map_error(e: &nono::NonoError) -> types::NonoErrorCode {
         nono::NonoError::Io(_) | nono::NonoError::CommandExecution(_) => NonoErrorCode::ErrIo,
         nono::NonoError::ObjectStore(_)
         | nono::NonoError::Snapshot(_)
+        | nono::NonoError::AuditLedgerCorrupt { .. }
         | nono::NonoError::HashMismatch { .. }
         | nono::NonoError::SessionNotFound(_) => NonoErrorCode::ErrIo,
         nono::NonoError::TrustVerification { .. }

--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -15,6 +15,11 @@ use std::path::{Path, PathBuf};
 const AUDIT_LEDGER_FILENAME: &str = "ledger.ndjson";
 const AUDIT_LEDGER_LOCK_FILENAME: &str = "ledger.lock";
 
+/// Path of the global append-only ledger.
+pub(crate) fn ledger_path() -> Result<PathBuf> {
+    Ok(audit_root()?.join(AUDIT_LEDGER_FILENAME))
+}
+
 pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord> {
     validate_ledger_session_id(&metadata.session_id)?;
 
@@ -163,6 +168,41 @@ mod tests {
         assert!(verified.session_digest_matches);
         assert!(verified.ledger_chain_verified);
         assert_eq!(verified.entry_count, 1);
+    }
+
+    #[test]
+    fn append_fails_closed_on_an_unparseable_ledger() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        std::fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        append_session(&sample_metadata("20260421-200000-11111")).unwrap();
+
+        // Two records on one line with no separator i.e. a corrupt ledger.
+        let path = ledger_path().unwrap();
+        let record = std::fs::read_to_string(&path).unwrap();
+        let record = record.trim_end();
+        let corrupt = format!("{record}{record}\n");
+        std::fs::write(&path, &corrupt).unwrap();
+
+        let err = match append_session(&sample_metadata("20260421-200001-22222")) {
+            Ok(_) => panic!("append onto an unparseable ledger should fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, NonoError::AuditLedgerCorrupt { .. }),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            corrupt,
+            "a failed append must leave the ledger byte-identical"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -575,6 +575,68 @@ pub fn print_applying_sandbox(silent: bool) {
     eprintln!();
 }
 
+/// Report that a completed session was not committed to the global audit ledger.
+///
+/// An append also fails on a lock timeout, a full disk, or an unwritable audit
+/// root, none of which outlive the run that hit them. Only a ledger that no
+/// longer parses is permanent, so only that error earns the "stopped growing"
+/// and "no repair command" story.
+pub fn print_audit_ledger_append_failure(error: &NonoError, ledger: Option<&Path>) {
+    let t = theme::current();
+    eprintln!();
+    eprintln!(
+        "  {} {}",
+        fg("warning:", t.red).bold(),
+        fg("this session was not recorded in the audit ledger", t.text),
+    );
+    eprintln!("    {}", fg(&error.to_string(), t.text));
+    if let Some(ledger) = ledger {
+        eprintln!(
+            "    {}",
+            fg(&format!("ledger: {}", ledger.display()), t.subtext),
+        );
+    }
+    if !matches!(error, NonoError::AuditLedgerCorrupt { .. }) {
+        return;
+    }
+    eprintln!(
+        "    {}",
+        fg(
+            "The tamper-evident chain has stopped growing: no run is recorded \
+             until the ledger parses again.",
+            t.subtext
+        ),
+    );
+    eprintln!(
+        "    {}",
+        fg(
+            "There is no repair command. Moving the file aside starts a fresh \
+             chain, after which `nono audit verify` no longer finds the sessions \
+             the old one held.",
+            t.subtext
+        ),
+    );
+}
+
+/// Report the status nono exits with after a session was left out of the ledger.
+///
+/// The failure itself is already on stderr from
+/// [`print_audit_ledger_append_failure`]; this only accounts for the status,
+/// which differs from the child's own only when a clean run is downgraded so
+/// that a gap in the chain cannot be read as a recorded success.
+pub fn print_audit_ledger_exit_status(child_exit_code: i32, reported_exit_code: i32) {
+    let t = theme::current();
+    let status = if child_exit_code == reported_exit_code {
+        format!("the command exited {child_exit_code}; that status is preserved")
+    } else {
+        format!(
+            "the command exited {child_exit_code}, but nono exits \
+             {reported_exit_code} because the run is missing from the ledger"
+        )
+    };
+    eprintln!("    {}", fg(&status, t.subtext));
+}
+
 /// Report a post-run finalization failure.
 ///
 /// Some work runs after the sandboxed command has already exited: the

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -575,6 +575,49 @@ pub fn print_applying_sandbox(silent: bool) {
     eprintln!();
 }
 
+/// Report a post-run finalization failure.
+///
+/// Some work runs after the sandboxed command has already exited: the
+/// audit-ledger append, session metadata, attestation and the rollback review.
+/// A failure there is nono's, not the child's, so `child_exit_code` is what the
+/// command itself returned and `reported_exit_code` is what nono will exit with.
+/// They differ only when a clean command is downgraded to signal that its
+/// session never finished.
+pub fn print_session_finalization_failure(
+    error: &NonoError,
+    child_exit_code: i32,
+    reported_exit_code: i32,
+) {
+    let t = theme::current();
+    eprintln!();
+    eprintln!(
+        "  {} {}",
+        fg("warning:", t.red).bold(),
+        fg(
+            "session finalization failed after the command exited",
+            t.text
+        ),
+    );
+    eprintln!("    {}", fg(&error.to_string(), t.text));
+    eprintln!(
+        "    {}",
+        fg(
+            "The rollback review, session metadata and attestation for this run \
+             may be missing or incomplete.",
+            t.subtext
+        ),
+    );
+    let status = if child_exit_code == reported_exit_code {
+        format!("the command exited {child_exit_code}; that status is preserved")
+    } else {
+        format!(
+            "the command exited {child_exit_code}, but nono exits \
+             {reported_exit_code} because the session could not be finalized"
+        )
+    };
+    eprintln!("    {}", fg(&status, t.subtext));
+}
+
 /// Print a styled warning message to stderr
 pub fn print_warning(message: &str) {
     let t = theme::current();

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -52,6 +52,18 @@ pub(crate) struct RollbackExitContext<'a> {
     pub(crate) rollback_prompt_disabled: bool,
 }
 
+/// What post-exit bookkeeping managed to complete.
+///
+/// The ledger append is reported rather than propagated so the audit shipping,
+/// rollback review and temp-file cleanup that follow it still run. The caller
+/// turns a missing entry into the exit status once all of that is done.
+#[must_use = "dropping the outcome loses the ledger gap the caller owes the exit status"]
+pub(crate) struct FinalizeOutcome {
+    /// False only when an append was attempted and failed. A run with auditing
+    /// off never attempts one, which is not a gap in the chain.
+    pub(crate) ledger_recorded: bool,
+}
+
 fn rollback_vcs_exclusions() -> Vec<String> {
     [".git", ".hg", ".svn"]
         .iter()
@@ -474,7 +486,23 @@ pub(crate) fn initialize_rollback_state(
     }))
 }
 
-pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<()> {
+/// Commit a completed session to the global audit ledger, reporting whether the
+/// entry landed.
+///
+/// The error is printed here instead of returned because the caller must keep
+/// going: an unappendable ledger may not cost the run its audit delivery or its
+/// rollback review. The gap still reaches the exit status via
+/// [`FinalizeOutcome`].
+#[must_use = "on `false` the session is absent from the chain and the caller MUST NOT report success"]
+fn record_session_in_ledger(metadata: &nono::undo::SessionMetadata) -> bool {
+    let Err(error) = audit_ledger::append_session(metadata) else {
+        return true;
+    };
+    output::print_audit_ledger_append_failure(&error, audit_ledger::ledger_path().ok().as_deref());
+    false
+}
+
+pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<FinalizeOutcome> {
     let RollbackExitContext {
         audit_state,
         rollback_state,
@@ -526,6 +554,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
 
     let scrubbed_command = nono::scrub_argv_with_policy(command, redaction_policy);
     let mut audit_saved = false;
+    let mut ledger_recorded = true;
 
     if let Some(RollbackRuntimeState {
         session_dir,
@@ -565,7 +594,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         manager.save_session_metadata(&meta)?;
         if let Some(audit_state) = audit_state {
             nono::undo::SnapshotManager::write_session_metadata(&audit_state.session_dir, &meta)?;
-            audit_ledger::append_session(&meta)?;
+            ledger_recorded = record_session_in_ledger(&meta);
             if let Err(error) = audit_client::maybe_ship_session(&audit_state.session_dir, &meta) {
                 warn!("Audit delivery remains queued: {error}");
             }
@@ -615,13 +644,13 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
             )?);
         }
         nono::undo::SnapshotManager::write_session_metadata(&audit_state.session_dir, &meta)?;
-        audit_ledger::append_session(&meta)?;
+        ledger_recorded = record_session_in_ledger(&meta);
         if let Err(error) = audit_client::maybe_ship_session(&audit_state.session_dir, &meta) {
             warn!("Audit delivery remains queued: {error}");
         }
     }
 
-    Ok(())
+    Ok(FinalizeOutcome { ledger_recorded })
 }
 
 #[cfg(test)]
@@ -940,5 +969,46 @@ mod tests {
             verify_audit_attestation(&audit_dir, &attested_metadata, None).expect("verify");
         assert!(verification.signature_verified);
         assert!(verification.verification_error.is_none());
+    }
+
+    /// A failed append has to leave a trace in the return value: reporting it on
+    /// stderr alone would let `finalize_supervised_exit` return a clean outcome
+    /// for a run that never entered the chain, and the caller's exit-status
+    /// downgrade is what keeps that from reading as success.
+    #[test]
+    fn a_failed_ledger_append_is_reported_as_unrecorded() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let mut metadata = SessionMetadata {
+            session_id: "20260421-200000-11111".to_string(),
+            started: "2026-04-21T20:00:00Z".to_string(),
+            ended: Some("2026-04-21T20:00:01Z".to_string()),
+            command: vec!["/bin/pwd".to_string()],
+            executable_identity: None,
+            tracked_paths: vec![PathBuf::from("/tmp/project")],
+            snapshot_count: 0,
+            exit_code: Some(0),
+            merkle_roots: Vec::new(),
+            network_events: Vec::new(),
+            audit_event_count: 2,
+            audit_integrity: None,
+            audit_attestation: None,
+        };
+        assert!(record_session_in_ledger(&metadata));
+
+        // Two records on one line with no separator i.e. a corrupt ledger.
+        let path = audit_ledger::ledger_path().unwrap();
+        let record = fs::read_to_string(&path).unwrap();
+        let record = record.trim_end().to_string();
+        fs::write(&path, format!("{record}{record}\n")).unwrap();
+
+        metadata.session_id = "20260421-200001-22222".to_string();
+        assert!(!record_session_in_ledger(&metadata));
     }
 }

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -157,6 +157,24 @@ fn resource_limits_unsupported_platform() -> nono::NonoError {
     )
 }
 
+/// Exit status for a run whose command succeeded but whose post-exit
+/// bookkeeping did not.
+const FINALIZATION_FAILURE_EXIT_CODE: i32 = 1;
+
+/// The status to report when post-exit bookkeeping failed.
+///
+/// A non-zero child status is the child's own report and must survive untouched.
+/// A zero one would otherwise hand the caller a clean success for a run whose
+/// rollback review, session metadata or attestation never completed.
+#[must_use]
+const fn exit_code_after_finalization_failure(child_exit_code: i32) -> i32 {
+    if child_exit_code == 0 {
+        FINALIZATION_FAILURE_EXIT_CODE
+    } else {
+        child_exit_code
+    }
+}
+
 /// True only for the exit code a whole-sandbox OOM kill produces (128 + SIGKILL =
 /// 137). Gating the memory-cap diagnostic on this keeps a clean exit, an ordinary
 /// crash, or a different signal from borrowing the "out of memory" story.
@@ -417,7 +435,9 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     }
 
     let ended = chrono::Local::now().to_rfc3339();
-    finalize_supervised_exit(RollbackExitContext {
+
+    // Bookkeeping after the child has exited.
+    let finalize_result = finalize_supervised_exit(RollbackExitContext {
         audit_state: audit_state.as_ref(),
         rollback_state,
         audit_snapshot_state,
@@ -435,7 +455,15 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         exit_code,
         silent,
         rollback_prompt_disabled: rollback.prompt_disabled,
-    })?;
+    });
+    if let Err(error) = finalize_result {
+        let reported = exit_code_after_finalization_failure(exit_code);
+        output::print_session_finalization_failure(&error, exit_code, reported);
+        // Returned as a status rather than an `Err` so the caller still runs the
+        // after-hook and drops the proxy handle; propagating would skip both and
+        // leave the TLS-intercept trust bundle behind on `process::exit`.
+        return Ok(reported);
+    }
 
     Ok(exit_code)
 }
@@ -443,6 +471,18 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
 #[cfg(test)]
 mod tests {
     use super::should_open_supervised_pty;
+
+    /// A finalize failure is nono's own, so it may not overwrite what the child
+    /// reported: only a clean run is downgraded, which is the one case where the
+    /// substituted status cannot be mistaken for the command's own.
+    #[test]
+    fn finalization_failure_downgrades_only_a_clean_exit() {
+        use super::exit_code_after_finalization_failure;
+        assert_eq!(exit_code_after_finalization_failure(0), 1);
+        assert_eq!(exit_code_after_finalization_failure(1), 1);
+        assert_eq!(exit_code_after_finalization_failure(7), 7);
+        assert_eq!(exit_code_after_finalization_failure(137), 137);
+    }
 
     /// Off-Linux, a requested memory limit is refused with UnsupportedPlatform (not
     /// SandboxInit), so it maps to the right diagnostic/exit and reads naturally.

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -4,7 +4,7 @@ use crate::launch_runtime::{
     ProxyLaunchOptions, RollbackLaunchOptions, SessionLaunchOptions, TrustLaunchOptions,
 };
 use crate::rollback_runtime::{
-    AuditState, RollbackExitContext, create_audit_state, finalize_supervised_exit,
+    AuditState, FinalizeOutcome, RollbackExitContext, create_audit_state, finalize_supervised_exit,
     initialize_audit_snapshots, initialize_rollback_state, warn_if_rollback_flags_ignored,
 };
 use crate::{
@@ -456,16 +456,31 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         silent,
         rollback_prompt_disabled: rollback.prompt_disabled,
     });
-    if let Err(error) = finalize_result {
-        let reported = exit_code_after_finalization_failure(exit_code);
-        output::print_session_finalization_failure(&error, exit_code, reported);
-        // Returned as a status rather than an `Err` so the caller still runs the
-        // after-hook and drops the proxy handle; propagating would skip both and
-        // leave the TLS-intercept trust bundle behind on `process::exit`.
-        return Ok(reported);
+    // Both arms return a status rather than an `Err` so the caller still runs the
+    // after-hook and drops the proxy handle; propagating would skip both and
+    // leave the TLS-intercept trust bundle behind on `process::exit`.
+    match finalize_result {
+        Err(error) => {
+            let reported = exit_code_after_finalization_failure(exit_code);
+            output::print_session_finalization_failure(&error, exit_code, reported);
+            Ok(reported)
+        }
+        // A skipped ledger append is the same class of failure as any other
+        // unfinished bookkeeping and gets the same downgrade: exiting 0 would
+        // report a recorded run to a caller that only reads the status, and the
+        // gap is permanent when the ledger no longer parses. The warning is
+        // already on stderr from the append itself.
+        Ok(FinalizeOutcome {
+            ledger_recorded: false,
+        }) => {
+            let reported = exit_code_after_finalization_failure(exit_code);
+            output::print_audit_ledger_exit_status(exit_code, reported);
+            Ok(reported)
+        }
+        Ok(FinalizeOutcome {
+            ledger_recorded: true,
+        }) => Ok(exit_code),
     }
-
-    Ok(exit_code)
 }
 
 #[cfg(test)]

--- a/crates/nono-cli/tests/audit_ledger.rs
+++ b/crates/nono-cli/tests/audit_ledger.rs
@@ -1,0 +1,99 @@
+//! Integration tests for behaviour under a corrupt global audit ledger.
+//!
+//! Regression test for #1583: an unparseable audit ledger used to abort finalization outright, so
+//! the audit delivery and rollback review after the append were skipped and a failing child's own
+//! exit status was replaced. The gap in the chain is still fail-closed — a clean run is downgraded
+//! to `1` — but only after the rest of the bookkeeping has run.
+
+use nono_test_support::{Argv, nono_test};
+use std::fs;
+use std::path::Path;
+
+/// Corrupt the ledger by dropping the newline between the last two records so one line holds two
+/// JSON objects and `serde_json` fails with "trailing characters".
+fn corrupt_last_newline(path: &Path) {
+    let contents =
+        fs::read_to_string(path).expect("callers only corrupt a ledger nono has already written");
+    // Only a trailing blank is dropped: filtering every empty line would silently repair unrelated
+    // damage, so the fixture could no longer claim the joined records are the sole corruption.
+    let mut lines: Vec<&str> = contents.lines().collect();
+    if lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    assert!(!lines.is_empty(), "ledger should have at least one record");
+    assert!(
+        lines.iter().all(|l| !l.is_empty()),
+        "ledger should hold one record per line"
+    );
+
+    let mut corrupted = String::new();
+    if lines.len() == 1 {
+        corrupted.push_str(lines[0]);
+        corrupted.push_str(lines[0]);
+    } else {
+        for line in &lines[..lines.len() - 2] {
+            corrupted.push_str(line);
+            corrupted.push('\n');
+        }
+        corrupted.push_str(lines[lines.len() - 2]);
+        corrupted.push_str(lines[lines.len() - 1]);
+    }
+    corrupted.push('\n');
+    fs::write(path, corrupted).expect("the ledger was just read from this same path");
+}
+
+/// A run left out of the ledger may not report success, but a child that failed on its own still
+/// owns the exit status — a substituted code there would be indistinguishable from the command's.
+#[test]
+fn corrupt_audit_ledger_downgrades_only_a_clean_exit() {
+    let t = nono_test!("audit-ledger");
+
+    // Create the ledger.
+    t.run()
+        .allow_cwd()
+        .exec("/bin/pwd")
+        .assert_success("seed run should succeed");
+
+    let ledger = t.audit_root().join("ledger.ndjson");
+    assert!(ledger.exists(), "ledger should exist after a run");
+    corrupt_last_newline(&ledger);
+
+    t.run()
+        .allow_cwd()
+        .exec("/bin/pwd")
+        .assert_exit_code(1, "an unrecorded run must not exit 0");
+
+    t.run()
+        .allow_cwd()
+        .exec(Argv::new("/bin/sh").arg("-c").arg("exit 7"))
+        .assert_exit_code(7, "the child's own code must survive a corrupt ledger");
+}
+
+#[test]
+fn corrupt_audit_ledger_is_reported_on_every_run_and_left_untouched() {
+    let t = nono_test!("audit-ledger-report");
+
+    t.run()
+        .allow_cwd()
+        .exec("/bin/pwd")
+        .assert_success("seed run should succeed");
+
+    let ledger = t.audit_root().join("ledger.ndjson");
+    corrupt_last_newline(&ledger);
+    let corrupt_bytes = fs::read(&ledger).expect("corrupt_last_newline just wrote this file");
+
+    for attempt in 1..=2 {
+        t.run()
+            .allow_cwd()
+            .exec("/bin/pwd")
+            .assert_stderr_contains("not recorded in the audit ledger")
+            // Printed only for a ledger that no longer parses, so it also pins that the permanent
+            // story is not told for a transient append failure.
+            .assert_stderr_contains("The tamper-evident chain has stopped growing");
+        assert_eq!(
+            fs::read(&ledger).expect("a run must never remove the ledger it could not parse"),
+            corrupt_bytes,
+            "run {attempt} must not rewrite the ledger it could not parse"
+        );
+    }
+}

--- a/crates/nono-test-support/src/cli.rs
+++ b/crates/nono-test-support/src/cli.rs
@@ -450,6 +450,18 @@ pub struct Completed {
 }
 
 impl Completed {
+    /// A signalled child has no code, so `Option` inequality also catches the
+    /// crash that `assert_failure` would wave through.
+    pub fn assert_exit_code(self, code: i32, why: &str) -> Self {
+        assert_eq!(
+            self.output.status.code(),
+            Some(code),
+            "{}",
+            self.context(&format!("expected exit {code}: {why}"))
+        );
+        self
+    }
+
     pub fn assert_failure(self, why: &str) -> Self {
         assert!(
             !self.output.status.success(),

--- a/crates/nono/src/audit.rs
+++ b/crates/nono/src/audit.rs
@@ -801,12 +801,11 @@ pub fn append_session_to_ledger_file(
             if line.trim().is_empty() {
                 continue;
             }
-            let record: LedgerRecord = serde_json::from_str(&line).map_err(|e| {
-                NonoError::Snapshot(format!(
-                    "Failed to parse audit ledger line {}: {e}",
-                    index.saturating_add(1)
-                ))
-            })?;
+            let record: LedgerRecord =
+                serde_json::from_str(&line).map_err(|e| NonoError::AuditLedgerCorrupt {
+                    line: index.saturating_add(1),
+                    reason: e.to_string(),
+                })?;
             previous_chain = Some(record.chain_hash);
             next_sequence = record.sequence.saturating_add(1);
         }
@@ -880,12 +879,11 @@ pub fn verify_session_in_ledger_reader<R: BufRead>(
         if line.trim().is_empty() {
             continue;
         }
-        let record: LedgerRecord = serde_json::from_str(&line).map_err(|e| {
-            NonoError::Snapshot(format!(
-                "Failed to parse audit ledger line {}: {e}",
-                index.saturating_add(1)
-            ))
-        })?;
+        let record: LedgerRecord =
+            serde_json::from_str(&line).map_err(|e| NonoError::AuditLedgerCorrupt {
+                line: index.saturating_add(1),
+                reason: e.to_string(),
+            })?;
         if record.sequence != entry_count {
             return Err(NonoError::Snapshot(format!(
                 "Audit ledger sequence mismatch at line {}",

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -146,6 +146,17 @@ pub enum NonoError {
     #[error("Session exited before attach could complete")]
     SessionGone,
 
+    // Audit errors
+    /// A line of the global audit ledger is not a valid record.
+    ///
+    /// Separate from [`Self::Snapshot`] because it is permanent: every later
+    /// append re-reads the same line and fails the same way, so no run is
+    /// recorded until the file parses again. The I/O failures that share the
+    /// append path clear themselves on the next write, and callers must not
+    /// tell a user the two stories interchangeably.
+    #[error("Failed to parse audit ledger line {line}: {reason}")]
+    AuditLedgerCorrupt { line: usize, reason: String },
+
     // Trust/attestation errors
     #[error("Trust verification failed for {path}: {reason}")]
     TrustVerification { path: String, reason: String },
@@ -250,6 +261,7 @@ impl NonoError {
             | Self::PathCanonicalization { .. }
             | Self::HashMismatch { .. }
             | Self::SessionNotFound(_)
+            | Self::AuditLedgerCorrupt { .. }
             | Self::ObjectStore(_)
             | Self::Snapshot(_) => NonoDiagnosticCode::Other,
             #[cfg(target_os = "linux")]

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -337,6 +337,8 @@ The audit trail is intentionally narrow in what it claims to prove.
 
 - The event log is recorded by the trusted supervisor, not by the sandboxed child.
 - The default integrity structure protects the audit event stream for a single session and also records that session into the global audit ledger.
+- Recording into the global ledger can fail after the command has already exited (for example when the ledger file no longer parses, or the audit directory is unwritable). The session's own directory is still written, but the ledger has no entry for that run, so `nono audit verify` reports it as missing from the chain. The failure is printed on stderr and the run's exit status is downgraded to `1` if the command itself succeeded; a command that failed keeps its own exit status, so a non-zero status is not by itself proof that the run was recorded.
+- A ledger that no longer parses stops every later run from being recorded, and there is no repair command. Moving the file aside starts a fresh chain, after which `nono audit verify` no longer finds the sessions the old one held.
 - `--audit-sign-key` adds a keyed supervisor-side signature over the session audit Merkle root and session context, but that still depends on trusting the configured signing key and how its public key is distributed.
 - Without an external timestamp, transparency log, or other anchor, this remains host-local attestation material rather than a globally witnessed timestamped proof.
 - For supervised runs, the supervisor hashes the main executable binary selected for launch and records its canonical path and SHA-256 digest.


### PR DESCRIPTION
## Linked Issue

Closes #1583

## Summary
Keeps child processes' exit codes past finalisation and reports errors after this stage locally.

Warns instead of aborting when a ledger append is skipped.

Doesn't attempt to fix corrupted ledgers.

## Test Plan

New integration test + steps to reproduce

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
