### PR TITLE
fix(net_filter): normalize hostnames before deny/allow-list matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,6 +2740,7 @@ dependencies = [
  "der 0.8.1",
  "getrandom 0.4.3",
  "globset",
+ "idna",
  "ignore",
  "jsonschema",
  "keyring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ globset = "0.4"
 nix = "0.31.3"
 landlock = "0.4"
 url = "2"
+idna = "1"
 getrandom = "0.4"
 base64 = "0.23"
 

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -297,6 +297,23 @@ mod tests {
     }
 
     #[test]
+    fn test_proxy_filter_denies_trailing_dot_metadata_hostname() {
+        // CONNECT-path callers pass the raw wire hostname straight through
+        // with no normalization; the filter itself must catch this.
+        let filter = ProxyFilter::allow_all();
+        let result = filter.check_host_with_ips("metadata.google.internal.", &[]);
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_proxy_filter_denies_unicode_form_of_punycode_deny_entry() {
+        let filter = ProxyFilter::allow_all().with_denied_hosts(&["xn--mnchen-3ya.de".to_string()]);
+        let result = filter.check_host_with_ips("münchen.de", &[]);
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
     fn test_proxy_filter_denies_resolved_aws_ipv6_metadata_ip() {
         let filter = ProxyFilter::allow_all();
         let resolved = vec![IpAddr::V6(Ipv6Addr::new(

--- a/crates/nono/Cargo.toml
+++ b/crates/nono/Cargo.toml
@@ -30,6 +30,7 @@ walkdir.workspace = true
 ignore.workspace = true
 globset.workspace = true
 regress = "0.11"
+idna.workspace = true
 
 # Unix socket IPC for supervisor
 libc = "0.2"

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -83,12 +83,18 @@ impl FilterResult {
     }
 
     /// A human-readable reason for the decision
+    ///
+    /// The host is untrusted, attacker-controlled input (it may not even have
+    /// passed [`normalize_host`]), and this string is printed directly to
+    /// terminals/logs by callers. Control characters (including the ESC that
+    /// begins an ANSI escape sequence) are stripped so a malicious hostname
+    /// can't spoof or hijack terminal output.
     #[must_use]
     pub fn reason(&self) -> String {
         match self {
             FilterResult::Allow => "allowed by host filter".to_string(),
             FilterResult::DenyHost { host } => {
-                format!("host {} is in the deny list", host)
+                format!("host {} is in the deny list", sanitize_for_display(host))
             }
             FilterResult::DenyLinkLocal { ip } => {
                 format!(
@@ -97,10 +103,20 @@ impl FilterResult {
                 )
             }
             FilterResult::DenyNotAllowed { host } => {
-                format!("host {} is not in the allowlist", host)
+                format!(
+                    "host {} is not in the allowlist",
+                    sanitize_for_display(host)
+                )
             }
         }
     }
+}
+
+/// Strip control characters (including ESC, which begins ANSI/CSI escape
+/// sequences) from untrusted text before it is embedded in a
+/// terminal-displayed or logged string.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
 }
 
 /// Check if an IP address is in the link-local range.
@@ -566,6 +582,24 @@ mod tests {
             host: "evil.com".to_string(),
         };
         assert!(deny.reason().contains("evil.com"));
+    }
+
+    #[test]
+    fn test_filter_result_reason_strips_terminal_escape_sequences() {
+        // A malicious hostname could smuggle ANSI escapes to spoof/hijack
+        // terminal output when the reason is printed by callers.
+        let deny = FilterResult::DenyNotAllowed {
+            host: "evil\x1b[31mFAKE ADMIN PROMPT\x1b[0m.com".to_string(),
+        };
+        let reason = deny.reason();
+        assert!(!reason.contains('\x1b'));
+        assert!(reason.contains("evil"));
+        assert!(reason.contains("FAKE ADMIN PROMPT"));
+
+        let deny_host = FilterResult::DenyHost {
+            host: "\x07evil.com".to_string(),
+        };
+        assert!(!deny_host.reason().contains('\x07'));
 
         let link_local = FilterResult::DenyLinkLocal {
             ip: IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -15,8 +15,43 @@
 //!   attacks targeting cloud metadata services.
 //! - **Wildcard subdomain matching**: `*.googleapis.com` matches
 //!   `storage.googleapis.com` but not `googleapis.com` itself.
+//! - **Normalized comparison**: hostnames are IDNA-normalized before
+//!   matching, so a trailing dot, mixed case, or Unicode/punycode spelling
+//!   can't slip past a deny entry. Unparseable hosts are denied.
 
 use std::net::IpAddr;
+
+/// Normalize a hostname for deny/allow-list comparison: strips a trailing
+/// FQDN dot, rejects control characters, and applies IDNA/punycode
+/// normalization (which also lowercases). Fails on malformed input rather
+/// than falling back to a raw string compare.
+fn normalize_host(host: &str) -> Result<String, idna::Errors> {
+    let trimmed = host.trim().trim_end_matches('.');
+    if trimmed.chars().any(char::is_control) {
+        return Err(idna::Errors::default());
+    }
+    let ascii = idna::domain_to_ascii(trimmed)?;
+    // domain_to_ascii folds Unicode label separators (e.g. U+3002) to ASCII
+    // '.', so a trailing one only shows up as a dot after this call.
+    Ok(ascii.trim_end_matches('.').to_string())
+}
+
+/// Normalize a stored filter entry, falling back to a plain trim/lowercase
+/// on malformed input. Unlike `normalize_host`, this never fails: an inert
+/// (non-matching) entry is safe on both the allow and deny side, since
+/// `check_host` denies any incoming host that fails normalization anyway.
+fn normalize_entry(entry: &str) -> String {
+    normalize_host(entry).unwrap_or_else(|_| entry.trim().trim_end_matches('.').to_lowercase())
+}
+
+/// Normalize a wildcard suffix (e.g. `.example.com`, taken from `*.example.com`),
+/// preserving the leading dot that anchors the subdomain match.
+fn normalize_suffix(suffix: &str) -> String {
+    match suffix.strip_prefix('.') {
+        Some(domain) => format!(".{}", normalize_entry(domain)),
+        None => normalize_entry(suffix),
+    }
+}
 
 /// Result of a host filter check.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -135,19 +170,18 @@ impl HostFilter {
         let mut suffixes = Vec::new();
 
         for host in allowed_hosts {
-            let lower = host.to_lowercase();
-            if let Some(suffix) = lower.strip_prefix('*') {
+            if let Some(suffix) = host.strip_prefix('*') {
                 // *.example.com -> .example.com
-                suffixes.push(suffix.to_string());
+                suffixes.push(normalize_suffix(suffix));
             } else {
-                exact.push(lower);
+                exact.push(normalize_entry(host));
             }
         }
 
         Self {
             allowed_hosts: exact,
             allowed_suffixes: suffixes,
-            deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            deny_hosts: DENY_HOSTS.iter().map(|s| normalize_entry(s)).collect(),
             deny_suffixes: Vec::new(),
             strict: false,
         }
@@ -169,7 +203,7 @@ impl HostFilter {
         Self {
             allowed_hosts: Vec::new(),
             allowed_suffixes: Vec::new(),
-            deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            deny_hosts: DENY_HOSTS.iter().map(|s| normalize_entry(s)).collect(),
             deny_suffixes: Vec::new(),
             strict: false,
         }
@@ -182,11 +216,10 @@ impl HostFilter {
     #[must_use]
     pub fn with_denied_hosts(mut self, denied: &[String]) -> Self {
         for entry in denied {
-            let lower = entry.to_lowercase();
-            if let Some(suffix) = lower.strip_prefix('*') {
-                self.deny_suffixes.push(suffix.to_string());
+            if let Some(suffix) = entry.strip_prefix('*') {
+                self.deny_suffixes.push(normalize_suffix(suffix));
             } else {
-                self.deny_hosts.push(lower);
+                self.deny_hosts.push(normalize_entry(entry));
             }
         }
         self
@@ -207,7 +240,13 @@ impl HostFilter {
     /// 4. Default deny (if not in allowlist and allowlist is non-empty)
     #[must_use]
     pub fn check_host(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
-        let lower_host = host.to_lowercase();
+        // 0. Normalize the incoming host (trailing-dot FQDN, case, Unicode/punycode).
+        // Malformed input is denied rather than compared raw.
+        let Ok(lower_host) = normalize_host(host) else {
+            return FilterResult::DenyNotAllowed {
+                host: host.to_string(),
+            };
+        };
 
         // 1. Check deny hosts (exact match)
         if self.deny_hosts.contains(&lower_host) {
@@ -556,5 +595,97 @@ mod tests {
         let filter = HostFilter::new(&[]);
         let result = filter.check_host("example.com", &public_ip());
         assert!(matches!(result, FilterResult::Allow));
+    }
+
+    #[test]
+    fn test_trailing_dot_bypass_on_hardcoded_metadata_deny() {
+        let filter = HostFilter::allow_all();
+        let result = filter.check_host("metadata.google.internal.", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+
+        let result = filter.check_host("metadata.azure.internal.", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_trailing_dot_bypass_on_user_deny_entry() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["evil.com".to_string()]);
+        let result = filter.check_host("evil.com.", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_trailing_dot_on_deny_entry_itself_still_matches() {
+        // A trailing dot on the *configured* deny entry should normalize the
+        // same way as a trailing dot on the incoming host.
+        let filter = HostFilter::allow_all().with_denied_hosts(&["evil.com.".to_string()]);
+        let result = filter.check_host("evil.com", &public_ip());
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_unicode_and_punycode_deny_entries_are_equivalent() {
+        // Denying the Unicode form must also deny requests spelled in punycode.
+        let filter = HostFilter::allow_all().with_denied_hosts(&["münchen.de".to_string()]);
+        let result = filter.check_host("xn--mnchen-3ya.de", &public_ip());
+        assert!(!result.is_allowed());
+
+        // And denying the punycode form must also deny the Unicode spelling.
+        let filter = HostFilter::allow_all().with_denied_hosts(&["xn--mnchen-3ya.de".to_string()]);
+        let result = filter.check_host("münchen.de", &public_ip());
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_unicode_dns_label_separators_normalize_like_dot() {
+        // U+3002 IDEOGRAPHIC FULL STOP is DNS-equivalent to '.'.
+        let filter = HostFilter::allow_all().with_denied_hosts(&["evil.com".to_string()]);
+        let result = filter.check_host("evil\u{3002}com", &public_ip());
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_trailing_unicode_label_separator_bypass_on_metadata_deny() {
+        // Trailing U+3002 only becomes a dot after domain_to_ascii runs.
+        let filter = HostFilter::allow_all();
+        let result = filter.check_host("metadata.google.internal\u{3002}", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_embedded_nul_byte_fails_closed() {
+        // A NUL byte could desync a resolver that truncates C strings at it.
+        let filter = HostFilter::allow_all();
+        let result = filter.check_host("metadata.google.internal\0", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn test_control_characters_fail_closed() {
+        let filter = HostFilter::allow_all();
+        for host in ["a\tb.com", "a\nb.com", "a\u{7f}b.com", "a\u{1}b.com"] {
+            let result = filter.check_host(host, &public_ip());
+            assert!(!result.is_allowed(), "host {host:?} should fail closed");
+        }
+    }
+
+    #[test]
+    fn test_malformed_punycode_host_fails_closed() {
+        let filter = HostFilter::allow_all();
+        let result = filter.check_host("xn--zz", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn test_trailing_dot_does_not_break_wildcard_allow() {
+        let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
+        let result = filter.check_host("storage.googleapis.com.", &public_ip());
+        assert!(result.is_allowed());
     }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #

## Summary

net_filter.rs compared hosts by lowercasing only, so a trailing-dot FQDN (example.com.) or a Unicode/punycode spelling mismatch could slip past a --deny-domain entry or the hardcoded cloud-metadata deny list, giving a sandboxed process an SSRF path since the CONNECT path in nono-proxy applied no normalization at all (the plain-HTTP path normalized via Url::parse but CONNECT did not).

Add normalize_host: strips a trailing FQDN dot, rejects control characters (a NUL byte in particular can desync a resolver that truncates C strings at it), and punycode-normalizes via idna, which also lowercases. Fails closed on malformed input instead of falling back to a raw string compare. Apply it uniformly to incoming hosts in check_host and to all stored entries (new, with_denied_hosts, allow_all), so both nono-proxy call sites inherit the fix for free without changing their code.

idna is promoted from a transitive dependency (via url) to a direct one; no new supply-chain surface.

Verified with a raw-socket adversarial corpus sent straight to the live proxy (trailing dot, Unicode label separators, zero-width/BOM, embedded NUL, Unicode<->punycode equivalence, malformed punycode) and confirmed no regressions in existing allow/deny/wildcard behavior.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
