### PR TITLE
refactor(test): share integration harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+crates/*/target/
 .vscode/
 .idea/
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@
 
 nono is a capability-based sandboxing system for running untrusted AI agents with OS-enforced isolation. It uses Landlock (Linux) and Seatbelt (macOS) to create sandboxes, and then layers on top a policy system, diagnostic tools, and a rollback mechanism for recovery. The library is designed to be a pure sandbox primitive with no built-in policy, while the CLI implements all security policy and UX.
 
-The project is a Cargo workspace with three members:
+The project is a Cargo workspace with five members:
 - **nono** (`crates/nono/`) - Core library. Pure sandbox primitive with no built-in security policy.
 - **nono-cli** (`crates/nono-cli/`) - CLI binary. Owns all security policy, profiles, hooks, and UX.
 - **nono-ffi** (`bindings/c/`) - C FFI bindings. Exposes the library via `extern "C"` functions and auto-generated `nono.h` header.
 - **nono-proxy** - Proxy that provides network filtering and credential injection
+- **nono-test-support** (`crates/nono-test-support/`) - Test-only harness for the `nono-cli` integration tests. Not published.
 
 ### Library vs CLI Boundary
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,6 +2786,7 @@ dependencies = [
  "nix 0.31.3",
  "nono",
  "nono-proxy",
+ "nono-test-support",
  "proptest",
  "rand 0.10.2",
  "regex",
@@ -2866,6 +2867,14 @@ dependencies = [
  "webpki-roots",
  "x509-parser",
  "zeroize",
+]
+
+[[package]]
+name = "nono-test-support"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/nono",
     "crates/nono-cli",
     "crates/nono-proxy",
+    "crates/nono-test-support",
     "bindings/c",
 ]
 

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -115,6 +115,10 @@ toml.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
+# Path-only on purpose: `cargo package` strips a versionless path
+# dev-dependency, so publishing nono-cli does not require this crate on
+# crates.io.
+nono-test-support = { path = "../nono-test-support" }
 jsonschema = "0.48"
 proptest = "1"
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/nono-cli/tests/audit_attestation.rs
+++ b/crates/nono-cli/tests/audit_attestation.rs
@@ -1,88 +1,24 @@
 //! Integration tests for supervisor-side audit attestation.
 
+use nono_test_support::{KeyRef, NonoTest, Rollback, nono_test};
 use serde_json::Value;
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
 
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn run_nono(args: &[&str], home: &Path, state: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_STATE_HOME", state)
-        .current_dir(cwd)
+fn generate_file_signing_key(t: &NonoTest) -> KeyRef {
+    let key = KeyRef::file(t.home().join("audit-signing-key.pk8.b64"));
+    t.trust()
+        .keygen(&key)
+        .force()
         .output()
-        .expect("failed to run nono")
+        .assert_success("trust keygen writes a file:// signing key");
+
+    assert!(key.private_key_path().exists(), "private key should exist");
+    assert!(key.public_key_path().exists(), "public key should exist");
+    key
 }
 
-fn assert_success(output: &Output) {
-    assert!(
-        output.status.success(),
-        "expected success, stdout: {}, stderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
-    let temp_root = std::env::current_dir()
-        .expect("cwd")
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create temp root");
-    let tmp = tempfile::Builder::new()
-        .prefix("nono-audit-attestation-it-")
-        .tempdir_in(&temp_root)
-        .expect("tempdir");
-    let home = tmp.path().join("home");
-    let state = tmp.path().join("state");
-    let workspace = tmp.path().join("workspace");
-    fs::create_dir_all(home.join(".config")).expect("create config dir");
-    fs::create_dir_all(&state).expect("create state dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, state, workspace)
-}
-
-fn audit_root(state: &Path) -> PathBuf {
-    state.join("nono").join("audit")
-}
-
-fn key_path(home: &Path) -> PathBuf {
-    home.join("audit-signing-key.pk8.b64")
-}
-
-fn pub_key_path_for_file(private_key_path: &Path) -> PathBuf {
-    let mut pub_path = private_key_path.as_os_str().to_owned();
-    pub_path.push(".pub");
-    PathBuf::from(pub_path)
-}
-
-fn generate_file_signing_key(home: &Path, state: &Path, cwd: &Path) -> PathBuf {
-    let key_path = key_path(home);
-    let keyref = format!("file://{}", key_path.display());
-    let output = run_nono(
-        &["trust", "keygen", "--force", "--keyref", &keyref],
-        home,
-        state,
-        cwd,
-    );
-    assert_success(&output);
-    assert!(key_path.exists(), "private key should exist");
-    assert!(
-        pub_key_path_for_file(&key_path).exists(),
-        "public key should exist"
-    );
-    key_path
-}
-
-fn only_audit_session_id(state: &Path) -> String {
-    let audit_root = audit_root(state);
-    let mut session_ids: Vec<String> = fs::read_dir(&audit_root)
+fn only_audit_session_id(t: &NonoTest) -> String {
+    let mut session_ids: Vec<String> = fs::read_dir(t.audit_root())
         .expect("read audit root")
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| {
@@ -100,43 +36,22 @@ fn only_audit_session_id(state: &Path) -> String {
 
 #[test]
 fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
-    let (_tmp, home, state, workspace) = setup_isolated_home();
-    let key_path = generate_file_signing_key(&home, &state, &workspace);
-    let keyref = format!("file://{}", key_path.display());
+    let t = nono_test!("audit-attestation");
+    let key = generate_file_signing_key(&t);
 
-    let run_output = run_nono(
-        &[
-            "run",
-            "--allow-cwd",
-            "--audit-sign-key",
-            &keyref,
-            "--",
-            "/bin/pwd",
-        ],
-        &home,
-        &state,
-        &workspace,
-    );
-    assert_success(&run_output);
+    t.run()
+        .allow_cwd()
+        .audit_sign_key(&key)
+        .exec("/bin/pwd")
+        .assert_success("a signed session runs to completion");
 
-    let session_id = only_audit_session_id(&state);
-    let pub_key_path = format!("{}", pub_key_path_for_file(&key_path).display());
-    let verify_output = run_nono(
-        &[
-            "audit",
-            "verify",
-            &session_id,
-            "--public-key-file",
-            &pub_key_path,
-            "--json",
-        ],
-        &home,
-        &state,
-        &workspace,
-    );
-    assert_success(&verify_output);
+    let session_id = only_audit_session_id(&t);
+    let json = t
+        .audit()
+        .verify(&session_id)
+        .public_key_file(key.public_key_path())
+        .json();
 
-    let json: Value = serde_json::from_slice(&verify_output.stdout).expect("parse verify json");
     assert_eq!(json["session"]["records_verified"], true);
     assert_eq!(json["ledger"]["session_digest_matches"], true);
     assert_eq!(json["ledger"]["ledger_chain_verified"], true);
@@ -149,31 +64,20 @@ fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
 
 #[test]
 fn rollback_signed_session_verifies_from_audit_dir_bundle() {
-    let (_tmp, home, state, workspace) = setup_isolated_home();
-    fs::write(workspace.join("tracked.txt"), "before\n").expect("write tracked file");
-    let key_path = generate_file_signing_key(&home, &state, &workspace);
-    let keyref = format!("file://{}", key_path.display());
+    let t = nono_test!("audit-attestation-rollback");
+    fs::write(t.workspace().join("tracked.txt"), "before\n").expect("write tracked file");
+    let key = generate_file_signing_key(&t);
 
-    let run_output = run_nono(
-        &[
-            "run",
-            "--allow-cwd",
-            "--rollback",
-            "--no-rollback-prompt",
-            "--audit-sign-key",
-            &keyref,
-            "--",
-            "/bin/pwd",
-        ],
-        &home,
-        &state,
-        &workspace,
-    );
-    assert_success(&run_output);
+    t.run()
+        .allow_cwd()
+        .rollback(Rollback::new().no_prompt())
+        .audit_sign_key(&key)
+        .exec("/bin/pwd")
+        .assert_success("a signed session with rollback runs to completion");
 
-    let session_id = only_audit_session_id(&state);
-    let audit_dir = audit_root(&state).join(&session_id);
-    let rollback_dir = state.join("nono").join("rollbacks").join(&session_id);
+    let session_id = only_audit_session_id(&t);
+    let audit_dir = t.audit_root().join(&session_id);
+    let rollback_dir = t.state().join("nono").join("rollbacks").join(&session_id);
     assert!(
         audit_dir.join("audit-attestation.bundle").exists(),
         "bundle should live in audit dir"
@@ -183,15 +87,7 @@ fn rollback_signed_session_verifies_from_audit_dir_bundle() {
         "bundle should not be required in rollback dir"
     );
 
-    let verify_output = run_nono(
-        &["audit", "verify", &session_id, "--json"],
-        &home,
-        &state,
-        &workspace,
-    );
-    assert_success(&verify_output);
-
-    let json: Value = serde_json::from_slice(&verify_output.stdout).expect("parse verify json");
+    let json = t.audit().verify(&session_id).json();
     assert_eq!(json["attestation"]["present"], true);
     assert_eq!(json["attestation"]["signature_verified"], true);
     assert_eq!(json["attestation"]["merkle_root_matches"], true);

--- a/crates/nono-cli/tests/config_flag.rs
+++ b/crates/nono-cli/tests/config_flag.rs
@@ -1,71 +1,55 @@
 //! Integration tests for `nono run --config <manifest>`.
 
-use std::io::Write;
-use std::process::Command;
+use nono_test_support::{Argv, NonoTest, nono_test};
+use std::fs;
+use std::path::PathBuf;
 
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
+/// Every case runs the same child; `--dry-run` never execs it.
+fn echo_hello() -> Argv {
+    Argv::new("echo").arg("hello")
+}
+
+fn write_manifest(t: &NonoTest, name: &str, json: &str) -> PathBuf {
+    let path = t.root().join(name);
+    fs::write(&path, json).expect("root is a fresh dir this test owns");
+    path
 }
 
 #[test]
 fn config_with_valid_manifest_is_accepted() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(
-        f,
-        r#"{{
+    let t = nono_test!("config-valid");
+    let manifest = write_manifest(
+        &t,
+        "valid.json",
+        r#"{
             "version": "0.1.0",
-            "filesystem": {{
-                "grants": [{{ "path": "/tmp", "access": "read" }}]
-            }},
-            "network": {{ "mode": "blocked" }}
-        }}"#
-    )
-    .expect("write manifest");
-
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
-
-    // --dry-run prints what would happen and exits 0
-    assert!(
-        output.status.success(),
-        "expected success, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+            "filesystem": {
+                "grants": [{ "path": "/tmp", "access": "read" }]
+            },
+            "network": { "mode": "blocked" }
+        }"#,
     );
+
+    t.run()
+        .config(&manifest)
+        .dry_run()
+        .exec(echo_hello())
+        .assert_success("--dry-run reports a valid manifest and exits 0");
 }
 
 #[test]
 fn config_with_invalid_json_fails() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(f, "not json at all").expect("write");
+    let t = nono_test!("config-invalid-json");
+    let manifest = write_manifest(&t, "invalid.json", "not json at all");
 
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
+    let completed = t
+        .run()
+        .config(&manifest)
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("a manifest that is not JSON is rejected");
 
-    assert!(
-        !output.status.success(),
-        "expected failure for invalid JSON"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = completed.stderr();
     assert!(
         stderr.contains("invalid") || stderr.contains("error"),
         "expected error message, got: {stderr}"
@@ -74,146 +58,80 @@ fn config_with_invalid_json_fails() {
 
 #[test]
 fn config_with_missing_version_fails() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(f, r#"{{ "filesystem": {{ }} }}"#).expect("write");
+    let t = nono_test!("config-missing-version");
+    let manifest = write_manifest(&t, "missing-version.json", r#"{ "filesystem": { } }"#);
 
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
-
-    assert!(
-        !output.status.success(),
-        "expected failure for missing version"
-    );
+    t.run()
+        .config(&manifest)
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("a manifest without a version is rejected");
 }
 
 #[test]
 fn config_conflicts_with_allow() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(f, r#"{{ "version": "0.1.0" }}"#).expect("write");
+    let t = nono_test!("config-vs-allow");
+    let manifest = write_manifest(&t, "conflict-allow.json", r#"{ "version": "0.1.0" }"#);
 
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--allow",
-            "/tmp",
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
-
-    assert!(
-        !output.status.success(),
-        "expected failure: --config conflicts with --allow"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("cannot be used with"),
-        "expected conflict error, got: {stderr}"
-    );
+    t.run()
+        .config(&manifest)
+        .allow("/tmp")
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("--config conflicts with --allow")
+        .assert_stderr_contains("cannot be used with");
 }
 
 #[test]
 fn config_conflicts_with_profile() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(f, r#"{{ "version": "0.1.0" }}"#).expect("write");
+    let t = nono_test!("config-vs-profile");
+    let manifest = write_manifest(&t, "conflict-profile.json", r#"{ "version": "0.1.0" }"#);
 
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--profile",
-            "default",
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
-
-    assert!(
-        !output.status.success(),
-        "expected failure: --config conflicts with --profile"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("cannot be used with"),
-        "expected conflict error, got: {stderr}"
-    );
+    t.run()
+        .config(&manifest)
+        .profile_name("default")
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("--config conflicts with --profile")
+        .assert_stderr_contains("cannot be used with");
 }
 
 #[test]
 fn config_nonexistent_file_fails() {
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            "/tmp/nono-test-does-not-exist-12345.json",
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
+    let t = nono_test!("config-missing-file");
 
-    assert!(
-        !output.status.success(),
-        "expected failure for nonexistent file"
-    );
+    t.run()
+        .config(t.root().join("does-not-exist.json"))
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("a manifest path that does not exist is rejected");
 }
 
 #[test]
 fn config_semantic_validation_rejects_bad_inject() {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-    write!(
-        f,
-        r#"{{
+    let t = nono_test!("config-bad-inject");
+    let manifest = write_manifest(
+        &t,
+        "bad-inject.json",
+        r#"{
             "version": "0.1.0",
-            "credentials": [{{
+            "credentials": [{
                 "name": "test",
                 "source": "env://TOKEN",
                 "upstream": "https://api.example.com",
-                "inject": {{ "mode": "url_path" }}
-            }}]
-        }}"#
-    )
-    .expect("write");
-
-    let output = nono_bin()
-        .args([
-            "run",
-            "--config",
-            f.path().to_str().expect("path"),
-            "--dry-run",
-            "--",
-            "echo",
-            "hello",
-        ])
-        .output()
-        .expect("failed to run nono");
-
-    assert!(
-        !output.status.success(),
-        "expected failure: url_path without path_pattern"
+                "inject": { "mode": "url_path" }
+            }]
+        }"#,
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let completed = t
+        .run()
+        .config(&manifest)
+        .dry_run()
+        .exec(echo_hello())
+        .assert_failure("url_path inject without path_pattern is rejected");
+
+    let stderr = completed.stderr();
     assert!(
         stderr.contains("url_path") || stderr.contains("path_pattern"),
         "expected validation error about url_path, got: {stderr}"

--- a/crates/nono-cli/tests/deny_overlap_run.rs
+++ b/crates/nono-cli/tests/deny_overlap_run.rs
@@ -16,47 +16,13 @@
 
 #![cfg(target_os = "linux")]
 
+use nono_test_support::{Argv, nono_test};
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
-
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf) {
-    let temp_root = std::env::current_dir()
-        .expect("cwd")
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create temp root");
-    let tmp = tempfile::Builder::new()
-        .prefix("nono-deny-overlap-run-it-")
-        .tempdir_in(&temp_root)
-        .expect("tempdir");
-    let home = tmp.path().join("home");
-    let workspace = tmp.path().join("workspace");
-    fs::create_dir_all(home.join(".config")).expect("create config dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, workspace)
-}
-
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        // Disable the detached-launch path and any interactive prompts —
-        // `--allow-cwd` already pre-confirms CWD sharing, but be defensive.
-        .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(cwd)
-        .output()
-        .expect("failed to run nono")
-}
 
 #[test]
 fn run_allow_cwd_with_profile_deny_under_workdir_fails_closed() {
-    let (_tmp, home, workspace) = setup_isolated_home();
+    let t = nono_test!("deny-overlap-run");
+    let workspace = t.workspace().to_path_buf();
 
     // Stand up a fake .ssh/id_rsa under the workspace. The profile denies it,
     // so even though `--allow-cwd` opens up the workspace, the run must abort
@@ -72,53 +38,27 @@ fn run_allow_cwd_with_profile_deny_under_workdir_fails_closed() {
     // exercising; the implicit default groups merged in by the loader do
     // not allow $WORKDIR, so the only allow that covers `.ssh` is the one
     // injected by `--allow-cwd`.
-    let profile_path = home.join("deny-overlap-repro.json");
-    let profile_json = format!(
-        r#"{{
+    let profile = t.write_profile(
+        "deny-overlap-repro",
+        &format!(
+            r#"{{
             "meta": {{ "name": "deny-overlap-repro" }},
             "workdir": {{ "access": "readwrite" }},
             "filesystem": {{
                 "deny": ["{workspace}/.ssh"]
             }}
         }}"#,
-        workspace = workspace.display()
-    );
-    fs::write(&profile_path, profile_json).expect("write profile");
-
-    let profile_arg = profile_path.to_string_lossy().into_owned();
-    let secret_arg = secret_path.to_string_lossy().into_owned();
-    let output = run_nono(
-        &[
-            "run",
-            "--allow-cwd",
-            "--profile",
-            &profile_arg,
-            "--",
-            "/bin/cat",
-            &secret_arg,
-        ],
-        &home,
-        &workspace,
+            workspace = workspace.display()
+        ),
     );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "nono run must fail closed when a profile deny overlaps --allow-cwd; \
-         instead it exited successfully.\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        stderr.contains("Landlock deny-overlap"),
-        "expected 'Landlock deny-overlap' refusal in stderr, got:\n{stderr}",
-    );
-    assert!(
-        !stderr.contains("Landlock cannot enforce deny '"),
-        "expected a single overlap summary warning, got per-deny warnings:\n{stderr}",
-    );
-    assert!(
-        !stdout.contains("fake-test-secret"),
-        "secret content leaked to stdout despite profile deny:\n{stdout}",
-    );
+    t.run()
+        .allow_cwd()
+        .profile(&profile)
+        .exec(Argv::new("/bin/cat").arg(&secret_path))
+        .assert_failure("a profile deny overlapping --allow-cwd must fail closed")
+        .assert_stderr_contains("Landlock deny-overlap")
+        // A single overlap summary, not one warning per deny.
+        .assert_stderr_lacks("Landlock cannot enforce deny '")
+        .assert_stdout_lacks("fake-test-secret");
 }

--- a/crates/nono-cli/tests/execution_strategy_run.rs
+++ b/crates/nono-cli/tests/execution_strategy_run.rs
@@ -11,57 +11,13 @@
 //!
 //! AF_UNIX mediation integration tests live in `socket_access_run.rs`.
 
+use nono_test_support::{Argv, Completed, NonoTest, Profile, Sandboxed, Sandboxing, nono_test};
 use std::fs;
 use std::net::TcpListener;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
-
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn setup_isolated_home(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
-    let temp_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create test-artifacts root");
-    let tmp = tempfile::Builder::new()
-        .prefix(&format!("nono-{prefix}-it-"))
-        .tempdir_in(&temp_root)
-        .expect("create tempdir");
-    let home = tmp.path().join("home");
-    let workspace = tmp.path().join("workspace");
-    fs::create_dir_all(home.join(".config")).expect("create .config dir");
-    fs::create_dir_all(home.join(".local").join("state")).expect("create state dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, workspace)
-}
-
-fn nono_cmd(args: &[&str], home: &Path, cwd: &Path) -> Command {
-    let mut cmd = nono_bin();
-    cmd.args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_STATE_HOME", home.join(".local").join("state"))
-        .env("NONO_NO_SAVE_PROMPT", "1")
-        .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(cwd);
-    cmd
-}
-
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_cmd(args, home, cwd)
-        .output()
-        .expect("failed to run nono")
-}
-
-fn write_profile(home: &Path, name: &str, json: &str) -> PathBuf {
-    let path = home.join(format!("{name}.json"));
-    fs::write(&path, json).expect("write profile");
-    path
-}
+use std::process::Command;
 
 fn python3_available() -> bool {
     Command::new("python3")
@@ -69,6 +25,21 @@ fn python3_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// A profile allowing only the test's workspace, with the network blocked.
+fn workspace_only_profile(t: &NonoTest, name: &str) -> Profile {
+    t.write_profile(
+        name,
+        &format!(
+            r#"{{
+                "meta": {{ "name": "{name}-test" }},
+                "filesystem": {{ "allow": ["{workspace}"] }},
+                "network": {{ "block": true }}
+            }}"#,
+            workspace = t.workspace().display()
+        ),
+    )
 }
 
 #[test]
@@ -79,7 +50,7 @@ fn cli_auto_block_net_uses_static_seccomp_baseline() {
         return;
     }
 
-    let (_tmp, home, workspace) = setup_isolated_home("network-baseline");
+    let t = nono_test!("network-baseline");
     let script = "import ctypes, socket
 try:
     socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -90,30 +61,15 @@ libc = ctypes.CDLL(None, use_errno=True)
 result = libc.syscall(425, 1, None)
 print('IO_URING', result, ctypes.get_errno())";
 
-    let output = run_nono(
-        &[
-            "run",
-            "--allow-cwd",
-            "--block-net",
-            "--no-rollback",
-            "--",
-            "python3",
-            "-c",
-            script,
-        ],
-        &home,
-        &workspace,
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "baseline probe failed\nstdout: {stdout}\nstderr: {stderr}"
-    );
-    assert!(stdout.contains("UDP_BLOCKED 1"), "stdout: {stdout}");
-    assert!(!stdout.contains("UDP_OPEN"), "stdout: {stdout}");
-    assert!(stdout.contains("IO_URING -1 1"), "stdout: {stdout}");
+    t.run()
+        .allow_cwd()
+        .block_net()
+        .no_rollback()
+        .exec(Argv::new("python3").arg("-c").arg(script))
+        .assert_success("the baseline probe itself runs")
+        .assert_stdout_contains("UDP_BLOCKED 1")
+        .assert_stdout_lacks("UDP_OPEN")
+        .assert_stdout_contains("IO_URING -1 1");
 }
 
 #[cfg(target_os = "linux")]
@@ -128,46 +84,15 @@ fn cc_available() -> bool {
 #[test]
 #[cfg(target_os = "linux")]
 fn direct_denies_path_outside_grant() {
-    let (_tmp, home, workspace) = setup_isolated_home("direct-deny");
+    let t = nono_test!("direct-deny");
+    let profile = workspace_only_profile(&t, "direct-deny");
 
-    let profile_path = write_profile(
-        &home,
-        "direct-deny",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "direct-deny-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
-
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "/bin/cat",
-            "/etc/shadow",
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "nono run must deny /etc/shadow outside the grant set\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("root:"),
-        "secret content must not appear in stdout\nstdout: {stdout}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("/bin/cat").arg("/etc/shadow"))
+        .assert_failure("/etc/shadow is outside the grant set")
+        .assert_stdout_lacks("root:");
 }
 
 /// On macOS, Seatbelt is used. `/etc/passwd` is world-readable and included in
@@ -177,190 +102,69 @@ fn direct_denies_path_outside_grant() {
 #[test]
 #[cfg(target_os = "macos")]
 fn direct_denies_path_outside_grant_macos() {
-    let (tmp, home, workspace) = setup_isolated_home("direct-deny-macos");
+    let t = nono_test!("direct-deny-macos");
 
-    let secret = tmp.path().join("outside-secret.txt");
+    let secret = t.root().join("outside-secret.txt");
     fs::write(&secret, "TOPSECRET-outside-grant\n").expect("write secret");
 
-    let profile_path = write_profile(
-        &home,
-        "direct-deny-macos",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "direct-deny-macos-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let profile = workspace_only_profile(&t, "direct-deny-macos");
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "/bin/cat",
-            secret.to_str().expect("secret path"),
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "nono run must deny a path outside the grant set\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("TOPSECRET"),
-        "secret content must not appear in stdout\nstdout: {stdout}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("/bin/cat").arg(&secret))
+        .assert_failure("a path outside the grant set is denied")
+        .assert_stdout_lacks("TOPSECRET");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn deny_outside_grant_produces_diagnostic_footer() {
-    let (_tmp, home, workspace) = setup_isolated_home("deny-diag");
+    let t = nono_test!("deny-diag");
 
-    let target = home.join("secret.txt");
+    let target = t.home().join("secret.txt");
     fs::write(&target, "forbidden-content").expect("write secret");
 
-    let profile_path = write_profile(
-        &home,
-        "deny-diag",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "deny-diag-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let profile = workspace_only_profile(&t, "deny-diag");
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "/bin/cat",
-            target.to_str().expect("target path"),
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "nono run must deny a path outside the grant set\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("forbidden-content"),
-        "forbidden content leaked to stdout\nstdout: {stdout}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("/bin/cat").arg(&target))
+        .assert_failure("a path outside the grant set is denied")
+        .assert_stdout_lacks("forbidden-content");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn supervised_denies_path_outside_grant() {
-    let (_tmp, home, workspace) = setup_isolated_home("supervised-deny");
+    let t = nono_test!("supervised-deny");
+    let profile = workspace_only_profile(&t, "supervised-deny");
 
-    let profile_path = write_profile(
-        &home,
-        "supervised-deny",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "supervised-deny-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
-
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "/bin/cat",
-            "/etc/shadow",
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "nono run must deny /etc/shadow outside the grant set\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("root:"),
-        "secret content must not appear in stdout\nstdout: {stdout}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("/bin/cat").arg("/etc/shadow"))
+        .assert_failure("/etc/shadow is outside the grant set")
+        .assert_stdout_lacks("root:");
 }
 
 /// Positive control: reading a file inside the granted set must succeed.
 #[test]
 fn granted_path_exits_zero() {
-    let (_tmp, home, workspace) = setup_isolated_home("grant-ok");
+    let t = nono_test!("grant-ok");
 
-    let sentinel = workspace.join("hello.txt");
+    let sentinel = t.workspace().join("hello.txt");
     fs::write(&sentinel, "hello from nono test").expect("write sentinel");
 
-    let profile_path = write_profile(
-        &home,
-        "grant-ok",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "grant-ok-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let profile = workspace_only_profile(&t, "grant-ok");
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "/bin/cat",
-            sentinel.to_str().expect("sentinel path"),
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "nono run must succeed for a path inside the grant set\nstderr: {stderr}",
-    );
-    assert!(
-        stdout.contains("hello from nono test"),
-        "expected sentinel content in stdout\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("/bin/cat").arg(&sentinel))
+        .assert_success("a path inside the grant set is readable")
+        .assert_stdout_contains("hello from nono test");
 }
 
 /// `network.block: true` must prevent outbound TCP connections. We bind a
@@ -373,23 +177,12 @@ fn network_block_denies_outbound_tcp() {
         return;
     }
 
-    let (_tmp, home, workspace) = setup_isolated_home("net-block");
+    let t = nono_test!("net-block");
 
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
     let port = listener.local_addr().expect("local addr").port();
 
-    let profile_path = write_profile(
-        &home,
-        "net-block",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "net-block-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let profile = workspace_only_profile(&t, "net-block");
 
     // connect_ex() returns the errno on failure so the script exits 1 on any
     // connect error. Without a sandbox, connecting to the bound listener
@@ -399,28 +192,11 @@ fn network_block_denies_outbound_tcp() {
          code=s.connect_ex(('127.0.0.1', {port})); sys.exit(0 if code == 0 else 1)"
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "python3",
-            "-c",
-            &py_script,
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "network block must deny outbound TCP to a live listener\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("python3").arg("-c").arg(&py_script))
+        .assert_failure("network block denies outbound TCP to a live listener");
 }
 
 /// A profile combining `env_credentials` (env://) and `command_policies` must
@@ -430,10 +206,9 @@ fn network_block_denies_outbound_tcp() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn env_credentials_with_command_policies_non_shim_entry_succeeds() {
-    let (_tmp, home, workspace) = setup_isolated_home("env-creds-cmd-policies");
+    let t = nono_test!("env-creds-cmd-policies");
 
-    let profile_path = write_profile(
-        &home,
+    let profile = t.write_profile(
         "env-creds-cmd-policies",
         &format!(
             r#"{{
@@ -451,38 +226,16 @@ fn env_credentials_with_command_policies_non_shim_entry_succeeds() {
                     }}
                 }}
             }}"#,
-            workspace = workspace.display()
+            workspace = t.workspace().display()
         ),
     );
 
-    let output = nono_bin()
-        .args([
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "sh",
-            "-c",
-            "exit 0",
-        ])
-        .env("HOME", &home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_STATE_HOME", home.join(".local").join("state"))
-        .env("NONO_NO_SAVE_PROMPT", "1")
+    t.run()
+        .profile(&profile)
+        .no_rollback()
         .env("API_TOKEN", "secret-value")
-        .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(&workspace)
-        .output()
-        .expect("failed to run nono");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "env_credentials + command_policies with a non-shim entry must succeed\nstdout: {stdout}\nstderr: {stderr}",
-    );
+        .exec(Argv::new("sh").arg("-c").arg("exit 0"))
+        .assert_success("env_credentials + command_policies with a non-shim entry launches");
 }
 
 /// A script written into a writable grant-dir (cwd) must still execute under
@@ -490,59 +243,21 @@ fn env_credentials_with_command_policies_non_shim_entry_succeeds() {
 #[test]
 #[cfg(target_os = "linux")]
 fn command_policies_allows_script_exec_in_writable_grant_dir() {
-    let (_tmp, home, workspace) = setup_isolated_home("cmd-policies-script-exec");
+    let t = nono_test!("cmd-policies-script-exec");
 
-    let script_path = workspace.join("s.sh");
+    let script_path = t.workspace().join("s.sh");
     fs::write(&script_path, "#!/usr/bin/env bash\necho ok\n").expect("write script");
     fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
         .expect("chmod script executable");
 
-    let profile_path = write_profile(
-        &home,
-        "cmd-policies-script-exec",
-        &format!(
-            r#"{{
-                "meta": {{ "name": "cmd-policies-script-exec-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }},
-                "command_policies": {{
-                    "commands": {{
-                        "cat": {{
-                            "executable": "/bin/cat"
-                        }}
-                    }}
-                }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let profile = command_policies_profile(&t, "cmd-policies-script-exec");
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "bash",
-            "-c",
-            "./s.sh",
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "a script in a writable grant-dir must still execute under command_policies\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        stdout.contains("ok"),
-        "expected script output in stdout\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("bash").arg("-c").arg("./s.sh"))
+        .assert_success("a script in a writable grant-dir executes under command_policies")
+        .assert_stdout_contains("ok");
 }
 
 /// Same as above but for a binary compiled at runtime, so it wasn't on disk
@@ -555,31 +270,43 @@ fn command_policies_allows_compiled_binary_exec_in_writable_grant_dir() {
         return;
     }
 
-    let (_tmp, home, workspace) = setup_isolated_home("cmd-policies-bin-exec");
+    let t = nono_test!("cmd-policies-bin-exec");
 
-    let source_path = workspace.join("b.c");
+    let source_path = t.workspace().join("b.c");
     fs::write(
         &source_path,
         "#include <stdio.h>\nint main(void) { printf(\"ok\\n\"); return 0; }\n",
     )
     .expect("write source");
-    let binary_path = workspace.join("b");
+    let binary_path = t.workspace().join("b");
     let compile_status = Command::new("cc")
-        .args([
-            "-o",
-            binary_path.to_str().expect("binary path"),
-            source_path.to_str().expect("source path"),
-        ])
+        .arg("-o")
+        .arg(&binary_path)
+        .arg(&source_path)
         .status()
         .expect("run cc");
     assert!(compile_status.success(), "cc must compile the test binary");
 
-    let profile_path = write_profile(
-        &home,
-        "cmd-policies-bin-exec",
+    let profile = command_policies_profile(&t, "cmd-policies-bin-exec");
+
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec(Argv::new("bash").arg("-c").arg("./b"))
+        .assert_success(
+            "a freshly compiled binary in a writable grant-dir executes under command_policies",
+        )
+        .assert_stdout_contains("ok");
+}
+
+/// Workspace-only profile with an active `command_policies` outer exec gate.
+#[cfg(target_os = "linux")]
+fn command_policies_profile(t: &NonoTest, name: &str) -> Profile {
+    t.write_profile(
+        name,
         &format!(
             r#"{{
-                "meta": {{ "name": "cmd-policies-bin-exec-test" }},
+                "meta": {{ "name": "{name}-test" }},
                 "filesystem": {{ "allow": ["{workspace}"] }},
                 "network": {{ "block": true }},
                 "command_policies": {{
@@ -590,102 +317,66 @@ fn command_policies_allows_compiled_binary_exec_in_writable_grant_dir() {
                     }}
                 }}
             }}"#,
-            workspace = workspace.display()
+            workspace = t.workspace().display()
         ),
-    );
-
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "bash",
-            "-c",
-            "./b",
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "a freshly compiled binary in a writable grant-dir must still execute under command_policies\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        stdout.contains("ok"),
-        "expected binary output in stdout\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    )
 }
 
 /// A granted project directory to hand the child via `--workdir`, plus a launch
 /// directory that is deliberately outside the capability set.
 struct WorkdirCase {
-    _tmp: tempfile::TempDir,
-    home: PathBuf,
-    profile: PathBuf,
+    t: NonoTest,
+    profile: Profile,
     launch: PathBuf,
     project: PathBuf,
 }
 
 fn setup_workdir_case(prefix: &str) -> WorkdirCase {
-    let (tmp, home, workspace) = setup_isolated_home(prefix);
-    let launch = tmp.path().join("launch");
-    fs::create_dir_all(&launch).expect("create launch dir");
+    let t = nono_test!(prefix);
+    let launch = t.root().join("launch");
+    fs::create_dir_all(&launch).expect("root is a fresh dir this test owns");
 
-    let profile = write_profile(
-        &home,
-        prefix,
-        &format!(
-            r#"{{
-                "meta": {{ "name": "{prefix}-test" }},
-                "filesystem": {{ "allow": ["{workspace}"] }},
-                "network": {{ "block": true }}
-            }}"#,
-            workspace = workspace.display()
-        ),
-    );
+    let project = t.workspace().to_path_buf();
+    let profile = workspace_only_profile(&t, prefix);
 
     WorkdirCase {
-        _tmp: tmp,
-        home,
+        t,
         profile,
         launch,
-        project: workspace,
+        project,
     }
 }
 
-/// The child's own `$PWD`, as reported by `/usr/bin/env`.
-fn child_pwd(stdout: &str) -> Option<&str> {
-    stdout.lines().find_map(|line| line.strip_prefix("PWD="))
+/// Asserts the child's own `$PWD` is the workdir.
+///
+/// Takes the first `PWD=` line rather than looking for a matching one anywhere:
+/// a corrected entry appended after a stale one would not undo it, since
+/// `getenv` resolves to the first match.
+fn assert_child_pwd(completed: &Completed, case: &WorkdirCase) {
+    let stdout = completed.stdout();
+    assert_eq!(
+        stdout.lines().find_map(|line| line.strip_prefix("PWD=")),
+        case.project.to_str(),
+        "--workdir must set the child's $PWD\nstdout: {stdout}\nstderr: {}",
+        completed.stderr(),
+    );
 }
 
-/// Run `nono <subcommand> --workdir <project>` from the uncovered launch directory,
-/// exporting `host_pwd` as the inherited `$PWD`.
-fn run_workdir_case(case: &WorkdirCase, subcommand: &str, host_pwd: &Path) -> Output {
-    let mut args = vec![
-        subcommand,
-        "--profile",
-        case.profile.to_str().expect("profile path"),
-    ];
-    if subcommand == "run" {
-        args.push("--no-rollback");
-    }
-    args.extend([
-        "--workdir",
-        case.project.to_str().expect("project path"),
-        "--",
-        "/usr/bin/env",
-    ]);
-
-    nono_cmd(&args, &case.home, &case.launch)
+/// Runs `nono <subcommand> --workdir <project> -- /usr/bin/env` from the
+/// uncovered launch directory, exporting `host_pwd` as the inherited `$PWD`.
+///
+/// Generic over the subcommand: `run` and `wrap` differ in which rollback flags
+/// they accept, so each caller supplies an already-configured builder.
+fn run_workdir_case<M: Sandboxing>(
+    case: &WorkdirCase,
+    cmd: Sandboxed<'_, M>,
+    host_pwd: &Path,
+) -> Completed {
+    cmd.profile(&case.profile)
+        .workdir(&case.project)
+        .launch_dir(&case.launch)
         .env("PWD", host_pwd)
-        .output()
-        .expect("failed to run nono")
+        .exec("/usr/bin/env")
 }
 
 /// `--workdir` must reach the child's `$PWD` even though nono was launched from a
@@ -693,59 +384,33 @@ fn run_workdir_case(case: &WorkdirCase, subcommand: &str, host_pwd: &Path) -> Ou
 #[test]
 fn direct_workdir_sets_child_pwd_from_uncovered_launch_dir() {
     let case = setup_workdir_case("workdir-pwd-direct");
-    let output = run_workdir_case(&case, "wrap", &case.launch);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        child_pwd(&stdout),
-        case.project.to_str(),
-        "nono wrap --workdir must set the child's $PWD to the workdir\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    let completed = run_workdir_case(&case, case.t.wrap(), &case.launch);
+    assert_child_pwd(&completed, &case);
 }
 
 #[test]
 fn supervised_workdir_sets_child_pwd_from_uncovered_launch_dir() {
     let case = setup_workdir_case("workdir-pwd-supervised");
-    let output = run_workdir_case(&case, "run", &case.launch);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        child_pwd(&stdout),
-        case.project.to_str(),
-        "nono run --workdir must set the child's $PWD to the workdir\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    let completed = run_workdir_case(&case, case.t.run().no_rollback(), &case.launch);
+    assert_child_pwd(&completed, &case);
 }
 
+/// A stale inherited `$PWD` — here a directory nono was not launched from —
+/// must not suppress the correction.
 #[test]
 fn direct_workdir_overrides_untrusted_host_pwd() {
     let case = setup_workdir_case("workdir-pwd-stale-direct");
-    let output = run_workdir_case(&case, "wrap", &case.home);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        child_pwd(&stdout),
-        case.project.to_str(),
-        "a stale inherited $PWD must not suppress the correction\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    let completed = run_workdir_case(&case, case.t.wrap(), case.t.home());
+    assert_child_pwd(&completed, &case);
 }
 
 #[test]
 fn supervised_workdir_overrides_untrusted_host_pwd() {
     let case = setup_workdir_case("workdir-pwd-stale-supervised");
-    let output = run_workdir_case(&case, "run", &case.home);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        child_pwd(&stdout),
-        case.project.to_str(),
-        "a stale inherited $PWD must not suppress the correction\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    let completed = run_workdir_case(&case, case.t.run().no_rollback(), case.t.home());
+    assert_child_pwd(&completed, &case);
 }

--- a/crates/nono-cli/tests/rollback_run.rs
+++ b/crates/nono-cli/tests/rollback_run.rs
@@ -3,63 +3,28 @@
 //! Exercises the baseline-snapshot → modify → rollback → verify-restored flow
 //! using `nono run --rollback` and `nono rollback` subcommands.
 
+use nono_test_support::{Argv, NonoTest, Rollback, nono_test};
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::path::PathBuf;
 
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn setup_isolated_dirs(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
-    let temp_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create test-artifacts root");
-    let tmp = tempfile::Builder::new()
-        .prefix(&format!("nono-{prefix}-it-"))
-        .tempdir_in(&temp_root)
-        .expect("create tempdir");
-    let home = tmp.path().join("home");
-    let workspace = tmp.path().join("workspace");
-    let rollback_dest = tmp.path().join("rollbacks");
-    fs::create_dir_all(home.join(".config")).expect("create .config dir");
-    fs::create_dir_all(home.join(".local").join("state")).expect("create state dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    fs::create_dir_all(&rollback_dest).expect("create rollback-dest dir");
-    (tmp, home, workspace, rollback_dest)
-}
-
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_STATE_HOME", home.join(".local").join("state"))
-        .env("NONO_NO_SAVE_PROMPT", "1")
-        .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(cwd)
-        .output()
-        .expect("failed to run nono")
-}
-
-fn write_profile(home: &Path, name: &str, json: &str) -> PathBuf {
-    let path = home.join(format!("{name}.json"));
-    fs::write(&path, json).expect("write profile");
-    path
+fn rollback_dest(t: &NonoTest) -> PathBuf {
+    let dest = t.root().join("rollbacks");
+    fs::create_dir_all(&dest).expect("root is a fresh dir this test owns");
+    dest
 }
 
 /// Verifies that `nono run --rollback` captures a baseline, the sandboxed
 /// command writes a new file, and `nono rollback list` exits cleanly afterward.
 #[test]
 fn rollback_restores_file_after_write() {
-    let (_tmp, home, workspace, rollback_dest) = setup_isolated_dirs("rollback-restore");
+    let t = nono_test!("rollback-restore");
+    let workspace = t.workspace().to_path_buf();
+    let rollback_dest = rollback_dest(&t);
 
     let baseline_file = workspace.join("baseline.txt");
     fs::write(&baseline_file, "pre-existing content").expect("write baseline");
 
-    let profile_path = write_profile(
-        &home,
+    let profile = t.write_profile(
         "rollback-restore",
         &format!(
             r#"{{
@@ -73,51 +38,34 @@ fn rollback_restores_file_after_write() {
     );
 
     let new_file = workspace.join("new_file.txt");
-    let new_file_arg = new_file.to_str().expect("new_file path");
-    let profile_arg = profile_path.to_str().expect("profile path");
-    let rollback_dest_arg = rollback_dest.to_str().expect("rollback_dest path");
 
-    let run_output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_arg,
-            "--rollback",
-            "--rollback-dest",
-            rollback_dest_arg,
-            "--no-rollback-prompt",
-            "--",
-            "/bin/sh",
-            "-c",
-            &format!("echo 'sandboxed-write' > {new_file_arg}"),
-        ],
-        &home,
-        &workspace,
-    );
+    t.run()
+        .profile(&profile)
+        .rollback(Rollback::new().dest(&rollback_dest).no_prompt())
+        .exec(
+            Argv::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("echo 'sandboxed-write' > {}", new_file.display())),
+        )
+        .assert_success("nono run --rollback completes");
 
-    let run_stdout = String::from_utf8_lossy(&run_output.stdout);
-    let run_stderr = String::from_utf8_lossy(&run_output.stderr);
-
-    assert!(
-        run_output.status.success(),
-        "nono run --rollback failed unexpectedly\nstdout: {run_stdout}\nstderr: {run_stderr}",
-    );
     assert!(
         new_file.exists(),
-        "expected sandboxed write to create {new_file_arg}",
+        "expected sandboxed write to create {}",
+        new_file.display(),
     );
     assert!(
         baseline_file.exists(),
         "baseline.txt disappeared after nono run",
     );
 
-    let list_output = run_nono(&["rollback", "list", "--json"], &home, &workspace);
-    let list_stderr = String::from_utf8_lossy(&list_output.stderr);
-
+    // Session count is deliberately not asserted: --rollback-dest writes the
+    // snapshot outside the state dir `rollback list` discovers, so an empty
+    // array is a legitimate result.
+    let listed = t.rollback().list().json();
     assert!(
-        list_output.status.success(),
-        "nono rollback list failed\nstdout: {}\nstderr: {list_stderr}",
-        String::from_utf8_lossy(&list_output.stdout),
+        listed.is_array(),
+        "rollback list --json must emit a top-level array, got: {listed}"
     );
 }
 
@@ -125,13 +73,14 @@ fn rollback_restores_file_after_write() {
 /// sandboxed run.
 #[test]
 fn dry_run_does_not_modify_workspace() {
-    let (_tmp, home, workspace, rollback_dest) = setup_isolated_dirs("rollback-dry");
+    let t = nono_test!("rollback-dry");
+    let workspace = t.workspace().to_path_buf();
+    let rollback_dest = rollback_dest(&t);
 
     let seed_file = workspace.join("seed.txt");
     fs::write(&seed_file, "seed content").expect("write seed");
 
-    let profile_path = write_profile(
-        &home,
+    let profile = t.write_profile(
         "rollback-dry",
         &format!(
             r#"{{
@@ -145,58 +94,37 @@ fn dry_run_does_not_modify_workspace() {
     );
 
     let new_file = workspace.join("extra.txt");
-    let new_file_arg = new_file.to_str().expect("new_file path");
-    let profile_arg = profile_path.to_str().expect("profile path");
-    let rollback_dest_arg = rollback_dest.to_str().expect("rollback_dest path");
 
-    let run_output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_arg,
-            "--rollback",
-            "--rollback-dest",
-            rollback_dest_arg,
-            "--no-rollback-prompt",
-            "--",
-            "/bin/sh",
-            "-c",
-            &format!("echo 'extra' > {new_file_arg}"),
-        ],
-        &home,
-        &workspace,
-    );
+    t.run()
+        .profile(&profile)
+        .rollback(Rollback::new().dest(&rollback_dest).no_prompt())
+        .exec(
+            Argv::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("echo 'extra' > {}", new_file.display())),
+        )
+        .assert_success("nono run --rollback (dry variant) completes");
 
-    let run_stdout = String::from_utf8_lossy(&run_output.stdout);
-    let run_stderr = String::from_utf8_lossy(&run_output.stderr);
-
-    assert!(
-        run_output.status.success(),
-        "nono run --rollback (dry variant) failed\nstdout: {run_stdout}\nstderr: {run_stderr}",
-    );
     assert!(
         new_file.exists(),
-        "expected sandboxed write to create {new_file_arg}",
+        "expected sandboxed write to create {}",
+        new_file.display(),
     );
 
-    let list_output = run_nono(&["rollback", "list"], &home, &workspace);
-    assert!(
-        list_output.status.success(),
-        "nono rollback list failed after run\nstderr: {}",
-        String::from_utf8_lossy(&list_output.stderr),
-    );
+    t.rollback()
+        .list()
+        .output()
+        .assert_success("nono rollback list exits 0 after a run");
 }
 
 /// `nono rollback cleanup --dry-run` must exit 0 even with no sessions.
 #[test]
 fn cleanup_dry_run_exits_zero() {
-    let (_tmp, home, workspace, _rollback_dest) = setup_isolated_dirs("rollback-cleanup");
+    let t = nono_test!("rollback-cleanup");
 
-    let output = run_nono(&["rollback", "cleanup", "--dry-run"], &home, &workspace);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "nono rollback cleanup --dry-run must exit 0\nstderr: {stderr}",
-    );
+    t.rollback()
+        .cleanup()
+        .dry_run()
+        .output()
+        .assert_success("nono rollback cleanup --dry-run exits 0 with no sessions");
 }

--- a/crates/nono-cli/tests/socket_access_run.rs
+++ b/crates/nono-cli/tests/socket_access_run.rs
@@ -6,48 +6,13 @@
 //! macOS: `filesystem.deny` on a socket path causes Seatbelt to emit both a
 //! filesystem deny and a `network-outbound` deny, blocking the connect.
 
+use nono_test_support::{Argv, nono_test};
+#[cfg(target_os = "linux")]
 use std::fs;
 #[cfg(target_os = "linux")]
 use std::os::unix::net::UnixDatagram;
 use std::os::unix::net::UnixListener;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
-
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn setup_isolated_home(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
-    let temp_root = std::env::current_dir()
-        .expect("cwd")
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create temp root");
-    let tmp = tempfile::Builder::new()
-        .prefix(&format!("nono-{prefix}-it-"))
-        .tempdir_in(&temp_root)
-        .expect("tempdir");
-    let home = tmp.path().join("home");
-    let workspace = tmp.path().join("workspace");
-    fs::create_dir_all(home.join(".config")).expect("create config dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, workspace)
-}
-
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("NONO_NO_SAVE_PROMPT", "1")
-        .env_remove("NONO_DETACHED_LAUNCH")
-        // Denials are the expected outcome in these tests; never open the
-        // post-run denied-path review UI on the cargo test runner's TTY.
-        .env("NONO_NO_SAVE_PROMPT", "1")
-        .current_dir(cwd)
-        .output()
-        .expect("failed to run nono")
-}
+use std::process::Command;
 
 // Socket paths must stay under the 104-byte SUN_LEN limit; use /tmp directly
 // rather than std::env::temp_dir() which on macOS expands to a long path
@@ -84,48 +49,29 @@ fn af_unix_mediation_pathname_blocks_connect_to_unlisted_socket() {
         return;
     };
 
-    let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation");
+    let t = nono_test!("af-unix-mediation");
     let sock_tmp = short_tempdir();
     let socket_path = sock_tmp.path().join("t.sock");
     let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
 
-    let profile_path = home.join("af-unix-test.json");
-    fs::write(
-        &profile_path,
+    let profile = t.write_profile(
+        "af-unix-test",
         r#"{"meta":{"name":"af-unix-test"},"workdir":{"access":"readwrite"},"linux":{"af_unix_mediation":"pathname"}}"#,
-    )
-    .expect("write profile");
+    );
 
     let socket_arg = socket_path.to_string_lossy().into_owned();
     let py_script = format!(
         "import socket; s=socket.socket(socket.AF_UNIX); s.connect({socket_arg:?}); print('connected')"
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            &profile_path.to_string_lossy(),
-            "--",
-            &py,
-            "-c",
-            &py_script,
-        ],
-        &home,
-        &workspace,
-    );
+    let completed = t
+        .run()
+        .profile(&profile)
+        .exec(Argv::new(&py).arg("-c").arg(&py_script))
+        .assert_failure("connect to an unlisted socket is denied")
+        .assert_stdout_lacks("connected");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "connect to unlisted socket must be denied\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("connected"),
-        "connect must not complete\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    let stderr = completed.stderr();
     assert!(
         stderr.contains("unix socket")
             || stderr.contains("Unix socket")
@@ -142,20 +88,18 @@ fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
         return;
     };
 
-    let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation-allow");
+    let t = nono_test!("af-unix-mediation-allow");
     let sock_tmp = short_tempdir();
     let socket_path = sock_tmp.path().join("a.sock");
     let _listener = UnixDatagram::bind(&socket_path).expect("bind test datagram socket");
 
     let socket_arg = socket_path.to_string_lossy().into_owned();
-    let profile_path = home.join("af-unix-allow-test.json");
-    fs::write(
-        &profile_path,
-        format!(
+    let profile = t.write_profile(
+        "af-unix-allow-test",
+        &format!(
             r#"{{"meta":{{"name":"af-unix-allow-test"}},"workdir":{{"access":"readwrite"}},"linux":{{"af_unix_mediation":"pathname"}},"filesystem":{{"unix_socket":["{socket_arg}"]}}}}"#
         ),
-    )
-    .expect("write profile");
+    );
 
     // Use SOCK_DGRAM: connect() sets the peer address without requiring an
     // accept() on the far end, so the child exits immediately after the
@@ -164,31 +108,13 @@ fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
         "import socket; s=socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM); s.connect({socket_arg:?}); print('ok')"
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            &profile_path.to_string_lossy(),
-            "--",
-            &py,
-            "-c",
-            &py_script,
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
     // The supervisor must not deny the allowlisted socket path. Other system
     // sockets touched by Python or libc may still be denied; those are
     // unrelated to the allowlist entry under test.
-    let denial_marker = format!("send {socket_arg}");
-    assert!(
-        !stderr.contains(&denial_marker),
-        "supervisor must not deny the allowlisted socket path\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new(&py).arg("-c").arg(&py_script))
+        .assert_stderr_lacks(&format!("send {socket_arg}"));
 }
 
 #[test]
@@ -199,50 +125,28 @@ fn filesystem_deny_blocks_unix_socket_connect_on_macos() {
         return;
     };
 
-    let (_tmp, home, workspace) = setup_isolated_home("macos-socket-deny");
+    let t = nono_test!("macos-socket-deny");
     let sock_tmp = short_tempdir();
     let socket_path = sock_tmp.path().join("d.sock");
     let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
 
     let socket_arg = socket_path.to_string_lossy().into_owned();
-    let profile_path = home.join("macos-socket-deny.json");
-    fs::write(
-        &profile_path,
-        format!(
+    let profile = t.write_profile(
+        "macos-socket-deny",
+        &format!(
             r#"{{"meta":{{"name":"macos-socket-deny"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"deny":["{socket_arg}"]}}}}"#
         ),
-    )
-    .expect("write profile");
+    );
 
     let py_script = format!(
         "import socket; s=socket.socket(socket.AF_UNIX); s.connect({socket_arg:?}); print('connected')"
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            &profile_path.to_string_lossy(),
-            "--",
-            &py,
-            "-c",
-            &py_script,
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        !output.status.success(),
-        "connect to denied socket path must be blocked\nstdout: {stdout}\nstderr: {stderr}",
-    );
-    assert!(
-        !stdout.contains("connected"),
-        "connect must not complete\nstdout: {stdout}\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new(&py).arg("-c").arg(&py_script))
+        .assert_failure("connect to a denied socket path is blocked")
+        .assert_stdout_lacks("connected");
 }
 
 /// Yama `ptrace_scope`, or `None` if it can't be read (non-Yama kernel).
@@ -275,19 +179,17 @@ fn af_unix_mediation_pathname_allows_orphaned_child_tcp_connect() {
         None => eprintln!("note: could not read ptrace_scope (non-Yama kernel?)"),
     }
 
-    let (_tmp, home, workspace) = setup_isolated_home("af-unix-orphan");
+    let t = nono_test!("af-unix-orphan");
 
     // Live loopback listener so an authorized connect completes locally without
     // egress (the handshake lands in the backlog; no accept() needed).
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
     let port = listener.local_addr().expect("local_addr").port();
 
-    let profile_path = home.join("af-unix-orphan.json");
-    fs::write(
-        &profile_path,
+    let profile = t.write_profile(
+        "af-unix-orphan",
         r#"{"meta":{"name":"af-unix-orphan"},"workdir":{"access":"readwrite"},"network":{"block":false},"linux":{"af_unix_mediation":"pathname"}}"#,
-    )
-    .expect("write profile");
+    );
 
     // Foreground connect (always in the supervisor's ancestry) then a
     // double-forked orphan that reparents to pid 1 before it connects.
@@ -316,40 +218,14 @@ print(os.read(r, 200).decode(), flush=True)
 "#
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            &profile_path.to_string_lossy(),
-            "--",
-            &py,
-            "-c",
-            &py_script,
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    // Sanity: foreground connect is authorized and completes.
-    assert!(
-        stdout.contains("foreground OK"),
-        "foreground connect should be authorized and complete\nstdout: {stdout}\nstderr: {stderr}",
-    );
-
-    // The fix: the orphaned grandchild's connect is authorized too (pre-fix it
-    // was "orphan errno=1" under ptrace_scope>=1).
-    assert!(
-        stdout.contains("orphan OK"),
-        "orphaned grandchild connect must be authorized (was EPERM before the \
-         child-subreaper fix)\nstdout: {stdout}\nstderr: {stderr}",
-    );
-
-    // Fingerprint of the ancestry-gated /proc/<pid>/mem read failing.
-    assert!(
-        !stderr.contains("Failed to read sockaddr"),
-        "supervisor failed to classify the orphan's connect (ancestry lost)\nstderr: {stderr}",
-    );
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new(&py).arg("-c").arg(&py_script))
+        // Sanity: foreground connect is authorized and completes.
+        .assert_stdout_contains("foreground OK")
+        // The fix: the orphaned grandchild's connect is authorized too (pre-fix
+        // it was "orphan errno=1" under ptrace_scope>=1).
+        .assert_stdout_contains("orphan OK")
+        // Fingerprint of the ancestry-gated /proc/<pid>/mem read failing.
+        .assert_stderr_lacks("Failed to read sockaddr");
 }

--- a/crates/nono-cli/tests/spiffe_run.rs
+++ b/crates/nono-cli/tests/spiffe_run.rs
@@ -14,55 +14,11 @@
 //! routes through the nono proxy, which fetches the SVID and injects the header.
 #![allow(clippy::unwrap_used)]
 
-use std::fs;
+use nono_test_support::{Argv, nono_test};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
 use std::sync::{Arc, Mutex};
 use std::thread;
-
-// ─── Helpers shared with other integration tests ─────────────────────────────
-
-fn nono_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nono"))
-}
-
-fn setup_isolated_home(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
-    let temp_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join("test-artifacts");
-    fs::create_dir_all(&temp_root).expect("create test-artifacts root");
-    let tmp = tempfile::Builder::new()
-        .prefix(&format!("nono-spiffe-{prefix}-"))
-        .tempdir_in(&temp_root)
-        .expect("create tempdir");
-    let home = tmp.path().join("home");
-    let workspace = tmp.path().join("workspace");
-    fs::create_dir_all(home.join(".config")).expect("create .config dir");
-    fs::create_dir_all(home.join(".local").join("state")).expect("create state dir");
-    fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, workspace)
-}
-
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_STATE_HOME", home.join(".local").join("state"))
-        .env("NONO_NO_SAVE_PROMPT", "1")
-        .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(cwd)
-        .output()
-        .expect("failed to run nono")
-}
-
-fn write_profile(home: &Path, name: &str, json: &str) -> PathBuf {
-    let path = home.join(format!("{name}.json"));
-    fs::write(&path, json).expect("write profile");
-    path
-}
 
 /// Returns the SPIRE agent socket path, or `None` to skip the test.
 fn live_socket() -> Option<String> {
@@ -146,15 +102,14 @@ fn spiffe_jwt_credential_injected_end_to_end() {
         None => return,
     };
 
-    let (_tmp, home, workspace) = setup_isolated_home("jwt-inject");
+    let t = nono_test!("spiffe-jwt-inject");
     let mock = MockHttpServer::start();
     let upstream = format!("http://127.0.0.1:{}", mock.port);
 
     // Credential name must be hyphen-free: it becomes MOCKAPI_BASE_URL / MOCKAPI_API_KEY
     // in the child environment. The proxy routes by URL path prefix (/mockapi/...) and
     // strips it before forwarding to the upstream.
-    let profile_path = write_profile(
-        &home,
+    let profile = t.write_profile(
         "spiffe-jwt",
         &format!(
             r#"{{
@@ -180,30 +135,16 @@ fn spiffe_jwt_credential_injected_end_to_end() {
     // curl routes $MOCKAPI_BASE_URL through HTTP_PROXY (127.0.0.1 is removed from
     // NO_PROXY because the upstream is loopback). The proxy normalises the absolute
     // URL, matches the mockapi route, fetches a JWT-SVID, and injects it.
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "sh",
-            "-c",
-            "curl --silent --show-error \"$MOCKAPI_BASE_URL/\"",
-        ],
-        &home,
-        &workspace,
+    let completed = t.run().profile(&profile).no_rollback().exec(
+        Argv::new("sh")
+            .arg("-c")
+            .arg("curl --silent --show-error \"$MOCKAPI_BASE_URL/\""),
     );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
 
     let headers = mock.wait_for_headers(std::time::Duration::from_secs(10));
 
-    assert!(
-        output.status.success(),
-        "nono run should succeed\nstdout: {stdout}\nstderr: {stderr}"
-    );
+    let stderr = completed.stderr().into_owned();
+    completed.assert_success("nono run with a SPIFFE credential completes");
 
     let auth_header = headers
         .iter()
@@ -236,10 +177,9 @@ fn spiffe_jwt_proxy_starts_with_live_agent() {
         None => return,
     };
 
-    let (_tmp, home, workspace) = setup_isolated_home("jwt-start");
+    let t = nono_test!("spiffe-jwt-start");
 
-    let profile_path = write_profile(
-        &home,
+    let profile = t.write_profile(
         "spiffe-jwt-start",
         &format!(
             r#"{{
@@ -262,24 +202,9 @@ fn spiffe_jwt_proxy_starts_with_live_agent() {
         ),
     );
 
-    let output = run_nono(
-        &[
-            "run",
-            "--profile",
-            profile_path.to_str().expect("profile path"),
-            "--no-rollback",
-            "--",
-            "true",
-        ],
-        &home,
-        &workspace,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "nono run should start cleanly with a live SPIRE agent\nstdout: {stdout}\nstderr: {stderr}"
-    );
+    t.run()
+        .profile(&profile)
+        .no_rollback()
+        .exec("true")
+        .assert_success("nono run starts cleanly with a live SPIRE agent");
 }

--- a/crates/nono-test-support/Cargo.toml
+++ b/crates/nono-test-support/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nono-test-support"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Shared scaffolding for nono integration tests"
+publish = false
+
+[dependencies]
+serde_json.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nono-test-support/src/cli.rs
+++ b/crates/nono-test-support/src/cli.rs
@@ -1,0 +1,536 @@
+//! Typed builders over the `nono` command line.
+//!
+//! Every subcommand the integration tests drive is a method on [`NonoTest`]
+//! returning a builder.
+
+use std::ffi::{OsStr, OsString};
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use crate::NonoTest;
+
+/// The argv handed to the sandboxed child, i.e. everything after `--`.
+#[derive(Clone, Debug)]
+pub struct Argv {
+    program: OsString,
+    args: Vec<OsString>,
+}
+
+impl Argv {
+    pub fn new(program: impl AsRef<OsStr>) -> Self {
+        Self {
+            program: program.as_ref().to_owned(),
+            args: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn arg(mut self, arg: impl AsRef<OsStr>) -> Self {
+        self.args.push(arg.as_ref().to_owned());
+        self
+    }
+}
+
+impl From<&str> for Argv {
+    fn from(program: &str) -> Self {
+        Self::new(program)
+    }
+}
+
+/// A profile written by [`NonoTest::write_profile`], passed to `--profile`.
+#[derive(Clone, Debug)]
+pub struct Profile {
+    path: PathBuf,
+}
+
+impl Profile {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// A `file://<path>` signing-key reference.
+#[derive(Clone, Debug)]
+pub struct KeyRef {
+    uri: String,
+    file: PathBuf,
+}
+
+impl KeyRef {
+    pub fn file(path: impl AsRef<Path>) -> Self {
+        let path = path.as_ref().to_path_buf();
+        Self {
+            uri: format!("file://{}", path.display()),
+            file: path,
+        }
+    }
+
+    pub fn private_key_path(&self) -> &Path {
+        &self.file
+    }
+
+    /// Where `trust keygen` writes the verifying half, alongside the private key.
+    pub fn public_key_path(&self) -> PathBuf {
+        let mut path = self.file.clone().into_os_string();
+        path.push(".pub");
+        PathBuf::from(path)
+    }
+
+    fn as_str(&self) -> &str {
+        &self.uri
+    }
+}
+
+/// The flags clap gates behind `--rollback`.
+#[derive(Debug, Default)]
+pub struct Rollback {
+    no_prompt: bool,
+    dest: Option<PathBuf>,
+}
+
+impl Rollback {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `--rollback-dest <PATH>`
+    #[must_use]
+    pub fn dest(mut self, dir: impl AsRef<Path>) -> Self {
+        self.dest = Some(dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// `--no-rollback-prompt`
+    #[must_use]
+    pub fn no_prompt(mut self) -> Self {
+        self.no_prompt = true;
+        self
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A subcommand that sandboxes a child process.
+pub trait Sandboxing: sealed::Sealed {
+    const SUBCOMMAND: &'static str;
+}
+
+/// `nono run` — supervised, owns the rollback and audit-signing flags.
+#[derive(Debug)]
+pub struct RunMode;
+
+impl Sandboxing for RunMode {
+    const SUBCOMMAND: &'static str = "run";
+}
+
+impl sealed::Sealed for RunMode {}
+
+/// `nono wrap` — direct exec. Takes `WrapSandboxArgs`, which has no rollback.
+#[derive(Debug)]
+pub struct WrapMode;
+
+impl Sandboxing for WrapMode {
+    const SUBCOMMAND: &'static str = "wrap";
+}
+
+impl sealed::Sealed for WrapMode {}
+
+/// Builder for `nono run` / `nono wrap`.
+#[must_use = "a dropped builder never spawns nono, so the test asserts nothing"]
+pub struct Sandboxed<'t, M: Sandboxing> {
+    inner: Invocation<'t>,
+    _mode: PhantomData<M>,
+}
+
+impl<'t, M: Sandboxing> Sandboxed<'t, M> {
+    /// `--allow <PATH>`, repeatable.
+    pub fn allow(mut self, path: impl AsRef<Path>) -> Self {
+        self.inner.opt("--allow", path.as_ref());
+        self
+    }
+
+    pub fn allow_cwd(mut self) -> Self {
+        self.inner.flag("--allow-cwd");
+        self
+    }
+
+    pub fn block_net(mut self) -> Self {
+        self.inner.flag("--block-net");
+        self
+    }
+
+    pub fn config(mut self, path: impl AsRef<Path>) -> Self {
+        self.inner.opt("--config", path.as_ref());
+        self
+    }
+
+    pub fn dry_run(mut self) -> Self {
+        self.inner.flag("--dry-run");
+        self
+    }
+
+    /// Environment for the `nono` process, on top of the hermetic set.
+    pub fn env(mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
+        self.inner.env(key, value);
+        self
+    }
+
+    /// The directory `nono` is launched from. Defaults to the workspace.
+    pub fn launch_dir(mut self, dir: impl AsRef<Path>) -> Self {
+        self.inner.launch_dir(dir);
+        self
+    }
+
+    pub fn profile(mut self, profile: &Profile) -> Self {
+        self.inner.opt("--profile", profile.path());
+        self
+    }
+
+    pub fn profile_name(mut self, name: &str) -> Self {
+        self.inner.opt("--profile", name);
+        self
+    }
+
+    pub fn workdir(mut self, dir: impl AsRef<Path>) -> Self {
+        self.inner.opt("--workdir", dir.as_ref());
+        self
+    }
+
+    #[must_use = "a Completed that is dropped asserts nothing about the run"]
+    pub fn exec(mut self, argv: impl Into<Argv>) -> Completed {
+        let argv = argv.into();
+        self.inner.raw("--");
+        self.inner.raw(&argv.program);
+        for arg in &argv.args {
+            self.inner.raw(arg);
+        }
+        self.inner.finish()
+    }
+
+    pub(crate) fn new(t: &'t NonoTest) -> Self {
+        Self {
+            inner: Invocation::new(t, &[M::SUBCOMMAND]),
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl Sandboxed<'_, RunMode> {
+    /// `--audit-sign-key`. `run`-only, same reason as [`Self::rollback`].
+    pub fn audit_sign_key(mut self, key: &KeyRef) -> Self {
+        self.inner.opt("--audit-sign-key", key.as_str());
+        self
+    }
+
+    /// `--no-rollback`. Mutually exclusive with [`Self::rollback`].
+    pub fn no_rollback(mut self) -> Self {
+        self.inner.flag("--no-rollback");
+        self
+    }
+
+    pub fn rollback(mut self, rollback: Rollback) -> Self {
+        self.inner.flag("--rollback");
+        if rollback.no_prompt {
+            self.inner.flag("--no-rollback-prompt");
+        }
+        if let Some(dest) = &rollback.dest {
+            self.inner.opt("--rollback-dest", dest);
+        }
+        self
+    }
+}
+
+/// `nono trust <…>`
+pub struct Trust<'t> {
+    t: &'t NonoTest,
+}
+
+impl<'t> Trust<'t> {
+    pub fn keygen(self, key: &KeyRef) -> Keygen<'t> {
+        let mut inner = Invocation::new(self.t, &["trust", "keygen"]);
+        inner.opt("--keyref", key.as_str());
+        Keygen { inner }
+    }
+
+    pub(crate) fn new(t: &'t NonoTest) -> Self {
+        Self { t }
+    }
+}
+
+#[must_use = "a dropped builder never spawns nono, so the test asserts nothing"]
+pub struct Keygen<'t> {
+    inner: Invocation<'t>,
+}
+
+impl Keygen<'_> {
+    pub fn force(mut self) -> Self {
+        self.inner.flag("--force");
+        self
+    }
+
+    #[must_use = "a Completed that is dropped asserts nothing about the run"]
+    pub fn output(self) -> Completed {
+        self.inner.finish()
+    }
+}
+
+/// `nono audit <…>`
+pub struct Audit<'t> {
+    t: &'t NonoTest,
+}
+
+impl<'t> Audit<'t> {
+    /// `session_id` is positional and required, so it is a parameter rather
+    /// than an optional builder method.
+    pub fn verify(self, session_id: &str) -> AuditVerify<'t> {
+        AuditVerify {
+            inner: Invocation::new(self.t, &["audit", "verify", session_id]),
+        }
+    }
+
+    pub(crate) fn new(t: &'t NonoTest) -> Self {
+        Self { t }
+    }
+}
+
+#[must_use = "a dropped builder never spawns nono, so the test asserts nothing"]
+pub struct AuditVerify<'t> {
+    inner: Invocation<'t>,
+}
+
+impl AuditVerify<'_> {
+    pub fn public_key_file(mut self, path: impl AsRef<Path>) -> Self {
+        self.inner.opt("--public-key-file", path.as_ref());
+        self
+    }
+
+    /// Adds `--json` and parses stdout. Panics unless the command succeeded, so
+    /// callers never parse the output of a failed run.
+    pub fn json(mut self) -> serde_json::Value {
+        self.inner.flag("--json");
+        self.inner.finish().json()
+    }
+}
+
+/// `nono rollback <…>`
+pub struct RollbackCmd<'t> {
+    t: &'t NonoTest,
+}
+
+impl<'t> RollbackCmd<'t> {
+    pub fn cleanup(self) -> RollbackCleanup<'t> {
+        RollbackCleanup {
+            inner: Invocation::new(self.t, &["rollback", "cleanup"]),
+        }
+    }
+
+    pub fn list(self) -> RollbackList<'t> {
+        RollbackList {
+            inner: Invocation::new(self.t, &["rollback", "list"]),
+        }
+    }
+
+    pub(crate) fn new(t: &'t NonoTest) -> Self {
+        Self { t }
+    }
+}
+
+#[must_use = "a dropped builder never spawns nono, so the test asserts nothing"]
+pub struct RollbackList<'t> {
+    inner: Invocation<'t>,
+}
+
+impl RollbackList<'_> {
+    pub fn json(mut self) -> serde_json::Value {
+        self.inner.flag("--json");
+        self.inner.finish().json()
+    }
+
+    #[must_use = "a Completed that is dropped asserts nothing about the run"]
+    pub fn output(self) -> Completed {
+        self.inner.finish()
+    }
+}
+
+#[must_use = "a dropped builder never spawns nono, so the test asserts nothing"]
+pub struct RollbackCleanup<'t> {
+    inner: Invocation<'t>,
+}
+
+impl RollbackCleanup<'_> {
+    pub fn dry_run(mut self) -> Self {
+        self.inner.flag("--dry-run");
+        self
+    }
+
+    #[must_use = "a Completed that is dropped asserts nothing about the run"]
+    pub fn output(self) -> Completed {
+        self.inner.finish()
+    }
+}
+
+/// Accumulates argv/env for one `nono` invocation.
+struct Invocation<'t> {
+    t: &'t NonoTest,
+    args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
+    launch_dir: Option<PathBuf>,
+}
+
+impl<'t> Invocation<'t> {
+    fn new(t: &'t NonoTest, subcommand: &[&str]) -> Self {
+        Self {
+            t,
+            args: subcommand.iter().map(OsString::from).collect(),
+            envs: Vec::new(),
+            launch_dir: None,
+        }
+    }
+
+    fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+        self.envs
+            .push((key.as_ref().to_owned(), value.as_ref().to_owned()));
+    }
+
+    fn flag(&mut self, flag: &str) {
+        self.raw(flag);
+    }
+
+    fn launch_dir(&mut self, dir: impl AsRef<Path>) {
+        self.launch_dir = Some(dir.as_ref().to_path_buf());
+    }
+
+    fn opt(&mut self, flag: &str, value: impl AsRef<OsStr>) {
+        self.raw(flag);
+        self.raw(value);
+    }
+
+    fn raw(&mut self, arg: impl AsRef<OsStr>) {
+        self.args.push(arg.as_ref().to_owned());
+    }
+
+    fn finish(self) -> Completed {
+        let mut cmd = self.t.hermetic_command();
+        cmd.args(&self.args);
+        for (key, value) in &self.envs {
+            cmd.env(key, value);
+        }
+        if let Some(dir) = &self.launch_dir {
+            cmd.current_dir(dir);
+        }
+        let output = cmd
+            .output()
+            .expect("cargo builds CARGO_BIN_EXE_nono before running this test binary");
+        Completed {
+            output,
+            invocation: render(&self.args),
+        }
+    }
+}
+
+fn render(args: &[OsString]) -> String {
+    let rendered: Vec<String> = args
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    format!("nono {}", rendered.join(" "))
+}
+
+/// A finished `nono` invocation.
+pub struct Completed {
+    output: Output,
+    invocation: String,
+}
+
+impl Completed {
+    pub fn assert_failure(self, why: &str) -> Self {
+        assert!(
+            !self.output.status.success(),
+            "{}",
+            self.context(&format!("expected failure: {why}"))
+        );
+        self
+    }
+
+    pub fn assert_stderr_contains(self, needle: &str) -> Self {
+        assert!(
+            self.stderr().contains(needle),
+            "{}",
+            self.context(&format!("stderr should contain {needle:?}"))
+        );
+        self
+    }
+
+    pub fn assert_stderr_lacks(self, needle: &str) -> Self {
+        assert!(
+            !self.stderr().contains(needle),
+            "{}",
+            self.context(&format!("stderr must not contain {needle:?}"))
+        );
+        self
+    }
+
+    pub fn assert_stdout_contains(self, needle: &str) -> Self {
+        assert!(
+            self.stdout().contains(needle),
+            "{}",
+            self.context(&format!("stdout should contain {needle:?}"))
+        );
+        self
+    }
+
+    pub fn assert_stdout_lacks(self, needle: &str) -> Self {
+        assert!(
+            !self.stdout().contains(needle),
+            "{}",
+            self.context(&format!("stdout must not contain {needle:?}"))
+        );
+        self
+    }
+
+    pub fn assert_success(self, why: &str) -> Self {
+        assert!(
+            self.output.status.success(),
+            "{}",
+            self.context(&format!("expected success: {why}"))
+        );
+        self
+    }
+
+    pub fn stderr(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.output.stderr)
+    }
+
+    pub fn stdout(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.output.stdout)
+    }
+
+    fn context(&self, what: &str) -> String {
+        format!(
+            "{what}\ncommand: {}\nexit: {:?}\nstdout: {}\nstderr: {}",
+            self.invocation,
+            self.output.status.code(),
+            self.stdout(),
+            self.stderr(),
+        )
+    }
+
+    /// Parses stdout as JSON, requiring success first: a non-zero exit means
+    /// stdout holds no document, and the parse error would hide the real cause.
+    fn json(self) -> serde_json::Value {
+        let this = self.assert_success("a --json command must exit 0 to emit a document");
+        serde_json::from_slice(&this.output.stdout).unwrap_or_else(|err| {
+            panic!(
+                "{}",
+                this.context(&format!("stdout is not valid JSON: {err}"))
+            );
+        })
+    }
+}

--- a/crates/nono-test-support/src/lib.rs
+++ b/crates/nono-test-support/src/lib.rs
@@ -1,0 +1,164 @@
+//! Shared scaffolding for the `nono-cli` integration tests.
+//!
+//! [`NonoTest`] owns a tempdir holding an isolated `HOME`, `$XDG_STATE_HOME`
+//! and workspace, and hands out builders for the real `nono` binary under a
+//! hermetic environment.
+//!
+//! Subcommands are typed: see [`cli`] for the builders.
+
+pub mod cli;
+
+pub use cli::{
+    Argv, Completed, KeyRef, Profile, Rollback, RunMode, Sandboxed, Sandboxing, WrapMode,
+};
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// An isolated environment for one integration test.
+pub struct NonoTest {
+    tmp: tempfile::TempDir,
+    bin: PathBuf,
+    home: PathBuf,
+    state: PathBuf,
+    workspace: PathBuf,
+}
+
+impl NonoTest {
+    /// Builds the tempdir tree. `bin` is `CARGO_BIN_EXE_nono` and `manifest_dir`
+    /// is `CARGO_MANIFEST_DIR`, both read at the call site — see [`nono_test!`].
+    pub fn new(bin: &str, manifest_dir: &str, prefix: &str) -> Self {
+        // Tempdirs must stay under <manifest_dir>/target/test-artifacts. Under
+        // Docker Desktop the repo bind mount is gRPC-FUSE, where Landlock
+        // grants are accepted but silently unenforced; Linux verification
+        // overlays a native volume at exactly `crates/nono-cli/target`, so
+        // relocating this root would quietly void every Linux deny assertion.
+        let temp_root = PathBuf::from(manifest_dir)
+            .join("target")
+            .join("test-artifacts");
+        fs::create_dir_all(&temp_root).expect("cargo owns target/ and it is writable");
+        let tmp = tempfile::Builder::new()
+            .prefix(&format!("nono-{prefix}-it-"))
+            .tempdir_in(&temp_root)
+            .expect("temp root was created directly above");
+
+        let home = tmp.path().join("home");
+        // State is a sibling of home rather than <home>/.local/state:
+        // `protected_paths` rejects capability grants that overlap
+        // $XDG_STATE_HOME/nono, so a test granting $HOME would otherwise fail
+        // for a reason that has nothing to do with what it exercises.
+        let state = tmp.path().join("state");
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(home.join(".config")).expect("tmp is a fresh dir this test owns");
+        fs::create_dir_all(&state).expect("tmp is a fresh dir this test owns");
+        fs::create_dir_all(&workspace).expect("tmp is a fresh dir this test owns");
+
+        Self {
+            tmp,
+            bin: PathBuf::from(bin),
+            home,
+            state,
+            workspace,
+        }
+    }
+
+    /// The tempdir root, for siblings of home/state/workspace.
+    pub fn root(&self) -> &Path {
+        self.tmp.path()
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    /// `$XDG_STATE_HOME` for runs launched through [`NonoTest::cmd`].
+    pub fn state(&self) -> &Path {
+        &self.state
+    }
+
+    /// The default working directory for [`NonoTest::cmd`].
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    /// `nono run`
+    pub fn run(&self) -> Sandboxed<'_, RunMode> {
+        Sandboxed::new(self)
+    }
+
+    /// `nono wrap`
+    pub fn wrap(&self) -> Sandboxed<'_, WrapMode> {
+        Sandboxed::new(self)
+    }
+
+    pub fn trust(&self) -> cli::Trust<'_> {
+        cli::Trust::new(self)
+    }
+
+    pub fn audit(&self) -> cli::Audit<'_> {
+        cli::Audit::new(self)
+    }
+
+    pub fn rollback(&self) -> cli::RollbackCmd<'_> {
+        cli::RollbackCmd::new(self)
+    }
+
+    /// A `nono` invocation with a hermetic environment and no arguments.
+    fn hermetic_command(&self) -> Command {
+        let mut cmd = Command::new(&self.bin);
+
+        // Fail secure: strip the whole `NONO_*` / `XDG_*` namespace.
+        for (key, _) in std::env::vars_os() {
+            if is_scrubbable(&key) {
+                cmd.env_remove(&key);
+            }
+        }
+
+        cmd.env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", self.home.join(".config"))
+            .env("XDG_STATE_HOME", &self.state)
+            .env("NONO_NO_SAVE_PROMPT", "1")
+            // Set unconditionally rather than preserved through the scrub
+            // above: no test may depend on the developer's environment to keep
+            // the background network update check off.
+            .env("NONO_NO_UPDATE_CHECK", "1")
+            .current_dir(&self.workspace);
+        cmd
+    }
+
+    /// Writes `<home>/<name>.json` and returns a handle for `--profile`.
+    pub fn write_profile(&self, name: &str, json: &str) -> Profile {
+        let path = self.home.join(format!("{name}.json"));
+        fs::write(&path, json).expect("home is a fresh dir this test owns");
+        Profile::new(path)
+    }
+
+    /// Where the CLI stores audit sessions under this test's state dir.
+    pub fn audit_root(&self) -> PathBuf {
+        self.state.join("nono").join("audit")
+    }
+}
+
+fn is_scrubbable(key: &OsStr) -> bool {
+    let name = key.to_string_lossy();
+    name.starts_with("NONO_") || name.starts_with("XDG_")
+}
+
+/// Constructs a [`NonoTest`] from the calling crate's compile-time environment.
+///
+/// `CARGO_BIN_EXE_nono` is defined only while compiling test targets of the
+/// package that declares the binary, and `CARGO_MANIFEST_DIR` inside this crate
+/// would point at `crates/nono-test-support`. `macro_rules!` expands in the
+/// calling crate, so both `env!`s read `nono-cli`'s environment.
+#[macro_export]
+macro_rules! nono_test {
+    ($prefix:expr) => {
+        $crate::NonoTest::new(
+            env!("CARGO_BIN_EXE_nono"),
+            env!("CARGO_MANIFEST_DIR"),
+            $prefix,
+        )
+    };
+}


### PR DESCRIPTION
## Linked Issue

Refs #1583 

## Summary

Lots of integration tests follow a pattern of launching nono and examining its outputs. This has been done with duplicated code (including my own).

This PR refactors the existing integration tests to use a unified harness.

#1596 is based on this PR/branch and adds a further integration test in the same pattern.

## Test Plan
`make ci`

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates