### PR TITLE
fix(proxy): honor profiles network.tls_intercept in `nono proxy`

### DIFF
--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -17,7 +17,9 @@ use crate::launch_runtime::{
     TlsInterceptIntent, UpstreamProxyIntent,
 };
 use crate::profile;
-use crate::proxy_runtime::{apply_tls_intercept_config, build_proxy_config_from_flags};
+use crate::proxy_runtime::{
+    apply_tls_intercept_config, build_proxy_config_from_flags, resolve_tls_intercept_options,
+};
 use colored::Colorize;
 use nono::{NonoError, Result};
 use tracing::info;
@@ -317,25 +319,38 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
         bypass: upstream_bypass,
     });
 
-    let ca_validity = args
-        .proxy_ca_validity
-        .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60));
+    // Merge the profile's `network.tls_intercept` with the CLI flags, mirroring
+    // the sandboxed `run`/`shell`/`wrap` path (`resolve_tls_intercept_options`)
+    // so `nono proxy` honors the same settings.
+    #[cfg(target_os = "macos")]
+    let trust_proxy_ca = args.trust_proxy_ca;
+    #[cfg(not(target_os = "macos"))]
+    let trust_proxy_ca = false;
+    let tls_options = resolve_tls_intercept_options(
+        trust_proxy_ca,
+        args.proxy_ca_validity,
+        network.and_then(|n| n.tls_intercept.as_ref()),
+    )?;
 
     #[cfg(target_os = "macos")]
-    let tls_intercept = if args.trust_proxy_ca || ca_validity.is_some() {
+    let tls_intercept = if tls_options.trust_proxy_ca
+        || tls_options.ca_validity.is_some()
+        || !tls_options.ca_env_vars.is_empty()
+    {
         Some(TlsInterceptIntent {
-            trust_proxy_ca: args.trust_proxy_ca,
-            ca_validity,
-            ca_env_vars: Vec::new(),
+            trust_proxy_ca: tls_options.trust_proxy_ca,
+            ca_validity: tls_options.ca_validity,
+            ca_env_vars: tls_options.ca_env_vars,
         })
     } else {
         None
     };
     #[cfg(not(target_os = "macos"))]
-    let tls_intercept = if ca_validity.is_some() {
+    let tls_intercept = if tls_options.ca_validity.is_some() || !tls_options.ca_env_vars.is_empty()
+    {
         Some(TlsInterceptIntent {
-            ca_validity,
-            ca_env_vars: Vec::new(),
+            ca_validity: tls_options.ca_validity,
+            ca_env_vars: tls_options.ca_env_vars,
         })
     } else {
         None
@@ -351,6 +366,7 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
         credentials: credentials_intent,
         upstream_proxy,
         tls_intercept,
+        proxy_leaf_validity: tls_options.leaf_validity,
         command_policies,
         credential_capture,
         session_id: crate::session::generate_session_id(),
@@ -635,6 +651,188 @@ mod tests {
         let args = parse_args(&["--allow-endpoint", "github:GET"]);
         let err = build_launch_options(&args).expect_err("missing path must fail");
         assert!(matches!(err, NonoError::ConfigParse(_)), "got {err:?}");
+    }
+
+    /// A profile requesting `ca_lifecycle: "trusted"` must set `trust_proxy_ca`
+    /// on the standalone `nono proxy` path exactly as it does for `nono run`.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn profile_tls_intercept_trusted_sets_trust_proxy_ca() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("trusted.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "trusted-test" },
+                "network": { "tls_intercept": { "ca_lifecycle": "trusted" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("trusted profile is valid");
+        let tls = opts
+            .tls_intercept
+            .expect("trusted lifecycle must produce a tls_intercept intent");
+        assert!(
+            tls.trust_proxy_ca,
+            "profile's trusted lifecycle was ignored"
+        );
+    }
+
+    #[test]
+    fn profile_tls_intercept_session_default_leaves_trust_off() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("session.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "session-test" },
+                "network": { "tls_intercept": { "ca_lifecycle": "session" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("session profile is valid");
+        assert!(opts.tls_intercept.is_none());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn profile_tls_intercept_trusted_rejected_off_macos() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("trusted.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "trusted-test" },
+                "network": { "tls_intercept": { "ca_lifecycle": "trusted" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let err = build_launch_options(&args).expect_err("trusted is macOS-only");
+        assert!(matches!(err, NonoError::ConfigParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn profile_ca_validity_carries_through() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("validity.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "validity-test" },
+                "network": { "tls_intercept": { "ca_validity": "365d" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("ca_validity profile is valid");
+        let tls = opts
+            .tls_intercept
+            .expect("ca_validity must produce a tls_intercept intent");
+        assert_eq!(
+            tls.ca_validity,
+            Some(std::time::Duration::from_secs(365 * 24 * 60 * 60))
+        );
+    }
+
+    #[test]
+    fn cli_ca_validity_flag_overrides_profile() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("validity.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "validity-test" },
+                "network": { "tls_intercept": { "ca_validity": "365d" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&[
+            "--profile",
+            profile_path.to_str().expect("valid utf8"),
+            "--proxy-ca-validity",
+            "10",
+        ]);
+        let opts = build_launch_options(&args).expect("flag + profile is valid");
+        let tls = opts.tls_intercept.expect("tls_intercept intent present");
+        assert_eq!(
+            tls.ca_validity,
+            Some(std::time::Duration::from_secs(10 * 24 * 60 * 60)),
+            "explicit --proxy-ca-validity must win over the profile value"
+        );
+    }
+
+    #[test]
+    fn profile_leaf_validity_carries_through() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("leaf.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "leaf-test" },
+                "network": { "tls_intercept": { "leaf_validity": "15m" } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("leaf_validity profile is valid");
+        assert_eq!(
+            opts.proxy_leaf_validity,
+            Some(std::time::Duration::from_secs(15 * 60))
+        );
+    }
+
+    #[test]
+    fn profile_ca_env_vars_carries_through() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("env.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "env-test" },
+                "network": { "tls_intercept": { "ca_env_vars": ["NODE_EXTRA_CA_CERTS"] } }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("ca_env_vars profile is valid");
+        let tls = opts
+            .tls_intercept
+            .expect("ca_env_vars must produce a tls_intercept intent");
+        assert_eq!(tls.ca_env_vars, vec!["NODE_EXTRA_CA_CERTS".to_string()]);
+    }
+
+    #[test]
+    fn no_profile_yields_no_tls_intercept() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let args = parse_args(&[]);
+        let opts = build_launch_options(&args).expect("empty args are valid");
+        assert!(opts.tls_intercept.is_none());
+        assert!(opts.proxy_leaf_validity.is_none());
     }
 
     /// Write a fresh, self-consistent CA key+cert pair to two temp files and

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1437,7 +1437,15 @@ pub(crate) fn prepare_proxy_launch_options(
         &mut tool_sandbox_proxy_credentials,
     )?;
     let allow_bind_ports = merge_dedup_ports(&prepared.listen_ports, &args.allow_bind);
-    let tls_options = resolve_tls_intercept_options(args, prepared)?;
+    #[cfg(target_os = "macos")]
+    let trust_proxy_ca = args.trust_proxy_ca;
+    #[cfg(not(target_os = "macos"))]
+    let trust_proxy_ca = false;
+    let tls_options = resolve_tls_intercept_options(
+        trust_proxy_ca,
+        args.proxy_ca_validity,
+        prepared.tls_intercept.as_ref(),
+    )?;
 
     let upstream_proxy_addr = if args.allow_net {
         None
@@ -1615,25 +1623,29 @@ pub(crate) fn prepare_proxy_launch_options(
     Ok(NetworkIntent::ProxyFiltered(Box::new(opts)))
 }
 
-struct ResolvedTlsInterceptOptions {
+pub(crate) struct ResolvedTlsInterceptOptions {
     #[cfg(target_os = "macos")]
-    trust_proxy_ca: bool,
-    ca_validity: Option<std::time::Duration>,
-    leaf_validity: Option<std::time::Duration>,
-    ca_env_vars: Vec<String>,
+    pub(crate) trust_proxy_ca: bool,
+    pub(crate) ca_validity: Option<std::time::Duration>,
+    pub(crate) leaf_validity: Option<std::time::Duration>,
+    pub(crate) ca_env_vars: Vec<String>,
 }
 
-fn resolve_tls_intercept_options(
-    args: &SandboxArgs,
-    prepared: &PreparedSandbox,
+/// Merges CLI flags with a profile's `network.tls_intercept` settings.
+///
+/// Shared by the sandboxed `run`/`shell`/`wrap` paths and the standalone
+/// `nono proxy` command so both honor the profile identically.
+pub(crate) fn resolve_tls_intercept_options(
+    trust_proxy_ca: bool,
+    proxy_ca_validity_days: Option<u32>,
+    profile_tls: Option<&crate::profile::TlsInterceptConfig>,
 ) -> Result<ResolvedTlsInterceptOptions> {
-    let profile_tls = prepared.tls_intercept.as_ref();
     #[cfg(target_os = "macos")]
     let profile_trusted = profile_tls
         .map(|tls| matches!(tls.ca_lifecycle, crate::profile::TlsCaLifecycle::Trusted))
         .unwrap_or(false);
     #[cfg(target_os = "macos")]
-    if args.trust_proxy_ca
+    if trust_proxy_ca
         && let Some(tls) = profile_tls
         && tls.ca_lifecycle == crate::profile::TlsCaLifecycle::Session
     {
@@ -1652,13 +1664,17 @@ fn resolve_tls_intercept_options(
                 .to_string(),
         ));
     }
+    // `trust_proxy_ca` only feeds `ResolvedTlsInterceptOptions::trust_proxy_ca`,
+    // which is macOS-only; silence the unused-parameter warning elsewhere
+    // without dropping the shared signature.
+    #[cfg(not(target_os = "macos"))]
+    let _ = trust_proxy_ca;
 
     let profile_ca_validity = profile_tls
         .and_then(|tls| tls.ca_validity.as_deref())
         .map(|value| crate::profile::parse_tls_duration("network.tls_intercept.ca_validity", value))
         .transpose()?;
-    let ca_validity = args
-        .proxy_ca_validity
+    let ca_validity = proxy_ca_validity_days
         .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60))
         .or(profile_ca_validity);
     let leaf_validity = profile_tls
@@ -1670,7 +1686,7 @@ fn resolve_tls_intercept_options(
 
     Ok(ResolvedTlsInterceptOptions {
         #[cfg(target_os = "macos")]
-        trust_proxy_ca: args.trust_proxy_ca || profile_trusted,
+        trust_proxy_ca: trust_proxy_ca || profile_trusted,
         ca_validity,
         leaf_validity,
         ca_env_vars: profile_tls


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1667 

@panga lmk if this works ok on your end, tested and was fine here!

## Summary

`nono proxy` built its TLS-intercept config from CLI flags only, ignoring a profiles ca_lifecycle/ca_validity/leaf_validity/ca_env_vars settings. A profile with ca_lifecycle=trusted was silently downgraded to an untrusted per-session CA, breaking any client (e.g. Docker) that verifies against the system trust store.

Generalize resolve_tls_intercept_options (previously SandboxArgs-only, used by `nono run`) to take plain params so both the sandboxed and standalone proxy paths share one implementation instead of drifting apart. Add regression tests, incl. Linux-only coverage for the trusted-lifecycle-off-macOS rejection path.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
