### PR TITLE
fix(cli): union separate read and write grants for `nono why --op readwrite`

### DIFF
--- a/crates/nono-cli/src/diagnostic/formatter.rs
+++ b/crates/nono-cli/src/diagnostic/formatter.rs
@@ -1335,14 +1335,13 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 
     fn actionable_observed_access(&self, path: &Path, inferred: AccessMode) -> Option<AccessMode> {
-        let Some(cap) = self.closest_covering_capability_any(path) else {
-            return Some(inferred);
-        };
-
-        if cap.access.contains(inferred) {
-            return None;
+        match self.covering_access_union(path) {
+            Some(access) if access.contains(inferred) => return None,
+            None => return Some(inferred),
+            Some(_) => {}
         }
 
+        let cap = self.closest_covering_capability_any(path)?;
         match (cap.access, inferred) {
             (AccessMode::Read, AccessMode::ReadWrite) => Some(AccessMode::Write),
             (AccessMode::Write, AccessMode::ReadWrite) => Some(AccessMode::Read),
@@ -1355,28 +1354,38 @@ impl<'a> DiagnosticFormatter<'a> {
         path: &Path,
     ) -> Option<&nono::capability::FsCapability> {
         let canonical = try_canonicalize(path);
-        let mut best_covering: Option<&nono::capability::FsCapability> = None;
-        let mut best_covering_score = 0usize;
+        self.caps
+            .scan_covering(AccessMode::ReadWrite, |cap| {
+                if cap.is_file {
+                    cap.resolved == canonical
+                } else {
+                    canonical.starts_with(&cap.resolved)
+                }
+            })
+            .best_covering
+    }
 
-        for cap in self.caps.fs_capabilities() {
-            let covers = if cap.is_file {
+    /// Union access covering `path` across *all* matching capabilities, not
+    /// just the single most-specific one. Read and write for the same path
+    /// can come from two separate grants (e.g. a broad read-only group plus
+    /// a narrower write-only group); neither alone is ReadWrite, but their
+    /// union is. Returns `None` if nothing covers `path`.
+    fn covering_access_union(&self, path: &Path) -> Option<AccessMode> {
+        let canonical = try_canonicalize(path);
+        let covering = self.caps.scan_covering(AccessMode::ReadWrite, |cap| {
+            if cap.is_file {
                 cap.resolved == canonical
             } else {
                 canonical.starts_with(&cap.resolved)
-            };
-
-            if !covers {
-                continue;
             }
+        });
 
-            let score = cap.resolved.as_os_str().len();
-            if score >= best_covering_score {
-                best_covering = Some(cap);
-                best_covering_score = score;
-            }
+        match (covering.best_read.is_some(), covering.best_write.is_some()) {
+            (true, true) => Some(AccessMode::ReadWrite),
+            (true, false) => Some(AccessMode::Read),
+            (false, true) => Some(AccessMode::Write),
+            (false, false) => None,
         }
-
-        best_covering
     }
 
     fn format_follow_up_from_diagnostics(
@@ -1936,11 +1945,14 @@ impl<'a> DiagnosticFormatter<'a> {
         path: &Path,
         requested: AccessMode,
     ) -> Option<String> {
-        let cap = self.closest_covering_capability_any(path)?;
-        if cap.access.contains(requested) {
+        if self
+            .covering_access_union(path)
+            .is_some_and(|access| access.contains(requested))
+        {
             return None;
         }
 
+        let cap = self.closest_covering_capability_any(path)?;
         let target = cap.resolved.clone();
 
         let requested = match (cap.access, requested) {
@@ -2952,6 +2964,47 @@ mod tests {
         ));
         assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&denied.display().to_string()));
+    }
+
+    #[test]
+    fn test_observed_readwrite_hint_satisfied_by_two_separate_grants_not_reported() {
+        // Read and write covering a path can come from two separate
+        // capabilities. An observed readwrite access must not be reported
+        // as missing when their union already satisfies it.
+        let mut caps = CapabilitySet::new().block_network();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test/project"),
+            resolved: PathBuf::from("/test/project"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("read_group".to_string()),
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test/project/sub"),
+            resolved: PathBuf::from("/test/project/sub"),
+            access: AccessMode::Write,
+            is_file: false,
+            source: CapabilitySource::Group("write_group".to_string()),
+        });
+
+        let path = PathBuf::from("/test/project/sub/file.txt");
+        let formatter = DiagnosticFormatter::new(&caps).with_error_observation(ErrorObservation {
+            primary_verdict: None,
+            blocked_protected_file: None,
+            path_hints: vec![ObservedPathHint {
+                path: path.clone(),
+                access: AccessMode::ReadWrite,
+            }],
+            missing_paths: Vec::new(),
+            non_sandbox_failure: None,
+            network_blocked_hint: false,
+        });
+
+        let output = formatter.format_footer(0);
+        assert!(
+            !output.contains("Sandbox denial:"),
+            "readwrite covered by two separate grants must not be reported as missing, got: {output}"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -141,44 +141,18 @@ pub fn query_path(
         });
     }
 
-    // Check capabilities. Prefer the most specific matching grant so broad system
-    // reads (e.g. /private on macOS) do not shadow explicit user grants.
-    let mut best_covering: Option<&nono::FsCapability> = None;
-    let mut best_sufficient: Option<&nono::FsCapability> = None;
-    let mut best_covering_score = 0usize;
-    let mut best_sufficient_score = 0usize;
-
-    for cap in caps.fs_capabilities() {
-        let covers = if cap.is_file {
+    // Prefer the most specific matching grant so broad system reads (e.g.
+    // /private on macOS) do not shadow explicit user grants, and union
+    // separate read/write grants for a `readwrite` query.
+    let covering = caps.scan_covering(requested, |cap| {
+        if cap.is_file {
             cap.resolved == canonical
         } else {
             canonical.starts_with(&cap.resolved)
-        };
-
-        if !covers {
-            continue;
         }
+    });
 
-        let score = cap.resolved.as_os_str().len();
-        if score >= best_covering_score {
-            best_covering = Some(cap);
-            best_covering_score = score;
-        }
-
-        let sufficient = matches!(
-            (cap.access, requested),
-            (AccessMode::ReadWrite, _)
-                | (AccessMode::Read, AccessMode::Read)
-                | (AccessMode::Write, AccessMode::Write)
-        );
-
-        if sufficient && score >= best_sufficient_score {
-            best_sufficient = Some(cap);
-            best_sufficient_score = score;
-        }
-    }
-
-    if let Some(cap) = best_sufficient {
+    if let Some(cap) = covering.best_sufficient {
         return Ok(QueryResult::Allowed {
             reason: "granted_path".to_string(),
             granted_path: Some(cap.resolved.display().to_string()),
@@ -189,7 +163,22 @@ pub fn query_path(
         });
     }
 
-    if let Some(cap) = best_covering {
+    if let (Some(read_cap), Some(write_cap)) = (covering.best_read, covering.best_write) {
+        return Ok(QueryResult::Allowed {
+            reason: "granted_path_union".to_string(),
+            granted_path: Some(format!(
+                "{} (read) + {} (write)",
+                read_cap.resolved.display(),
+                write_cap.resolved.display()
+            )),
+            access: Some("readwrite".to_string()),
+            source: Some(format!("{} + {}", read_cap.source, write_cap.source)),
+            endpoint_rules: None,
+            warning: None,
+        });
+    }
+
+    if let Some(cap) = covering.best_covering {
         return Ok(QueryResult::Denied {
             reason: "insufficient_access".to_string(),
             details: Some(format!(
@@ -885,6 +874,55 @@ mod tests {
                 assert_eq!(access.as_deref(), Some("read+write"));
             }
             _ => panic!("expected allowed result"),
+        }
+    }
+
+    #[test]
+    fn test_query_path_readwrite_from_two_separate_grants() {
+        // #1628: read and write granted by two separate capabilities should
+        // still satisfy a `readwrite` query.
+        let dir = tempdir().expect("Failed to create temp dir");
+        let dir_canonical = dir.path().canonicalize().expect("canonicalize dir");
+        let subdir = dir_canonical.join("sub");
+        std::fs::create_dir(&subdir).expect("create subdir");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: dir_canonical.clone(),
+            resolved: dir_canonical.clone(),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("read_group".to_string()),
+        });
+        caps.add_fs(FsCapability {
+            original: subdir.clone(),
+            resolved: subdir.clone(),
+            access: AccessMode::Write,
+            is_file: false,
+            source: CapabilitySource::Group("write_group".to_string()),
+        });
+
+        let result = query_path(&subdir, AccessMode::Read, &caps, &[]).expect("query failed");
+        assert!(
+            matches!(result, QueryResult::Allowed { .. }),
+            "expected read alone to be allowed"
+        );
+
+        let result = query_path(&subdir, AccessMode::Write, &caps, &[]).expect("query failed");
+        assert!(
+            matches!(result, QueryResult::Allowed { .. }),
+            "expected write alone to be allowed"
+        );
+
+        let result = query_path(&subdir, AccessMode::ReadWrite, &caps, &[]).expect("query failed");
+        match result {
+            QueryResult::Allowed { access, source, .. } => {
+                assert_eq!(access.as_deref(), Some("readwrite"));
+                let source = source.expect("expected a source");
+                assert!(source.contains("read_group"), "got: {source}");
+                assert!(source.contains("write_group"), "got: {source}");
+            }
+            other => panic!("expected readwrite to be allowed via union, got: {other:?}"),
         }
     }
 

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -133,6 +133,22 @@ pub struct FsCapability {
     pub source: CapabilitySource,
 }
 
+/// Result of [`CapabilitySet::scan_covering`].
+#[derive(Debug, Default)]
+pub struct CoveringCapabilities<'a> {
+    /// Most specific covering capability, regardless of access mode.
+    pub best_covering: Option<&'a FsCapability>,
+    /// Most specific covering capability whose own access alone satisfies
+    /// the requested mode.
+    pub best_sufficient: Option<&'a FsCapability>,
+    /// Most specific covering capability granting read access (only
+    /// populated when the requested mode is `ReadWrite`).
+    pub best_read: Option<&'a FsCapability>,
+    /// Most specific covering capability granting write access (only
+    /// populated when the requested mode is `ReadWrite`).
+    pub best_write: Option<&'a FsCapability>,
+}
+
 impl FsCapability {
     /// Create a new directory capability, canonicalizing the path
     ///
@@ -1407,6 +1423,74 @@ impl CapabilitySet {
     #[must_use]
     pub fn fs_capabilities(&self) -> &[FsCapability] {
         &self.fs
+    }
+
+    /// Scan filesystem capabilities for the ones covering a queried path,
+    /// scoring by specificity (longest `resolved` path wins) and tracking
+    /// read/write coverage separately.
+    ///
+    /// Read and write for the same path can come from two distinct
+    /// capabilities rather than one `ReadWrite` grant (e.g. a broad
+    /// read-only group plus a narrower write-only group); neither alone is
+    /// sufficient for a `ReadWrite` request, but their union is. Callers
+    /// asking a `ReadWrite` query should treat `best_read.is_some() &&
+    /// best_write.is_some()` as satisfying the request even when
+    /// `best_sufficient` is `None`.
+    ///
+    /// `covers` decides whether a capability applies to the queried path;
+    /// left to the caller since path canonicalization/fallback strategies
+    /// differ slightly between call sites.
+    #[must_use]
+    pub fn scan_covering(
+        &self,
+        requested: AccessMode,
+        mut covers: impl FnMut(&FsCapability) -> bool,
+    ) -> CoveringCapabilities<'_> {
+        let mut result = CoveringCapabilities::default();
+        let mut best_covering_score = 0usize;
+        let mut best_sufficient_score = 0usize;
+        let mut best_read_score = 0usize;
+        let mut best_write_score = 0usize;
+
+        for cap in &self.fs {
+            if !covers(cap) {
+                continue;
+            }
+
+            let score = cap.resolved.as_os_str().len();
+            if score >= best_covering_score {
+                result.best_covering = Some(cap);
+                best_covering_score = score;
+            }
+
+            let sufficient = matches!(
+                (cap.access, requested),
+                (AccessMode::ReadWrite, _)
+                    | (AccessMode::Read, AccessMode::Read)
+                    | (AccessMode::Write, AccessMode::Write)
+            );
+            if sufficient && score >= best_sufficient_score {
+                result.best_sufficient = Some(cap);
+                best_sufficient_score = score;
+            }
+
+            if requested == AccessMode::ReadWrite {
+                if matches!(cap.access, AccessMode::Read | AccessMode::ReadWrite)
+                    && score >= best_read_score
+                {
+                    result.best_read = Some(cap);
+                    best_read_score = score;
+                }
+                if matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite)
+                    && score >= best_write_score
+                {
+                    result.best_write = Some(cap);
+                    best_write_score = score;
+                }
+            }
+        }
+
+        result
     }
 
     /// Get AF_UNIX socket capabilities.

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -65,8 +65,9 @@ pub mod undo;
 
 // Re-exports for convenience
 pub use capability::{
-    AccessMode, CapabilitySet, CapabilitySource, FsCapability, IpcMode, NetworkMode,
-    ProcessInfoMode, SignalMode, SocketScope, UnixSocketCapability, UnixSocketMode, UnixSocketOp,
+    AccessMode, CapabilitySet, CapabilitySource, CoveringCapabilities, FsCapability, IpcMode,
+    NetworkMode, ProcessInfoMode, SignalMode, SocketScope, UnixSocketCapability, UnixSocketMode,
+    UnixSocketOp,
 };
 pub use diagnostic::{
     DenialReason, DenialRecord, IpcDenialRecord, NonoDiagnostic, NonoDiagnosticCode,

--- a/crates/nono/src/query.rs
+++ b/crates/nono/src/query.rs
@@ -84,8 +84,8 @@ impl QueryContext {
             query_path_buf.as_path()
         };
 
-        for cap in self.caps.fs_capabilities() {
-            let covers = if cap.is_file {
+        let covering = self.caps.scan_covering(requested, |cap| {
+            if cap.is_file {
                 // File capability: exact match against resolved, or if not
                 // canonicalized, also check against original
                 query_path == cap.resolved
@@ -96,28 +96,32 @@ impl QueryContext {
                 // (symlink path) for non-existent paths.
                 query_path.starts_with(&cap.resolved)
                     || (full_canonical.is_none() && path.starts_with(&cap.original))
-            };
-
-            if covers {
-                let sufficient = matches!(
-                    (cap.access, requested),
-                    (AccessMode::ReadWrite, _)
-                        | (AccessMode::Read, AccessMode::Read)
-                        | (AccessMode::Write, AccessMode::Write)
-                );
-
-                if sufficient {
-                    return QueryResult::Allowed(AllowReason::GrantedPath {
-                        granted_path: cap.resolved.display().to_string(),
-                        access: cap.access.to_string(),
-                    });
-                } else {
-                    return QueryResult::Denied(DenyReason::InsufficientAccess {
-                        granted: cap.access.to_string(),
-                        requested: requested.to_string(),
-                    });
-                }
             }
+        });
+
+        if let Some(cap) = covering.best_sufficient {
+            return QueryResult::Allowed(AllowReason::GrantedPath {
+                granted_path: cap.resolved.display().to_string(),
+                access: cap.access.to_string(),
+            });
+        }
+
+        if let (Some(read_cap), Some(write_cap)) = (covering.best_read, covering.best_write) {
+            return QueryResult::Allowed(AllowReason::GrantedPath {
+                granted_path: format!(
+                    "{} (read) + {} (write)",
+                    read_cap.resolved.display(),
+                    write_cap.resolved.display()
+                ),
+                access: AccessMode::ReadWrite.to_string(),
+            });
+        }
+
+        if let Some(cap) = covering.best_covering {
+            return QueryResult::Denied(DenyReason::InsufficientAccess {
+                granted: cap.access.to_string(),
+                requested: requested.to_string(),
+            });
         }
 
         QueryResult::Denied(DenyReason::PathNotGranted)
@@ -163,6 +167,62 @@ mod tests {
             result,
             QueryResult::Denied(DenyReason::PathNotGranted)
         ));
+    }
+
+    #[test]
+    fn test_query_path_prefers_most_specific_grant_regardless_of_order() {
+        // A broad grant added before a narrower, sufficient one must not
+        // shadow it just because it was inserted first.
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test"),
+            resolved: PathBuf::from("/test"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test/sub"),
+            resolved: PathBuf::from("/test/sub"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let ctx = QueryContext::new(caps);
+        let result = ctx.query_path(Path::new("/test/sub/file.txt"), AccessMode::Write);
+        assert!(
+            matches!(result, QueryResult::Allowed(_)),
+            "narrower ReadWrite grant should win over the broader read-only one, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_query_path_readwrite_from_two_separate_grants() {
+        // Read and write for the same path can come from two distinct
+        // capabilities rather than one ReadWrite grant.
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test"),
+            resolved: PathBuf::from("/test"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test/sub"),
+            resolved: PathBuf::from("/test/sub"),
+            access: AccessMode::Write,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let ctx = QueryContext::new(caps);
+        let result = ctx.query_path(Path::new("/test/sub/file.txt"), AccessMode::ReadWrite);
+        assert!(
+            matches!(result, QueryResult::Allowed(_)),
+            "readwrite covered by two separate grants should be allowed, got: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1628

## Summary

query_path only treated a `readwrite` query as satisfied when a single capability was already ReadWrite, so a path covered by two separate grants (e.g. a broad read-only group plus a narrower write-only group) was reported DENIED even though both read and write independently report ALLOWED and the sandbox itself permits both.

Track the best read-capable and write-capable covering grant separately and treat their union as sufficient when no single capability suffices, naming both contributing grants in the result.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
