### PR TITLE
docs: correct outdated/inaccurate sections across 4 doc pages

### DIFF
--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -182,7 +182,7 @@ Runs after the sandboxed process exits. Receives `NONO_SESSION_ID`, `NONO_WORKDI
 rm -rf "/tmp/$NONO_SESSION_ID"
 ```
 
-### AF_UNIX Socket Grants
+## AF_UNIX Socket Grants
 
 The `unix_socket*` filesystem fields grant `connect(2)` (and optionally
 `bind(2)`) on pathname AF_UNIX sockets. Abstract-namespace and unnamed
@@ -213,7 +213,7 @@ Under restricted network modes (`--block-net` or `--network-profile`),
 `connect(2)` to a Unix socket requires an explicit `unix_socket*` grant
 — a plain `allow_file`/`allow` grant no longer implicitly permits it.
 
-### Working Directory
+## Working Directory
 
 The `workdir` section controls whether and how the current working directory is automatically shared with the sandboxed process.
 
@@ -467,23 +467,11 @@ The `custom_credentials` field lets you define credential services for any API:
 
 See [Credential Injection](/cli/features/credential-injection#custom-credential-definitions) for complete documentation.
 
-### Hooks
+### Hooks (pack-declared, legacy profile field)
 
-The `hooks` section defines hooks that nono will automatically install for specific applications.
+The `hooks` field is a legacy declaration surface: since v0.44.0, setting it in a profile no longer installs anything itself — nono just prints a one-line note. Actual agent-hook wiring (e.g. installing a script into `~/.claude/hooks/` and patching `settings.json`) is now done by a pack's `package.json` `wiring` directives, executed on `nono pull`/`nono resolve`. See [Package Publishing](/cli/features/package-publishing) if you're authoring a pack that needs this.
 
-```json
-{
-  "hooks": {
-    "claude-code": {
-      "event": "PostToolUseFailure",
-      "matcher": "Read|Write|Edit|Bash",
-      "script": "nono-hook.sh"
-    }
-  }
-}
-```
-
-Hook installation is idempotent - nono only installs or updates when needed.
+This is unrelated to **Session Hooks** above, which is a currently-active profile feature for running host-privileged setup/cleanup scripts around the sandboxed process itself.
 
 ### Interactive Mode (deprecated)
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -145,7 +145,7 @@ Profiles use JSON format:
 
 ## Session Hooks
 
-Session hooks are scripts that run before or after the sandboxed process, outside the sandbox with host privileges. Useful for setup and cleanup tasks the sandboxed process should not have access to -- for example, creating a private TMPDIR per session.
+Session hooks are scripts that run before or after the sandboxed process, outside the sandbox with host privileges. This is the mechanism for custom instrumentation around a run — for example, replacing an external wrapper script that sets up or tears down per-session state. There are exactly two events, `before` and `after`; there is no mid-session or per-tool-call hook here. (That's a different, unrelated feature: see [Hooks](#hooks-pack-declared-legacy-profile-field) below, which packs use to install an *agent's own* hook system, e.g. Claude Code's tool-call hooks.)
 
 ### Configuration
 
@@ -160,18 +160,26 @@ Both `before` and `after` are optional. Each hook specifies a script path and an
 }
 ```
 
-- `script` (required): absolute path to an executable script.
-- `timeout_secs` (optional): kills the script if it exceeds this duration.
+- `script` (required): absolute path to an executable script. It must resolve to a regular file, be owned by you or root, and not sit in a world-writable directory — this rejects `/tmp` and similar shared directories even when the sticky bit is set. Put session hook scripts somewhere private, e.g. under `$XDG_CONFIG_HOME/nono/hooks/`.
+- `timeout_secs` (optional): kills the whole script process group if it exceeds this duration.
+
+Both hook types also receive `NONO_HOOK_TYPE` (`before` or `after`), in addition to the variables listed below.
+
+<Note>
+  **Hooks fail open.** An invalid script path, a non-zero exit, or a timeout never blocks the sandboxed process — nono logs a warning and continues. A timeout discards any environment variables the before-hook had already written; a plain non-zero exit does not — variables written before `exit` still take effect.
+</Note>
 
 ### Before hook
 
-Runs before the sandboxed process starts. The script receives `NONO_SESSION_ID`, `NONO_WORKDIR`, and `NONO_ENV_FILE` -- a temporary file where `KEY=VALUE` lines can be written to export environment variables to the sandboxed process.
+Runs before the sandboxed process starts. The script receives `NONO_SESSION_ID`, `NONO_WORKDIR`, and `NONO_ENV_FILE` -- a temporary file where `KEY=VALUE` lines (blank lines and `#` comments are skipped) can be written to export environment variables to the sandboxed process.
 
 ```sh
 #!/bin/sh
 mkdir -p "/tmp/$NONO_SESSION_ID"
 echo "TMPDIR=/tmp/$NONO_SESSION_ID" >> "$NONO_ENV_FILE"
 ```
+
+A small set of dangerous variables (e.g. `LD_PRELOAD`) is filtered out of the before-hook's exports before they reach the sandboxed process, regardless of what the script writes to `NONO_ENV_FILE`.
 
 ### After hook
 

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -23,7 +23,9 @@ A Tool Sandbox profile answers three questions:
 
 Each child command starts from a minimal runtime baseline. It does not inherit outer `--allow`, CWD access, broad profile groups, raw credential paths, or outer network access.
 
-When Tool Sandbox is active, the outer process can execute the initial program and the Tool Sandbox shims. Further tool launches should be modeled as command-policy hops. This keeps direct executable-path bypasses blocked without building a host-wide allow-list of every executable on `PATH`.
+When Tool Sandbox is active, the outer session's execute grant is built from every trusted directory on `PATH`: nono scans each non-writable `PATH` directory and allow-lists every executable file found there, plus its shared-library dependency closure — not just the initial program and the Tool Sandbox shims. A binary that lives outside `PATH` (for example a JVM's `jspawnhelper` under `/usr/lib/jvm/.../lib/`) is not covered by this scan and is denied unless it's reachable through `PATH`, added to `command_policies.executable_dirs`, or modeled as a command-policy hop with its own `sandbox.exec_paths` entry.
+
+Tool Sandbox's real security boundary is at policy-controlled *commands*, not at execute-vs-no-execute for the outer session: once a command becomes a Tool Sandbox entry, everything it invokes is governed by `can_use`/`from` edges regardless of `PATH` membership.
 
 ## Available Fields
 

--- a/docs/cli/internals/overview.mdx
+++ b/docs/cli/internals/overview.mdx
@@ -66,7 +66,7 @@ An agent could potentially leak small amounts of information through timing side
 
 ### Resource Exhaustion
 
-nono does not limit CPU, memory, or disk usage. A malicious agent could attempt denial-of-service through resource exhaustion.
+On Linux, nono can enforce memory and process-count ceilings on the sandboxed process tree via cgroup v2 (`memory.max`, `pids.max`) — see [Resource Limits](/cli/features/resource-limits). CPU and disk usage are not limited, and there is no equivalent enforcement on macOS yet. A malicious agent could still attempt denial-of-service through CPU or disk exhaustion, or resource exhaustion on macOS.
 
 ### Data Within Allowed Paths
 


### PR DESCRIPTION
## Summary

- **tool-sandbox.mdx**: fix Tool Sandbox mental model — the outer session's exec grant is built from every trusted PATH directory (allow-listing every executable found there), not just the initial program and shims. Verified against `crates/nono-cli/src/tool-sandbox/platform/linux.rs` and reproduced on a real Landlock host.
- **overview.mdx**: update "Resource Exhaustion" — memory and process-count are now enforced on Linux via cgroup v2 (`memory.max`, `pids.max`); CPU/disk and macOS remain unenforced. Verified against `resource_cgroup.rs` and reproduced with `--memory`/`--max-processes` triggering real OOM kills and fork `EAGAIN`.
- **profiles-groups.mdx**: fix "Hooks" section — profile-level `hooks.<target>` installation was removed in v0.44.0 and now only prints a note; actual wiring lives in pack `package.json` `wiring` directives. Clarify this is distinct from Session Hooks.
- **profiles-groups.mdx**: fix heading nesting — promote "AF_UNIX Socket Grants" and "Working Directory" from h3 to h2 so they're no longer nested under "Session Hooks".

Closes #1630
Closes #1664
Closes #1645
Closes #1644

## Verification

All four claims were manually verified, not just read from source:

- Ran a Landlock-enabled Linux VM (Lima) with a live Tool Sandbox profile: an undeclared PATH binary executed fine; an identical binary placed outside PATH was denied — confirming the corrected mental model in #1630.
- On the same VM, `nono run --memory 32M` triggered a real cgroup v2 OOM kill of the whole process tree, and `nono run --max-processes 5` triggered kernel fork `EAGAIN` without killing anything — confirming #1664's corrected text.
- Confirmed macOS explicitly rejects `--memory`/`--max-processes` ("resource limits are only enforced on Linux (cgroup v2)").
- Read `profile_runtime.rs::install_profile_hooks` to confirm profile-level `hooks` installation was removed in v0.44.0 (CHANGELOG confirms), which is a stronger correction than #1645 originally asked for.

## Test plan

- [x] Docs-only change — no code touched
- [x] Manually verified all four corrected claims against actual code/runtime behavior (see above)
- [x] CI docs build (if any) passes