### PR TITLE
fix(cli): grant read access to the sandbox own capability-state file

### DIFF
--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -9,7 +9,7 @@ use crate::{
     output, sandbox_state, session,
 };
 use nono::undo::{ContentHash, ExecutableIdentity};
-use nono::{CapabilitySet, NonoError, Result, Sandbox};
+use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
 use sha2::{Digest, Sha256};
 use std::fs::File;
 use std::io::Read;
@@ -347,6 +347,9 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         flags.silent,
     );
     let cap_file_path = cap_file.unwrap_or_else(|| std::path::PathBuf::from("/dev/null"));
+    if cap_file_path != Path::new("/dev/null") {
+        caps.add_fs(FsCapability::new_file(&cap_file_path, AccessMode::Read)?);
+    }
 
     for secret in &loaded_secrets {
         if exec_strategy::is_dangerous_env_var(&secret.env_var) {


### PR DESCRIPTION
Grant read-only access to the exact resolved cap-file path once its written, rather than requiring callers to open up /tmp.

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1487 

## Summary

`nono run` writes the capability-state file consulted by `nono why --self` under `std::env::temp_dir()`, but never added a grant for that exact path to the childs CapabilitySet. Under policies that dont broadly open /tmp (the Linux default, and any macOS profile excluding system_read_macos / system_write_macos), the sandboxed process couldnt open its own state file and `nono why --self` failed with a permission error.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
