### PR TITLE
fix(sandbox): enforce proxy-only destination check on Landlock V4+ kernels

### DIFF
--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -603,11 +603,14 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     #[cfg(target_os = "linux")]
     let seccomp_proxy_fallback = {
         let needs_proxy = matches!(caps.network_mode(), nono::NetworkMode::ProxyOnly { .. });
-        let external_network = matches!(
+        // Landlock policy opts out of seccomp-notify entirely (see its docs);
+        // honor that even though it leaves ProxyOnly's destination check unenforced.
+        let no_seccomp_fallback = matches!(
             flags.sandbox_policy,
             crate::profile::LinuxSandboxPolicy::External
+                | crate::profile::LinuxSandboxPolicy::Landlock
         );
-        if external_network {
+        if no_seccomp_fallback {
             false
         } else if needs_proxy && nono::is_wsl2() {
             let needs_seccomp_fallback = !Sandbox::detect_abi()
@@ -639,9 +642,10 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             }
             false
         } else if needs_proxy {
-            !Sandbox::detect_abi()
-                .ok()
-                .is_some_and(|abi| abi.has_network())
+            // Landlock's AccessNet filters by port only, never by destination
+            // address, on any ABI version — so this must always run, not just
+            // as a pre-V4 fallback, or the proxy's host allowlist is bypassable.
+            true
         } else {
             false
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2003,6 +2003,11 @@ pub enum LinuxSandboxPolicy {
     Auto,
     /// Landlock only. Returns an error at startup if the kernel cannot
     /// satisfy network restrictions via Landlock alone.
+    ///
+    /// Never installs a seccomp-notify listener. Since Landlock's TCP rules
+    /// filter by port only, `NetworkMode::ProxyOnly` under this policy cannot
+    /// restrict the child to 127.0.0.1:<port> — any host on that port is
+    /// reachable. Use `Auto` for real destination-host enforcement.
     Landlock,
     /// TCP network egress enforcement is managed externally (iptables,
     /// cgroups, systemd, etc.). nono still installs filesystem/process

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -926,9 +926,11 @@ pub struct CapabilitySet {
     ///
     /// On macOS (Seatbelt), outbound is scoped to localhost per-port.
     /// On Linux (Landlock), ConnectTcp/BindTcp filter by port only, not by
-    /// destination or bind address. `--block-net` blocks other ports but does
-    /// not narrow this grant to localhost; use proxy mode for destination-host
-    /// enforcement.
+    /// destination or bind address, and `--block-net` doesn't narrow this
+    /// grant to localhost either. `NetworkMode::ProxyOnly` gets real
+    /// destination-host enforcement from nono-cli's seccomp-notify layer
+    /// (`SeccompPolicy::proxy_fallback`); this port grant has no such layer
+    /// and stays port-only on Linux.
     localhost_ports: Vec<u16>,
     /// Inclusive port ranges for bidirectional localhost IPC (connect + bind).
     ///

--- a/docs/cli/features/networking.mdx
+++ b/docs/cli/features/networking.mdx
@@ -420,9 +420,9 @@ Restricted CLI network modes always include a static seccomp baseline:
 
 - Plain `--block-net` denies every non-Unix socket plus `io_uring_setup()`.
 - Policies with port exceptions permit only Internet TCP stream sockets; Landlock V4+ then enforces the TCP connect/bind port allowlist.
-- Proxy-only mode uses the same socket-family/type baseline. On pre-V4 kernels, seccomp user notification supplies the destination decision instead of Landlock.
+- Proxy-only mode adds a seccomp user notification layer on top, checking the real destination address of every `connect()`. This layer is always active for proxy-only mode, on every Landlock ABI, because Landlock's own network rules have no destination-address component.
 
-Landlock rules match TCP ports, not IP addresses. A connect grant for port 3000 permits that port on any destination address, and a bind grant can listen on any local interface. Use the domain proxy when destination-host enforcement is required.
+Landlock rules match TCP ports, not IP addresses: a plain `--allow-connect-port`/`--open-port` grant for port 3000 permits that port on any destination, and a bind grant can listen on any local interface. The domain proxy doesn't share this gap — its destination-host enforcement comes from the seccomp layer above, not from Landlock's port rule alone. Use the domain proxy, not a raw port grant, when destination-host enforcement matters.
 
 **Requirements:** Plain `--block-net` works on every Linux kernel supported by nono. TCP port exceptions require Landlock ABI V4+ (Linux 6.7+) and fail closed on older kernels.
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #

## Summary

Landlocks AccessNet filters TCP connect/bind by port only, on every ABI version — it has no destination-address component. The seccomp-notify layer that does check the real destination was only installed when the kernel lacked Landlock network support, so on V4+ kernels (the common case) proxy-only mode relied on Landlocks port-only rule alone. A sandboxed process could connect() to <any-host>:<proxy-port> and exfiltrate data past the domain proxys allowlist entirely.

Always install the destination-checking seccomp-notify listener for NetworkMode::ProxyOnly, regardless of Landlock ABI, except under the explicit --sandbox-policy landlock/external opt-outs which already forgo seccomp entirely and are documented accordingly.

Verified against a live exploit on Landlock V4 (kernel 6.8): a listener on a non-loopback address bound to the proxys port previously received sandboxed traffic; it no longer does. Full lib/cli unit and integration suites pass on macOS and Linux.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
