### PR TITLE
feat(audit): surface subtool audit

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -143,6 +143,7 @@ pub(crate) fn map_error(e: &nono::NonoError) -> types::NonoErrorCode {
         | nono::NonoError::TrustPolicy(_)
         | nono::NonoError::BlocklistBlocked { .. }
         | nono::NonoError::InstructionFileDenied { .. }
+        | nono::NonoError::AuditSessionOutsideRoot { .. }
         | nono::NonoError::PackageVerification { .. } => NonoErrorCode::ErrTrustVerification,
         nono::NonoError::PackageInstall(_)
         | nono::NonoError::RegistryError(_)

--- a/crates/nono-cli/src/audit_attestation.rs
+++ b/crates/nono-cli/src/audit_attestation.rs
@@ -221,6 +221,7 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
                 merkle_root: ContentHash::from_bytes([0x22; 32]),
             }),
             audit_attestation: None,
+            command_policy_summary: None,
         }
     }
 

--- a/crates/nono-cli/src/audit_client.rs
+++ b/crates/nono-cli/src/audit_client.rs
@@ -803,6 +803,7 @@ mod tests {
                     .unwrap(),
             }),
             audit_attestation: None,
+            command_policy_summary: None,
         };
         let fixture =
             include_str!("../../../tests/fixtures/audit-session-metadata-v1.json").trim_end();
@@ -831,6 +832,7 @@ mod tests {
             audit_event_count: integrity.event_count,
             audit_integrity: Some(integrity),
             audit_attestation: None,
+            command_policy_summary: None,
         }
     }
 

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -85,11 +85,85 @@ fn cmd_list(args: AuditListArgs) -> Result<()> {
                 status,
                 theme::fg(&cmd, theme::current().subtext),
             );
+            if !args.no_tools
+                && let Some(line) = format_tool_summary_line(s)
+            {
+                eprintln!("      {line}");
+            }
         }
         eprintln!();
     }
 
     Ok(())
+}
+
+/// Distinct mediated commands named on a session's list line before eliding.
+const TOOL_SUMMARY_MAX_COMMANDS: usize = 4;
+
+/// Render the mediated-tool rollup for one session, or `None` when it mediated
+/// nothing. Reads the denormalized summary in session metadata, never the event
+/// log, so listing stays independent of how many events a session recorded.
+fn format_tool_summary_line(session: &SessionInfo) -> Option<String> {
+    let summary = session.metadata.command_policy_summary.as_ref()?;
+    let theme = theme::current();
+
+    // Mediation ran but nothing reached a terminal decision, which is what a
+    // session killed mid-invocation looks like. Say so rather than rendering
+    // the session as if no tool was ever mediated.
+    if summary.commands.is_empty() {
+        return Some(format!(
+            "{} {} event(s), no completed invocations",
+            theme::fg("tools:", theme.subtext),
+            summary.event_count
+        ));
+    }
+
+    let mut parts = Vec::new();
+    for command in summary.commands.iter().take(TOOL_SUMMARY_MAX_COMMANDS) {
+        let mut counts = Vec::new();
+        if command.allowed > 0 {
+            counts
+                .push(theme::fg(&format!("{} allowed", command.allowed), theme.green).to_string());
+        }
+        if command.denied > 0 {
+            counts.push(
+                theme::fg(&format!("{} denied", command.denied), theme.red)
+                    .bold()
+                    .to_string(),
+            );
+        }
+        if command.other > 0 {
+            counts.push(
+                theme::fg(&format!("{} unclassified", command.other), theme.yellow).to_string(),
+            );
+        }
+        // Profile-supplied, so it reaches the terminal without ever having
+        // passed through the event log's sanitization on the `audit show` path.
+        parts.push(format!(
+            "{} ({})",
+            sanitize_for_terminal(&command.command),
+            counts.join(", ")
+        ));
+    }
+
+    let elided = summary
+        .commands
+        .len()
+        .saturating_sub(TOOL_SUMMARY_MAX_COMMANDS);
+    if elided > 0 {
+        parts.push(format!("+{elided} more"));
+    }
+    // The rollup itself dropped commands, so not even `audit show` can recover
+    // their per-command counts from metadata.
+    if summary.truncated {
+        parts.push(theme::fg("rollup truncated", theme.yellow).to_string());
+    }
+
+    Some(format!(
+        "{} {}",
+        theme::fg("tools:", theme.subtext),
+        parts.join(", ")
+    ))
 }
 
 fn filter_sessions(
@@ -242,6 +316,8 @@ fn print_list_json(sessions: &[SessionInfo]) -> Result<()> {
                 "disk_size": s.disk_size,
                 "is_alive": s.is_alive,
                 "is_stale": s.is_stale,
+                "tool_sandbox_active": s.metadata.command_policy_summary.is_some(),
+                "command_policy_summary": s.metadata.command_policy_summary,
             })
         })
         .collect();
@@ -1007,6 +1083,154 @@ fn sanitize_reason_for_terminal(input: &str) -> String {
 
     let sanitized = sanitize_for_terminal(input);
     crate::command_display::truncate_chars(&sanitized, MAX_REASON_CHARS)
+}
+
+#[cfg(test)]
+mod tool_summary_tests {
+    use super::{TOOL_SUMMARY_MAX_COMMANDS, format_tool_summary_line};
+    use crate::audit_session::SessionInfo;
+    use nono::undo::{CommandPolicyCommandSummary, CommandPolicySummary, SessionMetadata};
+    use std::path::PathBuf;
+
+    fn session(summary: Option<CommandPolicySummary>) -> SessionInfo {
+        SessionInfo {
+            metadata: SessionMetadata {
+                session_id: "20260806-120000-11111".to_string(),
+                started: "2026-08-06T12:00:00Z".to_string(),
+                ended: Some("2026-08-06T12:05:00Z".to_string()),
+                command: vec!["claude".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/work")],
+                snapshot_count: 0,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 0,
+                audit_integrity: None,
+                audit_attestation: None,
+                command_policy_summary: summary,
+            },
+            dir: PathBuf::from("/work"),
+            disk_size: 0,
+            is_alive: false,
+            is_stale: false,
+        }
+    }
+
+    fn command(name: &str, allowed: u64, denied: u64) -> CommandPolicyCommandSummary {
+        CommandPolicyCommandSummary {
+            command: name.to_string(),
+            allowed,
+            denied,
+            other: 0,
+        }
+    }
+
+    #[test]
+    fn sessions_without_tool_activity_stay_concise() {
+        assert!(format_tool_summary_line(&session(None)).is_none());
+    }
+
+    #[test]
+    fn summary_names_the_command_and_its_decisions() {
+        let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            event_count: 3,
+            invocation_count: 2,
+            commands: vec![command("gh", 1, 1)],
+            truncated: false,
+        })))
+        .expect("a summary with commands always renders a line");
+
+        assert!(line.contains("gh"));
+        assert!(line.contains("1 allowed"));
+        assert!(line.contains("1 denied"));
+    }
+
+    #[test]
+    fn mediation_without_a_completed_invocation_is_still_reported() {
+        let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            event_count: 1,
+            invocation_count: 0,
+            commands: Vec::new(),
+            truncated: false,
+        })))
+        .expect("a summary with events always renders a line");
+
+        assert!(line.contains("1 event(s)"));
+        assert!(line.contains("no completed invocations"));
+    }
+
+    #[test]
+    fn elided_and_truncated_commands_are_both_disclosed() {
+        let commands: Vec<_> = (0..TOOL_SUMMARY_MAX_COMMANDS.saturating_add(3))
+            .map(|index| command(&format!("cmd-{index}"), 1, 0))
+            .collect();
+        let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            event_count: commands.len() as u64,
+            invocation_count: commands.len() as u64,
+            commands,
+            truncated: true,
+        })))
+        .expect("a summary with commands always renders a line");
+
+        assert!(line.contains("+3 more"));
+        assert!(line.contains("rollup truncated"));
+    }
+
+    /// Drop the theme's own color sequences, which are present or absent
+    /// depending on whether the test binary's stdout is a terminal. Only
+    /// `m`-terminated CSI is removed, so any other escape the summary emitted
+    /// still reaches the caller's assertions.
+    fn strip_theme_color(line: &str) -> String {
+        let mut out = String::with_capacity(line.len());
+        let mut rest = line;
+
+        while let Some(start) = rest.find("\x1b[") {
+            let body = &rest[start.saturating_add(2)..];
+            let Some(end) = body.find(|c: char| ('\x40'..='\x7e').contains(&c)) else {
+                break;
+            };
+            if !body[end..].starts_with('m') {
+                break;
+            }
+            out.push_str(&rest[..start]);
+            rest = &body[end.saturating_add(1)..];
+        }
+
+        out.push_str(rest);
+        out
+    }
+
+    /// A shared profile is the one place a hostile command name can enter the
+    /// rollup, and unlike the `audit show` path it never passes through the
+    /// event log's sanitization on the way to the terminal.
+    #[test]
+    fn a_command_name_cannot_carry_escapes_into_the_listing() {
+        let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            mediation_active: true,
+            event_count: 1,
+            invocation_count: 1,
+            commands: vec![command("gh\x1b]0;pwned\x07\r", 0, 1)],
+            truncated: false,
+        })))
+        .expect("a summary with commands always renders a line");
+        let line = strip_theme_color(&line);
+
+        assert!(!line.contains('\x1b'), "{line:?}");
+        assert!(!line.contains('\x07'), "{line:?}");
+        assert!(!line.contains('\r'), "{line:?}");
+        assert!(!line.contains("pwned"), "{line:?}");
+        assert!(line.contains("1 denied"), "{line:?}");
+    }
+
+    #[test]
+    fn stripping_theme_color_leaves_other_escapes_for_inspection() {
+        assert_eq!(strip_theme_color("\x1b[1;38;2;1;2;3mgh\x1b[0m"), "gh");
+        assert_eq!(
+            strip_theme_color("gh\x1b[2J\x1b]0;x\x07"),
+            "gh\x1b[2J\x1b]0;x\x07"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -843,6 +843,7 @@ mod list_tests {
         AuditRecorder, CommandPolicyAuditEvent, CommandPolicyEnvAuditEntry,
         CommandPolicyStdioAudit, CommandPolicyStdioStreamAudit,
     };
+    use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
     use nono::undo::SessionMetadata;
 
     #[test]
@@ -861,6 +862,7 @@ mod list_tests {
             audit_event_count: 4,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         let session = SessionInfo {
@@ -897,41 +899,44 @@ mod list_tests {
     fn command_policy_events_json_includes_caller_context() -> nono::Result<()> {
         let dir = tempfile::tempdir().map_err(|e| nono::NonoError::Snapshot(e.to_string()))?;
         let mut recorder = AuditRecorder::new(dir.path().to_path_buf())?;
-        recorder.record_command_policy_event(CommandPolicyAuditEvent {
-            timestamp: "2026-05-03T16:30:30Z".to_string(),
-            session_id: Some("sess-tool_sandbox".to_string()),
-            command: "ssh".to_string(),
-            caller: "git".to_string(),
-            caller_kind: Some("command".to_string()),
-            caller_command: Some("git".to_string()),
-            caller_pid: Some(100),
-            shim_pid: Some(101),
-            session_root_pid: Some(99),
-            decision: "denied".to_string(),
-            reason: Some("missing from.git".to_string()),
-            stdio_mode: "direct_fds".to_string(),
-            argv_hash: "argv-hash".to_string(),
-            env_name_hash: "env-hash".to_string(),
-            cwd_hash: "cwd-hash".to_string(),
-            argv_display: vec!["ssh".to_string(), "-V".to_string()],
-            env_names_display: vec!["PATH".to_string()],
-            env_display: vec![CommandPolicyEnvAuditEntry {
-                name: "PATH".to_string(),
-                value_display: "/bin".to_string(),
-            }],
-            cwd_display: "/work".to_string(),
-            exit_code: None,
-            stdio: Some(CommandPolicyStdioAudit {
-                stdout: Some(CommandPolicyStdioStreamAudit {
-                    total_bytes: 1024,
-                    forwarded_bytes: 512,
-                    max_bytes: Some(512),
-                    limit_exceeded: true,
-                    on_limit: Some("truncate".to_string()),
+        recorder.record_command_policy_event(
+            CommandPolicyAuditEvent {
+                timestamp: "2026-05-03T16:30:30Z".to_string(),
+                session_id: Some("sess-tool_sandbox".to_string()),
+                command: "ssh".to_string(),
+                caller: "git".to_string(),
+                caller_kind: Some("command".to_string()),
+                caller_command: Some("git".to_string()),
+                caller_pid: Some(100),
+                shim_pid: Some(101),
+                session_root_pid: Some(99),
+                decision: CommandPolicyDecision::Denied.as_str().to_string(),
+                reason: Some("missing from.git".to_string()),
+                stdio_mode: "direct_fds".to_string(),
+                argv_hash: "argv-hash".to_string(),
+                env_name_hash: "env-hash".to_string(),
+                cwd_hash: "cwd-hash".to_string(),
+                argv_display: vec!["ssh".to_string(), "-V".to_string()],
+                env_names_display: vec!["PATH".to_string()],
+                env_display: vec![CommandPolicyEnvAuditEntry {
+                    name: "PATH".to_string(),
+                    value_display: "/bin".to_string(),
+                }],
+                cwd_display: "/work".to_string(),
+                exit_code: None,
+                stdio: Some(CommandPolicyStdioAudit {
+                    stdout: Some(CommandPolicyStdioStreamAudit {
+                        total_bytes: 1024,
+                        forwarded_bytes: 512,
+                        max_bytes: Some(512),
+                        limit_exceeded: true,
+                        on_limit: Some("truncate".to_string()),
+                    }),
+                    stderr: None,
                 }),
-                stderr: None,
-            }),
-        })?;
+            },
+            CommandPolicyDecision::Denied.outcome(),
+        )?;
 
         let events = command_policy_events_json(dir.path())?;
         assert_eq!(events.len(), 1);

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -16,7 +16,7 @@ use crate::cli::{
 use crate::command_display::{format_command_line, truncate_command};
 use crate::theme;
 use colored::Colorize;
-use nono::undo::SnapshotManager;
+use nono::undo::{CommandPolicySummary, SnapshotManager};
 use nono::{NonoError, Result};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -100,22 +100,35 @@ fn cmd_list(args: AuditListArgs) -> Result<()> {
 /// Distinct mediated commands named on a session's list line before eliding.
 const TOOL_SUMMARY_MAX_COMMANDS: usize = 4;
 
-/// Render the mediated-tool rollup for one session, or `None` when it mediated
-/// nothing. Reads the denormalized summary in session metadata, never the event
-/// log, so listing stays independent of how many events a session recorded.
+/// Render the mediated-tool rollup for one session, or `None` when the session
+/// neither configured mediation nor mediated anything.
+///
+/// Reads the denormalized summary in session metadata, never the event log, so
+/// listing stays independent of how many events a session recorded.
 fn format_tool_summary_line(session: &SessionInfo) -> Option<String> {
     let summary = session.metadata.command_policy_summary.as_ref()?;
+    Some(format!(
+        "{} {}",
+        theme::fg("tools:", theme::current().subtext),
+        format_tool_summary_detail(summary)
+    ))
+}
+
+/// Render a mediated-tool rollup without the `tools:` label, for callers with a
+/// label of their own.
+pub(crate) fn format_tool_summary_detail(summary: &CommandPolicySummary) -> String {
     let theme = theme::current();
 
-    // Mediation ran but nothing reached a terminal decision, which is what a
-    // session killed mid-invocation looks like. Say so rather than rendering
-    // the session as if no tool was ever mediated.
     if summary.commands.is_empty() {
-        return Some(format!(
-            "{} {} event(s), no completed invocations",
-            theme::fg("tools:", theme.subtext),
-            summary.event_count
-        ));
+        // Mediation was configured and no command ever reached it. A session
+        // that had none configured carries no summary and prints no line.
+        return if summary.event_count == 0 {
+            "active, no invocations".to_string()
+        } else {
+            // Events but no terminal decision, which is what a session killed
+            // mid-invocation looks like.
+            format!("{} event(s), no completed invocations", summary.event_count)
+        };
     }
 
     let mut parts = Vec::new();
@@ -159,11 +172,7 @@ fn format_tool_summary_line(session: &SessionInfo) -> Option<String> {
         parts.push(theme::fg("rollup truncated", theme.yellow).to_string());
     }
 
-    Some(format!(
-        "{} {}",
-        theme::fg("tools:", theme.subtext),
-        parts.join(", ")
-    ))
+    parts.join(", ")
 }
 
 fn filter_sessions(
@@ -316,6 +325,10 @@ fn print_list_json(sessions: &[SessionInfo]) -> Result<()> {
                 "disk_size": s.disk_size,
                 "is_alive": s.is_alive,
                 "is_stale": s.is_stale,
+                // Whether the session had a Tool Sandbox at all: mediation was
+                // configured, or a command reached mediation. Deliberately not
+                // the summary's own `mediation_active`, which reports only the
+                // first of those.
                 "tool_sandbox_active": s.metadata.command_policy_summary.is_some(),
                 "command_policy_summary": s.metadata.command_policy_summary,
             })
@@ -1134,6 +1147,7 @@ mod tool_summary_tests {
     #[test]
     fn summary_names_the_command_and_its_decisions() {
         let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            mediation_active: true,
             event_count: 3,
             invocation_count: 2,
             commands: vec![command("gh", 1, 1)],
@@ -1147,8 +1161,24 @@ mod tool_summary_tests {
     }
 
     #[test]
+    fn configured_mediation_is_reported_before_any_command_is_invoked() {
+        let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            mediation_active: true,
+            event_count: 0,
+            invocation_count: 0,
+            commands: Vec::new(),
+            truncated: false,
+        })))
+        .expect("an active-mediation summary always renders a line");
+
+        assert!(line.contains("active"));
+        assert!(line.contains("no invocations"));
+    }
+
+    #[test]
     fn mediation_without_a_completed_invocation_is_still_reported() {
         let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            mediation_active: true,
             event_count: 1,
             invocation_count: 0,
             commands: Vec::new(),
@@ -1166,6 +1196,7 @@ mod tool_summary_tests {
             .map(|index| command(&format!("cmd-{index}"), 1, 0))
             .collect();
         let line = format_tool_summary_line(&session(Some(CommandPolicySummary {
+            mediation_active: true,
             event_count: commands.len() as u64,
             invocation_count: commands.len() as u64,
             commands,

--- a/crates/nono-cli/src/audit_event_reader.rs
+++ b/crates/nono-cli/src/audit_event_reader.rs
@@ -1,11 +1,14 @@
 use crate::audit_integrity::{
     AUDIT_EVENTS_FILENAME, AuditEventPayload, AuditEventRecord, CommandPolicyAuditEvent,
+    CommandPolicySummaryBuilder,
 };
+use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
 use nono::supervisor::AuditEntry;
+use nono::undo::CommandPolicySummary;
 use nono::{NonoError, Result};
 use serde::Serialize;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 #[derive(Clone, Serialize)]
@@ -17,6 +20,57 @@ pub(crate) struct CommandPolicyAuditRecord {
     pub(crate) event: CommandPolicyAuditEvent,
 }
 
+/// Visit every record in a session's audit event log.
+///
+/// Returns whether a trailing record was skipped because it did not parse.
+/// `tolerate_partial_tail` is for readers of a log whose writer may not have
+/// finished its final record: only the final line can be such a record, so a
+/// parse failure anywhere earlier stays an error.
+///
+/// Reading stops at the length the log had when it was opened, so the parse
+/// walks a fixed snapshot without holding the whole log in memory. Deciding
+/// "is this the last line?" against the live file instead would race a
+/// concurrent writer: a record completed after a torn read but before the
+/// check would turn the tolerated tail into a hard error.
+fn for_each_event_record(
+    path: &Path,
+    tolerate_partial_tail: bool,
+    mut visit: impl FnMut(AuditEventRecord),
+) -> Result<bool> {
+    fn read_error(path: &Path, e: std::io::Error) -> NonoError {
+        NonoError::Snapshot(format!(
+            "Failed to read audit event log {}: {e}",
+            path.display()
+        ))
+    }
+
+    let file = File::open(path).map_err(|e| read_error(path, e))?;
+    let snapshot_len = file.metadata().map_err(|e| read_error(path, e))?.len();
+    let mut lines = BufReader::new(file.take(snapshot_len))
+        .lines()
+        .enumerate()
+        .peekable();
+    while let Some((index, line)) = lines.next() {
+        let line = line.map_err(|e| read_error(path, e))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: AuditEventRecord = match serde_json::from_str(&line) {
+            Ok(record) => record,
+            Err(_) if tolerate_partial_tail && lines.peek().is_none() => return Ok(true),
+            Err(e) => {
+                return Err(NonoError::Snapshot(format!(
+                    "Failed to parse audit event record {} line {}: {e}",
+                    path.display(),
+                    index.saturating_add(1)
+                )));
+            }
+        };
+        visit(record);
+    }
+    Ok(false)
+}
+
 pub(crate) fn load_command_policy_events(
     session_dir: &Path,
 ) -> Result<Vec<CommandPolicyAuditRecord>> {
@@ -24,31 +78,8 @@ pub(crate) fn load_command_policy_events(
     if !path.exists() {
         return Ok(Vec::new());
     }
-    let file = File::open(&path).map_err(|e| {
-        NonoError::Snapshot(format!(
-            "Failed to open audit event log {}: {e}",
-            path.display()
-        ))
-    })?;
-    let reader = BufReader::new(file);
     let mut events = Vec::new();
-    for (index, line) in reader.lines().enumerate() {
-        let line = line.map_err(|e| {
-            NonoError::Snapshot(format!(
-                "Failed to read audit event log {}: {e}",
-                path.display()
-            ))
-        })?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let record: AuditEventRecord = serde_json::from_str(&line).map_err(|e| {
-            NonoError::Snapshot(format!(
-                "Failed to parse audit event record {} line {}: {e}",
-                path.display(),
-                index.saturating_add(1)
-            ))
-        })?;
+    for_each_event_record(&path, false, |record| {
         if let AuditEventPayload::CommandPolicy { event } = record.event {
             events.push(CommandPolicyAuditRecord {
                 sequence: record.sequence,
@@ -57,8 +88,42 @@ pub(crate) fn load_command_policy_events(
                 event: *event,
             });
         }
-    }
+    })?;
     Ok(events)
+}
+
+/// Recompute a session's mediated-command rollup from its audit event log.
+///
+/// For callers reaching a session whose stored rollup is unavailable: the
+/// session is still running, or it died before finalizing `session.json`.
+/// Folds the same events in the same order as the recorder, so the result
+/// equals the summary the session would have committed.
+///
+/// Returns whether the log ended in a partial record. Either kind of writer —
+/// still appending, or killed mid-write — can legitimately leave its final
+/// record half-written, so a torn tail is reported through the flag rather
+/// than as an error; damage anywhere earlier stays an error. A session that
+/// finalized has an authoritative, digest-covered rollup in its metadata, and
+/// readers must use that instead of refolding the log.
+pub(crate) fn recompute_command_policy_summary(
+    session_dir: &Path,
+) -> Result<(Option<CommandPolicySummary>, bool)> {
+    let path = session_dir.join(AUDIT_EVENTS_FILENAME);
+    if !path.exists() {
+        return Ok((None, false));
+    }
+    let mut builder = CommandPolicySummaryBuilder::new();
+    let partial_tail = for_each_event_record(&path, true, |record| match record.event {
+        AuditEventPayload::CommandPolicy { event } => {
+            let outcome = CommandPolicyDecision::classify(&event.decision);
+            builder.observe(&event, outcome);
+        }
+        AuditEventPayload::SandboxRuntime { event } if event.tool_sandbox_active => {
+            builder.observe_mediation_active();
+        }
+        _ => {}
+    })?;
+    Ok((builder.finish(), partial_tail))
 }
 
 pub(crate) fn command_policy_events_json(session_dir: &Path) -> Result<Vec<serde_json::Value>> {
@@ -88,34 +153,205 @@ pub(crate) fn load_capability_decisions(session_dir: &Path) -> Result<Vec<AuditE
     if !path.exists() {
         return Ok(Vec::new());
     }
-    let file = File::open(&path).map_err(|e| {
-        NonoError::Snapshot(format!(
-            "Failed to open audit event log {}: {e}",
-            path.display()
-        ))
-    })?;
-    let reader = BufReader::new(file);
     let mut events = Vec::new();
-    for (index, line) in reader.lines().enumerate() {
-        let line = line.map_err(|e| {
-            NonoError::Snapshot(format!(
-                "Failed to read audit event log {}: {e}",
-                path.display()
-            ))
-        })?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let record: AuditEventRecord = serde_json::from_str(&line).map_err(|e| {
-            NonoError::Snapshot(format!(
-                "Failed to parse audit event record {} line {}: {e}",
-                path.display(),
-                index.saturating_add(1)
-            ))
-        })?;
+    for_each_event_record(&path, false, |record| {
         if let AuditEventPayload::CapabilityDecision { entry } = record.event {
             events.push(entry);
         }
-    }
+    })?;
     Ok(events)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::audit_integrity::{AuditRecorder, SandboxRuntimeAuditEvent};
+    use nono::undo::CommandPolicyOutcome;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    fn command_policy_event(
+        command: &str,
+        decision: CommandPolicyDecision,
+    ) -> CommandPolicyAuditEvent {
+        CommandPolicyAuditEvent {
+            timestamp: "2026-08-13T00:00:00Z".to_string(),
+            session_id: Some("20260813-120000-4242".to_string()),
+            command: command.to_string(),
+            caller: "session".to_string(),
+            caller_kind: Some("session".to_string()),
+            caller_command: None,
+            caller_pid: Some(41),
+            shim_pid: Some(42),
+            session_root_pid: Some(41),
+            decision: decision.as_str().to_string(),
+            reason: None,
+            stdio_mode: "direct_fds".to_string(),
+            argv_hash: "argv-hash".to_string(),
+            env_name_hash: "env-hash".to_string(),
+            cwd_hash: "cwd-hash".to_string(),
+            argv_display: vec![command.to_string()],
+            env_names_display: Vec::new(),
+            env_display: Vec::new(),
+            cwd_display: "/work".to_string(),
+            exit_code: None,
+            stdio: None,
+        }
+    }
+
+    fn mediating_recorder(session_dir: &Path) -> AuditRecorder {
+        let mut recorder = AuditRecorder::new(session_dir.to_path_buf()).unwrap();
+        recorder
+            .record_session_started(
+                "2026-08-13T00:00:00Z".to_string(),
+                vec!["claude".to_string()],
+            )
+            .unwrap();
+        recorder
+            .record_sandbox_runtime_event(SandboxRuntimeAuditEvent {
+                timestamp: "2026-08-13T00:00:00Z".to_string(),
+                platform: "linux".to_string(),
+                landlock_abi: Some("v5".to_string()),
+                landlock_execute_enforced: Some(true),
+                tool_sandbox_active: true,
+            })
+            .unwrap();
+        recorder
+    }
+
+    #[test]
+    fn recomputed_summary_matches_the_one_the_recorder_would_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = mediating_recorder(dir.path());
+        for decision in [
+            CommandPolicyDecision::InvocationAllowed,
+            CommandPolicyDecision::Allowed,
+            CommandPolicyDecision::Denied,
+        ] {
+            recorder
+                .record_command_policy_event(
+                    command_policy_event("gh", decision),
+                    decision.outcome(),
+                )
+                .unwrap();
+        }
+        recorder
+            .record_command_policy_event(
+                command_policy_event("git", CommandPolicyDecision::Allowed),
+                CommandPolicyOutcome::Allowed,
+            )
+            .unwrap();
+
+        let (recomputed, partial_tail) = recompute_command_policy_summary(dir.path()).unwrap();
+
+        assert_eq!(recomputed, recorder.command_policy_summary());
+        assert!(!partial_tail);
+    }
+
+    #[test]
+    fn configured_mediation_is_recomputed_before_any_invocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let _recorder = mediating_recorder(dir.path());
+
+        let (recomputed, _) = recompute_command_policy_summary(dir.path()).unwrap();
+
+        let summary = recomputed.expect("an active-mediation session always has a summary");
+        assert!(summary.mediation_active);
+        assert_eq!(summary.event_count, 0);
+        assert!(summary.commands.is_empty());
+    }
+
+    #[test]
+    fn a_session_without_mediation_has_no_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        recorder
+            .record_session_started("2026-08-13T00:00:00Z".to_string(), vec!["pwd".to_string()])
+            .unwrap();
+
+        assert_eq!(
+            recompute_command_policy_summary(dir.path()).unwrap(),
+            (None, false)
+        );
+    }
+
+    #[test]
+    fn a_session_with_no_event_log_has_no_summary() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            recompute_command_policy_summary(dir.path()).unwrap(),
+            (None, false)
+        );
+    }
+
+    #[test]
+    fn a_half_written_final_record_is_reported_not_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = mediating_recorder(dir.path());
+        recorder
+            .record_command_policy_event(
+                command_policy_event("gh", CommandPolicyDecision::Allowed),
+                CommandPolicyOutcome::Allowed,
+            )
+            .unwrap();
+        let mut log = OpenOptions::new()
+            .append(true)
+            .open(dir.path().join(AUDIT_EVENTS_FILENAME))
+            .unwrap();
+        log.write_all(br#"{"sequence":3,"prev_chain":"#).unwrap();
+        log.flush().unwrap();
+
+        let (recomputed, partial_tail) = recompute_command_policy_summary(dir.path()).unwrap();
+
+        assert!(partial_tail);
+        assert_eq!(recomputed, recorder.command_policy_summary());
+    }
+
+    /// Damage anywhere but the tail cannot be a record in flight, so a rollup
+    /// over it would quietly drop decisions the operator asked to see.
+    #[test]
+    fn damage_before_the_final_record_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = mediating_recorder(dir.path());
+        for decision in [
+            CommandPolicyDecision::Allowed,
+            CommandPolicyDecision::Denied,
+        ] {
+            recorder
+                .record_command_policy_event(
+                    command_policy_event("gh", decision),
+                    decision.outcome(),
+                )
+                .unwrap();
+        }
+        let path = dir.path().join(AUDIT_EVENTS_FILENAME);
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines: Vec<&str> = contents.lines().collect();
+        lines[1] = r#"{"sequence":1,"#;
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        assert!(recompute_command_policy_summary(dir.path()).is_err());
+    }
+
+    #[test]
+    fn strict_readers_reject_a_half_written_final_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = mediating_recorder(dir.path());
+        recorder
+            .record_command_policy_event(
+                command_policy_event("gh", CommandPolicyDecision::Allowed),
+                CommandPolicyOutcome::Allowed,
+            )
+            .unwrap();
+        let mut log = OpenOptions::new()
+            .append(true)
+            .open(dir.path().join(AUDIT_EVENTS_FILENAME))
+            .unwrap();
+        log.write_all(br#"{"sequence":3,"prev_chain":"#).unwrap();
+        log.flush().unwrap();
+
+        assert!(load_command_policy_events(dir.path()).is_err());
+    }
 }

--- a/crates/nono-cli/src/audit_integrity.rs
+++ b/crates/nono-cli/src/audit_integrity.rs
@@ -6,13 +6,14 @@ pub(crate) use nono::audit::{
 
 #[cfg(test)]
 pub(crate) use nono::audit::AUDIT_HASH_ALGORITHM;
-#[cfg(any(test, target_os = "linux"))]
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
 pub(crate) use nono::audit::SandboxRuntimeAuditEvent;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
     use nono::AccessMode;
     use nono::supervisor::{ApprovalDecision, ApprovalRequest, AuditEntry, UrlOpenRequest};
     use nono::undo::{NetworkAuditDecision, NetworkAuditEvent, NetworkAuditMode};
@@ -188,41 +189,44 @@ mod tests {
             })
             .unwrap();
         recorder
-            .record_command_policy_event(CommandPolicyAuditEvent {
-                timestamp: "2026-04-21T00:00:00Z".to_string(),
-                session_id: Some("sess-1".to_string()),
-                command: "curl".to_string(),
-                caller: "session".to_string(),
-                caller_kind: Some("session".to_string()),
-                caller_command: None,
-                caller_pid: Some(41),
-                shim_pid: Some(42),
-                session_root_pid: Some(41),
-                decision: "denied".to_string(),
-                reason: Some("entrypoint missing".to_string()),
-                stdio_mode: "pty".to_string(),
-                argv_hash: "argv-hash".to_string(),
-                env_name_hash: "env-hash".to_string(),
-                cwd_hash: "cwd-hash".to_string(),
-                argv_display: vec!["curl".to_string(), "--version".to_string()],
-                env_names_display: vec!["PATH".to_string()],
-                env_display: vec![CommandPolicyEnvAuditEntry {
-                    name: "PATH".to_string(),
-                    value_display: "/bin".to_string(),
-                }],
-                cwd_display: "/work".to_string(),
-                exit_code: None,
-                stdio: Some(CommandPolicyStdioAudit {
-                    stdout: Some(CommandPolicyStdioStreamAudit {
-                        total_bytes: 1024,
-                        forwarded_bytes: 512,
-                        max_bytes: Some(512),
-                        limit_exceeded: true,
-                        on_limit: Some("truncate".to_string()),
+            .record_command_policy_event(
+                CommandPolicyAuditEvent {
+                    timestamp: "2026-04-21T00:00:00Z".to_string(),
+                    session_id: Some("sess-1".to_string()),
+                    command: "curl".to_string(),
+                    caller: "session".to_string(),
+                    caller_kind: Some("session".to_string()),
+                    caller_command: None,
+                    caller_pid: Some(41),
+                    shim_pid: Some(42),
+                    session_root_pid: Some(41),
+                    decision: CommandPolicyDecision::Denied.as_str().to_string(),
+                    reason: Some("entrypoint missing".to_string()),
+                    stdio_mode: "pty".to_string(),
+                    argv_hash: "argv-hash".to_string(),
+                    env_name_hash: "env-hash".to_string(),
+                    cwd_hash: "cwd-hash".to_string(),
+                    argv_display: vec!["curl".to_string(), "--version".to_string()],
+                    env_names_display: vec!["PATH".to_string()],
+                    env_display: vec![CommandPolicyEnvAuditEntry {
+                        name: "PATH".to_string(),
+                        value_display: "/bin".to_string(),
+                    }],
+                    cwd_display: "/work".to_string(),
+                    exit_code: None,
+                    stdio: Some(CommandPolicyStdioAudit {
+                        stdout: Some(CommandPolicyStdioStreamAudit {
+                            total_bytes: 1024,
+                            forwarded_bytes: 512,
+                            max_bytes: Some(512),
+                            limit_exceeded: true,
+                            on_limit: Some("truncate".to_string()),
+                        }),
+                        stderr: None,
                     }),
-                    stderr: None,
-                }),
-            })
+                },
+                CommandPolicyDecision::Denied.outcome(),
+            )
             .unwrap();
         recorder
             .record_session_ended("2026-04-21T00:00:01Z".to_string(), 7)

--- a/crates/nono-cli/src/audit_integrity.rs
+++ b/crates/nono-cli/src/audit_integrity.rs
@@ -1,7 +1,7 @@
 pub(crate) use nono::audit::{
     AUDIT_EVENTS_FILENAME, AuditEventPayload, AuditEventRecord, AuditRecorder,
     CommandPolicyAuditEvent, CommandPolicyEnvAuditEntry, CommandPolicyStdioAudit,
-    CommandPolicyStdioStreamAudit, verify_audit_log,
+    CommandPolicyStdioStreamAudit, CommandPolicySummaryBuilder, verify_audit_log,
 };
 
 #[cfg(test)]

--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -147,6 +147,7 @@ mod tests {
             audit_event_count: 2,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         }
     }
 
@@ -282,6 +283,7 @@ mod tests {
                 merkle_root: ContentHash::from_bytes([3; 32]),
             }),
             audit_attestation: None,
+            command_policy_summary: None,
         };
         let base_digest = compute_session_digest(&base).unwrap();
 

--- a/crates/nono-cli/src/audit_session.rs
+++ b/crates/nono-cli/src/audit_session.rs
@@ -94,37 +94,86 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
     Ok(sessions)
 }
 
-/// Load a specific audit session by ID.
-pub fn load_session(session_id: &str) -> Result<SessionInfo> {
+/// Directories that could hold the named session, in discovery-root order.
+///
+/// Yielded lazily so callers that accept an earlier root's entry never
+/// evaluate later ones: a defective entry in the rollback root must not block
+/// a session that resolves validly under the primary audit root.
+///
+/// Each yielded directory is canonical and confirmed to resolve inside the
+/// root it was found under, so a symlinked session directory cannot point a
+/// reader outside the audit roots — and files later opened under the returned
+/// path stay inside the checked target even if the entry is re-pointed.
+fn candidate_session_dirs(session_id: &str) -> Result<impl Iterator<Item = Result<PathBuf>>> {
     validate_session_id(session_id)?;
-    let primary_root = audit_root()?;
-    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
     let mut roots: Vec<PathBuf> = state_paths::audit_discovery_roots()?;
     roots.extend(state_paths::rollback_discovery_roots()?);
+    let session_id = session_id.to_string();
 
-    for root in roots {
-        let dir = root.join(session_id);
+    Ok(roots.into_iter().filter_map(move |root| {
+        let dir = root.join(&session_id);
         if !dir.exists() {
+            return None;
+        }
+        Some(confirm_contained_session_dir(&root, &dir, &session_id))
+    }))
+}
+
+fn confirm_contained_session_dir(root: &Path, dir: &Path, session_id: &str) -> Result<PathBuf> {
+    let canonical_root = root.canonicalize().map_err(|e| {
+        NonoError::Snapshot(format!(
+            "Failed to canonicalize audit root {}: {e}",
+            root.display()
+        ))
+    })?;
+    // The entry exists, so a canonicalize failure is an I/O fault to surface;
+    // SessionNotFound would render it as a session that was never there.
+    let canonical_dir = dir.canonicalize().map_err(|e| {
+        NonoError::Snapshot(format!(
+            "Failed to canonicalize audit session directory {}: {e}",
+            dir.display()
+        ))
+    })?;
+    // Skipping the entry instead would leave the caller unable to separate
+    // an escape from a session that was never there.
+    if !canonical_dir.starts_with(&canonical_root) {
+        return Err(NonoError::AuditSessionOutsideRoot {
+            session_id: session_id.to_string(),
+            root: canonical_root.display().to_string(),
+        });
+    }
+    Ok(canonical_dir)
+}
+
+/// Resolve an audit session's directory without reading its metadata.
+///
+/// Sessions only gain a `session.json` when they finalize, so [`load_session`]
+/// cannot reach the event log of a session that is still running. Applies the
+/// same rollback-backed filter as [`load_session`] so the two agree on which
+/// directory, if any, holds a session's audit data.
+pub fn resolve_session_dir(session_id: &str) -> Result<PathBuf> {
+    for dir in candidate_session_dirs(session_id)? {
+        let dir = dir?;
+        // A directory without metadata is still a candidate: only
+        // finalization writes session.json.
+        if !is_primary_audit_session(&dir)
+            && SnapshotManager::load_session_metadata(&dir).is_ok_and(|m| m.snapshot_count > 0)
+        {
             continue;
         }
+        return Ok(dir);
+    }
+    Err(NonoError::SessionNotFound(session_id.to_string()))
+}
 
-        let canonical_root = root.canonicalize().map_err(|e| {
-            NonoError::SessionNotFound(format!(
-                "Cannot canonicalize audit root {}: {}",
-                root.display(),
-                e
-            ))
-        })?;
-        let canonical_dir = dir
-            .canonicalize()
-            .map_err(|_| NonoError::SessionNotFound(session_id.to_string()))?;
-        if !canonical_dir.starts_with(&canonical_root) {
-            continue;
-        }
+/// Load a specific audit session by ID.
+pub fn load_session(session_id: &str) -> Result<SessionInfo> {
+    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
 
+    for dir in candidate_session_dirs(session_id)? {
+        let dir = dir?;
         let metadata = SnapshotManager::load_session_metadata(&dir)?;
-        let is_primary = dir.starts_with(&primary_root);
-        if !is_primary && metadata.snapshot_count > 0 {
+        if !is_primary_audit_session(&dir) && metadata.snapshot_count > 0 {
             continue;
         }
 
@@ -423,5 +472,162 @@ mod tests {
         let sessions = discover_sessions().unwrap();
         assert_eq!(sessions.len(), 1);
         assert!(is_primary_audit_session(&sessions[0].dir));
+    }
+
+    #[test]
+    fn session_dir_resolves_before_the_session_writes_metadata() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let dir = audit_root().unwrap().join("20260813-120000-4242");
+        fs::create_dir_all(&dir).unwrap();
+
+        assert_eq!(
+            resolve_session_dir("20260813-120000-4242").unwrap(),
+            dir.canonicalize().unwrap(),
+            "a session directory without metadata should still resolve"
+        );
+        assert!(load_session("20260813-120000-4242").is_err());
+    }
+
+    /// A defective entry in a later discovery root must not block a session
+    /// that resolves validly under the primary audit root.
+    #[test]
+    fn a_bad_entry_in_a_later_root_does_not_block_the_primary_session() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let session_id = "20260813-120000-4242";
+        let dir = audit_root().unwrap().join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        SnapshotManager::write_session_metadata(
+            &dir,
+            &SessionMetadata {
+                session_id: session_id.to_string(),
+                started: "2026-08-13T12:00:00+01:00".to_string(),
+                ended: Some("2026-08-13T12:00:01+01:00".to_string()),
+                command: vec!["/bin/pwd".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/tmp/work")],
+                snapshot_count: 0,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 2,
+                audit_integrity: None,
+                audit_attestation: None,
+                command_policy_summary: None,
+            },
+        )
+        .unwrap();
+
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        let rollback_root = state_paths::rollback_root().unwrap();
+        fs::create_dir_all(&rollback_root).unwrap();
+        std::os::unix::fs::symlink(&outside, rollback_root.join(session_id)).unwrap();
+
+        assert_eq!(
+            resolve_session_dir(session_id).unwrap(),
+            dir.canonicalize().unwrap()
+        );
+        assert_eq!(
+            load_session(session_id).unwrap().metadata.session_id,
+            session_id
+        );
+    }
+
+    /// `resolve_session_dir` applies the same rollback-backed filter as
+    /// `load_session`, so `nono inspect` cannot summarize an event log that
+    /// `nono audit show` refuses to load.
+    #[test]
+    fn resolve_skips_rollback_backed_entries_like_load_does() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let session_id = "20260813-120000-4242";
+        let rollback_dir = state_paths::rollback_root().unwrap().join(session_id);
+        fs::create_dir_all(&rollback_dir).unwrap();
+        SnapshotManager::write_session_metadata(
+            &rollback_dir,
+            &SessionMetadata {
+                session_id: session_id.to_string(),
+                started: "2026-08-13T12:00:00+01:00".to_string(),
+                ended: Some("2026-08-13T12:00:01+01:00".to_string()),
+                command: vec!["/bin/pwd".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/tmp/work")],
+                snapshot_count: 2,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 2,
+                audit_integrity: None,
+                audit_attestation: None,
+                command_policy_summary: None,
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            resolve_session_dir(session_id),
+            Err(NonoError::SessionNotFound(_))
+        ));
+        assert!(matches!(
+            load_session(session_id),
+            Err(NonoError::SessionNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn session_dir_rejects_a_traversing_id() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        assert!(resolve_session_dir("../sessions").is_err());
+        assert!(resolve_session_dir("").is_err());
+    }
+
+    #[test]
+    fn session_dir_rejects_a_symlink_out_of_the_audit_root() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        let root = audit_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("20260813-120000-4242")).unwrap();
+
+        // Not SessionNotFound: callers render an absent session as ordinary.
+        assert!(matches!(
+            resolve_session_dir("20260813-120000-4242"),
+            Err(NonoError::AuditSessionOutsideRoot { .. })
+        ));
     }
 }

--- a/crates/nono-cli/src/audit_session.rs
+++ b/crates/nono-cli/src/audit_session.rs
@@ -266,6 +266,7 @@ mod tests {
                 audit_event_count: 2,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .unwrap();
@@ -290,6 +291,7 @@ mod tests {
                 audit_event_count: 2,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .unwrap();
@@ -314,6 +316,7 @@ mod tests {
                 audit_event_count: 2,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .unwrap();
@@ -359,6 +362,7 @@ mod tests {
                 audit_event_count: 1,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .unwrap();
@@ -411,6 +415,7 @@ mod tests {
                 audit_event_count: 1,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .unwrap();

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -2577,6 +2577,10 @@ pub struct AuditListArgs {
     #[arg(long, value_name = "N")]
     pub recent: Option<usize>,
 
+    /// Hide the per-session mediated tool summary
+    #[arg(long)]
+    pub no_tools: bool,
+
     /// Output as JSON
     #[arg(long)]
     pub json: bool,

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -1332,6 +1332,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         let session = SessionInfo {
@@ -1367,6 +1368,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
         let meta2 = SessionMetadata {
             session_id: "20260219-110000-67890".to_string(),
@@ -1382,6 +1384,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         let s1 = SessionInfo {
@@ -1428,6 +1431,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         let session = SessionInfo {

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -533,24 +533,25 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<F
         })?;
         network_events.extend(supervisor_events.drain(..));
     }
-    let (audit_event_count, audit_integrity) = if let Some(recorder_mutex) = audit_recorder {
-        let mut recorder = recorder_mutex
-            .lock()
-            .map_err(|_| nono::NonoError::Snapshot("Audit recorder lock poisoned".to_string()))?;
-        for event in &network_events {
-            recorder.record_network_event(event.clone())?;
-        }
-        recorder.record_session_ended(ended.to_string(), exit_code)?;
-        let event_count = recorder.event_count();
-        let integrity = if audit_integrity_enabled {
-            recorder.finalize()
+    let (audit_event_count, audit_integrity, command_policy_summary) =
+        if let Some(recorder_mutex) = audit_recorder {
+            let mut recorder = recorder_mutex.lock().map_err(|_| {
+                nono::NonoError::Snapshot("Audit recorder lock poisoned".to_string())
+            })?;
+            for event in &network_events {
+                recorder.record_network_event(event.clone())?;
+            }
+            recorder.record_session_ended(ended.to_string(), exit_code)?;
+            let event_count = recorder.event_count();
+            let integrity = if audit_integrity_enabled {
+                recorder.finalize()
+            } else {
+                None
+            };
+            (event_count, integrity, recorder.command_policy_summary())
         } else {
-            None
+            (0, None, None)
         };
-        (event_count, integrity)
-    } else {
-        (0, None)
-    };
 
     let scrubbed_command = nono::scrub_argv_with_policy(command, redaction_policy);
     let mut audit_saved = false;
@@ -582,7 +583,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<F
             audit_event_count,
             audit_integrity: audit_integrity.clone(),
             audit_attestation: None,
-            command_policy_summary: None,
+            command_policy_summary: command_policy_summary.clone(),
         };
         if let Some(signer) = audit_signer {
             meta.audit_attestation = Some(write_audit_attestation(
@@ -635,7 +636,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<F
             audit_event_count,
             audit_integrity,
             audit_attestation: None,
-            command_policy_summary: None,
+            command_policy_summary: command_policy_summary.clone(),
         };
         if let Some(signer) = audit_signer {
             meta.audit_attestation = Some(write_audit_attestation(

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -582,6 +582,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<F
             audit_event_count,
             audit_integrity: audit_integrity.clone(),
             audit_attestation: None,
+            command_policy_summary: None,
         };
         if let Some(signer) = audit_signer {
             meta.audit_attestation = Some(write_audit_attestation(
@@ -634,6 +635,7 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<F
             audit_event_count,
             audit_integrity,
             audit_attestation: None,
+            command_policy_summary: None,
         };
         if let Some(signer) = audit_signer {
             meta.audit_attestation = Some(write_audit_attestation(
@@ -939,6 +941,7 @@ mod tests {
                 merkle_root: nono::undo::ContentHash::from_bytes([0x22; 32]),
             }),
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         let summary = write_audit_attestation(
@@ -999,6 +1002,7 @@ mod tests {
             audit_event_count: 2,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
         assert!(record_session_in_ledger(&metadata));
 

--- a/crates/nono-cli/src/rollback_session.rs
+++ b/crates/nono-cli/src/rollback_session.rs
@@ -319,6 +319,7 @@ mod tests {
                 audit_event_count: 0,
                 audit_integrity: None,
                 audit_attestation: None,
+                command_policy_summary: None,
             },
         )
         .expect("write metadata");

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -8,6 +8,7 @@ use crate::command_display::{format_command_line, truncate_chars};
 use crate::session::{self, SessionAttachment, SessionRecord, SessionStatus};
 use colored::Colorize;
 use nix::libc;
+use nono::undo::{CommandPolicySummary, SnapshotManager};
 use nono::{NonoError, Result};
 use std::collections::VecDeque;
 use std::io::{BufRead, Seek, SeekFrom};
@@ -390,9 +391,15 @@ pub fn run_logs(args: &LogsArgs) -> Result<()> {
 /// Dispatch `nono inspect` — placeholder for Step 4.
 pub fn run_inspect(args: &InspectArgs) -> Result<()> {
     let record = session::load_session(&args.session)?;
+    let tools = ToolSummaryView::for_session(&record);
 
     if args.json {
-        let json = serde_json::to_string_pretty(&record)
+        let mut value = serde_json::to_value(&record)
+            .map_err(|e| NonoError::ConfigParse(format!("JSON serialization failed: {e}")))?;
+        if let Some(object) = value.as_object_mut() {
+            tools.extend_json(object)?;
+        }
+        let json = serde_json::to_string_pretty(&value)
             .map_err(|e| NonoError::ConfigParse(format!("JSON serialization failed: {e}")))?;
         println!("{json}");
         return Ok(());
@@ -421,8 +428,141 @@ pub fn run_inspect(args: &InspectArgs) -> Result<()> {
     if let Some(ref rollback) = record.rollback_session {
         println!("Rollback:   {}", rollback);
     }
+    if let Some(line) = tools.render() {
+        println!("Tools:      {line}");
+    }
 
     Ok(())
+}
+
+/// A session's mediated-command rollup, as `nono inspect` reports it.
+///
+/// Read from session metadata once the session has finalized — that rollup is
+/// authoritative and digest-covered — and recomputed from the audit event log
+/// otherwise, since only finalization writes the stored one.
+struct ToolSummaryView {
+    summary: Option<CommandPolicySummary>,
+    /// The session can still mediate commands, so the counts are not final.
+    live: bool,
+    /// The log ended mid-record, so the counts trail the running session.
+    partial: bool,
+    /// Why the log could not be summarized, reported rather than swallowed.
+    error: Option<String>,
+}
+
+impl ToolSummaryView {
+    fn for_session(record: &SessionRecord) -> Self {
+        let live = record.status != SessionStatus::Exited;
+        let empty = Self {
+            summary: None,
+            live,
+            partial: false,
+            error: None,
+        };
+
+        let Some(session_id) = record.rollback_session.as_deref() else {
+            return empty;
+        };
+        let session_dir = match crate::audit_session::resolve_session_dir(session_id) {
+            Ok(dir) => dir,
+            // Audit sessions are removed by `nono audit cleanup` independently
+            // of the session registry, so a missing directory is ordinary.
+            Err(NonoError::SessionNotFound(_)) => {
+                debug!("No audit session directory for {session_id}");
+                return empty;
+            }
+            // A containment failure must not render as "mediated nothing".
+            Err(e) => {
+                return Self {
+                    error: Some(e.to_string()),
+                    ..empty
+                };
+            }
+        };
+
+        if !live {
+            match SnapshotManager::load_session_metadata(&session_dir) {
+                Ok(metadata) => {
+                    return Self {
+                        summary: metadata.command_policy_summary,
+                        ..empty
+                    };
+                }
+                // No session.json: the session died before finalizing, so the
+                // log is all there is and its tail may be legitimately torn.
+                Err(NonoError::SessionNotFound(_)) => {}
+                // Unreadable metadata must not render as "mediated nothing".
+                Err(e) => {
+                    return Self {
+                        error: Some(e.to_string()),
+                        ..empty
+                    };
+                }
+            }
+        }
+
+        match crate::audit_event_reader::recompute_command_policy_summary(&session_dir) {
+            Ok((summary, partial)) => Self {
+                summary,
+                live,
+                partial,
+                error: None,
+            },
+            Err(e) => Self {
+                error: Some(e.to_string()),
+                ..empty
+            },
+        }
+    }
+
+    /// The reported line, or `None` when the session never mediated anything.
+    fn render(&self) -> Option<String> {
+        if let Some(error) = self.error.as_deref() {
+            return Some(format!("unavailable: {error}"));
+        }
+        let mut line = match self.summary.as_ref() {
+            Some(summary) => crate::audit_commands::format_tool_summary_detail(summary),
+            // A log whose only content is a torn record may be hiding the
+            // session's only mediation events, so it must not go silent while
+            // the JSON output reports the partial flag.
+            None if self.partial => "no complete records".to_string(),
+            None => return None,
+        };
+        if self.live {
+            line.push_str(" [live]");
+        }
+        if self.partial {
+            line.push_str(if self.live {
+                " [a record is still being written]"
+            } else {
+                " [the log ends mid-record]"
+            });
+        }
+        Some(line)
+    }
+
+    fn extend_json(&self, object: &mut serde_json::Map<String, serde_json::Value>) -> Result<()> {
+        let summary = serde_json::to_value(&self.summary)
+            .map_err(|e| NonoError::ConfigParse(format!("JSON serialization failed: {e}")))?;
+        object.insert("command_policy_summary".to_string(), summary);
+        object.insert(
+            "command_policy_summary_live".to_string(),
+            serde_json::Value::Bool(self.live),
+        );
+        if self.partial {
+            object.insert(
+                "command_policy_summary_partial".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        if let Some(error) = self.error.as_deref() {
+            object.insert(
+                "command_policy_summary_error".to_string(),
+                serde_json::Value::String(error.to_string()),
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Dispatch `nono prune`.
@@ -618,5 +758,280 @@ mod tests {
         let started = (now - chrono::Duration::minutes(5)).to_rfc3339();
         let result = format_uptime(&started);
         assert!(result.ends_with('m'));
+    }
+
+    mod tool_summary {
+        use super::super::*;
+        use crate::audit_integrity::{AuditRecorder, SandboxRuntimeAuditEvent};
+        use crate::test_env::{ENV_LOCK, EnvVarGuard};
+        use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
+        use nono::audit::CommandPolicyAuditEvent;
+        use std::path::PathBuf;
+
+        const SESSION_ID: &str = "20260813-120000-4242";
+
+        fn running_session(rollback_session: Option<&str>) -> SessionRecord {
+            SessionRecord {
+                session_id: "abc123".to_string(),
+                name: Some("brave-otter".to_string()),
+                supervisor_pid: 41,
+                child_pid: 42,
+                started: "2026-08-13T12:00:00Z".to_string(),
+                started_epoch: 0,
+                status: SessionStatus::Running,
+                attachment: SessionAttachment::Attached,
+                exit_code: None,
+                command: vec!["claude".to_string()],
+                profile: Some("claude".to_string()),
+                workdir: PathBuf::from("/work"),
+                network: "blocked".to_string(),
+                rollback_session: rollback_session.map(str::to_string),
+            }
+        }
+
+        /// Writes a mediating session's event log where the CLI will look for
+        /// it, without the `session.json` that only finalization writes.
+        fn write_running_audit_session(state: &std::path::Path) {
+            let dir = state.join("nono").join("audit").join(SESSION_ID);
+            std::fs::create_dir_all(&dir).expect("the test owns this temp state dir");
+            let mut recorder = AuditRecorder::new(dir).expect("the directory was just created");
+            recorder
+                .record_sandbox_runtime_event(SandboxRuntimeAuditEvent {
+                    timestamp: "2026-08-13T12:00:00Z".to_string(),
+                    platform: "linux".to_string(),
+                    landlock_abi: Some("v5".to_string()),
+                    landlock_execute_enforced: Some(true),
+                    tool_sandbox_active: true,
+                })
+                .expect("recorder writes to a directory it opened");
+            for decision in [
+                CommandPolicyDecision::Allowed,
+                CommandPolicyDecision::Denied,
+            ] {
+                recorder
+                    .record_command_policy_event(
+                        CommandPolicyAuditEvent {
+                            timestamp: "2026-08-13T12:00:01Z".to_string(),
+                            session_id: Some(SESSION_ID.to_string()),
+                            command: "gh".to_string(),
+                            caller: "session".to_string(),
+                            caller_kind: Some("session".to_string()),
+                            caller_command: None,
+                            caller_pid: Some(41),
+                            shim_pid: Some(42),
+                            session_root_pid: Some(41),
+                            decision: decision.as_str().to_string(),
+                            reason: None,
+                            stdio_mode: "direct_fds".to_string(),
+                            argv_hash: "argv-hash".to_string(),
+                            env_name_hash: "env-hash".to_string(),
+                            cwd_hash: "cwd-hash".to_string(),
+                            argv_display: vec!["gh".to_string()],
+                            env_names_display: Vec::new(),
+                            env_display: Vec::new(),
+                            cwd_display: "/work".to_string(),
+                            exit_code: None,
+                            stdio: None,
+                        },
+                        decision.outcome(),
+                    )
+                    .expect("recorder writes to a directory it opened");
+            }
+        }
+
+        #[test]
+        fn a_running_session_reports_its_decisions_so_far() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+            write_running_audit_session(&state);
+
+            let line = ToolSummaryView::for_session(&running_session(Some(SESSION_ID)))
+                .render()
+                .expect("a mediating session renders a rollup");
+
+            assert!(line.contains("gh"), "{line}");
+            assert!(line.contains("1 allowed"), "{line}");
+            assert!(line.contains("1 denied"), "{line}");
+            assert!(
+                line.contains("[live]"),
+                "a running session's counts are not final: {line}"
+            );
+        }
+
+        #[test]
+        fn an_exited_session_reports_final_counts() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+            write_running_audit_session(&state);
+
+            let mut record = running_session(Some(SESSION_ID));
+            record.status = SessionStatus::Exited;
+            record.exit_code = Some(0);
+
+            let line = ToolSummaryView::for_session(&record)
+                .render()
+                .expect("a mediating session renders a rollup");
+
+            assert!(!line.contains("[live]"), "{line}");
+        }
+
+        /// The finalized rollup is authoritative and digest-covered, so an
+        /// exited session's line must come from metadata, not a refold that
+        /// post-finalize log damage could poison.
+        #[test]
+        fn a_finalized_session_reports_the_stored_summary() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+            write_running_audit_session(&state);
+
+            let dir = state.join("nono").join("audit").join(SESSION_ID);
+            nono::undo::SnapshotManager::write_session_metadata(
+                &dir,
+                &nono::undo::SessionMetadata {
+                    session_id: SESSION_ID.to_string(),
+                    started: "2026-08-13T12:00:00Z".to_string(),
+                    ended: Some("2026-08-13T12:00:02Z".to_string()),
+                    command: vec!["claude".to_string()],
+                    executable_identity: None,
+                    tracked_paths: Vec::new(),
+                    snapshot_count: 0,
+                    exit_code: Some(0),
+                    merkle_roots: Vec::new(),
+                    network_events: Vec::new(),
+                    audit_event_count: 4,
+                    audit_integrity: None,
+                    audit_attestation: None,
+                    command_policy_summary: Some(nono::undo::CommandPolicySummary {
+                        mediation_active: true,
+                        event_count: 3,
+                        invocation_count: 3,
+                        commands: vec![nono::undo::CommandPolicyCommandSummary {
+                            command: "git".to_string(),
+                            allowed: 3,
+                            denied: 0,
+                            other: 0,
+                        }],
+                        truncated: false,
+                    }),
+                },
+            )
+            .expect("the test owns this audit session dir");
+            // Damage the log after finalize: the stored rollup must survive it.
+            std::fs::write(dir.join("audit-events.ndjson"), b"{\"sequence\":0,")
+                .expect("the test owns this audit session dir");
+
+            let mut record = running_session(Some(SESSION_ID));
+            record.status = SessionStatus::Exited;
+            record.exit_code = Some(0);
+
+            let line = ToolSummaryView::for_session(&record)
+                .render()
+                .expect("a finalized mediating session renders its stored rollup");
+
+            assert!(line.contains("git"), "{line}");
+            assert!(line.contains("3 allowed"), "{line}");
+        }
+
+        /// A session killed before finalizing has no stored rollup and may
+        /// have a legitimately torn final record; the decisions recorded
+        /// before the kill must still be reported.
+        #[test]
+        fn a_killed_session_reports_the_decisions_before_the_torn_tail() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+            write_running_audit_session(&state);
+
+            let log = state
+                .join("nono")
+                .join("audit")
+                .join(SESSION_ID)
+                .join("audit-events.ndjson");
+            let mut contents = std::fs::read(&log).expect("the recorder wrote this log");
+            contents.extend_from_slice(br#"{"sequence":5,"prev_chain":"#);
+            std::fs::write(&log, contents).expect("the test owns this audit session dir");
+
+            let mut record = running_session(Some(SESSION_ID));
+            record.status = SessionStatus::Exited;
+            record.exit_code = Some(-1);
+
+            let line = ToolSummaryView::for_session(&record)
+                .render()
+                .expect("the decisions recorded before the kill are reported");
+
+            assert!(line.contains("1 allowed"), "{line}");
+            assert!(line.contains("1 denied"), "{line}");
+            assert!(line.contains("[the log ends mid-record]"), "{line}");
+            assert!(!line.contains("[live]"), "{line}");
+        }
+
+        #[test]
+        fn a_session_that_mediated_nothing_reports_nothing() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+            assert!(
+                ToolSummaryView::for_session(&running_session(None))
+                    .render()
+                    .is_none()
+            );
+            assert!(
+                ToolSummaryView::for_session(&running_session(Some(SESSION_ID)))
+                    .render()
+                    .is_none(),
+                "a cleaned-up audit session is not an error"
+            );
+        }
+
+        /// An escape resolves to no directory just as cleanup does, so reusing
+        /// cleanup's silence here would report a containment failure as a
+        /// session that mediated nothing.
+        #[test]
+        fn a_session_directory_outside_the_audit_root_is_reported() {
+            let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = tmp.path().join("state");
+            std::fs::create_dir_all(&state).expect("the test owns this temp dir");
+            let home = tmp.path().to_string_lossy().to_string();
+            let state_str = state.to_string_lossy().to_string();
+            let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+            let outside = tmp.path().join("outside");
+            std::fs::create_dir_all(&outside).expect("the test owns this temp dir");
+            let root = crate::audit_session::audit_root().expect("HOME is set above");
+            std::fs::create_dir_all(&root).expect("the test owns this temp dir");
+            std::os::unix::fs::symlink(&outside, root.join(SESSION_ID))
+                .expect("the test owns this temp dir");
+
+            let line = ToolSummaryView::for_session(&running_session(Some(SESSION_ID)))
+                .render()
+                .expect("a containment failure is reported, not swallowed");
+
+            assert!(line.starts_with("unavailable:"), "{line}");
+        }
     }
 }

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -278,14 +278,29 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
             .lock()
             .map_err(|_| nono::NonoError::Snapshot("Audit recorder lock poisoned".to_string()))?;
         recorder.record_session_started(started.clone(), command.to_vec())?;
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(tool_sandbox_runtime) = config.tool_sandbox_runtime {
+            #[cfg(target_os = "linux")]
+            let (platform, landlock_abi, landlock_execute_enforced) = (
+                "linux",
+                Some(tool_sandbox_runtime.landlock_abi_version().to_string()),
+                Some(true),
+            );
+            // Seatbelt has no Landlock analogue to report, but the mediation
+            // marker must still be recorded: without it a macOS session that
+            // configured mediation and invoked nothing is indistinguishable
+            // from one that ran unmediated in every audit reader.
+            #[cfg(target_os = "macos")]
+            let (platform, landlock_abi, landlock_execute_enforced) = {
+                let _ = tool_sandbox_runtime;
+                ("macos", None::<String>, None::<bool>)
+            };
             recorder.record_sandbox_runtime_event(
                 crate::audit_integrity::SandboxRuntimeAuditEvent {
                     timestamp: chrono::Utc::now().to_rfc3339(),
-                    platform: "linux".to_string(),
-                    landlock_abi: Some(tool_sandbox_runtime.landlock_abi_version().to_string()),
-                    landlock_execute_enforced: Some(true),
+                    platform: platform.to_string(),
+                    landlock_abi,
+                    landlock_execute_enforced,
                     tool_sandbox_active: true,
                 },
             )?;

--- a/crates/nono-cli/src/tool-sandbox/command_policy_decision.rs
+++ b/crates/nono-cli/src/tool-sandbox/command_policy_decision.rs
@@ -1,0 +1,148 @@
+//! The `decision` vocabulary the tool sandbox writes into command policy audit
+//! events.
+//!
+//! Emitters name a variant rather than a string literal, so a new decision
+//! cannot reach the audit log without declaring how it folds into a session
+//! rollup.
+
+use nono::undo::CommandPolicyOutcome;
+
+/// Declare the vocabulary once: variant, persisted string, and the outcome the
+/// decision folds into.
+///
+/// Single-sourcing the table is what closes the gap the vocabulary used to
+/// have. The emitters, the string written to the log, and the classification
+/// all come from these rows, so there is no second list to leave un-updated.
+macro_rules! command_policy_decisions {
+    ($($variant:ident => $persisted:literal => $outcome:ident,)+) => {
+        /// A decision recorded for a mediated command.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum CommandPolicyDecision {
+            $($variant,)+
+        }
+
+        impl CommandPolicyDecision {
+            /// The string persisted as the event's `decision` field.
+            pub(crate) fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $persisted,)+
+                }
+            }
+
+            /// How the decision folds into a session rollup.
+            pub(crate) fn outcome(self) -> CommandPolicyOutcome {
+                match self {
+                    $(Self::$variant => CommandPolicyOutcome::$outcome,)+
+                }
+            }
+        }
+    };
+}
+
+command_policy_decisions! {
+    Allowed => "allowed" => Allowed,
+    ApproveDenied => "approve_denied" => Denied,
+    ApproveGranted => "approve_granted" => Pending,
+    Capture => "capture" => Allowed,
+    CaptureCredential => "capture_credential" => Allowed,
+    CaptureCredentialCached => "capture_credential_cached" => Allowed,
+    Denied => "denied" => Denied,
+    Exec => "exec" => Allowed,
+    InvocationAllowed => "invocation_allowed" => Pending,
+    InvocationApproveDenied => "invocation_approve_denied" => Denied,
+    InvocationApproveGranted => "invocation_approve_granted" => Pending,
+    InvocationDenied => "invocation_denied" => Denied,
+    Respond => "respond" => Allowed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A log has to re-summarize the way it summarized when it was written, so
+    /// what an existing decision persists as and folds into is asserted here
+    /// rather than derived from the table being checked.
+    const FROZEN: [(CommandPolicyDecision, &str, CommandPolicyOutcome); 13] = [
+        (
+            CommandPolicyDecision::Allowed,
+            "allowed",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::Respond,
+            "respond",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::Capture,
+            "capture",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::Exec,
+            "exec",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::CaptureCredential,
+            "capture_credential",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::CaptureCredentialCached,
+            "capture_credential_cached",
+            CommandPolicyOutcome::Allowed,
+        ),
+        (
+            CommandPolicyDecision::Denied,
+            "denied",
+            CommandPolicyOutcome::Denied,
+        ),
+        (
+            CommandPolicyDecision::InvocationDenied,
+            "invocation_denied",
+            CommandPolicyOutcome::Denied,
+        ),
+        (
+            CommandPolicyDecision::InvocationApproveDenied,
+            "invocation_approve_denied",
+            CommandPolicyOutcome::Denied,
+        ),
+        (
+            CommandPolicyDecision::ApproveDenied,
+            "approve_denied",
+            CommandPolicyOutcome::Denied,
+        ),
+        (
+            CommandPolicyDecision::InvocationAllowed,
+            "invocation_allowed",
+            CommandPolicyOutcome::Pending,
+        ),
+        (
+            CommandPolicyDecision::InvocationApproveGranted,
+            "invocation_approve_granted",
+            CommandPolicyOutcome::Pending,
+        ),
+        (
+            CommandPolicyDecision::ApproveGranted,
+            "approve_granted",
+            CommandPolicyOutcome::Pending,
+        ),
+    ];
+
+    #[test]
+    fn the_decision_to_outcome_mapping_is_frozen() {
+        for (decision, persisted, outcome) in FROZEN {
+            assert_eq!(
+                decision.as_str(),
+                persisted,
+                "{decision:?} persisted unexpectedly"
+            );
+            assert_eq!(
+                decision.outcome(),
+                outcome,
+                "{decision:?} classified unexpectedly"
+            );
+        }
+    }
+}

--- a/crates/nono-cli/src/tool-sandbox/command_policy_decision.rs
+++ b/crates/nono-cli/src/tool-sandbox/command_policy_decision.rs
@@ -22,6 +22,8 @@ macro_rules! command_policy_decisions {
         }
 
         impl CommandPolicyDecision {
+            const ALL: &'static [Self] = &[$(Self::$variant),+];
+
             /// The string persisted as the event's `decision` field.
             pub(crate) fn as_str(self) -> &'static str {
                 match self {
@@ -53,6 +55,24 @@ command_policy_decisions! {
     InvocationApproveGranted => "invocation_approve_granted" => Pending,
     InvocationDenied => "invocation_denied" => Denied,
     Respond => "respond" => Allowed,
+}
+
+impl CommandPolicyDecision {
+    /// Classify a `decision` string read back from an event log.
+    ///
+    /// The mapping is frozen: a row may be added, but the outcome of an
+    /// existing string must never change, or a log would re-summarize
+    /// differently than when it was written. A string outside the table
+    /// classifies as [`CommandPolicyOutcome::Other`] rather than joining either
+    /// tally, so a reader older than the log it is folding surfaces the gap
+    /// instead of miscounting it.
+    pub(crate) fn classify(decision: &str) -> CommandPolicyOutcome {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == decision)
+            .map_or(CommandPolicyOutcome::Other, Self::outcome)
+    }
 }
 
 #[cfg(test)]
@@ -144,5 +164,29 @@ mod tests {
                 "{decision:?} classified unexpectedly"
             );
         }
+    }
+
+    /// Two rows sharing a persisted string would leave the second unreachable
+    /// on the read-back path, summarizing an old log as the first row's outcome.
+    #[test]
+    fn every_decision_round_trips_through_its_persisted_string() {
+        for decision in CommandPolicyDecision::ALL.iter().copied() {
+            assert_eq!(
+                CommandPolicyDecision::classify(decision.as_str()),
+                decision.outcome(),
+                "{decision:?} classified differently when read back"
+            );
+        }
+        // A new decision joins the frozen list too, so that adding one is a
+        // deliberate statement about how an old log folds.
+        assert_eq!(CommandPolicyDecision::ALL.len(), FROZEN.len());
+    }
+
+    #[test]
+    fn a_decision_outside_the_vocabulary_joins_neither_tally() {
+        assert_eq!(
+            CommandPolicyDecision::classify("some_future_decision"),
+            CommandPolicyOutcome::Other
+        );
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/mod.rs
+++ b/crates/nono-cli/src/tool-sandbox/mod.rs
@@ -29,6 +29,9 @@ pub(crate) fn log_main_total() {}
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod audit_context;
+// Unconditional: readers of an event log classify decisions on every platform,
+// and both platforms' emitters type-check against the same vocabulary.
+pub(crate) mod command_policy_decision;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod credentials;
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -9,6 +9,7 @@ use crate::command_policy::{
 };
 use crate::lineage_cgroup::LineageMarker;
 use crate::profile;
+use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
     apply_environment_set_vars, apply_export_env, default_env_allow_patterns,
@@ -1281,7 +1282,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 None,
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -1298,7 +1299,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "denied",
+            CommandPolicyDecision::Denied,
             Some("legacy_blocked_command".to_string()),
             None,
         )?;
@@ -1332,7 +1333,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -1348,7 +1349,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "denied",
+            CommandPolicyDecision::Denied,
             Some(err.to_string()),
             None,
         )?;
@@ -1369,7 +1370,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_denied",
+                    CommandPolicyDecision::InvocationDenied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1388,7 +1389,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "invocation_denied",
+                        CommandPolicyDecision::InvocationDenied,
                         Some(err.to_string()),
                         None,
                     )?;
@@ -1405,7 +1406,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_allowed",
+                    CommandPolicyDecision::InvocationAllowed,
                     None,
                     None,
                 )?;
@@ -1419,7 +1420,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_denied",
+                    CommandPolicyDecision::InvocationDenied,
                     Some(reason.clone()),
                     None,
                 )?;
@@ -1449,7 +1450,7 @@ fn handle_shim_stream_inner(
                             auth.peer_pid,
                             session_root_pid,
                             Some(&caller),
-                            "invocation_approve_denied",
+                            CommandPolicyDecision::InvocationApproveDenied,
                             Some(err.to_string()),
                             None,
                         )?;
@@ -1473,7 +1474,7 @@ fn handle_shim_stream_inner(
                             auth.peer_pid,
                             session_root_pid,
                             Some(&caller),
-                            "invocation_approve_denied",
+                            CommandPolicyDecision::InvocationApproveDenied,
                             Some(err.to_string()),
                             None,
                         )?;
@@ -1510,10 +1511,10 @@ fn handle_shim_stream_inner(
                     move || backend.request_approval(&approval_request),
                 )?;
                 let (audit_decision, deny_reason) = if decision.is_granted() {
-                    ("invocation_approve_granted", None)
+                    (CommandPolicyDecision::InvocationApproveGranted, None)
                 } else {
                     (
-                        "invocation_approve_denied",
+                        CommandPolicyDecision::InvocationApproveDenied,
                         Some(super::approval_deny_reason(&decision)),
                     )
                 };
@@ -1557,7 +1558,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "denied",
+                        CommandPolicyDecision::Denied,
                         Some(err.to_string()),
                         None,
                     )?;
@@ -1591,7 +1592,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "respond",
+            CommandPolicyDecision::Respond,
             None,
             Some(0),
         )?;
@@ -1637,10 +1638,10 @@ fn handle_shim_stream_inner(
             run_with_timeout(timeout, move || backend.request_approval(&approval_request))?;
 
         let (audit_decision, deny_reason) = if decision.is_granted() {
-            ("approve_granted", None)
+            (CommandPolicyDecision::ApproveGranted, None)
         } else {
             (
-                "approve_denied",
+                CommandPolicyDecision::ApproveDenied,
                 Some(super::approval_deny_reason(&decision)),
             )
         };
@@ -1686,7 +1687,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "capture_credential_cached",
+                CommandPolicyDecision::CaptureCredentialCached,
                 None,
                 Some(0),
             )?;
@@ -1704,7 +1705,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1728,7 +1729,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "denied",
+                        CommandPolicyDecision::Denied,
                         Some("credential_capture_failed".to_string()),
                         Some(exit_code),
                     )?;
@@ -1753,7 +1754,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "capture_credential",
+                    CommandPolicyDecision::CaptureCredential,
                     None,
                     Some(0),
                 )?;
@@ -1768,7 +1769,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1792,7 +1793,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1828,7 +1829,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "capture",
+                    CommandPolicyDecision::Capture,
                     None,
                     Some(*exit_code),
                 )?;
@@ -1843,7 +1844,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1864,7 +1865,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1898,7 +1899,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "denied",
+                        CommandPolicyDecision::Denied,
                         Some(reason.clone()),
                         None,
                         launch_result.stdio,
@@ -1916,7 +1917,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "exec",
+                    CommandPolicyDecision::Exec,
                     None,
                     Some(launch_result.exit_code),
                     launch_result.stdio,
@@ -1932,7 +1933,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1952,7 +1953,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "denied",
+            CommandPolicyDecision::Denied,
             Some("resource_limit".to_string()),
             None,
         )?;
@@ -1977,7 +1978,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(reason.clone()),
                     None,
                     launch_result.stdio,
@@ -1995,7 +1996,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "allowed",
+                CommandPolicyDecision::Allowed,
                 None,
                 Some(launch_result.exit_code),
                 launch_result.stdio,
@@ -2011,7 +2012,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -2349,7 +2350,7 @@ fn record_command_policy_audit(
     shim_pid: u32,
     session_root_pid: u32,
     caller: Option<&Caller>,
-    decision: &str,
+    decision: CommandPolicyDecision,
     reason: Option<String>,
     exit_code: Option<i32>,
 ) -> Result<()> {
@@ -2377,7 +2378,7 @@ fn record_command_policy_audit_with_stdio(
     shim_pid: u32,
     session_root_pid: u32,
     caller: Option<&Caller>,
-    decision: &str,
+    decision: CommandPolicyDecision,
     reason: Option<String>,
     exit_code: Option<i32>,
     stdio: Option<CommandPolicyStdioAudit>,
@@ -2397,7 +2398,7 @@ fn record_command_policy_audit_with_stdio(
         caller_pid: caller_pid(caller),
         shim_pid: Some(shim_pid),
         session_root_pid: Some(session_root_pid),
-        decision: decision.to_string(),
+        decision: decision.as_str().to_string(),
         reason,
         stdio_mode: selected_stdio_mode(request).to_string(),
         argv_hash: hash_byte_fields(&request.argv),
@@ -2413,7 +2414,7 @@ fn record_command_policy_audit_with_stdio(
     let mut recorder = recorder
         .lock()
         .map_err(|_| NonoError::Snapshot("Audit recorder lock poisoned".to_string()))?;
-    recorder.record_command_policy_event(event)
+    recorder.record_command_policy_event(event, decision.outcome())
 }
 
 fn hash_byte_fields(fields: &[Vec<u8>]) -> String {

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -6,6 +6,7 @@ use crate::command_policy::{
     CommandPoliciesConfig, CommandSandboxConfig, InterceptActionConfig, ResolvedCommandBinaries,
     ResolvedCommandBinary, has_explicit_self_invocation_entry,
 };
+use crate::tool_sandbox::command_policy_decision::CommandPolicyDecision;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
     apply_environment_set_vars, apply_export_env, default_env_allow_patterns,
@@ -974,7 +975,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             None,
-            "denied",
+            CommandPolicyDecision::Denied,
             Some("legacy_blocked_command".to_string()),
             None,
         )?;
@@ -995,7 +996,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 None,
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -1026,7 +1027,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -1042,7 +1043,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "denied",
+            CommandPolicyDecision::Denied,
             Some(err.to_string()),
             None,
         )?;
@@ -1063,7 +1064,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_denied",
+                    CommandPolicyDecision::InvocationDenied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1082,7 +1083,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "invocation_denied",
+                        CommandPolicyDecision::InvocationDenied,
                         Some(err.to_string()),
                         None,
                     )?;
@@ -1099,7 +1100,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_allowed",
+                    CommandPolicyDecision::InvocationAllowed,
                     None,
                     None,
                 )?;
@@ -1113,7 +1114,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "invocation_denied",
+                    CommandPolicyDecision::InvocationDenied,
                     Some(reason.clone()),
                     None,
                 )?;
@@ -1143,7 +1144,7 @@ fn handle_shim_stream_inner(
                             auth.peer_pid,
                             session_root_pid,
                             Some(&caller),
-                            "invocation_approve_denied",
+                            CommandPolicyDecision::InvocationApproveDenied,
                             Some(err.to_string()),
                             None,
                         )?;
@@ -1167,7 +1168,7 @@ fn handle_shim_stream_inner(
                             auth.peer_pid,
                             session_root_pid,
                             Some(&caller),
-                            "invocation_approve_denied",
+                            CommandPolicyDecision::InvocationApproveDenied,
                             Some(err.to_string()),
                             None,
                         )?;
@@ -1204,10 +1205,10 @@ fn handle_shim_stream_inner(
                     move || backend.request_approval(&approval_request),
                 )?;
                 let (audit_decision, deny_reason) = if decision.is_granted() {
-                    ("invocation_approve_granted", None)
+                    (CommandPolicyDecision::InvocationApproveGranted, None)
                 } else {
                     (
-                        "invocation_approve_denied",
+                        CommandPolicyDecision::InvocationApproveDenied,
                         Some(super::approval_deny_reason(&decision)),
                     )
                 };
@@ -1255,7 +1256,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -1279,7 +1280,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "respond",
+            CommandPolicyDecision::Respond,
             None,
             Some(0),
         )?;
@@ -1323,10 +1324,10 @@ fn handle_shim_stream_inner(
         let decision =
             run_with_timeout(timeout, move || backend.request_approval(&approval_request))?;
         let (audit_decision, deny_reason) = if decision.is_granted() {
-            ("approve_granted", None)
+            (CommandPolicyDecision::ApproveGranted, None)
         } else {
             (
-                "approve_denied",
+                CommandPolicyDecision::ApproveDenied,
                 Some(super::approval_deny_reason(&decision)),
             )
         };
@@ -1373,7 +1374,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "capture_credential_cached",
+                CommandPolicyDecision::CaptureCredentialCached,
                 None,
                 Some(0),
             )?;
@@ -1391,7 +1392,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1415,7 +1416,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "denied",
+                        CommandPolicyDecision::Denied,
                         Some("credential_capture_failed".to_string()),
                         Some(exit_code),
                     )?;
@@ -1440,7 +1441,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "capture_credential",
+                    CommandPolicyDecision::CaptureCredential,
                     None,
                     Some(0),
                 )?;
@@ -1455,7 +1456,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1477,7 +1478,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1513,7 +1514,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "capture",
+                    CommandPolicyDecision::Capture,
                     None,
                     Some(exit_code),
                 )?;
@@ -1528,7 +1529,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1550,7 +1551,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some("resource_limit".to_string()),
                 None,
             )?;
@@ -1584,7 +1585,7 @@ fn handle_shim_stream_inner(
                         auth.peer_pid,
                         session_root_pid,
                         Some(&caller),
-                        "denied",
+                        CommandPolicyDecision::Denied,
                         Some(reason.clone()),
                         None,
                         launch_result.stdio,
@@ -1602,7 +1603,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "exec",
+                    CommandPolicyDecision::Exec,
                     None,
                     Some(launch_result.exit_code),
                     launch_result.stdio,
@@ -1618,7 +1619,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(err.to_string()),
                     None,
                 )?;
@@ -1639,7 +1640,7 @@ fn handle_shim_stream_inner(
             auth.peer_pid,
             session_root_pid,
             Some(&caller),
-            "denied",
+            CommandPolicyDecision::Denied,
             Some("resource_limit".to_string()),
             None,
         )?;
@@ -1663,7 +1664,7 @@ fn handle_shim_stream_inner(
                     auth.peer_pid,
                     session_root_pid,
                     Some(&caller),
-                    "denied",
+                    CommandPolicyDecision::Denied,
                     Some(reason.clone()),
                     None,
                     launch_result.stdio,
@@ -1681,7 +1682,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "allowed",
+                CommandPolicyDecision::Allowed,
                 None,
                 Some(launch_result.exit_code),
                 launch_result.stdio,
@@ -1697,7 +1698,7 @@ fn handle_shim_stream_inner(
                 auth.peer_pid,
                 session_root_pid,
                 Some(&caller),
-                "denied",
+                CommandPolicyDecision::Denied,
                 Some(err.to_string()),
                 None,
             )?;
@@ -4123,7 +4124,7 @@ fn record_command_policy_audit(
     peer_pid: u32,
     session_root_pid: u32,
     caller: Option<&Caller>,
-    decision: &str,
+    decision: CommandPolicyDecision,
     reason: Option<String>,
     exit_code: Option<i32>,
 ) -> Result<()> {
@@ -4151,7 +4152,7 @@ fn record_command_policy_audit_with_stdio(
     peer_pid: u32,
     session_root_pid: u32,
     caller: Option<&Caller>,
-    decision: &str,
+    decision: CommandPolicyDecision,
     reason: Option<String>,
     exit_code: Option<i32>,
     stdio: Option<CommandPolicyStdioAudit>,
@@ -4171,7 +4172,7 @@ fn record_command_policy_audit_with_stdio(
         caller_pid: Some(peer_pid),
         shim_pid: Some(peer_pid),
         session_root_pid: Some(session_root_pid),
-        decision: decision.to_string(),
+        decision: decision.as_str().to_string(),
         reason,
         stdio_mode: selected_stdio_mode(request).to_string(),
         argv_hash: hash_byte_fields(&request.argv),
@@ -4187,7 +4188,7 @@ fn record_command_policy_audit_with_stdio(
     let mut recorder = recorder
         .lock()
         .map_err(|_| NonoError::Snapshot("Audit recorder lock poisoned".to_string()))?;
-    recorder.record_command_policy_event(event)
+    recorder.record_command_policy_event(event, decision.outcome())
 }
 
 fn hash_byte_fields(fields: &[Vec<u8>]) -> String {
@@ -5038,7 +5039,7 @@ mod tests {
             Some(&Caller::Command {
                 name: "claude".to_string(),
             }),
-            "invocation_approve_granted",
+            CommandPolicyDecision::InvocationApproveGranted,
             None,
             Some(0),
         )?;

--- a/crates/nono/src/audit.rs
+++ b/crates/nono/src/audit.rs
@@ -493,23 +493,35 @@ impl AuditRecorder {
     /// Record sandbox runtime metadata.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub fn record_sandbox_runtime_event(&mut self, event: SandboxRuntimeAuditEvent) -> Result<()> {
-        self.append_event(AuditEventPayload::SandboxRuntime { event })
+        let mediation_active = event.tool_sandbox_active;
+        self.append_event(AuditEventPayload::SandboxRuntime { event })?;
+        if mediation_active {
+            self.command_policy_summary.observe_mediation_active();
+        }
+        Ok(())
     }
 
     /// Record a tool sandbox command policy decision.
     ///
     /// `outcome` is how the event's `decision` folds into the session rollup;
     /// the caller owns that vocabulary and so owns the classification.
+    ///
+    /// The rollup is folded only after the record reaches the log: a failed
+    /// append refuses one command but leaves the session alive to finalize, so
+    /// folding first would commit a `session.json` rollup claiming events the
+    /// log does not hold.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub fn record_command_policy_event(
         &mut self,
         event: CommandPolicyAuditEvent,
         outcome: CommandPolicyOutcome,
     ) -> Result<()> {
-        self.command_policy_summary.observe(&event, outcome);
+        let event = Box::new(event);
         self.append_event(AuditEventPayload::CommandPolicy {
-            event: Box::new(event),
-        })
+            event: event.clone(),
+        })?;
+        self.command_policy_summary.observe(&event, outcome);
+        Ok(())
     }
 
     /// Rollup of the command policy events recorded so far.
@@ -574,6 +586,7 @@ impl AuditRecorder {
 /// the number of events, so an endlessly mediating session stays fixed-size.
 #[derive(Debug, Default, Clone)]
 pub struct CommandPolicySummaryBuilder {
+    mediation_active: bool,
     event_count: u64,
     invocation_count: u64,
     commands: BTreeMap<String, CommandPolicyCommandSummary>,
@@ -585,6 +598,14 @@ impl CommandPolicySummaryBuilder {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Note that command mediation was configured for this session.
+    ///
+    /// Separate from [`Self::observe`] because a session can configure mediation
+    /// without ever invoking a command, and the two must not read alike.
+    pub fn observe_mediation_active(&mut self) {
+        self.mediation_active = true;
     }
 
     /// Fold one command policy event into the rollup.
@@ -624,13 +645,15 @@ impl CommandPolicySummaryBuilder {
         }
     }
 
-    /// Finish the rollup, or `None` when no command policy events were observed.
+    /// Finish the rollup, or `None` when the session neither configured
+    /// mediation nor recorded a command policy event.
     #[must_use]
     pub fn finish(self) -> Option<CommandPolicySummary> {
-        if self.event_count == 0 {
+        if !self.mediation_active && self.event_count == 0 {
             return None;
         }
         Some(CommandPolicySummary {
+            mediation_active: self.mediation_active,
             event_count: self.event_count,
             invocation_count: self.invocation_count,
             commands: self.commands.into_values().collect(),
@@ -1832,6 +1855,84 @@ mod tests {
     }
 
     #[test]
+    fn mediation_active_is_summarized_without_any_invocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        recorder
+            .record_session_started("2026-04-21T00:00:00Z".to_string(), vec!["pwd".to_string()])
+            .unwrap();
+        recorder
+            .record_sandbox_runtime_event(SandboxRuntimeAuditEvent {
+                timestamp: "2026-04-21T00:00:00Z".to_string(),
+                platform: "linux".to_string(),
+                landlock_abi: Some("v5".to_string()),
+                landlock_execute_enforced: Some(true),
+                tool_sandbox_active: true,
+            })
+            .unwrap();
+
+        let summary = recorder.command_policy_summary().unwrap();
+        assert!(summary.mediation_active);
+        assert_eq!(summary.event_count, 0);
+        assert!(summary.commands.is_empty());
+    }
+
+    #[test]
+    fn a_session_without_mediation_has_no_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        recorder
+            .record_session_started("2026-04-21T00:00:00Z".to_string(), vec!["pwd".to_string()])
+            .unwrap();
+        recorder
+            .record_sandbox_runtime_event(SandboxRuntimeAuditEvent {
+                timestamp: "2026-04-21T00:00:00Z".to_string(),
+                platform: "linux".to_string(),
+                landlock_abi: Some("v5".to_string()),
+                landlock_execute_enforced: Some(true),
+                tool_sandbox_active: false,
+            })
+            .unwrap();
+
+        assert!(recorder.command_policy_summary().is_none());
+    }
+
+    /// A failed append refuses one command but leaves the session running to
+    /// finalize, and `session.json` presents its rollup as a digest-covered
+    /// claim about the log. Counting an event the log never received would
+    /// make that claim unverifiable against a refold of the log.
+    #[test]
+    fn an_append_failure_is_left_out_of_the_rollup() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        // A read-only handle to the same log fails every write without
+        // disturbing the rest of the recorder's state.
+        recorder.file = File::open(dir.path().join(AUDIT_EVENTS_FILENAME)).unwrap();
+
+        assert!(
+            recorder
+                .record_sandbox_runtime_event(SandboxRuntimeAuditEvent {
+                    timestamp: "2026-04-21T00:00:00Z".to_string(),
+                    platform: "linux".to_string(),
+                    landlock_abi: Some("v5".to_string()),
+                    landlock_execute_enforced: Some(true),
+                    tool_sandbox_active: true,
+                })
+                .is_err()
+        );
+        assert!(
+            recorder
+                .record_command_policy_event(
+                    command_policy_event("gh", "allowed"),
+                    CommandPolicyOutcome::Allowed,
+                )
+                .is_err()
+        );
+
+        assert!(recorder.command_policy_summary().is_none());
+    }
+
+    #[test]
     fn summary_bounds_distinct_commands() {
         let mut builder = CommandPolicySummaryBuilder::new();
         let overflow = COMMAND_POLICY_SUMMARY_MAX_COMMANDS.saturating_add(10);
@@ -1857,6 +1958,7 @@ mod tests {
 
         let mut with_summary = baseline.clone();
         with_summary.command_policy_summary = Some(CommandPolicySummary {
+            mediation_active: true,
             event_count: 2,
             invocation_count: 1,
             commands: vec![CommandPolicyCommandSummary {

--- a/crates/nono/src/audit.rs
+++ b/crates/nono/src/audit.rs
@@ -8,12 +8,15 @@
 use crate::supervisor::{AuditEntry, UrlOpenRequest};
 use crate::trust;
 use crate::undo::{
-    AuditAttestationSummary, AuditIntegritySummary, ContentHash, NetworkAuditEvent, SessionMetadata,
+    AuditAttestationSummary, AuditIntegritySummary, COMMAND_POLICY_SUMMARY_MAX_COMMANDS,
+    CommandPolicyCommandSummary, CommandPolicyOutcome, CommandPolicySummary, ContentHash,
+    NetworkAuditEvent, SessionMetadata,
 };
 use crate::{NonoError, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sigstore_verify::types::bundle::SignatureContent;
+use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 #[cfg(unix)]
@@ -262,6 +265,10 @@ struct SessionDigestPayload<'a> {
     audit_event_count: u64,
     audit_integrity: &'a Option<AuditIntegritySummary>,
     audit_attestation: &'a Option<AuditAttestationSummary>,
+    // Skipped when absent so that sessions written before the summary existed
+    // still hash to the digest they were committed to the ledger under.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command_policy_summary: &'a Option<CommandPolicySummary>,
 }
 
 #[derive(Serialize)]
@@ -405,6 +412,7 @@ pub struct AuditRecorder {
     previous_chain: Option<ContentHash>,
     leaf_hashes: Vec<ContentHash>,
     redaction_policy: crate::ScrubPolicy,
+    command_policy_summary: CommandPolicySummaryBuilder,
 }
 
 impl AuditRecorder {
@@ -435,6 +443,7 @@ impl AuditRecorder {
             previous_chain: None,
             leaf_hashes: Vec::new(),
             redaction_policy,
+            command_policy_summary: CommandPolicySummaryBuilder::new(),
         })
     }
 
@@ -488,11 +497,25 @@ impl AuditRecorder {
     }
 
     /// Record a tool sandbox command policy decision.
+    ///
+    /// `outcome` is how the event's `decision` folds into the session rollup;
+    /// the caller owns that vocabulary and so owns the classification.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    pub fn record_command_policy_event(&mut self, event: CommandPolicyAuditEvent) -> Result<()> {
+    pub fn record_command_policy_event(
+        &mut self,
+        event: CommandPolicyAuditEvent,
+        outcome: CommandPolicyOutcome,
+    ) -> Result<()> {
+        self.command_policy_summary.observe(&event, outcome);
         self.append_event(AuditEventPayload::CommandPolicy {
             event: Box::new(event),
         })
+    }
+
+    /// Rollup of the command policy events recorded so far.
+    #[must_use]
+    pub fn command_policy_summary(&self) -> Option<CommandPolicySummary> {
+        self.command_policy_summary.clone().finish()
     }
 
     /// Number of events appended by this recorder.
@@ -542,6 +565,77 @@ impl AuditRecorder {
         self.previous_chain = Some(chain_hash);
         self.leaf_hashes.push(leaf_hash);
         Ok(())
+    }
+}
+
+/// Running rollup of command policy events, folded one event at a time.
+///
+/// Memory is bounded by the number of distinct mediated commands rather than by
+/// the number of events, so an endlessly mediating session stays fixed-size.
+#[derive(Debug, Default, Clone)]
+pub struct CommandPolicySummaryBuilder {
+    event_count: u64,
+    invocation_count: u64,
+    commands: BTreeMap<String, CommandPolicyCommandSummary>,
+    truncated: bool,
+}
+
+impl CommandPolicySummaryBuilder {
+    /// Create an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one command policy event into the rollup.
+    ///
+    /// The caller classifies: the `decision` vocabulary is authored by whoever
+    /// writes the events, so only they can say which strings are terminal.
+    pub fn observe(&mut self, event: &CommandPolicyAuditEvent, outcome: CommandPolicyOutcome) {
+        self.event_count = self.event_count.saturating_add(1);
+
+        if outcome == CommandPolicyOutcome::Pending {
+            return;
+        }
+        self.invocation_count = self.invocation_count.saturating_add(1);
+
+        let entry = match self.commands.get_mut(&event.command) {
+            Some(entry) => entry,
+            None => {
+                if self.commands.len() >= COMMAND_POLICY_SUMMARY_MAX_COMMANDS {
+                    self.truncated = true;
+                    return;
+                }
+                self.commands
+                    .entry(event.command.clone())
+                    .or_insert(CommandPolicyCommandSummary {
+                        command: event.command.clone(),
+                        allowed: 0,
+                        denied: 0,
+                        other: 0,
+                    })
+            }
+        };
+        match outcome {
+            CommandPolicyOutcome::Allowed => entry.allowed = entry.allowed.saturating_add(1),
+            CommandPolicyOutcome::Denied => entry.denied = entry.denied.saturating_add(1),
+            CommandPolicyOutcome::Other => entry.other = entry.other.saturating_add(1),
+            CommandPolicyOutcome::Pending => {}
+        }
+    }
+
+    /// Finish the rollup, or `None` when no command policy events were observed.
+    #[must_use]
+    pub fn finish(self) -> Option<CommandPolicySummary> {
+        if self.event_count == 0 {
+            return None;
+        }
+        Some(CommandPolicySummary {
+            event_count: self.event_count,
+            invocation_count: self.invocation_count,
+            commands: self.commands.into_values().collect(),
+            truncated: self.truncated,
+        })
     }
 }
 
@@ -737,6 +831,7 @@ pub fn canonical_session_digest_payload(metadata: &SessionMetadata) -> Result<Ve
         audit_event_count: metadata.audit_event_count,
         audit_integrity: &metadata.audit_integrity,
         audit_attestation: &metadata.audit_attestation,
+        command_policy_summary: &metadata.command_policy_summary,
     };
     serde_json::to_vec(&payload).map_err(|e| {
         NonoError::Snapshot(format!("Failed to serialize session digest payload: {e}"))
@@ -1675,6 +1770,117 @@ mod tests {
         assert!(!verify_inclusion_proof(&proof));
     }
 
+    fn command_policy_event(command: &str, decision: &str) -> CommandPolicyAuditEvent {
+        CommandPolicyAuditEvent {
+            timestamp: "2026-04-21T00:00:00Z".to_string(),
+            session_id: Some("sess-1".to_string()),
+            command: command.to_string(),
+            caller: "session".to_string(),
+            caller_kind: Some("session".to_string()),
+            caller_command: None,
+            caller_pid: Some(41),
+            shim_pid: Some(42),
+            session_root_pid: Some(41),
+            decision: decision.to_string(),
+            reason: None,
+            stdio_mode: "direct_fds".to_string(),
+            argv_hash: "argv-hash".to_string(),
+            env_name_hash: "env-hash".to_string(),
+            cwd_hash: "cwd-hash".to_string(),
+            argv_display: vec![command.to_string()],
+            env_names_display: Vec::new(),
+            env_display: Vec::new(),
+            cwd_display: "/work".to_string(),
+            exit_code: None,
+            stdio: None,
+        }
+    }
+
+    #[test]
+    fn summary_counts_one_invocation_per_terminal_decision() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut recorder = AuditRecorder::new(dir.path().to_path_buf()).unwrap();
+        // One invocation passes the gate and runs; a second is refused at it.
+        // Three events, two invocations.
+        recorder
+            .record_command_policy_event(
+                command_policy_event("gh", "invocation_allowed"),
+                CommandPolicyOutcome::Pending,
+            )
+            .unwrap();
+        recorder
+            .record_command_policy_event(
+                command_policy_event("gh", "allowed"),
+                CommandPolicyOutcome::Allowed,
+            )
+            .unwrap();
+        recorder
+            .record_command_policy_event(
+                command_policy_event("gh", "invocation_denied"),
+                CommandPolicyOutcome::Denied,
+            )
+            .unwrap();
+
+        let summary = recorder.command_policy_summary().unwrap();
+        assert_eq!(summary.event_count, 3);
+        assert_eq!(summary.invocation_count, 2);
+        assert_eq!(summary.commands.len(), 1);
+        assert_eq!(summary.commands[0].command, "gh");
+        assert_eq!(summary.commands[0].allowed, 1);
+        assert_eq!(summary.commands[0].denied, 1);
+        assert_eq!(summary.commands[0].other, 0);
+    }
+
+    #[test]
+    fn summary_bounds_distinct_commands() {
+        let mut builder = CommandPolicySummaryBuilder::new();
+        let overflow = COMMAND_POLICY_SUMMARY_MAX_COMMANDS.saturating_add(10);
+        for index in 0..overflow {
+            builder.observe(
+                &command_policy_event(&format!("cmd-{index:04}"), "denied"),
+                CommandPolicyOutcome::Denied,
+            );
+        }
+        let summary = builder.finish().unwrap();
+
+        assert_eq!(summary.commands.len(), COMMAND_POLICY_SUMMARY_MAX_COMMANDS);
+        assert_eq!(summary.event_count, overflow as u64);
+        // Totals stay honest even for commands dropped from the rollup.
+        assert_eq!(summary.invocation_count, overflow as u64);
+        assert!(summary.truncated);
+    }
+
+    #[test]
+    fn session_digest_covers_the_command_policy_summary() {
+        let baseline = sample_metadata("20260421-200000-11111");
+        let baseline_digest = compute_session_digest(&baseline).unwrap();
+
+        let mut with_summary = baseline.clone();
+        with_summary.command_policy_summary = Some(CommandPolicySummary {
+            event_count: 2,
+            invocation_count: 1,
+            commands: vec![CommandPolicyCommandSummary {
+                command: "gh".to_string(),
+                allowed: 0,
+                denied: 1,
+                other: 0,
+            }],
+            truncated: false,
+        });
+        let with_summary_digest = compute_session_digest(&with_summary).unwrap();
+        assert_ne!(baseline_digest, with_summary_digest);
+
+        let mut tampered = with_summary.clone();
+        if let Some(summary) = tampered.command_policy_summary.as_mut() {
+            summary.commands[0].denied = 0;
+            summary.commands[0].allowed = 1;
+        }
+        assert_ne!(
+            compute_session_digest(&tampered).unwrap(),
+            with_summary_digest
+        );
+    }
+
     fn sample_metadata(id: &str) -> SessionMetadata {
         SessionMetadata {
             session_id: id.to_string(),
@@ -1690,6 +1896,7 @@ mod tests {
             audit_event_count: 2,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         }
     }
 
@@ -1795,6 +2002,7 @@ mod tests {
                 merkle_root: ContentHash::from_bytes([3; 32]),
             }),
             audit_attestation: None,
+            command_policy_summary: None,
         };
         let base_digest = compute_session_digest(&base).unwrap();
 
@@ -1912,6 +2120,28 @@ mod tests {
         assert_eq!(
             compute_session_digest(&meta).unwrap().to_string(),
             "3a1ed53d426d6ea2544cec6cf6b95ccdc31fda4570d86931239ee0f7d7d39012"
+        );
+
+        // A summary is skipped when absent, so the vector above pins only the
+        // encoding every session written before the field existed still hashes
+        // under. Without this second vector a port could omit the field
+        // entirely and match on every pre-existing session.
+        let mut mediated = sample_metadata("20260421-200000-11111");
+        mediated.command_policy_summary = Some(CommandPolicySummary {
+            mediation_active: true,
+            event_count: 3,
+            invocation_count: 2,
+            commands: vec![CommandPolicyCommandSummary {
+                command: "gh".to_string(),
+                allowed: 1,
+                denied: 1,
+                other: 0,
+            }],
+            truncated: false,
+        });
+        assert_eq!(
+            compute_session_digest(&mediated).unwrap().to_string(),
+            "20ed86fc30467af40a12f1b9d70b77f1bf3b11f24bcf7cf1fed094fe84f01b37"
         );
 
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -157,6 +157,15 @@ pub enum NonoError {
     #[error("Failed to parse audit ledger line {line}: {reason}")]
     AuditLedgerCorrupt { line: usize, reason: String },
 
+    /// A session directory resolved outside the audit root that named it.
+    ///
+    /// Separate from [`Self::SessionNotFound`] because a caller that only sees
+    /// "no directory" cannot tell a session `audit cleanup` removed from one a
+    /// symlink points outside the audit roots, and reporting a containment
+    /// failure as an ordinary absence hides it.
+    #[error("Audit session {session_id} resolves outside audit root {root}")]
+    AuditSessionOutsideRoot { session_id: String, root: String },
+
     // Trust/attestation errors
     #[error("Trust verification failed for {path}: {reason}")]
     TrustVerification { path: String, reason: String },
@@ -227,6 +236,7 @@ impl NonoError {
             | Self::TrustPolicy(_)
             | Self::BlocklistBlocked { .. }
             | Self::InstructionFileDenied { .. }
+            | Self::AuditSessionOutsideRoot { .. }
             | Self::PackageVerification { .. } => NonoDiagnosticCode::TrustVerificationFailed,
             Self::Snapshot(msg) | Self::ObjectStore(msg) if msg.contains("budget exceeded") => {
                 NonoDiagnosticCode::RollbackBudgetExceeded

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -1581,6 +1581,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
 
         manager.save_session_metadata(&meta).expect("save metadata");
@@ -1640,6 +1641,7 @@ mod tests {
             audit_event_count: 0,
             audit_integrity: None,
             audit_attestation: None,
+            command_policy_summary: None,
         };
         manager.save_session_metadata(&meta).expect("save");
 

--- a/crates/nono/src/undo/types.rs
+++ b/crates/nono/src/undo/types.rs
@@ -454,6 +454,12 @@ pub struct CommandPolicyCommandSummary {
 /// invocation gate and then runs contributes exactly one `allowed`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandPolicySummary {
+    /// Whether command mediation was configured for the session.
+    ///
+    /// Derived from the sandbox runtime audit event. Sessions recorded before
+    /// macOS emitted that event can report `false` despite having mediated.
+    #[serde(default)]
+    pub mediation_active: bool,
     /// Every command policy event, including non-terminal lifecycle stages.
     pub event_count: u64,
     /// Terminal decisions across all commands.

--- a/crates/nono/src/undo/types.rs
+++ b/crates/nono/src/undo/types.rs
@@ -410,6 +410,60 @@ pub struct AuditIntegritySummary {
     pub merkle_root: ContentHash,
 }
 
+/// Maximum distinct mediated command names retained in a command policy summary.
+///
+/// Command names come from profile configuration rather than from the sandboxed
+/// process, but the bound keeps a pathological profile from growing
+/// `session.json` without limit. Commands past it are counted in the totals
+/// only, and set `truncated`.
+pub const COMMAND_POLICY_SUMMARY_MAX_COMMANDS: usize = 256;
+
+/// Terminal classification of a command policy decision.
+///
+/// An event's `decision` is an open, platform-defined vocabulary mixing
+/// lifecycle stages with terminal outcomes. This closed classification is never
+/// persisted, so `decision` stays the event schema's single source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandPolicyOutcome {
+    /// The mediated command was permitted to run.
+    Allowed,
+    /// The mediated command was refused.
+    Denied,
+    /// A non-terminal lifecycle stage; a later event carries the outcome.
+    Pending,
+    /// A decision outside the classifier's vocabulary.
+    Other,
+}
+
+/// Per-command rollup of mediated command policy decisions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandPolicyCommandSummary {
+    /// Mediated command name.
+    pub command: String,
+    /// Invocations permitted to run.
+    pub allowed: u64,
+    /// Invocations refused.
+    pub denied: u64,
+    /// Invocations with a terminal decision the classifier did not recognize.
+    pub other: u64,
+}
+
+/// Denormalized rollup of the command policy events in a session's audit log.
+///
+/// Only terminal decisions are counted, so an invocation that passes an
+/// invocation gate and then runs contributes exactly one `allowed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandPolicySummary {
+    /// Every command policy event, including non-terminal lifecycle stages.
+    pub event_count: u64,
+    /// Terminal decisions across all commands.
+    pub invocation_count: u64,
+    /// Per-command rollup, ordered by command name.
+    pub commands: Vec<CommandPolicyCommandSummary>,
+    /// Whether distinct commands exceeded [`COMMAND_POLICY_SUMMARY_MAX_COMMANDS`].
+    pub truncated: bool,
+}
+
 /// Signed attestation metadata for an audit session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditAttestationSummary {
@@ -466,6 +520,12 @@ pub struct SessionMetadata {
     /// Optional keyed signature over the audit Merkle root and session context
     #[serde(default)]
     pub audit_attestation: Option<AuditAttestationSummary>,
+    /// Optional rollup of command policy events, denormalized for session listing.
+    ///
+    /// Omitted rather than emitted as null so that metadata written before the
+    /// field existed keeps its session digest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command_policy_summary: Option<CommandPolicySummary>,
 }
 
 /// A snapshot manifest capturing filesystem state at a point in time

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -49,6 +49,7 @@ Each session records:
 | **Merkle roots** | Filesystem-state commitments (when `--audit-integrity` or `--rollback` is active) |
 | **Snapshots** | Content-addressable rollback metadata (when `--rollback` is active) |
 | **Audit integrity summary** | Hash-chain head and Merkle root for the audit event stream unless disabled with `--no-audit-integrity` |
+| **Command policy summary** | Per-command rollup of allowed and denied [Sandboxed Tool Execution](/cli/features/tool-sandbox) decisions (when the profile mediates commands) |
 
 ## Modes
 
@@ -328,7 +329,7 @@ Audit, audit integrity, and rollback are separate layers that share the same ses
 | Default | Always on | Event-log integrity on by default; filesystem hashing opt-in via `--audit-integrity` | Opt-in (`--rollback`) |
 | Opt-out | `--no-audit` | `--no-audit-integrity` disables event-log integrity | `--no-rollback` |
 | Purpose | Record what happened | Detect tampering in the recorded audit log and optionally commit filesystem state | Restore filesystem state |
-| Data | Command, timestamps, exit code, audit events, network events, tracked paths, optional audit attestation | Event count, chain head, Merkle root, optional filesystem Merkle roots | Full file content snapshots + Merkle roots |
+| Data | Command, timestamps, exit code, audit events, network events, tracked paths, command policy summary, optional audit attestation | Event count, chain head, Merkle root, optional filesystem Merkle roots | Full file content snapshots + Merkle roots |
 | Commands | `nono audit list/show/verify/cleanup` | `nono audit show/verify` | `nono rollback list/show/restore/verify/cleanup` |
 
 When rollback is active, it enriches the audit record with snapshots and restore metadata. When filesystem audit integrity is active, `nono audit show` also includes tracked paths and filesystem Merkle roots.
@@ -341,6 +342,8 @@ The audit trail is intentionally narrow in what it claims to prove.
 - The default integrity structure protects the audit event stream for a single session and also records that session into the global audit ledger.
 - Recording into the global ledger can fail after the command has already exited (for example when the ledger file no longer parses, or the audit directory is unwritable). The session's own directory is still written, but the ledger has no entry for that run, so `nono audit verify` reports it as missing from the chain. The failure is printed on stderr and the run's exit status is downgraded to `1` if the command itself succeeded; a command that failed keeps its own exit status, so a non-zero status is not by itself proof that the run was recorded.
 - A ledger that no longer parses stops every later run from being recorded, and there is no repair command. Moving the file aside starts a fresh chain, after which `nono audit verify` no longer finds the sessions the old one held.
+- The command policy rollup in `session.json` is a convenience view for listing sessions, not an independent record. It is covered by the session digest committed to the ledger, so editing it fails `nono audit verify`; `nono audit show` remains the per-decision record.
+- That rollup names a bounded number of distinct commands. A session that mediates more than the bound drops the per-command counts for the overflow and sets `truncated`; the session totals stay correct and every decision is still in the event log.
 - `--audit-sign-key` adds a keyed supervisor-side signature over the session audit Merkle root and session context, but that still depends on trusting the configured signing key and how its public key is distributed.
 - Without an external timestamp, transparency log, or other anchor, this remains host-local attestation material rather than a globally witnessed timestamped proof.
 - For supervised runs, the supervisor hashes the main executable binary selected for launch and records its canonical path and SHA-256 digest.

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -99,6 +99,8 @@ Every audited session writes an append-only `audit-events.ndjson` file. In plain
 | **Session** | One audited `nono run` |
 | **Audit event** | One recorded fact within that session, such as `session_started`, `session_ended`, a capability decision, or a supervisor-observed URL-open event |
 | **Filesystem-state hashing** | Walking the tracked writable paths and hashing the files under them to commit their state before and after the run |
+| **Command policy event** | One mediated tool decision recorded by the Capability Broker, carrying the `decision` string that names the lifecycle stage or terminal result |
+| **Invocation** | One mediated tool decision that reached a terminal outcome. An invocation that clears an invocation gate and then runs records two events but counts once |
 
 ## Integrity Flow
 

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -214,6 +214,9 @@ nono audit list --path ~/dev/my-project
 # Show only the 10 most recent
 nono audit list --recent 10
 
+# Hide the per-session mediated tool summary
+nono audit list --no-tools
+
 # Machine-readable output
 nono audit list --json
 ```
@@ -225,6 +228,7 @@ nono 14 command(s)
 
   ~/dev/sprockets (11 commands)
     20260219-092017-8117  just now  completed  claude
+      tools: gh (3 allowed, 1 denied), git (12 allowed)
     20260219-091403-90291  5m ago  completed  claude
     20260218-134433-28210  1d ago  completed  claude
     ...
@@ -241,6 +245,21 @@ Filters can be combined:
 # Claude sessions from last week that touched the project directory
 nono audit list --command claude --path ~/project --since 2026-02-10
 ```
+
+#### Mediated Tool Summary
+
+Sessions that ran under a profile with [Sandboxed Tool Execution](/cli/features/tool-sandbox) get a second `tools:` line naming each mediated command with its allowed and denied counts. Sessions that mediated no command print nothing extra, and `--no-tools` suppresses the line entirely.
+
+The line is read from the rollup stored in `session.json`, never from the event log, so listing stays fast no matter how many events a session recorded. A few renderings are worth recognizing:
+
+| Rendering | Meaning |
+|---|---|
+| `N event(s), no completed invocations` | Command policy events were recorded but none reached a terminal decision, which is what a session killed mid-invocation looks like |
+| `N unclassified` | A terminal decision nono could not classify as allowed or denied. Read the event itself with `nono audit show` |
+| `+N more` | More distinct commands were mediated than the list line names. The full per-command rollup is still in `nono audit list --json` |
+| `rollup truncated` | The stored rollup itself dropped commands past its bound, so per-command counts for them are not recoverable from session metadata. The session totals still include them |
+
+`--no-tools` only affects the human-readable listing. `--json` always carries the same data per session as `tool_sandbox_active` and the full `command_policy_summary` object, and `nono audit show --json` reports the underlying `command_policy_events`, one entry per mediated decision.
 
 ### `nono audit show`
 
@@ -284,6 +303,8 @@ When an attestation is present, verification checks:
 - the attested Merkle root against the session's stored audit integrity summary
 - the session id bound into the attestation predicate
 - the provided public key, if `--public-key-file` is supplied
+
+The command policy rollup shown by `nono audit list` is covered by the session digest committed to the ledger, so editing `session.json` to hide a denial changes the digest and fails verification. The rollup is a view over events that remain individually recorded and hash-chained; `nono audit show` is where an operator confirms what the rollup summarizes.
 
 ## Use Cases
 

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -248,18 +248,32 @@ nono audit list --command claude --path ~/project --since 2026-02-10
 
 #### Mediated Tool Summary
 
-Sessions that ran under a profile with [Sandboxed Tool Execution](/cli/features/tool-sandbox) get a second `tools:` line naming each mediated command with its allowed and denied counts. Sessions that mediated no command print nothing extra, and `--no-tools` suppresses the line entirely.
+Sessions that ran under a profile with [Sandboxed Tool Execution](/cli/features/tool-sandbox) get a second `tools:` line naming each mediated command with its allowed and denied counts. Sessions that ran without mediation print nothing extra, and `--no-tools` suppresses the line entirely.
 
 The line is read from the rollup stored in `session.json`, never from the event log, so listing stays fast no matter how many events a session recorded. A few renderings are worth recognizing:
 
 | Rendering | Meaning |
 |---|---|
+| `active, no invocations` | Mediation was configured and no mediated command was ever invoked. Distinct from a session that ran without mediation at all, which prints no `tools:` line |
 | `N event(s), no completed invocations` | Command policy events were recorded but none reached a terminal decision, which is what a session killed mid-invocation looks like |
 | `N unclassified` | A terminal decision nono could not classify as allowed or denied. Read the event itself with `nono audit show` |
 | `+N more` | More distinct commands were mediated than the list line names. The full per-command rollup is still in `nono audit list --json` |
 | `rollup truncated` | The stored rollup itself dropped commands past its bound, so per-command counts for them are not recoverable from session metadata. The session totals still include them |
 
 `--no-tools` only affects the human-readable listing. `--json` always carries the same data per session as `tool_sandbox_active` and the full `command_policy_summary` object, and `nono audit show --json` reports the underlying `command_policy_events`, one entry per mediated decision.
+
+Those two fields answer different questions, so read them apart:
+
+| Field | True when |
+|---|---|
+| `tool_sandbox_active` | The session has a rollup at all: mediation was configured, or a mediated command was invoked. Equivalent to `command_policy_summary != null` |
+| `command_policy_summary.mediation_active` | Mediation was configured, read from the sandbox runtime audit event. Sessions recorded before macOS emitted that event can report `false` despite having mediated commands |
+
+A session only writes `session.json` when it finalizes, so `nono audit list` and `nono audit show` cover finished sessions. For a session that is still running, [`nono inspect`](/cli/features/session-lifecycle#mediated-tools-while-the-session-runs) reports the same rollup recomputed from the event log.
+
+<Note>
+  Whether mediation was configured is read from the sandbox runtime audit event. Sessions recorded by older nono versions (before macOS emitted that event) that configured mediation but never invoked a mediated command print no `tools:` line, the same as a session that ran without mediation.
+</Note>
 
 ### `nono audit show`
 

--- a/docs/cli/features/session-lifecycle.mdx
+++ b/docs/cli/features/session-lifecycle.mdx
@@ -178,12 +178,25 @@ It includes:
 - workdir
 - network mode
 - rollback session id, when present
+- mediated tool decisions so far, when the profile mediates commands
 
 For scripts and tooling:
 
 ```bash
 nono inspect a3f7c2 --json
 ```
+
+### Mediated Tools While the Session Runs
+
+Sessions running under [Sandboxed Tool Execution](/cli/features/tool-sandbox) report their allowed and denied counts as they accumulate:
+
+```
+Tools:      gh (3 allowed, 1 denied), git (12 allowed) [live]
+```
+
+The rollup is recomputed from the session's audit event log, which the supervisor appends and flushes on every mediated decision. `[live]` marks a session that can still mediate more commands, so the counts are not final; it is absent once the session has exited. If the log ends mid-record, the line says so and the counts trail the session by that record. Once a session has finalized, `nono inspect` reports the digest-covered rollup stored in `session.json` instead; the event log is refolded for an exited session only when it died before finalizing, where a mid-record tail marks the counts as trailing the kill.
+
+`nono audit list` reports the same rollup from `session.json`, which a session only writes when it finalizes — so `nono inspect` is where a running session's decisions are visible. In `--json`, the same data is `command_policy_summary`, with `command_policy_summary_live` marking a session that can still mediate.
 
 ## Pruning Old Session Records
 

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -684,6 +684,12 @@ results, such as `invocation_allowed` for clearing an invocation gate and
 grows, and a decision an older nono does not recognize is summarized as
 unclassified rather than counted as allowed or denied.
 
+The broker also folds these events into a per-command rollup stored in the
+session's `session.json`, so listing sessions never has to parse event logs. The
+rollup classifies each `decision` as allowed, denied, or unclassifiable, and
+counts only terminal ones, so a command that clears an invocation gate and then
+runs records two events but counts as one allowed invocation.
+
 ## Direct Exec Bypass
 
 Policy-controlled commands are meant to be reached through shims. A direct path like `/usr/bin/ssh` is denied unless explicitly configured:

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -690,6 +690,27 @@ rollup classifies each `decision` as allowed, denied, or unclassifiable, and
 counts only terminal ones, so a command that clears an invocation gate and then
 runs records two events but counts as one allowed invocation.
 
+`nono audit list` names the mediated commands per session, and `nono audit show`
+still carries every individual decision:
+
+```bash
+# Which tools did recent sessions mediate, and what was denied?
+nono audit list --recent 10
+
+# Every mediated decision for one session, with reasons and stdio counts
+nono audit show <session-id> --json
+```
+
+```
+20260219-092017-8117  just now  completed  claude
+  tools: gh (3 allowed, 1 denied), git (12 allowed)
+```
+
+The rollup is covered by the session digest committed to the ledger, so a denial
+edited out of `session.json` fails `nono audit verify`. See
+[Audit Trail](/cli/features/audit#mediated-tool-summary) for the rollup's bounds
+and how it renders.
+
 ## Direct Exec Bypass
 
 Policy-controlled commands are meant to be reached through shims. A direct path like `/usr/bin/ssh` is denied unless explicitly configured:

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -674,6 +674,16 @@ is active:
 }
 ```
 
+## Audit Record
+
+Every command-policy decision is recorded as an audit event by the broker, not by
+the mediated tool. Each event records what the broker decided as a `decision`
+string drawn from a closed vocabulary that mixes lifecycle stages with terminal
+results, such as `invocation_allowed` for clearing an invocation gate and
+`allowed`, `denied`, or `capture` for a terminal result. The vocabulary only ever
+grows, and a decision an older nono does not recognize is summarized as
+unclassified rather than counted as allowed or denied.
+
 ## Direct Exec Bypass
 
 Policy-controlled commands are meant to be reached through shims. A direct path like `/usr/bin/ssh` is denied unless explicitly configured:

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -699,6 +699,9 @@ nono audit list --recent 10
 
 # Every mediated decision for one session, with reasons and stdio counts
 nono audit show <session-id> --json
+
+# What has a session mediated so far, while it is still running
+nono inspect <session-id>
 ```
 
 ```
@@ -710,6 +713,11 @@ The rollup is covered by the session digest committed to the ledger, so a denial
 edited out of `session.json` fails `nono audit verify`. See
 [Audit Trail](/cli/features/audit#mediated-tool-summary) for the rollup's bounds
 and how it renders.
+
+A session writes `session.json` only when it finalizes. While it is still
+running, `nono inspect` reports the same rollup recomputed from the event log,
+marked `[live]` because the session can still mediate more commands. See
+[Session Lifecycle](/cli/features/session-lifecycle#mediated-tools-while-the-session-runs).
 
 ## Direct Exec Bypass
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -287,6 +287,7 @@ The audit subsystem has a narrower security claim than the sandbox itself.
 - The keyed audit attestation is only as strong as the signing key distribution model. If the verifier does not pin the expected public key, a rewritten session could also rewrite the embedded public key and remain self-consistent.
 - `nono audit verify --public-key-file <FILE>` is the path that pins verification to an expected signer key. Without that, attestation verification checks the keyed signature against the public key recorded in session metadata.
 - Filesystem Merkle roots under `--audit-integrity` or `--rollback` commit tracked writable paths, not the full machine state.
+- Session metadata carries a denormalized rollup of Tool Sandbox command-policy decisions so that session listings do not have to parse event logs. That rollup is derived data, not a second record: it is covered by the session digest committed to the ledger, so editing it fails `nono audit verify`, but it is not independently recomputed from the events during verification. A rollup read without verifying is only as trustworthy as the file it came from, and `nono audit show` is the authoritative per-decision record.
 
 The correct way to read the feature today is:
 


### PR DESCRIPTION
## Linked Issue

Closes #1574

## Summary
Records a per-session rollup of tool sandbox command-policy decisions, surfaced in `nono audit list`, `nono audit show --json` and `nono inspect`.

## Test Plan
Run steps manually:

```
S=$(mktemp -d)
mkdir -p "$S/config/nono/profiles" "$S/ws"
printf 'public data\n' > "$S/ws/allowed.txt"
printf 'top secret\n'  > "$S/ws/secret.txt"
cat > "$S/config/nono/profiles/toolsum.json" <<EOF
{
  "meta": { "name": "toolsum" },
  "filesystem": { "allow": ["$S/ws"] },
  "network": { "block": true },
  "command_policies": { "commands": { "cat": {
    "executable": "/bin/cat",
    "from": { "session": {
      "sandbox": { "fs_read": ["$S/ws"] },
      "invocation_policy": {
        "default": "allow",
        "deny": [{ "argv": { "contains": ["secret.txt"] }, "reason": "secrets are not readable" }]
      }
    }}
  }}}
}
EOF

export XDG_CONFIG_HOME="$S/config"
export XDG_STATE_HOME="$HOME/.nono-repro/state"
N=./target/debug/nono

$N run --profile toolsum --no-rollback --workdir "$S/ws" -- \
  sh -c 'cat allowed.txt; cat secret.txt'
$N audit list        # tools: cat (1 allowed, 1 denied)
$N audit list --no-tools    # line suppressed
```



## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
