### PR TITLE
fix(cli): add profile schema fields missing from Rust model

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1037,9 +1037,58 @@
     },
     "CustomCredentialDef": {
       "type": "object",
-      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must have exactly one of: credential_key, auth, or aws_auth (mutually exclusive).",
+      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. credential_key, auth, aws_auth, and spiffe are mutually exclusive — at most one may be set.",
       "additionalProperties": false,
       "required": ["upstream"],
+      "anyOf": [
+        { "required": ["credential_key"] },
+        { "required": ["auth"] },
+        { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } },
+        { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
+      ],
+      "allOf": [
+        { "not": { "allOf": [{ "required": ["credential_key"] }, { "required": ["auth"] }] } },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["credential_key"] },
+              { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["credential_key"] },
+              { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["auth"] },
+              { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["auth"] },
+              { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } },
+              { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
+            ]
+          }
+        }
+      ],
       "properties": {
         "upstream": {
           "type": "string",
@@ -1257,6 +1306,33 @@
        "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret (or a client_assertion, e.g. SPIFFE private_key_jwt) for an access_token, caches it, and refreshes automatically before expiry. client_assertion is mutually exclusive with client_id/client_secret.",
        "additionalProperties": false,
        "required": ["token_url"],
+       "anyOf": [
+         { "required": ["client_id", "client_secret"] },
+         {
+           "required": ["client_assertion"],
+           "properties": {
+             "client_assertion": { "$ref": "#/$defs/ClientAssertionConfig" }
+           }
+         }
+       ],
+       "allOf": [
+         {
+           "not": {
+             "allOf": [
+               { "required": ["client_id"] },
+               { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
+             ]
+           }
+         },
+         {
+           "not": {
+             "allOf": [
+               { "required": ["client_secret"] },
+               { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
+             ]
+           }
+         }
+       ],
        "properties": {
          "token_url": {
            "type": "string",
@@ -1400,7 +1476,12 @@
            "allOf": [
              { "$ref": "#" },
              { "not": { "required": ["extends"] } },
-             { "not": { "required": ["platform_overrides"] } }
+             {
+               "not": {
+                 "required": ["platform_overrides"],
+                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
+               }
+             }
            ],
            "description": "Override block applied only on macOS. Nesting extends or platform_overrides here is a parse error."
          },
@@ -1408,7 +1489,12 @@
            "allOf": [
              { "$ref": "#" },
              { "not": { "required": ["extends"] } },
-             { "not": { "required": ["platform_overrides"] } }
+             {
+               "not": {
+                 "required": ["platform_overrides"],
+                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
+               }
+             }
            ],
            "description": "Override block applied only on Linux. Nesting extends or platform_overrides here is a parse error."
          },
@@ -1416,7 +1502,12 @@
            "allOf": [
              { "$ref": "#" },
              { "not": { "required": ["extends"] } },
-             { "not": { "required": ["platform_overrides"] } }
+             {
+               "not": {
+                 "required": ["platform_overrides"],
+                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
+               }
+             }
            ],
            "description": "Override block applied only on Windows. Nesting extends or platform_overrides here is a parse error."
          }

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -17,7 +17,8 @@
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1
-        }
+        },
+        { "type": "null" }
       ],
       "description": "Name of a base profile (or array of base profiles) to inherit from. All fields from the base profile are used as defaults, with this profile's values taking precedence. When an array is given, bases are merged left-to-right before the child is applied. Shared transitive bases are deduplicated: each profile is resolved at most once."
     },
@@ -1041,17 +1042,24 @@
       "additionalProperties": false,
       "required": ["upstream"],
       "anyOf": [
-        { "required": ["credential_key"] },
-        { "required": ["auth"] },
+        { "required": ["credential_key"], "properties": { "credential_key": { "not": { "type": "null" } } } },
+        { "required": ["auth"], "properties": { "auth": { "not": { "type": "null" } } } },
         { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } },
         { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
       ],
       "allOf": [
-        { "not": { "allOf": [{ "required": ["credential_key"] }, { "required": ["auth"] }] } },
         {
           "not": {
             "allOf": [
-              { "required": ["credential_key"] },
+              { "required": ["credential_key"], "properties": { "credential_key": { "not": { "type": "null" } } } },
+              { "required": ["auth"], "properties": { "auth": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["credential_key"], "properties": { "credential_key": { "not": { "type": "null" } } } },
               { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } }
             ]
           }
@@ -1059,7 +1067,7 @@
         {
           "not": {
             "allOf": [
-              { "required": ["credential_key"] },
+              { "required": ["credential_key"], "properties": { "credential_key": { "not": { "type": "null" } } } },
               { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
             ]
           }
@@ -1067,7 +1075,7 @@
         {
           "not": {
             "allOf": [
-              { "required": ["auth"] },
+              { "required": ["auth"], "properties": { "auth": { "not": { "type": "null" } } } },
               { "required": ["aws_auth"], "properties": { "aws_auth": { "not": { "type": "null" } } } }
             ]
           }
@@ -1075,7 +1083,7 @@
         {
           "not": {
             "allOf": [
-              { "required": ["auth"] },
+              { "required": ["auth"], "properties": { "auth": { "not": { "type": "null" } } } },
               { "required": ["spiffe"], "properties": { "spiffe": { "not": { "type": "null" } } } }
             ]
           }
@@ -1095,11 +1103,17 @@
           "description": "Upstream URL to proxy requests to (e.g., \"https://api.telegram.org\"). Must use HTTPS, or HTTP only for loopback addresses."
         },
         "credential_key": {
-          "type": "string",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
           "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, env:// URI (e.g., \"env://MY_TOKEN\"), or cmd:// URI backed by credential_capture. Mutually exclusive with auth and aws_auth."
         },
         "auth": {
-          "$ref": "#/$defs/OAuth2Config",
+          "oneOf": [
+            { "$ref": "#/$defs/OAuth2Config" },
+            { "type": "null" }
+          ],
           "description": "OAuth2 client_credentials configuration. When present, the proxy handles token exchange automatically. Mutually exclusive with credential_key and aws_auth."
         },
         "aws_auth": {
@@ -1302,242 +1316,257 @@
       }
     },
     "OAuth2Config": {
-       "type": "object",
-       "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret (or a client_assertion, e.g. SPIFFE private_key_jwt) for an access_token, caches it, and refreshes automatically before expiry. client_assertion is mutually exclusive with client_id/client_secret.",
-       "additionalProperties": false,
-       "required": ["token_url"],
-       "anyOf": [
-         { "required": ["client_id", "client_secret"] },
-         {
-           "required": ["client_assertion"],
-           "properties": {
-             "client_assertion": { "$ref": "#/$defs/ClientAssertionConfig" }
-           }
-         }
-       ],
-       "allOf": [
-         {
-           "not": {
-             "allOf": [
-               { "required": ["client_id"] },
-               { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
-             ]
-           }
-         },
-         {
-           "not": {
-             "allOf": [
-               { "required": ["client_secret"] },
-               { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
-             ]
-           }
-         }
-       ],
-       "properties": {
-         "token_url": {
-           "type": "string",
-           "description": "Token endpoint URL (e.g., \"https://auth.example.com/oauth/token\"). Must use HTTPS, or HTTP only for loopback addresses."
-         },
-         "client_id": {
-           "type": "string",
-           "description": "Client ID — plain value or credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
-           "default": ""
-         },
-         "client_secret": {
-           "type": "string",
-           "description": "Client secret — credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
-           "default": ""
-         },
-         "scope": {
-           "type": "string",
-           "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
-           "default": ""
-         },
-         "client_assertion": {
-           "oneOf": [
-             { "$ref": "#/$defs/ClientAssertionConfig" },
-             { "type": "null" }
-           ],
-           "description": "Client assertion configuration (e.g. SPIFFE private_key_jwt) used in place of client_id/client_secret."
-         },
-         "extra_params": {
-           "type": "object",
-           "additionalProperties": { "type": "string" },
-           "description": "Extra parameters merged into the token exchange POST body verbatim.",
-           "default": {}
-         }
-       }
-     },
-     "ClientAssertionConfig": {
-       "type": "object",
-       "description": "Client assertion used for OAuth2 token exchange instead of a client secret.",
-       "oneOf": [
-         {
-           "type": "object",
-           "additionalProperties": false,
-           "required": ["type", "workload_api_socket", "audience"],
-           "properties": {
-             "type": { "type": "string", "enum": ["spiffe_jwt"] },
-             "workload_api_socket": {
-               "type": "string",
-               "description": "Path to the SPIRE agent Unix domain socket."
-             },
-             "audience": {
-               "type": "array",
-               "items": { "type": "string" },
-               "description": "Audience(s) for the minted JWT-SVID."
-             },
-             "svid_hint": {
-               "oneOf": [
-                 { "type": "string" },
-                 { "type": "null" }
-               ],
-               "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload."
-             }
-           }
-         }
-       ]
-     },
-     "AwsAuthConfig": {
-       "type": "object",
-       "description": "AWS SigV4 signing configuration for a credential route. All fields are optional: an empty {} block uses the default credential chain with region and service auto-detected from the upstream URL.",
-       "additionalProperties": false,
-       "properties": {
-         "profile": {
-           "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-           ],
-           "description": "AWS profile name to use for credentials. If omitted, the default credential chain is used (environment variables → AWS_PROFILE → default profile → instance metadata). Must be non-empty if set."
-         },
-         "region": {
-           "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-           ],
-           "description": "Explicit SigV4 signing region (e.g., \"us-east-1\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
-         },
-         "service": {
-           "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-           ],
-           "description": "Explicit SigV4 service name (e.g., \"bedrock\", \"s3\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
-         }
-       }
-     },
-     "SpiffeAuthConfig": {
-       "type": "object",
-       "description": "SPIFFE/SPIRE Workload API authentication. Currently only type \"jwt\" is supported: a JWT-SVID is fetched from the SPIRE Workload API and injected as a bearer token; the sandboxed process sends plain requests with no credentials.",
-       "additionalProperties": false,
-       "required": ["type", "workload_api_socket", "audience"],
-       "properties": {
-         "type": {
-           "type": "string",
-           "enum": ["jwt"],
-           "description": "SPIFFE auth variant. Only \"jwt\" is currently supported."
-         },
-         "workload_api_socket": {
-           "type": "string",
-           "description": "Path to the SPIRE agent Unix domain socket."
-         },
-         "audience": {
-           "type": "array",
-           "items": { "type": "string" },
-           "description": "Audience(s) for the minted JWT-SVID."
-         },
-         "inject_header": {
-           "type": "string",
-           "description": "HTTP header to inject the JWT into.",
-           "default": "Authorization"
-         },
-         "credential_format": {
-           "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-           ],
-           "description": "Template with {} for the token. Defaults to \"Bearer {}\"."
-         },
-         "svid_hint": {
-           "oneOf": [
-             { "type": "string" },
-             { "type": "null" }
-           ],
-           "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload. When absent, the first SVID returned by the agent is used."
-         }
-       }
-     },
-     "PlatformOverrides": {
-       "type": "object",
-       "description": "Per-OS profile patches merged after extends resolution. Only the entry matching the current platform is applied; others are ignored.",
-       "additionalProperties": false,
-       "properties": {
-         "macos": {
-           "allOf": [
-             { "$ref": "#" },
-             { "not": { "required": ["extends"] } },
-             {
-               "not": {
-                 "required": ["platform_overrides"],
-                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
-               }
-             }
-           ],
-           "description": "Override block applied only on macOS. Nesting extends or platform_overrides here is a parse error."
-         },
-         "linux": {
-           "allOf": [
-             { "$ref": "#" },
-             { "not": { "required": ["extends"] } },
-             {
-               "not": {
-                 "required": ["platform_overrides"],
-                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
-               }
-             }
-           ],
-           "description": "Override block applied only on Linux. Nesting extends or platform_overrides here is a parse error."
-         },
-         "windows": {
-           "allOf": [
-             { "$ref": "#" },
-             { "not": { "required": ["extends"] } },
-             {
-               "not": {
-                 "required": ["platform_overrides"],
-                 "properties": { "platform_overrides": { "not": { "type": "null" } } }
-               }
-             }
-           ],
-           "description": "Override block applied only on Windows. Nesting extends or platform_overrides here is a parse error."
-         }
-       }
-     },
-     "RouteRateLimitConfig": {
-       "type": "object",
-       "description": "Per-route request-rate limit (RouteRateLimiter). A token bucket refilling at requests_per_minute and holding up to burst tokens. When the bucket is empty, a request is delayed up to max_delay_secs; a request that would wait longer is rejected with HTTP 429 (bounded delay then reject).",
-       "additionalProperties": false,
-       "required": ["requests_per_minute"],
-       "properties": {
-         "requests_per_minute": {
-           "type": "integer",
-           "minimum": 0,
-           "description": "Sustained request rate, in requests per minute. The token bucket refills at this rate. 0 disables the limiter for the route."
-         },
-         "burst": {
-           "type": "integer",
-           "minimum": 0,
-           "default": 5,
-           "description": "Burst capacity: instantaneous requests allowed before throttling begins. Clamped to at least 1 at runtime."
-         },
-         "max_delay_secs": {
-           "type": "integer",
-           "minimum": 0,
-           "default": 5,
-           "description": "Maximum seconds a request may be delayed before it is rejected with HTTP 429. Bounds the delay queue so a flood cannot exhaust proxy resources."
-         }
-       }
-     },
+      "type": "object",
+      "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret (or a client_assertion, e.g. SPIFFE private_key_jwt) for an access_token, caches it, and refreshes automatically before expiry. client_assertion is mutually exclusive with client_id/client_secret.",
+      "additionalProperties": false,
+      "required": ["token_url"],
+      "anyOf": [
+        { "required": ["client_id", "client_secret"] },
+        {
+          "required": ["client_assertion"],
+          "properties": {
+            "client_assertion": { "$ref": "#/$defs/ClientAssertionConfig" }
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "not": {
+            "allOf": [
+              { "required": ["client_id"] },
+              { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
+            ]
+          }
+        },
+        {
+          "not": {
+            "allOf": [
+              { "required": ["client_secret"] },
+              { "required": ["client_assertion"], "properties": { "client_assertion": { "not": { "type": "null" } } } }
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "token_url": {
+          "type": "string",
+          "description": "Token endpoint URL (e.g., \"https://auth.example.com/oauth/token\"). Must use HTTPS, or HTTP only for loopback addresses."
+        },
+        "client_id": {
+          "type": "string",
+          "description": "Client ID — plain value or credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
+          "default": ""
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "Client secret — credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
+          "default": ""
+        },
+        "scope": {
+          "type": "string",
+          "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
+          "default": ""
+        },
+        "client_assertion": {
+          "oneOf": [
+            { "$ref": "#/$defs/ClientAssertionConfig" },
+            { "type": "null" }
+          ],
+          "description": "Client assertion configuration (e.g. SPIFFE private_key_jwt) used in place of client_id/client_secret."
+        },
+        "extra_params": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Extra parameters merged into the token exchange POST body verbatim.",
+          "default": {}
+        }
+      }
+    },
+    "ClientAssertionConfig": {
+      "type": "object",
+      "description": "Client assertion used for OAuth2 token exchange instead of a client secret.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "workload_api_socket", "audience"],
+          "properties": {
+            "type": { "type": "string", "enum": ["spiffe_jwt"] },
+            "workload_api_socket": {
+              "type": "string",
+              "description": "Path to the SPIRE agent Unix domain socket."
+            },
+            "audience": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Audience(s) for the minted JWT-SVID."
+            },
+            "svid_hint": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
+              "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload."
+            }
+          }
+        }
+      ]
+    },
+    "AwsAuthConfig": {
+      "type": "object",
+      "description": "AWS SigV4 signing configuration for a credential route. All fields are optional: an empty {} block uses the default credential chain with region and service auto-detected from the upstream URL.",
+      "additionalProperties": false,
+      "properties": {
+        "profile": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "AWS profile name to use for credentials. If omitted, the default credential chain is used (environment variables → AWS_PROFILE → default profile → instance metadata). Must be non-empty if set."
+        },
+        "region": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Explicit SigV4 signing region (e.g., \"us-east-1\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
+        },
+        "service": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Explicit SigV4 service name (e.g., \"bedrock\", \"s3\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
+        }
+      }
+    },
+    "SpiffeAuthConfig": {
+      "type": "object",
+      "description": "SPIFFE/SPIRE Workload API authentication. Currently only type \"jwt\" is supported: a JWT-SVID is fetched from the SPIRE Workload API and injected as a bearer token; the sandboxed process sends plain requests with no credentials.",
+      "additionalProperties": false,
+      "required": ["type", "workload_api_socket", "audience"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["jwt"],
+          "description": "SPIFFE auth variant. Only \"jwt\" is currently supported."
+        },
+        "workload_api_socket": {
+          "type": "string",
+          "description": "Path to the SPIRE agent Unix domain socket."
+        },
+        "audience": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Audience(s) for the minted JWT-SVID."
+        },
+        "inject_header": {
+          "type": "string",
+          "description": "HTTP header to inject the JWT into.",
+          "default": "Authorization"
+        },
+        "credential_format": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Template with {} for the token. Defaults to \"Bearer {}\"."
+        },
+        "svid_hint": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload. When absent, the first SVID returned by the agent is used."
+        }
+      }
+    },
+    "PlatformOverrides": {
+      "type": "object",
+      "description": "Per-OS profile patches merged after extends resolution. Only the entry matching the current platform is applied; others are ignored.",
+      "additionalProperties": false,
+      "properties": {
+        "macos": {
+          "allOf": [
+            { "$ref": "#" },
+            {
+              "not": {
+                "required": ["extends"],
+                "properties": { "extends": { "not": { "type": "null" } } }
+              }
+            },
+            {
+              "not": {
+                "required": ["platform_overrides"],
+                "properties": { "platform_overrides": { "not": { "type": "null" } } }
+              }
+            }
+          ],
+          "description": "Override block applied only on macOS. Nesting extends or platform_overrides here is a parse error."
+        },
+        "linux": {
+          "allOf": [
+            { "$ref": "#" },
+            {
+              "not": {
+                "required": ["extends"],
+                "properties": { "extends": { "not": { "type": "null" } } }
+              }
+            },
+            {
+              "not": {
+                "required": ["platform_overrides"],
+                "properties": { "platform_overrides": { "not": { "type": "null" } } }
+              }
+            }
+          ],
+          "description": "Override block applied only on Linux. Nesting extends or platform_overrides here is a parse error."
+        },
+        "windows": {
+          "allOf": [
+            { "$ref": "#" },
+            {
+              "not": {
+                "required": ["extends"],
+                "properties": { "extends": { "not": { "type": "null" } } }
+              }
+            },
+            {
+              "not": {
+                "required": ["platform_overrides"],
+                "properties": { "platform_overrides": { "not": { "type": "null" } } }
+              }
+            }
+          ],
+          "description": "Override block applied only on Windows. Nesting extends or platform_overrides here is a parse error."
+        }
+      }
+    },
+    "RouteRateLimitConfig": {
+      "type": "object",
+      "description": "Per-route request-rate limit (RouteRateLimiter). A token bucket refilling at requests_per_minute and holding up to burst tokens. When the bucket is empty, a request is delayed up to max_delay_secs; a request that would wait longer is rejected with HTTP 429 (bounded delay then reject).",
+      "additionalProperties": false,
+      "required": ["requests_per_minute"],
+      "properties": {
+        "requests_per_minute": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sustained request rate, in requests per minute. The token bucket refills at this rate. 0 disables the limiter for the route."
+        },
+        "burst": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 5,
+          "description": "Burst capacity: instantaneous requests allowed before throttling begins. Clamped to at least 1 at runtime."
+        },
+        "max_delay_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 5,
+          "description": "Maximum seconds a request may be delayed before it is rejected with HTTP 429. Bounds the delay queue so a flood cannot exhaust proxy resources."
+        }
+      }
+    },
     "SecretsConfig": {
       "type": "object",
       "description": "Maps keystore account names (or op://, bw://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore under the service name \"nono\".",

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -154,6 +154,32 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "macOS-only. Expert escape hatch: raw Seatbelt S-expression rules applied verbatim to the sandbox policy. Each entry must be a valid S-expression, e.g. \"(allow iokit-open)\". Rules are validated at load time and rejected if malformed. Ignored on Linux. Surfaced prominently in 'nono profile show' output. If a rule pattern becomes common, prefer promoting it to a typed first-class capability instead."
+    },
+    "allow_parent_of_protected": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "null" }
+      ],
+      "description": "Opt-in to allow parent-of-protected-root grants on macOS. When true (and on macOS), --allow ~ is permitted because Seatbelt deny rules protect ~/.nono. Ignored on Linux. Set to null to inherit from the base profile. Default is false."
+    },
+    "skipdirs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Directory names to skip during trust scanning and rollback preflight. Treated like built-in heavy directories (for example \"target\")."
+    },
+    "binary": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "null" }
+      ],
+      "description": "Binary path or command name to run when no trailing -- <command> is given. Resolved via PATH lookup or canonicalized if absolute. Only honoured for user-authored profiles (ignored for pack and built-in profiles)."
+    },
+    "platform_overrides": {
+      "oneOf": [
+        { "$ref": "#/$defs/PlatformOverrides" },
+        { "type": "null" }
+      ],
+      "description": "Per-OS profile patches merged after extends resolution. Only the entry matching the current platform is applied. Nesting extends or platform_overrides inside an override block is a parse error."
     }
   },
   "$defs": {
@@ -346,6 +372,20 @@
           "items": { "$ref": "#/$defs/UrlOrigin" },
           "minItems": 1,
           "description": "API URL origins where phantom tokens issued by this provider may be resolved back to real credentials on egress."
+        },
+        "inject_header": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "HTTP header the resolved credential is injected into on api_hosts egress. Defaults to Authorization (OAuth Bearer APIs). Some providers (e.g. Vault) need a different header, such as X-Vault-Token. Must be a valid HTTP header name (RFC 7230 token)."
+        },
+        "credential_format": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Format applied to the resolved credential before injection; {} is replaced by the token. Defaults to \"Bearer {}\". Use \"{}\" alone for a raw token (e.g. Vault)."
         },
         "credential_store": {
           "oneOf": [
@@ -614,6 +654,13 @@
             { "type": "null" }
           ],
           "description": "Opt-in pathname AF_UNIX mediation. 'off' preserves compatibility. 'pathname' requires explicit filesystem.unix_socket* grants for pathname Unix socket connect/bind."
+        },
+        "sandbox_policy": {
+          "oneOf": [
+            { "$ref": "#/$defs/LinuxSandboxPolicy" },
+            { "type": "null" }
+          ],
+          "description": "Which Linux sandboxing mechanism to install. Defaults to 'auto' (Landlock plus a static seccomp network baseline, falling back to seccomp-only networking when the kernel ABI lacks Landlock network support)."
         }
       }
     },
@@ -621,6 +668,11 @@
       "type": "string",
       "enum": ["off", "pathname"],
       "description": "Linux pathname AF_UNIX mediation mode."
+    },
+    "LinuxSandboxPolicy": {
+      "type": "string",
+      "enum": ["auto", "landlock", "external"],
+      "description": "Which sandboxing mechanism nono installs on Linux. 'auto' (default): Landlock plus a static seccomp network baseline, with automatic seccomp fallback when the kernel ABI lacks Landlock network support (< V4). 'landlock': Landlock only; errors at startup if the kernel cannot satisfy network restrictions via Landlock alone. 'external': TCP network egress enforcement is managed externally (iptables, cgroups, systemd, etc.); nono still installs filesystem/process sandboxing and skips only its own TCP network lockdown."
     },
     "ProfileSignalMode": {
       "type": "string",
@@ -724,6 +776,36 @@
           "type": "array",
           "items": { "$ref": "#/$defs/ConditionalPath" },
           "description": "Single files with write-only access."
+        },
+        "unix_socket": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Single AF_UNIX socket paths, connect only. Implies read access on the socket path."
+        },
+        "unix_socket_bind": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Single AF_UNIX socket paths, connect and bind. Implies read+write access on the socket path when it exists, or on its parent directory when it does not yet exist. Dangling symlinks are rejected at grant time; prefer unix_socket_dir_bind for runtime-generated filenames."
+        },
+        "unix_socket_dir": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Directories where any direct-child AF_UNIX socket may be connected to. Non-recursive. Implies read access on the directory."
+        },
+        "unix_socket_dir_bind": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Directories where any direct-child AF_UNIX socket may be connected to or bound. Non-recursive. Implies read+write access on the directory."
+        },
+        "unix_socket_subtree": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Directories where any descendant AF_UNIX socket may be connected to. Recursive. Implies read access on the directory."
+        },
+        "unix_socket_subtree_bind": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConditionalPath" },
+          "description": "Directories where any descendant AF_UNIX socket may be connected to or bound. Recursive. Implies read+write access on the directory."
         },
         "deny": {
           "type": "array",
@@ -837,6 +919,36 @@
           "type": "array",
           "items": { "type": "integer" },
           "description": "Localhost TCP IPC (connect+bind). Port 0: macOS only (localhost:* outbound); Linux needs explicit ports."
+        },
+        "connect_port": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "Outbound TCP ports the sandboxed child may connect to (dial-only, no listen). Linux Landlock V4+ only; not supported on macOS: Seatbelt cannot filter outbound connections by TCP port."
+        },
+        "open_port_range": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "description": "Inclusive port ranges for bidirectional localhost TCP IPC (connect + bind), e.g. [[3000, 3010], [8000, 8100]]. macOS enforces a combined limit of 16,384 unique ports across all ranges; Linux has no such restriction. Overlapping ranges are merged before applying rules."
+        },
+        "listen_port_range": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "description": "Inclusive port ranges for TCP listen (bind only). Same platform behaviour as open_port_range for the bind side; no outbound connect rules are added. Overlapping ranges are merged before applying rules."
+        },
+        "deny_domain": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Domains to deny through the proxy regardless of the allowlist. Supports the same wildcard syntax as allow_domain (e.g. *.ads.example.com)."
         },
         "port_allow": {
           "type": "array",
@@ -1035,6 +1147,20 @@
             { "type": "null" }
           ],
           "description": "Optional per-route request-rate limit (RouteRateLimiter). Caps the rate of L7 requests forwarded to this credential's upstream to contain a runaway or compromised agent. Applies only to L7-visible traffic (reverse-proxy and TLS-intercepted CONNECT); it has no effect on opaque CONNECT tunnels."
+        },
+        "endpoint_policy": {
+          "oneOf": [
+            { "$ref": "#/$defs/EndpointPolicyConfig" },
+            { "type": "null" }
+          ],
+          "description": "Explicit L7 endpoint policy with allow/deny/approve routes. Alternative to endpoint_rules for more granular control."
+        },
+        "spiffe": {
+          "oneOf": [
+            { "$ref": "#/$defs/SpiffeAuthConfig" },
+            { "type": "null" }
+          ],
+          "description": "SPIFFE/SPIRE Workload API authentication. Mutually exclusive with credential_key, auth, and aws_auth."
         }
       }
     },
@@ -1128,9 +1254,9 @@
     },
     "OAuth2Config": {
        "type": "object",
-       "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret for an access_token, caches it, and refreshes automatically before expiry.",
+       "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret (or a client_assertion, e.g. SPIFFE private_key_jwt) for an access_token, caches it, and refreshes automatically before expiry. client_assertion is mutually exclusive with client_id/client_secret.",
        "additionalProperties": false,
-       "required": ["token_url", "client_id", "client_secret"],
+       "required": ["token_url"],
        "properties": {
          "token_url": {
            "type": "string",
@@ -1138,18 +1264,63 @@
          },
          "client_id": {
            "type": "string",
-           "description": "Client ID — plain value or credential reference (env://, file://, op://)."
+           "description": "Client ID — plain value or credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
+           "default": ""
          },
          "client_secret": {
            "type": "string",
-           "description": "Client secret — credential reference (env://, file://, op://)."
+           "description": "Client secret — credential reference (env://, file://, op://). Mutually exclusive with client_assertion.",
+           "default": ""
          },
          "scope": {
            "type": "string",
            "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
            "default": ""
+         },
+         "client_assertion": {
+           "oneOf": [
+             { "$ref": "#/$defs/ClientAssertionConfig" },
+             { "type": "null" }
+           ],
+           "description": "Client assertion configuration (e.g. SPIFFE private_key_jwt) used in place of client_id/client_secret."
+         },
+         "extra_params": {
+           "type": "object",
+           "additionalProperties": { "type": "string" },
+           "description": "Extra parameters merged into the token exchange POST body verbatim.",
+           "default": {}
          }
        }
+     },
+     "ClientAssertionConfig": {
+       "type": "object",
+       "description": "Client assertion used for OAuth2 token exchange instead of a client secret.",
+       "oneOf": [
+         {
+           "type": "object",
+           "additionalProperties": false,
+           "required": ["type", "workload_api_socket", "audience"],
+           "properties": {
+             "type": { "type": "string", "enum": ["spiffe_jwt"] },
+             "workload_api_socket": {
+               "type": "string",
+               "description": "Path to the SPIRE agent Unix domain socket."
+             },
+             "audience": {
+               "type": "array",
+               "items": { "type": "string" },
+               "description": "Audience(s) for the minted JWT-SVID."
+             },
+             "svid_hint": {
+               "oneOf": [
+                 { "type": "string" },
+                 { "type": "null" }
+               ],
+               "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload."
+             }
+           }
+         }
+       ]
      },
      "AwsAuthConfig": {
        "type": "object",
@@ -1176,6 +1347,78 @@
              { "type": "null" }
            ],
            "description": "Explicit SigV4 service name (e.g., \"bedrock\", \"s3\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
+         }
+       }
+     },
+     "SpiffeAuthConfig": {
+       "type": "object",
+       "description": "SPIFFE/SPIRE Workload API authentication. Currently only type \"jwt\" is supported: a JWT-SVID is fetched from the SPIRE Workload API and injected as a bearer token; the sandboxed process sends plain requests with no credentials.",
+       "additionalProperties": false,
+       "required": ["type", "workload_api_socket", "audience"],
+       "properties": {
+         "type": {
+           "type": "string",
+           "enum": ["jwt"],
+           "description": "SPIFFE auth variant. Only \"jwt\" is currently supported."
+         },
+         "workload_api_socket": {
+           "type": "string",
+           "description": "Path to the SPIRE agent Unix domain socket."
+         },
+         "audience": {
+           "type": "array",
+           "items": { "type": "string" },
+           "description": "Audience(s) for the minted JWT-SVID."
+         },
+         "inject_header": {
+           "type": "string",
+           "description": "HTTP header to inject the JWT into.",
+           "default": "Authorization"
+         },
+         "credential_format": {
+           "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+           ],
+           "description": "Template with {} for the token. Defaults to \"Bearer {}\"."
+         },
+         "svid_hint": {
+           "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+           ],
+           "description": "Select a specific SVID by SPIFFE ID when the Workload API returns multiple SVIDs for the same workload. When absent, the first SVID returned by the agent is used."
+         }
+       }
+     },
+     "PlatformOverrides": {
+       "type": "object",
+       "description": "Per-OS profile patches merged after extends resolution. Only the entry matching the current platform is applied; others are ignored.",
+       "additionalProperties": false,
+       "properties": {
+         "macos": {
+           "allOf": [
+             { "$ref": "#" },
+             { "not": { "required": ["extends"] } },
+             { "not": { "required": ["platform_overrides"] } }
+           ],
+           "description": "Override block applied only on macOS. Nesting extends or platform_overrides here is a parse error."
+         },
+         "linux": {
+           "allOf": [
+             { "$ref": "#" },
+             { "not": { "required": ["extends"] } },
+             { "not": { "required": ["platform_overrides"] } }
+           ],
+           "description": "Override block applied only on Linux. Nesting extends or platform_overrides here is a parse error."
+         },
+         "windows": {
+           "allOf": [
+             { "$ref": "#" },
+             { "not": { "required": ["extends"] } },
+             { "not": { "required": ["platform_overrides"] } }
+           ],
+           "description": "Override block applied only on Windows. Nesting extends or platform_overrides here is a parse error."
          }
        }
      },

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -860,6 +860,12 @@ fn validate_oauth2_auth(name: &str, auth: &OAuth2Config) -> Result<()> {
     // When using client_assertion, client_id/client_secret are not required,
     // but the assertion config itself must have valid fields.
     if let Some(ref assertion) = auth.client_assertion {
+        if !auth.client_id.is_empty() || !auth.client_secret.is_empty() {
+            return Err(NonoError::ProfileParse(format!(
+                "auth.client_assertion for custom credential '{}' is mutually exclusive with client_id/client_secret",
+                name
+            )));
+        }
         match assertion {
             nono_proxy::config::ClientAssertionConfig::SpiffeJwt {
                 workload_api_socket,
@@ -6159,6 +6165,64 @@ mod tests {
         let err = result.expect_err("empty client_secret should be rejected");
         assert!(err.to_string().contains("client_secret"));
         assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_client_assertion_valid() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: String::new(),
+            client_secret: String::new(),
+            scope: String::new(),
+            client_assertion: Some(nono_proxy::config::ClientAssertionConfig::SpiffeJwt {
+                workload_api_socket: "/run/spire/sockets/agent.sock".to_string(),
+                audience: vec!["auth.example.com".to_string()],
+                svid_hint: None,
+            }),
+            extra_params: Default::default(),
+        });
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth2_client_assertion_and_client_id_mutually_exclusive() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: "my-client".to_string(),
+            client_secret: String::new(),
+            scope: String::new(),
+            client_assertion: Some(nono_proxy::config::ClientAssertionConfig::SpiffeJwt {
+                workload_api_socket: "/run/spire/sockets/agent.sock".to_string(),
+                audience: vec!["auth.example.com".to_string()],
+                svid_hint: None,
+            }),
+            extra_params: Default::default(),
+        });
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("client_id with client_assertion should be rejected");
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_client_assertion_and_client_secret_mutually_exclusive() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: String::new(),
+            client_secret: "env://CLIENT_SECRET".to_string(),
+            scope: String::new(),
+            client_assertion: Some(nono_proxy::config::ClientAssertionConfig::SpiffeJwt {
+                workload_api_socket: "/run/spire/sockets/agent.sock".to_string(),
+                audience: vec!["auth.example.com".to_string()],
+                svid_hint: None,
+            }),
+            extra_params: Default::default(),
+        });
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("client_secret with client_assertion should be rejected");
+        assert!(err.to_string().contains("mutually exclusive"));
     }
 
     #[test]

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -430,6 +430,26 @@ fn test_schema_validates_credential_key_with_explicit_null_spiffe_and_aws_auth()
 }
 
 #[test]
+fn test_schema_validates_aws_auth_with_explicit_null_credential_key_and_auth() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    // credential_key/auth are Option<T> in Rust, so an explicit null deserializes
+    // identically to an omitted field and must not be treated as a conflict.
+    let profile = json!({
+        "network": { "custom_credentials": { "internal-api": {
+            "upstream": "https://internal.example.com",
+            "credential_key": null,
+            "auth": null,
+            "aws_auth": { "region": "us-east-1" }
+        } } }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("aws_auth with explicitly-null credential_key/auth should validate");
+}
+
+#[test]
 fn test_schema_rejects_custom_credential_with_no_auth_mechanism() {
     let schema = load_schema();
     let validator = jsonschema::validator_for(&schema).expect("schema compiles");

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -16,16 +16,25 @@ fn load_schema() -> Value {
     serde_json::from_str(&content).expect("embedded profile schema is valid JSON")
 }
 
-fn assert_schema_properties(schema: &Value, def_name: &str, expected: &[&str]) {
+fn assert_properties_at(schema: &Value, pointer: &str, label: &str, expected: &[&str]) {
     let props = schema
-        .pointer(&format!("/$defs/{def_name}/properties"))
+        .pointer(pointer)
         .and_then(Value::as_object)
-        .unwrap_or_else(|| panic!("{def_name}.properties is an object"));
+        .unwrap_or_else(|| panic!("{pointer} is an object"));
     let actual = props.keys().map(String::as_str).collect::<BTreeSet<_>>();
     let expected = expected.iter().copied().collect::<BTreeSet<_>>();
     assert_eq!(
         actual, expected,
-        "{def_name}.properties must match the Rust command-policy model"
+        "{label}.properties must match the Rust command-policy model"
+    );
+}
+
+fn assert_schema_properties(schema: &Value, def_name: &str, expected: &[&str]) {
+    assert_properties_at(
+        schema,
+        &format!("/$defs/{def_name}/properties"),
+        def_name,
+        expected,
     );
 }
 
@@ -84,51 +93,45 @@ fn test_schema_network_config_matches_rust_model() {
 #[test]
 fn test_schema_top_level_profile_matches_rust_model() {
     let schema = load_schema();
-    let props = schema
-        .pointer("/properties")
-        .and_then(Value::as_object)
-        .expect("root properties is an object");
-    let actual = props.keys().map(String::as_str).collect::<BTreeSet<_>>();
-    let expected = [
-        "$schema",
-        "extends",
-        "meta",
-        "security",
-        "groups",
-        "commands",
-        "filesystem",
-        "network",
-        "diagnostics",
-        "linux",
-        "env_credentials",
-        "secrets",
-        "environment",
-        "command_policies",
-        "credential_capture",
-        "credential_providers",
-        "credential_routes",
-        "workdir",
-        "hooks",
-        "session_hooks",
-        "rollback",
-        "undo",
-        "open_urls",
-        "allow_launch_services",
-        "allow_gpu",
-        "allow_parent_of_protected",
-        "interactive",
-        "skipdirs",
-        "packs",
-        "binary",
-        "command_args",
-        "unsafe_macos_seatbelt_rules",
-        "platform_overrides",
-    ]
-    .into_iter()
-    .collect::<BTreeSet<_>>();
-    assert_eq!(
-        actual, expected,
-        "top-level Profile properties must match the Rust Profile model"
+    assert_properties_at(
+        &schema,
+        "/properties",
+        "Profile",
+        &[
+            "$schema",
+            "extends",
+            "meta",
+            "security",
+            "groups",
+            "commands",
+            "filesystem",
+            "network",
+            "diagnostics",
+            "linux",
+            "env_credentials",
+            "secrets",
+            "environment",
+            "command_policies",
+            "credential_capture",
+            "credential_providers",
+            "credential_routes",
+            "workdir",
+            "hooks",
+            "session_hooks",
+            "rollback",
+            "undo",
+            "open_urls",
+            "allow_launch_services",
+            "allow_gpu",
+            "allow_parent_of_protected",
+            "interactive",
+            "skipdirs",
+            "packs",
+            "binary",
+            "command_args",
+            "unsafe_macos_seatbelt_rules",
+            "platform_overrides",
+        ],
     );
 }
 
@@ -153,6 +156,299 @@ fn test_schema_validates_profile_with_platform_overrides_skipdirs_binary() {
     validator
         .validate(&profile)
         .expect("skipdirs/binary/allow_parent_of_protected/platform_overrides should validate");
+}
+
+#[test]
+fn test_schema_validates_explicit_null_platform_overrides_inside_override() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    // platform_overrides: null deserializes to the same None as an omitted field
+    // (Option<PlatformOverrides>), so PlatformOverride::deserialize accepts it —
+    // the schema must not flag it as illegal nesting.
+    let profile = json!({
+        "platform_overrides": {
+            "macos": {
+                "network": { "block": true },
+                "platform_overrides": null
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("explicit null platform_overrides inside an override block should validate");
+}
+
+#[test]
+fn test_schema_rejects_nested_extends_in_platform_overrides() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "platform_overrides": {
+            "macos": {
+                "extends": "base"
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "nesting extends inside platform_overrides must fail schema validation, \
+         matching PlatformOverride::deserialize's parse error"
+    );
+}
+
+#[test]
+fn test_schema_rejects_nested_platform_overrides_in_platform_overrides() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "platform_overrides": {
+            "linux": {
+                "platform_overrides": {
+                    "macos": { "network": { "block": true } }
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "nesting platform_overrides inside platform_overrides must fail schema validation, \
+         matching PlatformOverride::deserialize's parse error"
+    );
+}
+
+#[test]
+fn test_schema_oauth2_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "OAuth2Config",
+        &[
+            "token_url",
+            "client_id",
+            "client_secret",
+            "scope",
+            "client_assertion",
+            "extra_params",
+        ],
+    );
+    assert_properties_at(
+        &schema,
+        "/$defs/ClientAssertionConfig/oneOf/0/properties",
+        "ClientAssertionConfig",
+        &["type", "workload_api_socket", "audience", "svid_hint"],
+    );
+}
+
+#[test]
+fn test_schema_rejects_oauth2_with_null_client_assertion_and_no_credentials() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    // client_assertion: null is indistinguishable from omitted once deserialized
+    // (both become None), so this must be rejected exactly like an oauth2 config
+    // with no credentials at all — see validate_oauth2_auth's client_id.is_empty()
+    // fallback path in crates/nono-cli/src/profile/mod.rs.
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "auth": {
+                        "token_url": "https://auth.example.com/oauth/token",
+                        "client_assertion": null
+                    }
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "oauth2 config with client_assertion explicitly null and no client_id/client_secret \
+         must fail schema validation, matching the Rust loader's rejection"
+    );
+}
+
+#[test]
+fn test_schema_validates_oauth2_with_client_assertion() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "auth": {
+                        "token_url": "https://auth.example.com/oauth/token",
+                        "client_assertion": {
+                            "type": "spiffe_jwt",
+                            "workload_api_socket": "/run/spire/sockets/agent.sock",
+                            "audience": ["auth.example.com"]
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("oauth2 with client_assertion (no client_id/client_secret) should validate");
+}
+
+#[test]
+fn test_schema_validates_client_id_secret_with_explicit_null_client_assertion() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    // client_assertion: null deserializes to the same None as an omitted field
+    // (Option<ClientAssertionConfig>), so it must not be flagged as a conflict
+    // with client_id/client_secret.
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "auth": {
+                        "token_url": "https://auth.example.com/oauth/token",
+                        "client_id": "abc",
+                        "client_secret": "xyz",
+                        "client_assertion": null
+                    }
+                }
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("client_id/client_secret with explicitly-null client_assertion should validate");
+}
+
+#[test]
+fn test_schema_rejects_oauth2_without_credentials_or_assertion() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "auth": {
+                        "token_url": "https://auth.example.com/oauth/token"
+                    }
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "oauth2 config with neither client_id/client_secret nor client_assertion must fail schema validation"
+    );
+}
+
+#[test]
+fn test_schema_rejects_oauth2_with_client_id_and_assertion() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "auth": {
+                        "token_url": "https://auth.example.com/oauth/token",
+                        "client_id": "abc",
+                        "client_assertion": {
+                            "type": "spiffe_jwt",
+                            "workload_api_socket": "/run/spire/sockets/agent.sock",
+                            "audience": ["auth.example.com"]
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "oauth2 config combining client_id with client_assertion must fail schema validation"
+    );
+}
+
+#[test]
+fn test_schema_rejects_custom_credential_with_spiffe_and_credential_key() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "credential_key": "internal_api_token",
+                    "spiffe": {
+                        "type": "jwt",
+                        "workload_api_socket": "/run/spire/sockets/agent.sock",
+                        "audience": ["internal-api"]
+                    }
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "custom credential combining spiffe with credential_key must fail schema validation"
+    );
+}
+
+#[test]
+fn test_schema_validates_credential_key_with_explicit_null_spiffe_and_aws_auth() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    // spiffe: null / aws_auth: null deserialize to the same None as omitting the
+    // field entirely, so this must NOT be flagged as a mutual-exclusion conflict
+    // with credential_key.
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "credential_key": "internal_api_token",
+                    "spiffe": null,
+                    "aws_auth": null
+                }
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("credential_key with explicitly-null spiffe/aws_auth should validate");
+}
+
+#[test]
+fn test_schema_rejects_custom_credential_with_no_auth_mechanism() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com"
+                }
+            }
+        }
+    });
+
+    assert!(
+        validator.validate(&profile).is_err(),
+        "custom credential with none of credential_key/auth/aws_auth/spiffe set \
+         must fail schema validation, matching validate_custom_credential's \
+         'must have either ... set' check"
+    );
 }
 
 #[test]

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -48,6 +48,172 @@ fn test_schema_has_canonical_top_level_commands() {
 }
 
 #[test]
+fn test_schema_network_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "NetworkConfig",
+        &[
+            "block",
+            "allow_http2",
+            "network_profile",
+            "allow_domain",
+            "proxy_allow",
+            "allow_proxy",
+            "deny_domain",
+            "credentials",
+            "proxy_credentials",
+            "open_port",
+            "port_allow",
+            "allow_port",
+            "open_port_range",
+            "listen_port",
+            "listen_port_range",
+            "connect_port",
+            "no_proxy",
+            "custom_credentials",
+            "tls_intercept",
+            "upstream_proxy",
+            "external_proxy",
+            "upstream_bypass",
+            "external_proxy_bypass",
+        ],
+    );
+}
+
+#[test]
+fn test_schema_top_level_profile_matches_rust_model() {
+    let schema = load_schema();
+    let props = schema
+        .pointer("/properties")
+        .and_then(Value::as_object)
+        .expect("root properties is an object");
+    let actual = props.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected = [
+        "$schema",
+        "extends",
+        "meta",
+        "security",
+        "groups",
+        "commands",
+        "filesystem",
+        "network",
+        "diagnostics",
+        "linux",
+        "env_credentials",
+        "secrets",
+        "environment",
+        "command_policies",
+        "credential_capture",
+        "credential_providers",
+        "credential_routes",
+        "workdir",
+        "hooks",
+        "session_hooks",
+        "rollback",
+        "undo",
+        "open_urls",
+        "allow_launch_services",
+        "allow_gpu",
+        "allow_parent_of_protected",
+        "interactive",
+        "skipdirs",
+        "packs",
+        "binary",
+        "command_args",
+        "unsafe_macos_seatbelt_rules",
+        "platform_overrides",
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    assert_eq!(
+        actual, expected,
+        "top-level Profile properties must match the Rust Profile model"
+    );
+}
+
+#[test]
+fn test_schema_validates_profile_with_platform_overrides_skipdirs_binary() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "skipdirs": ["vendor"],
+        "binary": "node",
+        "allow_parent_of_protected": true,
+        "platform_overrides": {
+            "macos": {
+                "network": { "block": true }
+            },
+            "linux": {
+                "filesystem": { "allow": ["/tmp"] }
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("skipdirs/binary/allow_parent_of_protected/platform_overrides should validate");
+}
+
+#[test]
+fn test_schema_custom_credential_def_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "CustomCredentialDef",
+        &[
+            "upstream",
+            "credential_key",
+            "auth",
+            "aws_auth",
+            "spiffe",
+            "inject_mode",
+            "inject_header",
+            "credential_format",
+            "path_pattern",
+            "path_replacement",
+            "query_param_name",
+            "proxy",
+            "env_var",
+            "endpoint_rules",
+            "endpoint_policy",
+            "tls_ca",
+            "tls_client_cert",
+            "tls_client_key",
+            "rate_limit",
+        ],
+    );
+}
+
+#[test]
+fn test_schema_validates_custom_credential_with_spiffe_and_endpoint_policy() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "network": {
+            "custom_credentials": {
+                "internal-api": {
+                    "upstream": "https://internal.example.com",
+                    "spiffe": {
+                        "type": "jwt",
+                        "workload_api_socket": "/run/spire/sockets/agent.sock",
+                        "audience": ["internal-api"]
+                    },
+                    "endpoint_policy": {
+                        "default": "deny",
+                        "allow": [{ "method": "GET", "path": "/health" }]
+                    }
+                }
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("custom credential with spiffe and endpoint_policy should validate");
+}
+
+#[test]
 fn test_schema_has_linux_af_unix_mediation() {
     let schema = load_schema();
     assert!(
@@ -475,23 +641,29 @@ fn test_schema_allows_empty_invocation_argv_matcher_for_compatibility() {
 }
 
 #[test]
-fn test_schema_filesystem_has_deny_and_bypass_protection() {
+fn test_schema_filesystem_config_matches_rust_model() {
     let schema = load_schema();
-    let props = schema
-        .pointer("/$defs/FilesystemConfig/properties")
-        .and_then(Value::as_object)
-        .expect("FilesystemConfig.properties is an object");
-    assert!(
-        props.contains_key("deny"),
-        "FilesystemConfig.deny missing from canonical schema"
-    );
-    assert!(
-        props.contains_key("bypass_protection"),
-        "FilesystemConfig.bypass_protection missing from canonical schema"
-    );
-    assert!(
-        props.contains_key("suppress_save_prompt"),
-        "FilesystemConfig.suppress_save_prompt missing from canonical schema"
+    assert_schema_properties(
+        &schema,
+        "FilesystemConfig",
+        &[
+            "allow",
+            "read",
+            "write",
+            "allow_file",
+            "read_file",
+            "write_file",
+            "unix_socket",
+            "unix_socket_bind",
+            "unix_socket_dir",
+            "unix_socket_dir_bind",
+            "unix_socket_subtree",
+            "unix_socket_subtree_bind",
+            "deny",
+            "bypass_protection",
+            "suppress_save_prompt",
+            "ignore",
+        ],
     );
 }
 
@@ -571,4 +743,189 @@ fn test_schema_security_has_no_legacy_groups_or_allowed_commands() {
         !props.contains_key("allowed_commands"),
         "SecurityConfig.allowed_commands still present; canonical location is top-level /properties/commands"
     );
+}
+
+#[test]
+fn test_schema_security_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "SecurityConfig",
+        &[
+            "signal_mode",
+            "process_info_mode",
+            "ipc_mode",
+            "capability_elevation",
+            "wsl2_proxy_policy",
+        ],
+    );
+}
+
+#[test]
+fn test_schema_linux_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "LinuxConfig",
+        &["af_unix_mediation", "sandbox_policy"],
+    );
+}
+
+#[test]
+fn test_schema_validates_linux_sandbox_policy() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    for policy in ["auto", "landlock", "external"] {
+        let profile = json!({ "linux": { "sandbox_policy": policy } });
+        validator
+            .validate(&profile)
+            .unwrap_or_else(|e| panic!("sandbox_policy {policy} should validate: {e}"));
+    }
+}
+
+#[test]
+fn test_schema_workdir_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(&schema, "WorkdirConfig", &["access"]);
+}
+
+#[test]
+fn test_schema_rollback_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "RollbackConfig",
+        &["exclude_patterns", "exclude_globs"],
+    );
+}
+
+#[test]
+fn test_schema_diagnostics_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(&schema, "DiagnosticsConfig", &["suppress_system_services"]);
+}
+
+#[test]
+fn test_schema_tls_intercept_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "TlsInterceptConfig",
+        &[
+            "ca_lifecycle",
+            "ca_validity",
+            "leaf_validity",
+            "ca_env_vars",
+        ],
+    );
+}
+
+#[test]
+fn test_schema_environment_config_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "EnvironmentConfig",
+        &["allow_vars", "deny_vars", "set_vars"],
+    );
+}
+
+#[test]
+fn test_schema_profile_meta_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "ProfileMeta",
+        &["name", "version", "description", "author"],
+    );
+}
+
+#[test]
+fn test_schema_credential_capture_entry_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "CredentialCaptureEntry",
+        &[
+            "command",
+            "provider",
+            "timeout_secs",
+            "ttl_secs",
+            "cache_ttl_secs",
+            "cache_path_regex",
+            "stdin",
+            "output",
+            "interaction",
+        ],
+    );
+    assert_schema_properties(&schema, "CredentialCaptureProvider", &["command", "config"]);
+    assert_schema_properties(
+        &schema,
+        "CredentialCaptureOutputConfig",
+        &["format", "allow_headers"],
+    );
+    assert_schema_properties(
+        &schema,
+        "CredentialCaptureInteraction",
+        &["allow_launch_services", "open_urls", "stdin", "stdio"],
+    );
+}
+
+#[test]
+fn test_schema_credential_provider_def_matches_rust_model() {
+    let schema = load_schema();
+    assert_schema_properties(
+        &schema,
+        "CredentialProviderDef",
+        &[
+            "type",
+            "token_endpoints",
+            "api_hosts",
+            "inject_header",
+            "credential_format",
+            "credential_store",
+            "helpers",
+        ],
+    );
+    assert_schema_properties(
+        &schema,
+        "CredentialProviderTokenEndpoint",
+        &[
+            "host",
+            "path",
+            "response_fields",
+            "request_body",
+            "request_nonce_fields",
+        ],
+    );
+    assert_schema_properties(
+        &schema,
+        "CredentialProviderHelpers",
+        &["status", "login", "logout"],
+    );
+}
+
+#[test]
+fn test_schema_validates_credential_provider_inject_header_and_format() {
+    let schema = load_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let profile = json!({
+        "credential_providers": {
+            "vault": {
+                "type": "oauth_capture",
+                "token_endpoints": [{
+                    "host": "https://vault.example.com",
+                    "path": "/v1/auth/token",
+                    "response_fields": [{ "path": "auth.client_token" }]
+                }],
+                "api_hosts": ["https://vault.example.com"],
+                "inject_header": "X-Vault-Token",
+                "credential_format": "{}"
+            }
+        }
+    });
+
+    validator
+        .validate(&profile)
+        .expect("credential provider inject_header/credential_format should validate");
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1236
Closes #951 

## Summary

The JSON profile schema was hand-maintained and had drifted out of sync with the Rust config structs in several places, so valid profiles using these fields failed schema validation even though the loader accepted them fine via serde:

- NetworkConfig: connect_port, open_port_range, listen_port_range, deny_domain
- FilesystemConfig: unix_socket, unix_socket_bind, unix_socket_dir, unix_socket_dir_bind, unix_socket_subtree, unix_socket_subtree_bind
- CustomCredentialDef: endpoint_policy, spiffe (new SpiffeAuthConfig def)
- Profile (top-level): allow_parent_of_protected, skipdirs, binary, platform_overrides (new PlatformOverrides def, self-referencing the root schema)

Add exhaustive assert_schema_properties regression tests for NetworkConfig, FilesystemConfig, CustomCredentialDef, and the top-level Profile so future field additions fail schema_shape.rs instead of silently drifting, plus validation tests exercising the newly-added fields end to end.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
