### PR TITLE
fix(macos): refuse noninteractive proxy CA trust mutation

### DIFF
--- a/crates/nono-cli/src/macos_trust.rs
+++ b/crates/nono-cli/src/macos_trust.rs
@@ -12,6 +12,7 @@ use security_framework::certificate::SecCertificate;
 use security_framework::os::macos::keychain::SecKeychain;
 use security_framework::passwords;
 use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
+use std::io::IsTerminal;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, info, warn};
 use x509_parser::pem::parse_x509_pem;
@@ -24,6 +25,12 @@ enum TrustCertError {
     Other(NonoError),
 }
 
+enum ProxyCaOutcome {
+    Ready(PreloadedCa),
+    EphemeralFallback,
+    InteractionUnavailable,
+}
+
 // Service name for Keychain items. Sufficiently specific to avoid collision
 // with other apps. set_generic_password overwrites on conflict (desired).
 const KEYCHAIN_SERVICE: &str = "nono-proxy-ca";
@@ -31,24 +38,39 @@ const KEYCHAIN_ACCOUNT: &str = "ca-bundle";
 
 /// Load or generate a shared CA and ensure it's trusted in the macOS user
 /// trust store. Returns `Some(PreloadedCa)` on success, `None` if the user
-/// cancelled the auth prompt or setup failed (fallback to ephemeral CA).
+/// cancelled the auth prompt or setup failed (fallback to ephemeral CA), and
+/// refuses if a persistent trust mutation would require unavailable user
+/// interaction.
 ///
-/// All logging happens internally — the caller just checks the Option.
-pub(crate) fn load_or_generate_proxy_ca(validity: Duration) -> Option<PreloadedCa> {
-    match try_ensure_trusted_ca(validity) {
-        Ok(Some(ca)) => Some(ca),
-        Ok(None) => None,
+/// All logging happens internally — the caller propagates the result and
+/// checks the Option.
+pub(crate) fn load_or_generate_proxy_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
+    finish_proxy_ca_outcome(try_ensure_trusted_ca(validity))
+}
+
+fn finish_proxy_ca_outcome(outcome: Result<ProxyCaOutcome>) -> Result<Option<PreloadedCa>> {
+    match outcome {
+        Ok(ProxyCaOutcome::Ready(ca)) => Ok(Some(ca)),
+        Ok(ProxyCaOutcome::EphemeralFallback) => Ok(None),
+        Ok(ProxyCaOutcome::InteractionUnavailable) => Err(NonoError::SandboxInit(
+            "--trust-proxy-ca cannot add or re-trust the proxy CA without an interactive \
+             terminal; establish trust interactively once or use a session-scoped CA bundle"
+                .to_string(),
+        )),
         Err(e) => {
             warn!("Shared CA setup failed: {e}. Falling back to ephemeral CA.");
-            None
+            Ok(None)
         }
     }
 }
 
-fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
+fn try_ensure_trusted_ca(validity: Duration) -> Result<ProxyCaOutcome> {
     match load_existing_ca()? {
         Some((key_der, cert_pem)) => {
             if !cert_pem_is_valid(&cert_pem)? {
+                if !persistent_trust_interaction_available() {
+                    return Ok(ProxyCaOutcome::InteractionUnavailable);
+                }
                 debug!("stored proxy CA has expired; regenerating");
                 remove_cert_from_keychain(&cert_pem);
                 delete_existing_ca();
@@ -61,6 +83,9 @@ fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
             })?;
 
             if !is_cert_trusted(&cert) {
+                if !persistent_trust_interaction_available() {
+                    return Ok(ProxyCaOutcome::InteractionUnavailable);
+                }
                 info!("Re-trusting proxy CA (you may be prompted for authentication)...");
                 if let Err(e) = trust_cert(&cert) {
                     match e {
@@ -69,7 +94,7 @@ fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
                                 "Trust store auth cancelled. Falling back to ephemeral CA. \
                                  Go CLI tools won't validate proxy certs; other tools still work."
                             );
-                            return Ok(None);
+                            return Ok(ProxyCaOutcome::EphemeralFallback);
                         }
                         TrustCertError::Other(err) => return Err(err),
                     }
@@ -79,13 +104,21 @@ fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
                 info!("Reusing proxy CA from Keychain (already trusted)");
             }
 
-            Ok(Some(PreloadedCa { key_der, cert_pem }))
+            Ok(ProxyCaOutcome::Ready(PreloadedCa { key_der, cert_pem }))
         }
         None => {
             debug!("no existing proxy CA in Keychain; generating new one");
             generate_and_trust_new_ca(validity)
         }
     }
+}
+
+fn persistent_trust_interaction_available() -> bool {
+    persistent_trust_interaction_available_for(std::io::stderr().is_terminal())
+}
+
+const fn persistent_trust_interaction_available_for(stderr_is_terminal: bool) -> bool {
+    stderr_is_terminal
 }
 
 fn load_existing_ca() -> Result<Option<(Zeroizing<Vec<u8>>, String)>> {
@@ -100,7 +133,11 @@ fn load_existing_ca() -> Result<Option<(Zeroizing<Vec<u8>>, String)>> {
         .map_err(|e| NonoError::SandboxInit(format!("{e}")))
 }
 
-fn generate_and_trust_new_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
+fn generate_and_trust_new_ca(validity: Duration) -> Result<ProxyCaOutcome> {
+    if !persistent_trust_interaction_available() {
+        return Ok(ProxyCaOutcome::InteractionUnavailable);
+    }
+
     let ca =
         nono_proxy::tls_intercept::ca::EphemeralCa::generate_with_cn("nono-proxy-ca", validity)
             .map_err(|e| NonoError::SandboxInit(format!("failed to generate CA: {e}")))?;
@@ -131,14 +168,14 @@ fn generate_and_trust_new_ca(validity: Duration) -> Result<Option<PreloadedCa>> 
                     "Trust store auth cancelled. Falling back to ephemeral CA. \
                      Go CLI tools won't validate proxy certs; other tools still work."
                 );
-                return Ok(None);
+                return Ok(ProxyCaOutcome::EphemeralFallback);
             }
             TrustCertError::Other(err) => return Err(err),
         }
     }
 
     info!("Proxy CA added to macOS trust store");
-    Ok(Some(PreloadedCa { key_der, cert_pem }))
+    Ok(ProxyCaOutcome::Ready(PreloadedCa { key_der, cert_pem }))
 }
 
 fn ensure_cert_in_keychain(cert: &SecCertificate) -> Result<()> {
@@ -308,5 +345,29 @@ mod tests {
         assert!(is_user_cancelled_osstatus(ERR_SEC_INTERACTION_NOT_ALLOWED));
         assert!(!is_user_cancelled_osstatus(-25299)); // errSecDuplicateItem
         assert!(!is_user_cancelled_osstatus(0));
+    }
+
+    #[test]
+    fn persistent_trust_mutation_requires_an_interactive_terminal() {
+        assert!(persistent_trust_interaction_available_for(true));
+        assert!(!persistent_trust_interaction_available_for(false));
+    }
+
+    #[test]
+    fn unavailable_interaction_is_a_typed_startup_refusal() {
+        let Err(error) = finish_proxy_ca_outcome(Ok(ProxyCaOutcome::InteractionUnavailable)) else {
+            panic!("noninteractive trust mutation must refuse");
+        };
+        assert!(matches!(
+            error,
+            NonoError::SandboxInit(message)
+                if message.contains("without an interactive terminal")
+        ));
+
+        assert!(
+            finish_proxy_ca_outcome(Ok(ProxyCaOutcome::EphemeralFallback))
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2835,7 +2835,7 @@ pub(crate) fn apply_tls_intercept_config(
                 .as_ref()
                 .and_then(|t| t.ca_validity)
                 .unwrap_or(nono_proxy::tls_intercept::ca::CA_VALIDITY_DEFAULT);
-            proxy_config.preloaded_ca = crate::macos_trust::load_or_generate_proxy_ca(validity);
+            proxy_config.preloaded_ca = crate::macos_trust::load_or_generate_proxy_ca(validity)?;
         } else {
             tracing::warn!(
                 "--trust-proxy-ca has no effect without TLS-intercepting credential routes"

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -825,6 +825,11 @@ nono run --allow-cwd --credential github --trust-proxy-ca -- gh api /user
 
 The first run triggers a single biometric/password prompt. Subsequent runs reuse the existing CA with zero prompts. The CA regenerates automatically when it expires (default: 1 day, configurable via [`--proxy-ca-validity`](/cli/usage/flags#--proxy-ca-validity)).
 
+The first trust operation and any later re-trust require an interactive
+terminal. If either mutation is needed from a noninteractive invocation, nono
+refuses before launching the child. An already-trusted CA remains reusable from
+noninteractive automation.
+
 See [`--trust-proxy-ca`](/cli/usage/flags#--trust-proxy-ca) for details.
 
 ## Security Properties

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -538,6 +538,11 @@ The CA is persisted in macOS Keychain and shared across sessions. It regenerates
 - **Subsequent runs**: Loads from Keychain with zero prompts
 - **After expiry**: Removes the expired CA and regenerates
 
+Adding or re-trusting the CA requires an interactive terminal. A noninteractive
+invocation that needs either mutation refuses before the requested child starts,
+instead of waiting indefinitely for an authorization interaction that the caller
+cannot service. Noninteractive invocations may still reuse an already-trusted CA.
+
 <Note>
 This flag has no effect without `--credential` (or another TLS-intercepting route). If no credential routes are configured, nono warns and skips CA generation.
 </Note>


### PR DESCRIPTION
## Linked Issue

Closes #1627

## Summary

- reuse an already-trusted macOS proxy CA in noninteractive invocations
- refuse before `SecTrustSettingsSetTrustSettings` and before child launch when a first trust or re-trust would require unavailable terminal interaction
- preserve the existing interactive prompt, cancellation, and ephemeral-fallback behavior
- document the noninteractive contract for `--trust-proxy-ca`

## Agent Disclosure

I am an AI coding agent contributing at the repository owner's request. Before changing source, I reviewed `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CLAUDE.md`, the affected `macos_trust.rs` and `proxy_runtime.rs` paths, and the related CLI documentation. Issue #1627 disclosed my identity, intent, approach, test plan, risks, and tradeoff before implementation.

No external implementation was copied or adapted. The change is newly written against the repository's existing CA lifecycle and `NonoError` patterns.

## Test Plan

- `cargo test -p nono-cli macos_trust` — 7 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used` — passed
- `cargo fmt --all -- --check` — passed
- `cargo test -p nono` plus schema, manifest, and doctest stages — passed (748 core tests, 40 schema tests, 16 manifest tests, 7 doctests)
- `cargo test -p nono-cli` inside the aggregate `make ci` run — 1,909 passed, 1 ignored, and one unrelated parallel-only macOS temp-state test failed; that test passes alone at both untouched base `0a7852dc` and this head. A prior aggregate run had two such parallel-only failures, both of which also pass alone at base and head. Hosted CI is left to adjudicate the clean source in its ordinary environment.

No real Keychain mutation or persistent trust change was performed while testing.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code; no external implementation was reused
- [x] I did not use forbidden patterns such as unwrap/expect in production code
- [x] I used `NonoError` where required
- [x] I validated and canonicalized all relevant paths; this change introduces no path input or filesystem target
- [x] This PR matches the disclosed issue scope
