### PR TITLE
fix(supervisor): enforce peer-UID check in SupervisorSocket::bind()

### DIFF
--- a/crates/nono/src/supervisor/socket.rs
+++ b/crates/nono/src/supervisor/socket.rs
@@ -93,6 +93,8 @@ impl SupervisorSocket {
             NonoError::SandboxInit(format!("Failed to accept supervisor connection: {e}"))
         })?;
 
+        check_peer_uid(&stream, "supervisor")?;
+
         Ok(SupervisorSocket {
             stream,
             socket_path: Some(path.to_path_buf()),
@@ -472,6 +474,23 @@ pub fn peer_credentials(sock_fd: RawFd) -> Result<PeerCredentials> {
     }
 }
 
+/// Reject a connection whose peer UID does not match the current process's UID.
+///
+/// `label` identifies the connection kind (e.g. "supervisor", "URL open") in the
+/// error message.
+fn check_peer_uid(stream: &UnixStream, label: &str) -> Result<()> {
+    let peer = peer_credentials(stream.as_raw_fd())?;
+    // SAFETY: getuid() is always safe to call.
+    let our_uid = unsafe { libc::getuid() };
+    if peer.uid != our_uid {
+        return Err(NonoError::SandboxInit(format!(
+            "Rejected {label} connection from uid {} (expected {})",
+            peer.uid, our_uid
+        )));
+    }
+    Ok(())
+}
+
 #[doc(hidden)]
 #[cfg(target_os = "linux")]
 pub fn peer_in_same_user_namespace(peer_pid: u32) -> Result<bool> {
@@ -608,15 +627,7 @@ impl SupervisorListener {
             ))
         })?;
 
-        let peer = peer_credentials(stream.as_raw_fd())?;
-        // SAFETY: getuid() is always safe to call.
-        let our_uid = unsafe { libc::getuid() };
-        if peer.uid != our_uid {
-            return Err(NonoError::SandboxInit(format!(
-                "Rejected URL open connection from uid {} (expected {})",
-                peer.uid, our_uid
-            )));
-        }
+        check_peer_uid(&stream, "URL open")?;
 
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #

## Summary

SupervisorSocket::bind() accepted connections without verifying the peers UID, unlike SupervisorListener::accept() which already checked it via SO_PEERCRED/getpeereid. Extract the check into a shared check_peer_uid() helper and apply it in both accept paths so identity verification doesnt depend solely on filesystem permissions/umask timing.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
