### PR TITLE
fix(fs): validate unix socket nodes and normalize landlock

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -98,7 +98,9 @@ pub(crate) fn map_error(e: &nono::NonoError) -> types::NonoErrorCode {
     match e {
         nono::NonoError::PathNotFound(_) => NonoErrorCode::ErrPathNotFound,
         nono::NonoError::ExpectedDirectory(_) => NonoErrorCode::ErrExpectedDirectory,
-        nono::NonoError::ExpectedFile(_) => NonoErrorCode::ErrExpectedFile,
+        nono::NonoError::ExpectedFile(_) | nono::NonoError::ExpectedUnixSocket(_) => {
+            NonoErrorCode::ErrExpectedFile
+        }
         nono::NonoError::PathCanonicalization { .. } => NonoErrorCode::ErrPathCanonicalization,
         nono::NonoError::NoCapabilities | nono::NonoError::NoCommand => {
             NonoErrorCode::ErrNoCapabilities

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -2977,7 +2977,7 @@ mod tests {
     fn test_allow_unix_socket_adds_cap_and_implied_read_fs_grant() {
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("a.sock");
-        std::fs::write(&sock, b"").expect("create socket stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
 
         let args = SandboxArgs {
             allow_unix_socket: vec![sock.clone()],
@@ -3000,6 +3000,23 @@ mod tests {
             .collect();
         assert_eq!(fs_matches.len(), 1);
         assert_eq!(fs_matches[0].access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_rejects_existing_non_socket() {
+        let dir = tempdir().expect("tempdir");
+        let regular = dir.path().join("not-a-socket");
+        std::fs::write(&regular, b"data").expect("create regular file");
+        let args = SandboxArgs {
+            allow_unix_socket: vec![regular.clone()],
+            ..sandbox_args()
+        };
+
+        let error = from_args_locked(&args).expect_err("regular file must not be a socket grant");
+        assert!(
+            matches!(error, NonoError::ExpectedUnixSocket(ref path) if path == &regular),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -3095,7 +3112,7 @@ mod tests {
     fn test_allow_unix_socket_bind_existing_grants_readwrite_fs() {
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("b.sock");
-        std::fs::write(&sock, b"").expect("create socket stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
 
         let args = SandboxArgs {
             allow_unix_socket_bind: vec![sock.clone()],
@@ -3241,7 +3258,7 @@ mod tests {
     fn test_profile_unix_socket_field_connect_file() {
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("a.sock");
-        std::fs::write(&sock, b"").expect("create socket stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
         let profile = profile_with_fs_field("unix_socket", &sock.display().to_string());
 
         let (caps, _) =
@@ -3261,7 +3278,7 @@ mod tests {
     fn test_profile_unix_socket_field_connect_bind_file() {
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("b.sock");
-        std::fs::write(&sock, b"").expect("create socket stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
         let profile = profile_with_fs_field("unix_socket_bind", &sock.display().to_string());
 
         let (caps, _) =

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -1420,7 +1420,7 @@ mod tests {
         // test output. Dry-run-style `verbose=1` path is also exercised.
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("a.sock");
-        std::fs::write(&sock, b"").expect("create socket stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
 
         let caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -5548,9 +5548,11 @@ mod tests {
                     source,
                 })?;
         let socket_path = temp.path().join("url.sock");
-        std::fs::File::create(&socket_path).map_err(|source| NonoError::ConfigRead {
-            path: socket_path.clone(),
-            source,
+        std::os::unix::net::UnixListener::bind(&socket_path).map_err(|source| {
+            NonoError::ConfigRead {
+                path: socket_path.clone(),
+                source,
+            }
         })?;
         let socket_path =
             socket_path
@@ -5598,9 +5600,11 @@ mod tests {
                     source,
                 })?;
         let socket_path = temp.path().join("url.sock");
-        std::fs::File::create(&socket_path).map_err(|source| NonoError::ConfigRead {
-            path: socket_path.clone(),
-            source,
+        std::os::unix::net::UnixListener::bind(&socket_path).map_err(|source| {
+            NonoError::ConfigRead {
+                path: socket_path.clone(),
+                source,
+            }
         })?;
         let socket_path =
             socket_path

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -184,7 +184,11 @@ impl FsCapability {
         })
     }
 
-    /// Create a new single file capability, canonicalizing the path
+    /// Create a capability for one non-directory filesystem node.
+    ///
+    /// This includes regular files, device nodes, FIFOs, and pathname socket
+    /// nodes.  The capability grants filesystem access only; use
+    /// [`UnixSocketCapability`] as well to authorize AF_UNIX operations.
     ///
     /// Canonicalizes first, then checks metadata on the resolved path
     /// to avoid TOCTOU races between exists() and canonicalize().
@@ -401,8 +405,8 @@ impl<'de> Deserialize<'de> for UnixSocketCapability {
 impl UnixSocketCapability {
     /// Grant for a single socket file.
     ///
-    /// If `mode == Connect`, the path must already exist and must not be
-    /// a directory.
+    /// If `mode == Connect`, the path must already exist and identify a
+    /// pathname Unix socket.
     ///
     /// If `mode == ConnectBind`, the path may not yet exist (bind creates
     /// it). In that case the parent directory must exist; canonicalisation
@@ -411,10 +415,30 @@ impl UnixSocketCapability {
         let path = path.as_ref();
 
         let resolved = match path.canonicalize() {
-            Ok(p) if p.is_dir() => {
-                return Err(NonoError::ExpectedFile(path.to_path_buf()));
+            Ok(p) => {
+                #[cfg(not(unix))]
+                {
+                    let _ = p;
+                    return Err(NonoError::UnsupportedPlatform(
+                        "pathname Unix socket capabilities require a Unix platform".to_string(),
+                    ));
+                }
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::FileTypeExt;
+                    let metadata =
+                        p.metadata()
+                            .map_err(|source| NonoError::PathCanonicalization {
+                                path: path.to_path_buf(),
+                                source,
+                            })?;
+                    if !metadata.file_type().is_socket() {
+                        return Err(NonoError::ExpectedUnixSocket(path.to_path_buf()));
+                    }
+                    p
+                }
             }
-            Ok(p) => p,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // ConnectBind is allowed to grant paths that do not exist
                 // yet — bind(2) will create the socket file. Canonicalise
@@ -2189,6 +2213,7 @@ mod procfs_remap_tests {
 mod tests {
     use super::*;
     use std::fs;
+    use std::os::unix::net::UnixListener;
     use tempfile::tempdir;
 
     #[test]
@@ -2212,6 +2237,26 @@ mod tests {
         assert_eq!(cap.access, AccessMode::Read);
         assert!(cap.resolved.is_absolute());
         assert!(cap.is_file);
+    }
+
+    #[test]
+    fn test_fs_capability_accepts_non_directory_nodes() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+
+        let dir = tempdir().unwrap();
+        let fifo = dir.path().join("events.fifo");
+        mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+        let fifo_cap = FsCapability::new_file(&fifo, AccessMode::ReadWrite).unwrap();
+        assert!(fifo_cap.is_file);
+
+        let socket = dir.path().join("service.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        let socket_cap = FsCapability::new_file(&socket, AccessMode::ReadWrite).unwrap();
+        assert!(socket_cap.is_file);
+
+        let device_cap = FsCapability::new_file("/dev/null", AccessMode::ReadWrite).unwrap();
+        assert!(device_cap.is_file);
     }
 
     #[test]
@@ -3337,15 +3382,57 @@ mod tests {
     }
 
     #[test]
-    fn test_unix_socket_connect_on_existing_file() {
+    fn test_unix_socket_connect_on_existing_socket() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("existing.sock");
-        fs::write(&path, b"").unwrap(); // stand-in for a real socket file
+        let _listener = UnixListener::bind(&path).unwrap();
 
         let cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
         assert_eq!(cap.mode, UnixSocketMode::Connect);
         assert!(!cap.is_directory());
         assert!(cap.resolved.is_absolute());
+    }
+
+    #[test]
+    fn test_unix_socket_file_resolves_symlink_to_socket() {
+        let dir = tempdir().unwrap();
+        let socket = dir.path().join("service.sock");
+        let alias = dir.path().join("service-link.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        std::os::unix::fs::symlink(&socket, &alias).unwrap();
+
+        let cap = UnixSocketCapability::new_file(&alias, UnixSocketMode::Connect).unwrap();
+        assert_eq!(cap.original, alias);
+        assert_eq!(cap.resolved, socket.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_unix_socket_file_rejects_regular_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("not-a-socket");
+        fs::write(&path, b"").unwrap();
+
+        let result = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect);
+        assert!(matches!(result, Err(NonoError::ExpectedUnixSocket(_))));
+    }
+
+    #[test]
+    fn test_unix_socket_file_rejects_fifo_and_device() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+
+        let dir = tempdir().unwrap();
+        let fifo = dir.path().join("not-a-socket.fifo");
+        mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+
+        let fifo_result = UnixSocketCapability::new_file(&fifo, UnixSocketMode::Connect);
+        assert!(matches!(fifo_result, Err(NonoError::ExpectedUnixSocket(_))));
+
+        let device_result = UnixSocketCapability::new_file("/dev/null", UnixSocketMode::Connect);
+        assert!(matches!(
+            device_result,
+            Err(NonoError::ExpectedUnixSocket(_))
+        ));
     }
 
     #[test]
@@ -3381,7 +3468,7 @@ mod tests {
 
         let result = UnixSocketCapability::new_file(dir.path(), UnixSocketMode::Connect);
         assert!(
-            matches!(result, Err(NonoError::ExpectedFile(_))),
+            matches!(result, Err(NonoError::ExpectedUnixSocket(_))),
             "new_file must reject a directory path: {result:?}"
         );
     }
@@ -3442,7 +3529,7 @@ mod tests {
     fn test_unix_socket_covers_file_exact_match() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("a.sock");
-        fs::write(&path, b"").unwrap();
+        UnixListener::bind(&path).unwrap();
         let cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
 
         // Exact match covers; anything else does not.
@@ -3506,7 +3593,7 @@ mod tests {
     fn test_unix_socket_display() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("a.sock");
-        fs::write(&path, b"").unwrap();
+        UnixListener::bind(&path).unwrap();
 
         let file_cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
         let rendered = format!("{file_cap}");
@@ -3530,7 +3617,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let a = dir.path().join("a.sock");
         let b = dir.path().join("b.sock");
-        fs::write(&a, b"").unwrap();
+        UnixListener::bind(&a).unwrap();
 
         let caps = CapabilitySet::new()
             .allow_unix_socket(&a, UnixSocketMode::Connect)
@@ -3556,7 +3643,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let connect_sock = dir.path().join("connect-only.sock");
         let bind_sock = dir.path().join("bind.sock");
-        fs::write(&connect_sock, b"").unwrap();
+        UnixListener::bind(&connect_sock).unwrap();
         // bind_sock deliberately does not exist — allow_unix_socket with
         // ConnectBind must accept that.
 
@@ -3626,7 +3713,7 @@ mod tests {
     fn test_capability_set_unix_socket_send_covered_by_connect_grant() {
         let dir = tempdir().unwrap();
         let sock = dir.path().join("dgram.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)
@@ -3646,7 +3733,7 @@ mod tests {
     fn test_deduplicate_unix_sockets_merges_identical_grants() {
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let mut caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)
@@ -3665,7 +3752,7 @@ mod tests {
         // path, the retained entry ends up as ConnectBind (superset).
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let mut caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)
@@ -3686,7 +3773,7 @@ mod tests {
         // because a group/default also covers it.
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let group_cap = UnixSocketCapability {
             original: sock.clone(),
@@ -3724,7 +3811,7 @@ mod tests {
         // different keys — both should survive.
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let mut caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)
@@ -3740,7 +3827,7 @@ mod tests {
     fn test_summary_includes_unix_sockets() {
         let dir = tempdir().unwrap();
         let sock = dir.path().join("a.sock");
-        fs::write(&sock, b"").unwrap();
+        UnixListener::bind(&sock).unwrap();
 
         let caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)

--- a/crates/nono/src/error.rs
+++ b/crates/nono/src/error.rs
@@ -16,6 +16,9 @@ pub enum NonoError {
     #[error("Expected a file but got a directory: {0}")]
     ExpectedFile(PathBuf),
 
+    #[error("Expected a pathname Unix socket: {0}")]
+    ExpectedUnixSocket(PathBuf),
+
     #[error("Failed to canonicalize path {path}: {source}")]
     PathCanonicalization {
         path: PathBuf,
@@ -258,6 +261,7 @@ impl NonoError {
             Self::PathNotFound(_)
             | Self::ExpectedDirectory(_)
             | Self::ExpectedFile(_)
+            | Self::ExpectedUnixSocket(_)
             | Self::PathCanonicalization { .. }
             | Self::HashMismatch { .. }
             | Self::SessionNotFound(_)

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -592,6 +592,46 @@ fn access_to_landlock(access: AccessMode, abi: ABI) -> LandlockAccess {
     }
 }
 
+/// Normalize a prepared path rule against the inode opened for enforcement.
+///
+/// `landlock::PathBeneath` performs this compatibility step internally, but
+/// the allocation-free prepared path emits raw Landlock rules and must mirror
+/// it explicitly.  In particular, Linux rejects directory-only access rights
+/// such as `ReadDir`, `MakeReg`, and `Refer` when `parent_fd` identifies a
+/// non-directory inode.
+fn normalize_prepared_path_access(
+    cap: &crate::capability::FsCapability,
+    metadata: &std::fs::Metadata,
+    abi: ABI,
+) -> Result<BitFlags<AccessFs>> {
+    let is_directory = metadata.is_dir();
+    if cap.is_file == is_directory {
+        return Err(if cap.is_file {
+            NonoError::ExpectedFile(cap.resolved.clone())
+        } else {
+            NonoError::ExpectedDirectory(cap.resolved.clone())
+        });
+    }
+
+    let mut access = access_to_landlock(cap.access, abi).effective;
+    if !is_directory {
+        access &= AccessFs::from_file(abi);
+    }
+
+    use std::os::unix::fs::FileTypeExt;
+    let file_type = metadata.file_type();
+    let is_device = file_type.is_char_device() || file_type.is_block_device();
+    let is_device_directory = is_directory && cap.resolved.starts_with("/dev");
+    if AccessFs::from_all(abi).contains(AccessFs::IoctlDev)
+        && matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite)
+        && (is_device || is_device_directory)
+    {
+        access |= AccessFs::IoctlDev;
+    }
+
+    Ok(access)
+}
+
 /// Legacy check: whether the simple block-all seccomp filter can be used.
 ///
 /// Only true for plain `NetworkMode::Blocked` with no port exceptions.
@@ -872,18 +912,8 @@ fn prepare_with_abi_inner(
         }
     }
 
-    let ioctl_dev_available = AccessFs::from_all(target_abi).contains(AccessFs::IoctlDev);
     let mut path_rules = Vec::with_capacity(caps.fs_capabilities().len());
     for cap in caps.fs_capabilities() {
-        let result = access_to_landlock(cap.access, target_abi);
-        let mut access = result.effective;
-        if ioctl_dev_available
-            && matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite)
-            && (is_device_path(&cap.resolved) || is_device_directory(&cap.resolved))
-        {
-            access |= AccessFs::IoctlDev;
-        }
-
         let file = std::fs::OpenOptions::new()
             .read(true)
             .custom_flags(libc::O_PATH | libc::O_CLOEXEC)
@@ -895,6 +925,14 @@ fn prepare_with_abi_inner(
                     e
                 ))
             })?;
+        let metadata = file.metadata().map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "Cannot inspect pre-opened Landlock rule path {}: {}",
+                cap.resolved.display(),
+                e
+            ))
+        })?;
+        let access = normalize_prepared_path_access(cap, &metadata, target_abi)?;
         let path_fd = move_fd_above_stdio(file.into()).map_err(|e| {
             NonoError::SandboxInit(format!(
                 "Cannot reserve Landlock rule descriptor for {}: {}",
@@ -4884,6 +4922,127 @@ mod tests {
                 .iter()
                 .all(|rule| rule.path_fd.as_raw_fd() >= 3)
         );
+    }
+
+    #[test]
+    fn prepared_path_rules_mask_directory_rights_for_non_directories() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+        use std::os::unix::net::UnixListener;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let regular = temp.path().join("regular.txt");
+        std::fs::write(&regular, b"data").expect("create regular file");
+        let fifo = temp.path().join("events.fifo");
+        mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).expect("create fifo");
+        let socket = temp.path().join("service.sock");
+        let _listener = UnixListener::bind(&socket).expect("bind unix socket");
+
+        let caps = CapabilitySet::new()
+            .allow_path(temp.path(), AccessMode::ReadWrite)
+            .expect("directory capability")
+            .allow_file(&regular, AccessMode::ReadWrite)
+            .expect("regular file capability")
+            .allow_file(&fifo, AccessMode::ReadWrite)
+            .expect("fifo capability")
+            .allow_file(&socket, AccessMode::ReadWrite)
+            .expect("socket node capability")
+            .allow_file("/dev/null", AccessMode::ReadWrite)
+            .expect("device capability");
+        let abi = DetectedAbi::new(ABI::V5);
+
+        let prepared =
+            prepare_seccomp_with_abi(&caps, &abi, SeccompOpts::preinstalled_tcp_filter())
+                .expect("prepare policy");
+        assert_eq!(prepared.path_rules.len(), 5);
+
+        let directory_access = prepared.path_rules[0].allowed_access;
+        assert_ne!(
+            directory_access & BitFlags::from(AccessFs::ReadDir).bits(),
+            0
+        );
+        assert_ne!(
+            directory_access & BitFlags::from(AccessFs::MakeReg).bits(),
+            0
+        );
+
+        let valid_file_access = AccessFs::from_file(ABI::V5).bits();
+        for rule in &prepared.path_rules[1..] {
+            assert_eq!(rule.allowed_access & !valid_file_access, 0);
+        }
+
+        for rule in &prepared.path_rules[1..4] {
+            assert_eq!(
+                rule.allowed_access & BitFlags::from(AccessFs::IoctlDev).bits(),
+                0
+            );
+        }
+        assert_ne!(
+            prepared.path_rules[4].allowed_access & BitFlags::from(AccessFs::IoctlDev).bits(),
+            0
+        );
+    }
+
+    #[test]
+    fn prepared_v2_file_rule_matches_landlock_file_compatibility() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let regular = temp.path().join("regular.txt");
+        std::fs::write(&regular, b"data").expect("create regular file");
+        let caps = CapabilitySet::new()
+            .allow_file(&regular, AccessMode::ReadWrite)
+            .expect("regular file capability")
+            .allow_file("/dev/null", AccessMode::ReadWrite)
+            .expect("device capability");
+        let abi = DetectedAbi::new(ABI::V2);
+
+        let prepared =
+            prepare_seccomp_with_abi(&caps, &abi, SeccompOpts::preinstalled_tcp_filter())
+                .expect("prepare policy");
+        let requested = access_to_landlock(AccessMode::ReadWrite, ABI::V2).effective;
+        let expected = (requested & AccessFs::from_file(ABI::V2)).bits();
+        assert_eq!(prepared.path_rules.len(), 2);
+        for rule in &prepared.path_rules {
+            assert_eq!(rule.allowed_access, expected);
+        }
+    }
+
+    #[test]
+    fn prepared_path_type_changes_fail_closed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let file_path = temp.path().join("file-to-dir");
+        std::fs::write(&file_path, b"data").expect("create file");
+        let file_cap = crate::capability::FsCapability::new_file(&file_path, AccessMode::ReadWrite)
+            .expect("file capability");
+        std::fs::remove_file(&file_path).expect("remove file");
+        std::fs::create_dir(&file_path).expect("replace file with directory");
+        let mut file_caps = CapabilitySet::new();
+        file_caps.add_fs(file_cap);
+        let Err(error) = prepare_seccomp_with_abi(
+            &file_caps,
+            &DetectedAbi::new(ABI::V2),
+            SeccompOpts::preinstalled_tcp_filter(),
+        ) else {
+            panic!("file capability must reject a replacement directory");
+        };
+        assert!(matches!(error, NonoError::ExpectedFile(_)));
+
+        let dir_path = temp.path().join("dir-to-file");
+        std::fs::create_dir(&dir_path).expect("create directory");
+        let dir_cap = crate::capability::FsCapability::new_dir(&dir_path, AccessMode::ReadWrite)
+            .expect("directory capability");
+        std::fs::remove_dir(&dir_path).expect("remove directory");
+        std::fs::write(&dir_path, b"data").expect("replace directory with file");
+        let mut dir_caps = CapabilitySet::new();
+        dir_caps.add_fs(dir_cap);
+        let Err(error) = prepare_seccomp_with_abi(
+            &dir_caps,
+            &DetectedAbi::new(ABI::V2),
+            SeccompOpts::preinstalled_tcp_filter(),
+        ) else {
+            panic!("directory capability must reject a replacement file");
+        };
+        assert!(matches!(error, NonoError::ExpectedDirectory(_)));
     }
 
     #[test]

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -553,10 +553,10 @@ struct LandlockAccess {
 /// writes (write to .tmp -> rename to target), which is the standard pattern
 /// used by most applications for safe config/build artifact updates.
 ///
-/// IoctlDev is NOT included here — it is added selectively in `apply_with_abi_inner()`
-/// only for paths that are actual device files (char/block devices), detected
-/// via `stat()` at rule-addition time. This avoids granting device ioctl access
-/// to non-device paths.
+/// IoctlDev is NOT included here — it is added selectively by
+/// `normalize_path_access()` only for opened inodes that are actual device files
+/// (char/block devices) or intended device directories. This avoids granting
+/// device ioctl access to non-device paths.
 fn access_to_landlock(access: AccessMode, abi: ABI) -> LandlockAccess {
     let available = AccessFs::from_all(abi);
 
@@ -592,18 +592,24 @@ fn access_to_landlock(access: AccessMode, abi: ABI) -> LandlockAccess {
     }
 }
 
-/// Normalize a prepared path rule against the inode opened for enforcement.
+/// A Landlock path rule normalized against the inode opened for enforcement.
+struct OpenedPathRule {
+    path_fd: OwnedFd,
+    access: LandlockAccess,
+}
+
+/// Normalize a path rule against metadata from the inode opened for enforcement.
 ///
 /// `landlock::PathBeneath` performs this compatibility step internally, but
 /// the allocation-free prepared path emits raw Landlock rules and must mirror
 /// it explicitly.  In particular, Linux rejects directory-only access rights
 /// such as `ReadDir`, `MakeReg`, and `Refer` when `parent_fd` identifies a
 /// non-directory inode.
-fn normalize_prepared_path_access(
+fn normalize_path_access(
     cap: &crate::capability::FsCapability,
     metadata: &std::fs::Metadata,
     abi: ABI,
-) -> Result<BitFlags<AccessFs>> {
+) -> Result<LandlockAccess> {
     let is_directory = metadata.is_dir();
     if cap.is_file == is_directory {
         return Err(if cap.is_file {
@@ -613,9 +619,9 @@ fn normalize_prepared_path_access(
         });
     }
 
-    let mut access = access_to_landlock(cap.access, abi).effective;
+    let mut result = access_to_landlock(cap.access, abi);
     if !is_directory {
-        access &= AccessFs::from_file(abi);
+        result.effective &= AccessFs::from_file(abi);
     }
 
     use std::os::unix::fs::FileTypeExt;
@@ -626,10 +632,41 @@ fn normalize_prepared_path_access(
         && matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite)
         && (is_device || is_device_directory)
     {
-        access |= AccessFs::IoctlDev;
+        result.effective |= AccessFs::IoctlDev;
     }
 
-    Ok(access)
+    Ok(result)
+}
+
+/// Open a Landlock rule path once and derive all enforcement state from that FD.
+///
+/// Returning the same descriptor used for metadata validation prevents a path
+/// replacement between type/device classification and rule installation.
+fn open_path_rule(cap: &crate::capability::FsCapability, abi: ABI) -> Result<OpenedPathRule> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_PATH | libc::O_CLOEXEC)
+        .open(&cap.resolved)
+        .map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "Cannot open Landlock rule path {}: {}",
+                cap.resolved.display(),
+                e
+            ))
+        })?;
+    let metadata = file.metadata().map_err(|e| {
+        NonoError::SandboxInit(format!(
+            "Cannot inspect opened Landlock rule path {}: {}",
+            cap.resolved.display(),
+            e
+        ))
+    })?;
+    let access = normalize_path_access(cap, &metadata, abi)?;
+
+    Ok(OpenedPathRule {
+        path_fd: file.into(),
+        access,
+    })
 }
 
 /// Legacy check: whether the simple block-all seccomp filter can be used.
@@ -697,31 +734,6 @@ fn unsupported_filesystem_dev(path: &Path) -> Option<u64> {
             None
         }
     }
-}
-
-/// Check if a path is a character or block device file.
-///
-/// Used to selectively grant `IoctlDev` only for actual device files
-/// (e.g., `/dev/tty`, `/dev/null`), not for regular files or directories.
-fn is_device_path(path: &Path) -> bool {
-    use std::os::unix::fs::FileTypeExt;
-    std::fs::metadata(path)
-        .map(|m| {
-            let ft = m.file_type();
-            ft.is_char_device() || ft.is_block_device()
-        })
-        .unwrap_or(false)
-}
-
-/// Check if a path is a directory that contains device files (e.g., `/dev/pts`).
-///
-/// For directories under `/dev`, we grant `IoctlDev` because Landlock's
-/// `PathBeneath` applies to all files within the subtree, and those files
-/// are device nodes that need ioctl access for terminal operations.
-fn is_device_directory(path: &Path) -> bool {
-    // Only consider directories directly under /dev as device directories.
-    // This avoids granting IoctlDev to arbitrary directories.
-    path.starts_with("/dev") && path.is_dir()
 }
 
 /// Determine which Landlock scopes must be enabled for these capabilities.
@@ -914,26 +926,8 @@ fn prepare_with_abi_inner(
 
     let mut path_rules = Vec::with_capacity(caps.fs_capabilities().len());
     for cap in caps.fs_capabilities() {
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_PATH | libc::O_CLOEXEC)
-            .open(&cap.resolved)
-            .map_err(|e| {
-                NonoError::SandboxInit(format!(
-                    "Cannot pre-open Landlock rule path {}: {}",
-                    cap.resolved.display(),
-                    e
-                ))
-            })?;
-        let metadata = file.metadata().map_err(|e| {
-            NonoError::SandboxInit(format!(
-                "Cannot inspect pre-opened Landlock rule path {}: {}",
-                cap.resolved.display(),
-                e
-            ))
-        })?;
-        let access = normalize_prepared_path_access(cap, &metadata, target_abi)?;
-        let path_fd = move_fd_above_stdio(file.into()).map_err(|e| {
+        let opened = open_path_rule(cap, target_abi)?;
+        let path_fd = move_fd_above_stdio(opened.path_fd).map_err(|e| {
             NonoError::SandboxInit(format!(
                 "Cannot reserve Landlock rule descriptor for {}: {}",
                 cap.resolved.display(),
@@ -942,7 +936,7 @@ fn prepare_with_abi_inner(
         })?;
         path_rules.push(PreparedPathRule {
             path_fd,
-            allowed_access: access.bits(),
+            allowed_access: opened.access.effective.bits(),
         });
     }
 
@@ -1241,21 +1235,20 @@ fn apply_with_abi_inner(
     // directory grants, so SocketScope::DirChildren and SocketScope::DirSubtree
     // are not distinguishable on this Linux path until the seccomp AF_UNIX
     // allowlist work enforces UnixSocketCapability::covers().
-    let ioctl_dev_available = AccessFs::from_all(target_abi).contains(AccessFs::IoctlDev);
     // Track device IDs of mounts already warned about to emit one warning
     // per mount, not one per capability path.
     let mut warned_unsupported_devs: std::collections::HashSet<u64> =
         std::collections::HashSet::new();
 
     for cap in caps.fs_capabilities() {
-        let result = access_to_landlock(cap.access, target_abi);
-        let mut access = result.effective;
+        let opened = open_path_rule(cap, target_abi)?;
+        let access = opened.access.effective;
 
-        if !result.dropped.is_empty() {
+        if !opened.access.dropped.is_empty() {
             debug!(
                 "Landlock ABI {:?} does not support {:?} for path {} (requested for {:?})",
                 target_abi,
-                result.dropped,
+                opened.access.dropped,
                 cap.resolved.display(),
                 cap.access
             );
@@ -1266,11 +1259,7 @@ fn apply_with_abi_inner(
         // Without it, TUI programs fail with EACCES on /dev/tty and /dev/pts.
         // We restrict this to actual devices to avoid granting ioctl access to
         // regular files and non-device directories.
-        if ioctl_dev_available
-            && matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite)
-            && (is_device_path(&cap.resolved) || is_device_directory(&cap.resolved))
-        {
-            access |= AccessFs::IoctlDev;
+        if access.contains(AccessFs::IoctlDev) {
             debug!(
                 "Adding IoctlDev for device path: {}",
                 cap.resolved.display()
@@ -1295,9 +1284,8 @@ fn apply_with_abi_inner(
             access
         );
 
-        let path_fd = PathFd::new(&cap.resolved)?;
         ruleset = ruleset
-            .add_rule(PathBeneath::new(path_fd, access))
+            .add_rule(PathBeneath::new(opened.path_fd, access))
             .map_err(|e| {
                 NonoError::SandboxInit(format!(
                     "Cannot add Landlock rule for {}: {} (filesystem may not support Landlock)",
@@ -3724,34 +3712,61 @@ mod tests {
     }
 
     #[test]
-    fn test_is_device_path_dev_null() {
-        // /dev/null is a character device on all Unix systems
-        assert!(is_device_path(Path::new("/dev/null")));
-    }
+    fn test_open_path_rule_classifies_ioctl_from_opened_inode() {
+        let device_cap =
+            crate::capability::FsCapability::new_file("/dev/null", AccessMode::ReadWrite)
+                .expect("device capability");
+        let device_rule = open_path_rule(&device_cap, ABI::V5).expect("open device rule");
+        assert!(device_rule.access.effective.contains(AccessFs::IoctlDev));
 
-    #[test]
-    fn test_is_device_path_regular_file() {
-        // A regular file should not be detected as a device
-        assert!(!is_device_path(Path::new("/etc/hosts")));
-    }
+        let regular = tempfile::NamedTempFile::new().expect("regular file");
+        let regular_cap =
+            crate::capability::FsCapability::new_file(regular.path(), AccessMode::ReadWrite)
+                .expect("regular file capability");
+        let regular_rule = open_path_rule(&regular_cap, ABI::V5).expect("open regular rule");
+        assert!(!regular_rule.access.effective.contains(AccessFs::IoctlDev));
 
-    #[test]
-    fn test_is_device_path_nonexistent() {
-        assert!(!is_device_path(Path::new("/nonexistent/path/12345")));
-    }
+        let ordinary_dir = tempfile::tempdir().expect("ordinary directory");
+        let ordinary_dir_cap =
+            crate::capability::FsCapability::new_dir(ordinary_dir.path(), AccessMode::ReadWrite)
+                .expect("ordinary directory capability");
+        let ordinary_dir_rule =
+            open_path_rule(&ordinary_dir_cap, ABI::V5).expect("open ordinary directory rule");
+        assert!(
+            !ordinary_dir_rule
+                .access
+                .effective
+                .contains(AccessFs::IoctlDev)
+        );
 
-    #[test]
-    fn test_is_device_directory_dev_pts() {
-        // /dev/pts is a directory under /dev
         if Path::new("/dev/pts").exists() {
-            assert!(is_device_directory(Path::new("/dev/pts")));
+            let device_dir_cap =
+                crate::capability::FsCapability::new_dir("/dev/pts", AccessMode::ReadWrite)
+                    .expect("device directory capability");
+            let device_dir_rule =
+                open_path_rule(&device_dir_cap, ABI::V5).expect("open device directory rule");
+            assert!(
+                device_dir_rule
+                    .access
+                    .effective
+                    .contains(AccessFs::IoctlDev)
+            );
         }
     }
 
     #[test]
-    fn test_is_device_directory_not_dev() {
-        // /tmp is a directory but not under /dev
-        assert!(!is_device_directory(Path::new("/tmp")));
+    fn test_open_path_rule_rejects_removed_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("removed.txt");
+        std::fs::write(&path, b"data").expect("create file");
+        let cap = crate::capability::FsCapability::new_file(&path, AccessMode::ReadWrite)
+            .expect("file capability");
+        std::fs::remove_file(&path).expect("remove file");
+
+        let Err(error) = open_path_rule(&cap, ABI::V5) else {
+            panic!("removed path must fail closed");
+        };
+        assert!(matches!(error, NonoError::SandboxInit(_)));
     }
 
     #[test]
@@ -5007,7 +5022,7 @@ mod tests {
     }
 
     #[test]
-    fn prepared_path_type_changes_fail_closed() {
+    fn path_rule_type_changes_fail_closed() {
         let temp = tempfile::tempdir().expect("tempdir");
 
         let file_path = temp.path().join("file-to-dir");
@@ -5016,6 +5031,11 @@ mod tests {
             .expect("file capability");
         std::fs::remove_file(&file_path).expect("remove file");
         std::fs::create_dir(&file_path).expect("replace file with directory");
+        let Err(error) = open_path_rule(&file_cap, ABI::V2) else {
+            panic!("shared path rule builder must reject a replacement directory");
+        };
+        assert!(matches!(error, NonoError::ExpectedFile(_)));
+
         let mut file_caps = CapabilitySet::new();
         file_caps.add_fs(file_cap);
         let Err(error) = prepare_seccomp_with_abi(
@@ -5033,6 +5053,11 @@ mod tests {
             .expect("directory capability");
         std::fs::remove_dir(&dir_path).expect("remove directory");
         std::fs::write(&dir_path, b"data").expect("replace directory with file");
+        let Err(error) = open_path_rule(&dir_cap, ABI::V2) else {
+            panic!("shared path rule builder must reject a replacement file");
+        };
+        assert!(matches!(error, NonoError::ExpectedDirectory(_)));
+
         let mut dir_caps = CapabilitySet::new();
         dir_caps.add_fs(dir_cap);
         let Err(error) = prepare_seccomp_with_abi(

--- a/crates/nono/src/state.rs
+++ b/crates/nono/src/state.rs
@@ -342,7 +342,7 @@ mod tests {
         use tempfile::tempdir;
         let dir = tempdir().expect("tempdir");
         let sock = dir.path().join("a.sock");
-        std::fs::write(&sock, b"").expect("stub");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
 
         let caps = CapabilitySet::new()
             .allow_unix_socket(&sock, UnixSocketMode::Connect)


### PR DESCRIPTION
Introduce stricter validation for unix socket capabilities and ensure Landlock filesystem rules are correctly applied based on inode type.

- `UnixSocketCapability::new_file` now explicitly validates that the target path identifies a Unix domain socket using `FileTypeExt::is_socket()`. Paths that are regular files, FIFOs, or device nodes are now rejected with a new `NonoError::ExpectedUnixSocket` error.
- All relevant test cases have been updated to create actual Unix domain sockets using `UnixListener::bind` instead of stubbing with `std::fs::write`.
- Landlock prepared path rules now perform a fail-closed validation (`normalize_prepared_path_access`) to ensure the inode type at rule preparation time matches the capability's intent (e.g., a file capability must still point to a file, not a directory).
- Landlock access rights for prepared paths are now normalized: directory-specific rights (like `ReadDir`) are stripped for non-directory inodes, and `IoctlDev` is correctly added for device nodes and paths within `/dev`.

Closes: #1653

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
