### PR TITLE
fix(proxy): read chunked HTTP request bodies on L7 forward path

### DIFF
--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -28,8 +28,7 @@ use base64::Engine as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 use tracing::{debug, warn};
@@ -570,8 +569,7 @@ pub async fn handle_reverse_proxy(
 
     let strip_header = cred.map(|c| c.proxy_header_name.as_str()).unwrap_or("");
     let filtered_headers = filter_headers(remaining_header, strip_header);
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(body) => body,
         None => return Ok(()),
     };
@@ -848,8 +846,7 @@ async fn handle_spiffe_route(
         remaining_header,
         &[inject_header_str, "Authorization", "x-api-key"],
     );
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(body) => body,
         None => return Ok(()),
     };
@@ -1484,8 +1481,7 @@ async fn handle_oauth2_like(
         remaining_header,
         &[inject_header, "Authorization", "x-api-key"],
     );
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(b) => b,
         None => return Ok(()),
     };
@@ -1611,15 +1607,32 @@ async fn handle_oauth2_credential(
 /// `buffered_body` contains bytes the BufReader read ahead beyond headers.
 /// Generic over the inbound stream so the TLS-intercept handler can reuse
 /// it on a `TlsStream<…>` without duplication.
+///
+/// When `Transfer-Encoding: chunked` is present, the body is decoded from
+/// the stream and returned as a plain buffer (re-framed upstream with
+/// `Content-Length`). Malformed chunk framing yields 400 Bad Request.
 pub(crate) async fn read_request_body<S>(
     stream: &mut S,
-    content_length: Option<usize>,
+    header_bytes: &[u8],
     buffered_body: &[u8],
 ) -> Result<Option<Vec<u8>>>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    if let Some(len) = content_length {
+    if has_chunked_transfer_encoding(header_bytes) {
+        return match read_chunked_request_body(stream, buffered_body).await {
+            Ok(body) => Ok(Some(body)),
+            Err(ProxyError::HttpParse(ref msg)) if msg.contains("exceeds size limit") => {
+                send_error_generic(stream, 413, "Payload Too Large").await?;
+                Ok(None)
+            }
+            Err(_) => {
+                send_error_generic(stream, 400, "Bad Request").await?;
+                Ok(None)
+            }
+        };
+    }
+    if let Some(len) = extract_content_length(header_bytes) {
         if len > MAX_REQUEST_BODY {
             send_error_generic(stream, 413, "Payload Too Large").await?;
             return Ok(None);
@@ -1630,12 +1643,106 @@ where
         let remaining = len - pre;
         if remaining > 0 {
             let mut rest = vec![0u8; remaining];
-            stream.read_exact(&mut rest).await?;
+            stream.read_exact(&mut rest).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated Content-Length request body: {e}"))
+            })?;
             buf.extend_from_slice(&rest);
         }
         Ok(Some(buf))
     } else {
         Ok(Some(Vec::new()))
+    }
+}
+
+/// Returns true when headers declare `Transfer-Encoding: chunked`.
+pub(crate) fn has_chunked_transfer_encoding(header_bytes: &[u8]) -> bool {
+    let header_str = match std::str::from_utf8(header_bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    for line in header_str.lines() {
+        if line.to_lowercase().starts_with("transfer-encoding:") {
+            let value = line.split_once(':').map(|(_, v)| v).unwrap_or("");
+            if value
+                .split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+async fn read_chunked_request_body<S>(stream: &mut S, buffered_body: &[u8]) -> Result<Vec<u8>>
+where
+    S: tokio::io::AsyncRead + Unpin,
+{
+    let prefix = std::io::Cursor::new(buffered_body.to_vec());
+    let chained = prefix.chain(stream);
+    let mut reader = BufReader::new(chained);
+    let mut out = Vec::new();
+    let mut total = 0usize;
+    loop {
+        let mut size_line = String::new();
+        if crate::line_reader::read_line_limited_string(
+            &mut reader,
+            &mut size_line,
+            crate::line_reader::MAX_LINE_SIZE,
+        )
+        .await?
+            == 0
+        {
+            return Err(ProxyError::HttpParse(
+                "truncated chunked request".to_string(),
+            ));
+        }
+        let size_text = size_line.trim_end().split(';').next().unwrap_or("");
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| ProxyError::HttpParse("invalid chunk size".to_string()))?;
+        total = total
+            .checked_add(size)
+            .ok_or_else(|| ProxyError::HttpParse("chunked request size overflow".to_string()))?;
+        if total > MAX_REQUEST_BODY {
+            return Err(ProxyError::HttpParse(
+                "chunked request exceeds size limit".to_string(),
+            ));
+        }
+        if size > 0 {
+            let mut chunk = vec![0u8; size];
+            reader.read_exact(&mut chunk).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated chunked request body: {e}"))
+            })?;
+            let mut crlf = [0u8; 2];
+            reader.read_exact(&mut crlf).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated chunked request body: {e}"))
+            })?;
+            if crlf != *b"\r\n" {
+                return Err(ProxyError::HttpParse(
+                    "malformed chunk data terminator".to_string(),
+                ));
+            }
+            out.extend_from_slice(&chunk);
+            continue;
+        }
+        loop {
+            let mut trailer = String::new();
+            if crate::line_reader::read_line_limited_string(
+                &mut reader,
+                &mut trailer,
+                crate::line_reader::MAX_LINE_SIZE,
+            )
+            .await?
+                == 0
+            {
+                return Err(ProxyError::HttpParse(
+                    "truncated chunked request trailers".to_string(),
+                ));
+            }
+            if trailer == "\r\n" || trailer == "\n" {
+                return Ok(out);
+            }
+        }
     }
 }
 
@@ -1800,6 +1907,7 @@ fn validate_phantom_token(
 /// Always strips:
 /// - `Host` (rewritten to upstream)
 /// - `Content-Length` (re-added after body is read)
+/// - `Transfer-Encoding` (body is decoded and re-framed upstream)
 /// - `Proxy-Authorization` (hop-by-hop, contains session token)
 ///
 /// When `cred_header` is non-empty, also strips that header (it contains
@@ -1818,6 +1926,7 @@ pub(crate) fn filter_headers_multi(header_bytes: &[u8], strip: &[&str]) -> Vec<(
         let lower = line.to_lowercase();
         if lower.starts_with("host:")
             || lower.starts_with("content-length:")
+            || lower.starts_with("transfer-encoding:")
             || lower.starts_with("connection:")
             || lower.starts_with("proxy-connection:")
             || lower.starts_with("proxy-authorization:")
@@ -1846,6 +1955,7 @@ pub(crate) fn filter_headers(header_bytes: &[u8], cred_header: &str) -> Vec<(Str
         let lower = line.to_lowercase();
         if lower.starts_with("host:")
             || lower.starts_with("content-length:")
+            || lower.starts_with("transfer-encoding:")
             || lower.starts_with("connection:")
             || lower.starts_with("proxy-connection:")
             || lower.starts_with("proxy-authorization:")
@@ -3019,6 +3129,106 @@ mod tests {
     fn test_extract_content_length_missing() {
         let header = b"Content-Type: application/json\r\n\r\n";
         assert_eq!(extract_content_length(header), None);
+    }
+
+    #[test]
+    fn test_has_chunked_transfer_encoding() {
+        let header = b"Transfer-Encoding: chunked\r\nHost: example.com\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+        let header = b"Transfer-Encoding: gzip, chunked\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+        let header = b"Content-Type: application/json\r\n\r\n";
+        assert!(!has_chunked_transfer_encoding(header));
+    }
+
+    #[test]
+    fn test_filter_headers_strips_transfer_encoding() {
+        let header = b"Transfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
+        let filtered = filter_headers(header, "");
+        assert!(
+            !filtered
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("transfer-encoding"))
+        );
+        assert!(
+            filtered
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_request_body_decodes_chunked_body() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let payload = b"hello";
+        let chunked = format!("5\r\n{}\r\n0\r\n\r\n", String::from_utf8_lossy(payload));
+        let (mut client, server) = tokio::io::duplex(4096);
+        client.write_all(chunked.as_bytes()).await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, payload);
+    }
+
+    #[tokio::test]
+    async fn read_request_body_decodes_empty_chunked_body() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"0\r\n\r\n").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_request_body_malformed_chunk_returns_none_after_400() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        client.write_all(b"not-hex\r\n").await.unwrap();
+        let read_task =
+            tokio::spawn(async move { read_request_body(&mut server, headers, &[]).await });
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        let result = read_task.await.unwrap().unwrap();
+        assert!(result.is_none());
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("400 Bad Request"));
+    }
+
+    #[tokio::test]
+    async fn read_request_body_content_length_regression() {
+        let headers = b"Content-Length: 5\r\n\r\n";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"hello").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn read_request_body_chunked_uses_buffered_prefix() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let buffered = b"5\r\nhel";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"lo\r\n0\r\n\r\n").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, buffered)
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, b"hello");
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -879,7 +879,9 @@ async fn handle_spiffe_route(
     }
 
     request.push_str("Connection: close\r\n");
-    if !body.is_empty() {
+    // Always re-frame when the client declared a body (CL or chunked TE),
+    // including empty bodies — otherwise upstreams may answer 411 or hang.
+    if should_reframe_with_content_length(remaining_header) {
         request.push_str(&format!("Content-Length: {}\r\n", body.len()));
     }
     request.push_str("\r\n");
@@ -1674,6 +1676,15 @@ pub(crate) fn has_chunked_transfer_encoding(header_bytes: &[u8]) -> bool {
     false
 }
 
+/// True when the inbound request declared a body framing header that we strip
+/// and must re-add as `Content-Length` after decode (including length 0).
+pub(crate) fn should_reframe_with_content_length(header_bytes: &[u8]) -> bool {
+    has_chunked_transfer_encoding(header_bytes) || extract_content_length(header_bytes).is_some()
+}
+
+/// Cap on trailer header lines after the final `0` chunk (DoS bound).
+const MAX_CHUNK_TRAILER_LINES: usize = 64;
+
 async fn read_chunked_request_body<S>(stream: &mut S, buffered_body: &[u8]) -> Result<Vec<u8>>
 where
     S: tokio::io::AsyncRead + Unpin,
@@ -1725,6 +1736,7 @@ where
             out.extend_from_slice(&chunk);
             continue;
         }
+        let mut trailer_lines = 0usize;
         loop {
             let mut trailer = String::new();
             if crate::line_reader::read_line_limited_string(
@@ -1741,6 +1753,14 @@ where
             }
             if trailer == "\r\n" || trailer == "\n" {
                 return Ok(out);
+            }
+            trailer_lines = trailer_lines.checked_add(1).ok_or_else(|| {
+                ProxyError::HttpParse("chunked request trailer count overflow".to_string())
+            })?;
+            if trailer_lines > MAX_CHUNK_TRAILER_LINES {
+                return Err(ProxyError::HttpParse(
+                    "too many chunked request trailers".to_string(),
+                ));
             }
         }
     }
@@ -3142,6 +3162,22 @@ mod tests {
     }
 
     #[test]
+    fn test_should_reframe_with_content_length() {
+        assert!(should_reframe_with_content_length(
+            b"Transfer-Encoding: chunked\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Content-Length: 0\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Content-Length: 5\r\n\r\n"
+        ));
+        assert!(!should_reframe_with_content_length(
+            b"Content-Type: text/plain\r\n\r\n"
+        ));
+    }
+
+    #[test]
     fn test_filter_headers_strips_transfer_encoding() {
         let header = b"Transfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
         let filtered = filter_headers(header, "");
@@ -3229,6 +3265,26 @@ mod tests {
             .unwrap()
             .expect("body");
         assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn read_request_body_rejects_excessive_trailers() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let mut payload = String::from("0\r\n");
+        for i in 0..=MAX_CHUNK_TRAILER_LINES {
+            payload.push_str(&format!("X-Trailer-{i}: 1\r\n"));
+        }
+        payload.push_str("\r\n");
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        client.write_all(payload.as_bytes()).await.unwrap();
+        let read_task =
+            tokio::spawn(async move { read_request_body(&mut server, headers, &[]).await });
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        let result = read_task.await.unwrap().unwrap();
+        assert!(result.is_none());
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("400 Bad Request"));
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -1656,21 +1656,37 @@ where
     }
 }
 
+/// Split one header line into a trimmed field name and the raw value.
+/// Missing `:` or an empty name fail closed (`None`).
+fn split_header_name_value(line: &str) -> Option<(&str, &str)> {
+    let (name, value) = line.split_once(':')?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, value))
+}
+
 /// Returns true when headers declare `Transfer-Encoding: chunked`.
+///
+/// Names are split on `:` and trimmed so detection matches hop-header stripping.
 pub(crate) fn has_chunked_transfer_encoding(header_bytes: &[u8]) -> bool {
     let header_str = match std::str::from_utf8(header_bytes) {
         Ok(s) => s,
         Err(_) => return false,
     };
     for line in header_str.lines() {
-        if line.to_lowercase().starts_with("transfer-encoding:") {
-            let value = line.split_once(':').map(|(_, v)| v).unwrap_or("");
-            if value
-                .split(',')
-                .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
-            {
-                return true;
-            }
+        let Some((name, value)) = split_header_name_value(line) else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case("transfer-encoding") {
+            continue;
+        }
+        if value
+            .split(',')
+            .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
+        {
+            return true;
         }
     }
     false
@@ -2055,13 +2071,19 @@ pub(crate) fn filter_headers_for_upgrade(
 }
 
 /// Extract Content-Length value from raw headers.
+///
+/// Header names are matched after `split(':')` and trim, matching hop-header
+/// stripping. Missing `:` or a non-integer value fail closed (`None`).
 pub(crate) fn extract_content_length(header_bytes: &[u8]) -> Option<usize> {
     let header_str = std::str::from_utf8(header_bytes).ok()?;
     for line in header_str.lines() {
-        if line.to_lowercase().starts_with("content-length:") {
-            let value = line.split_once(':')?.1.trim();
-            return value.parse().ok();
+        let Some((name, value)) = split_header_name_value(line) else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case("content-length") {
+            continue;
         }
+        return value.trim().parse().ok();
     }
     None
 }
@@ -3275,6 +3297,35 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_content_length_accepts_space_before_colon() {
+        let header = b"Content-Type: application/json\r\nContent-Length : 42\r\n\r\n";
+        assert_eq!(extract_content_length(header), Some(42));
+    }
+
+    #[test]
+    fn test_extract_content_length_malformed_header_fails_closed() {
+        assert_eq!(
+            extract_content_length(b"Content-Length 42\r\n\r\n"),
+            None,
+            "missing colon must not parse a length"
+        );
+        assert_eq!(
+            extract_content_length(b" : 42\r\n\r\n"),
+            None,
+            "empty name must not parse a length"
+        );
+        assert_eq!(
+            extract_content_length(b"Content-Length:\r\n\r\n"),
+            None,
+            "empty value must not parse a length"
+        );
+        assert_eq!(
+            extract_content_length(b"Content-Length: not-a-number\r\n\r\n"),
+            None
+        );
+    }
+
+    #[test]
     fn test_has_chunked_transfer_encoding() {
         let header = b"Transfer-Encoding: chunked\r\nHost: example.com\r\n\r\n";
         assert!(has_chunked_transfer_encoding(header));
@@ -3282,6 +3333,32 @@ mod tests {
         assert!(has_chunked_transfer_encoding(header));
         let header = b"Content-Type: application/json\r\n\r\n";
         assert!(!has_chunked_transfer_encoding(header));
+    }
+
+    #[test]
+    fn test_has_chunked_transfer_encoding_accepts_space_before_colon() {
+        let header = b"Transfer-Encoding : chunked\r\nHost: example.com\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+        let header = b"Transfer-Encoding : gzip, chunked\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+    }
+
+    #[test]
+    fn test_has_chunked_transfer_encoding_malformed_header_fails_closed() {
+        assert!(
+            !has_chunked_transfer_encoding(b"Transfer-Encoding chunked\r\n\r\n"),
+            "missing colon must not be treated as chunked"
+        );
+        assert!(
+            !has_chunked_transfer_encoding(b" : chunked\r\n\r\n"),
+            "empty name must not be treated as chunked"
+        );
+        assert!(!has_chunked_transfer_encoding(
+            b"Transfer-Encoding:\r\n\r\n"
+        ));
+        assert!(!has_chunked_transfer_encoding(
+            b"Transfer-Encoding: gzip\r\n\r\n"
+        ));
     }
 
     #[test]
@@ -3297,6 +3374,12 @@ mod tests {
         ));
         assert!(!should_reframe_with_content_length(
             b"Content-Type: text/plain\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Transfer-Encoding : chunked\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Content-Length : 0\r\n\r\n"
         ));
     }
 

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -879,7 +879,9 @@ async fn handle_spiffe_route(
     }
 
     request.push_str("Connection: close\r\n");
-    if !body.is_empty() {
+    // Always re-frame when the client declared a body (CL or chunked TE),
+    // including empty bodies — otherwise upstreams may answer 411 or hang.
+    if should_reframe_with_content_length(remaining_header) {
         request.push_str(&format!("Content-Length: {}\r\n", body.len()));
     }
     request.push_str("\r\n");
@@ -1674,6 +1676,15 @@ pub(crate) fn has_chunked_transfer_encoding(header_bytes: &[u8]) -> bool {
     false
 }
 
+/// True when the inbound request declared a body framing header that we strip
+/// and must re-add as `Content-Length` after decode (including length 0).
+pub(crate) fn should_reframe_with_content_length(header_bytes: &[u8]) -> bool {
+    has_chunked_transfer_encoding(header_bytes) || extract_content_length(header_bytes).is_some()
+}
+
+/// Cap on trailer header lines after the final `0` chunk (DoS bound).
+const MAX_CHUNK_TRAILER_LINES: usize = 64;
+
 async fn read_chunked_request_body<S>(stream: &mut S, buffered_body: &[u8]) -> Result<Vec<u8>>
 where
     S: tokio::io::AsyncRead + Unpin,
@@ -1725,6 +1736,7 @@ where
             out.extend_from_slice(&chunk);
             continue;
         }
+        let mut trailer_lines = 0usize;
         loop {
             let mut trailer = String::new();
             if crate::line_reader::read_line_limited_string(
@@ -1741,6 +1753,14 @@ where
             }
             if trailer == "\r\n" || trailer == "\n" {
                 return Ok(out);
+            }
+            trailer_lines = trailer_lines.checked_add(1).ok_or_else(|| {
+                ProxyError::HttpParse("chunked request trailer count overflow".to_string())
+            })?;
+            if trailer_lines > MAX_CHUNK_TRAILER_LINES {
+                return Err(ProxyError::HttpParse(
+                    "too many chunked request trailers".to_string(),
+                ));
             }
         }
     }
@@ -3265,6 +3285,22 @@ mod tests {
     }
 
     #[test]
+    fn test_should_reframe_with_content_length() {
+        assert!(should_reframe_with_content_length(
+            b"Transfer-Encoding: chunked\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Content-Length: 0\r\n\r\n"
+        ));
+        assert!(should_reframe_with_content_length(
+            b"Content-Length: 5\r\n\r\n"
+        ));
+        assert!(!should_reframe_with_content_length(
+            b"Content-Type: text/plain\r\n\r\n"
+        ));
+    }
+
+    #[test]
     fn test_filter_headers_strips_transfer_encoding() {
         let header = b"Transfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
         let filtered = filter_headers(header, "");
@@ -3352,6 +3388,26 @@ mod tests {
             .unwrap()
             .expect("body");
         assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn read_request_body_rejects_excessive_trailers() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let mut payload = String::from("0\r\n");
+        for i in 0..=MAX_CHUNK_TRAILER_LINES {
+            payload.push_str(&format!("X-Trailer-{i}: 1\r\n"));
+        }
+        payload.push_str("\r\n");
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        client.write_all(payload.as_bytes()).await.unwrap();
+        let read_task =
+            tokio::spawn(async move { read_request_body(&mut server, headers, &[]).await });
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        let result = read_task.await.unwrap().unwrap();
+        assert!(result.is_none());
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("400 Bad Request"));
     }
 
     #[test]

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -28,8 +28,7 @@ use base64::Engine as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 use tracing::{debug, warn};
@@ -570,8 +569,7 @@ pub async fn handle_reverse_proxy(
 
     let strip_header = cred.map(|c| c.proxy_header_name.as_str()).unwrap_or("");
     let filtered_headers = filter_headers(remaining_header, strip_header);
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(body) => body,
         None => return Ok(()),
     };
@@ -848,8 +846,7 @@ async fn handle_spiffe_route(
         remaining_header,
         &[inject_header_str, "Authorization", "x-api-key"],
     );
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(body) => body,
         None => return Ok(()),
     };
@@ -1484,8 +1481,7 @@ async fn handle_oauth2_like(
         remaining_header,
         &[inject_header, "Authorization", "x-api-key"],
     );
-    let content_length = extract_content_length(remaining_header);
-    let body = match read_request_body(stream, content_length, buffered_body).await? {
+    let body = match read_request_body(stream, remaining_header, buffered_body).await? {
         Some(b) => b,
         None => return Ok(()),
     };
@@ -1611,15 +1607,32 @@ async fn handle_oauth2_credential(
 /// `buffered_body` contains bytes the BufReader read ahead beyond headers.
 /// Generic over the inbound stream so the TLS-intercept handler can reuse
 /// it on a `TlsStream<…>` without duplication.
+///
+/// When `Transfer-Encoding: chunked` is present, the body is decoded from
+/// the stream and returned as a plain buffer (re-framed upstream with
+/// `Content-Length`). Malformed chunk framing yields 400 Bad Request.
 pub(crate) async fn read_request_body<S>(
     stream: &mut S,
-    content_length: Option<usize>,
+    header_bytes: &[u8],
     buffered_body: &[u8],
 ) -> Result<Option<Vec<u8>>>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    if let Some(len) = content_length {
+    if has_chunked_transfer_encoding(header_bytes) {
+        return match read_chunked_request_body(stream, buffered_body).await {
+            Ok(body) => Ok(Some(body)),
+            Err(ProxyError::HttpParse(ref msg)) if msg.contains("exceeds size limit") => {
+                send_error_generic(stream, 413, "Payload Too Large").await?;
+                Ok(None)
+            }
+            Err(_) => {
+                send_error_generic(stream, 400, "Bad Request").await?;
+                Ok(None)
+            }
+        };
+    }
+    if let Some(len) = extract_content_length(header_bytes) {
         if len > MAX_REQUEST_BODY {
             send_error_generic(stream, 413, "Payload Too Large").await?;
             return Ok(None);
@@ -1630,12 +1643,106 @@ where
         let remaining = len - pre;
         if remaining > 0 {
             let mut rest = vec![0u8; remaining];
-            stream.read_exact(&mut rest).await?;
+            stream.read_exact(&mut rest).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated Content-Length request body: {e}"))
+            })?;
             buf.extend_from_slice(&rest);
         }
         Ok(Some(buf))
     } else {
         Ok(Some(Vec::new()))
+    }
+}
+
+/// Returns true when headers declare `Transfer-Encoding: chunked`.
+pub(crate) fn has_chunked_transfer_encoding(header_bytes: &[u8]) -> bool {
+    let header_str = match std::str::from_utf8(header_bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    for line in header_str.lines() {
+        if line.to_lowercase().starts_with("transfer-encoding:") {
+            let value = line.split_once(':').map(|(_, v)| v).unwrap_or("");
+            if value
+                .split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+async fn read_chunked_request_body<S>(stream: &mut S, buffered_body: &[u8]) -> Result<Vec<u8>>
+where
+    S: tokio::io::AsyncRead + Unpin,
+{
+    let prefix = std::io::Cursor::new(buffered_body.to_vec());
+    let chained = prefix.chain(stream);
+    let mut reader = BufReader::new(chained);
+    let mut out = Vec::new();
+    let mut total = 0usize;
+    loop {
+        let mut size_line = String::new();
+        if crate::line_reader::read_line_limited_string(
+            &mut reader,
+            &mut size_line,
+            crate::line_reader::MAX_LINE_SIZE,
+        )
+        .await?
+            == 0
+        {
+            return Err(ProxyError::HttpParse(
+                "truncated chunked request".to_string(),
+            ));
+        }
+        let size_text = size_line.trim_end().split(';').next().unwrap_or("");
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| ProxyError::HttpParse("invalid chunk size".to_string()))?;
+        total = total
+            .checked_add(size)
+            .ok_or_else(|| ProxyError::HttpParse("chunked request size overflow".to_string()))?;
+        if total > MAX_REQUEST_BODY {
+            return Err(ProxyError::HttpParse(
+                "chunked request exceeds size limit".to_string(),
+            ));
+        }
+        if size > 0 {
+            let mut chunk = vec![0u8; size];
+            reader.read_exact(&mut chunk).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated chunked request body: {e}"))
+            })?;
+            let mut crlf = [0u8; 2];
+            reader.read_exact(&mut crlf).await.map_err(|e| {
+                ProxyError::HttpParse(format!("truncated chunked request body: {e}"))
+            })?;
+            if crlf != *b"\r\n" {
+                return Err(ProxyError::HttpParse(
+                    "malformed chunk data terminator".to_string(),
+                ));
+            }
+            out.extend_from_slice(&chunk);
+            continue;
+        }
+        loop {
+            let mut trailer = String::new();
+            if crate::line_reader::read_line_limited_string(
+                &mut reader,
+                &mut trailer,
+                crate::line_reader::MAX_LINE_SIZE,
+            )
+            .await?
+                == 0
+            {
+                return Err(ProxyError::HttpParse(
+                    "truncated chunked request trailers".to_string(),
+                ));
+            }
+            if trailer == "\r\n" || trailer == "\n" {
+                return Ok(out);
+            }
+        }
     }
 }
 
@@ -1843,6 +1950,7 @@ fn validate_phantom_token_basic(
 /// Always strips:
 /// - `Host` (rewritten to upstream)
 /// - `Content-Length` (re-added after body is read)
+/// - `Transfer-Encoding` (body is decoded and re-framed upstream)
 /// - `Proxy-Authorization` (hop-by-hop, contains session token)
 ///
 /// When `cred_header` is non-empty, also strips that header (it contains
@@ -1861,6 +1969,7 @@ pub(crate) fn filter_headers_multi(header_bytes: &[u8], strip: &[&str]) -> Vec<(
         let lower = line.to_lowercase();
         if lower.starts_with("host:")
             || lower.starts_with("content-length:")
+            || lower.starts_with("transfer-encoding:")
             || lower.starts_with("connection:")
             || lower.starts_with("proxy-connection:")
             || lower.starts_with("proxy-authorization:")
@@ -1889,6 +1998,7 @@ pub(crate) fn filter_headers(header_bytes: &[u8], cred_header: &str) -> Vec<(Str
         let lower = line.to_lowercase();
         if lower.starts_with("host:")
             || lower.starts_with("content-length:")
+            || lower.starts_with("transfer-encoding:")
             || lower.starts_with("connection:")
             || lower.starts_with("proxy-connection:")
             || lower.starts_with("proxy-authorization:")
@@ -3142,6 +3252,106 @@ mod tests {
     fn test_extract_content_length_missing() {
         let header = b"Content-Type: application/json\r\n\r\n";
         assert_eq!(extract_content_length(header), None);
+    }
+
+    #[test]
+    fn test_has_chunked_transfer_encoding() {
+        let header = b"Transfer-Encoding: chunked\r\nHost: example.com\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+        let header = b"Transfer-Encoding: gzip, chunked\r\n\r\n";
+        assert!(has_chunked_transfer_encoding(header));
+        let header = b"Content-Type: application/json\r\n\r\n";
+        assert!(!has_chunked_transfer_encoding(header));
+    }
+
+    #[test]
+    fn test_filter_headers_strips_transfer_encoding() {
+        let header = b"Transfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
+        let filtered = filter_headers(header, "");
+        assert!(
+            !filtered
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("transfer-encoding"))
+        );
+        assert!(
+            filtered
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_request_body_decodes_chunked_body() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let payload = b"hello";
+        let chunked = format!("5\r\n{}\r\n0\r\n\r\n", String::from_utf8_lossy(payload));
+        let (mut client, server) = tokio::io::duplex(4096);
+        client.write_all(chunked.as_bytes()).await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, payload);
+    }
+
+    #[tokio::test]
+    async fn read_request_body_decodes_empty_chunked_body() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"0\r\n\r\n").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_request_body_malformed_chunk_returns_none_after_400() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        client.write_all(b"not-hex\r\n").await.unwrap();
+        let read_task =
+            tokio::spawn(async move { read_request_body(&mut server, headers, &[]).await });
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        let result = read_task.await.unwrap().unwrap();
+        assert!(result.is_none());
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("400 Bad Request"));
+    }
+
+    #[tokio::test]
+    async fn read_request_body_content_length_regression() {
+        let headers = b"Content-Length: 5\r\n\r\n";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"hello").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, &[])
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn read_request_body_chunked_uses_buffered_prefix() {
+        let headers = b"Transfer-Encoding: chunked\r\n\r\n";
+        let buffered = b"5\r\nhel";
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"lo\r\n0\r\n\r\n").await.unwrap();
+        drop(client);
+        let mut stream = server;
+        let body = read_request_body(&mut stream, headers, buffered)
+            .await
+            .unwrap()
+            .expect("body");
+        assert_eq!(body, b"hello");
     }
 
     #[test]

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -2028,7 +2028,9 @@ async fn handle_forward_http(
     let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 64);
     request_bytes.extend_from_slice(origin_line.as_bytes());
     request_bytes.extend_from_slice(&filtered_headers);
-    if !body.is_empty() {
+    // Always re-frame when the client declared a body (CL or chunked TE),
+    // including empty bodies — otherwise upstreams may answer 411 or hang.
+    if reverse::should_reframe_with_content_length(header_bytes) {
         request_bytes.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
     }
     request_bytes.extend_from_slice(b"\r\n");

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -170,6 +170,8 @@ fn strip_proxy_headers(header_bytes: &[u8]) -> Vec<u8> {
         let name = line.split(':').next().unwrap_or("").trim();
         if name.eq_ignore_ascii_case("proxy-connection")
             || name.eq_ignore_ascii_case("proxy-authorization")
+            || name.eq_ignore_ascii_case("content-length")
+            || name.eq_ignore_ascii_case("transfer-encoding")
         {
             continue;
         }
@@ -203,6 +205,8 @@ fn strip_and_redeem_proxy_headers(
         let trimmed_name = name.trim();
         if trimmed_name.eq_ignore_ascii_case("proxy-connection")
             || trimmed_name.eq_ignore_ascii_case("proxy-authorization")
+            || trimmed_name.eq_ignore_ascii_case("content-length")
+            || trimmed_name.eq_ignore_ascii_case("transfer-encoding")
         {
             continue;
         }
@@ -1978,8 +1982,16 @@ async fn handle_forward_http(
         return Ok(());
     }
 
-    // 3. Build the origin-form request bytes: rewritten request line +
-    //    proxy-header-stripped header block + terminating CRLF.
+    // 3. Read the request body before building upstream headers so chunked
+    //    framing can be decoded and re-written with Content-Length.
+    let body = match reverse::read_request_body(stream, header_bytes, buffered).await? {
+        Some(body) => body,
+        None => return Ok(()), // send_error already written (e.g. 413 / 400)
+    };
+
+    // Build the origin-form request bytes: rewritten request line +
+    // proxy-header-stripped header block + optional Content-Length +
+    // terminating CRLF.
     let origin_line = rewrite_absolute_to_origin_form(first_line)?;
     let inbound_path = origin_line
         .split_whitespace()
@@ -2012,18 +2024,14 @@ async fn handle_forward_http(
             }
             _ => (strip_proxy_headers(header_bytes), false),
         };
-    let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 2);
+
+    let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 64);
     request_bytes.extend_from_slice(origin_line.as_bytes());
     request_bytes.extend_from_slice(&filtered_headers);
+    if !body.is_empty() {
+        request_bytes.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
+    }
     request_bytes.extend_from_slice(b"\r\n");
-
-    // Read the request body honoring Content-Length. `buffered` holds any
-    // bytes the BufReader already read past the header terminator.
-    let content_length = reverse::extract_content_length(header_bytes);
-    let body = match reverse::read_request_body(stream, content_length, buffered).await? {
-        Some(body) => body,
-        None => return Ok(()), // send_error already written (e.g. 413)
-    };
 
     // 4. Choose the upstream strategy: chain through the external/enterprise
     //    proxy when configured (unless the host is a bypass host), else

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -2121,7 +2121,9 @@ async fn handle_forward_http(
     let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 64);
     request_bytes.extend_from_slice(origin_line.as_bytes());
     request_bytes.extend_from_slice(&filtered_headers);
-    if !body.is_empty() {
+    // Always re-frame when the client declared a body (CL or chunked TE),
+    // including empty bodies — otherwise upstreams may answer 411 or hang.
+    if reverse::should_reframe_with_content_length(header_bytes) {
         request_bytes.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
     }
     request_bytes.extend_from_slice(b"\r\n");

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -170,6 +170,8 @@ fn strip_proxy_headers(header_bytes: &[u8]) -> Vec<u8> {
         let name = line.split(':').next().unwrap_or("").trim();
         if name.eq_ignore_ascii_case("proxy-connection")
             || name.eq_ignore_ascii_case("proxy-authorization")
+            || name.eq_ignore_ascii_case("content-length")
+            || name.eq_ignore_ascii_case("transfer-encoding")
         {
             continue;
         }
@@ -230,6 +232,8 @@ fn strip_and_redeem_proxy_headers(
         let trimmed_name = name.trim();
         if trimmed_name.eq_ignore_ascii_case("proxy-connection")
             || trimmed_name.eq_ignore_ascii_case("proxy-authorization")
+            || trimmed_name.eq_ignore_ascii_case("content-length")
+            || trimmed_name.eq_ignore_ascii_case("transfer-encoding")
         {
             continue;
         }
@@ -2065,8 +2069,16 @@ async fn handle_forward_http(
         return Ok(());
     }
 
-    // 3. Build the origin-form request bytes: rewritten request line +
-    //    proxy-header-stripped header block + terminating CRLF.
+    // 3. Read the request body before building upstream headers so chunked
+    //    framing can be decoded and re-written with Content-Length.
+    let body = match reverse::read_request_body(stream, header_bytes, buffered).await? {
+        Some(body) => body,
+        None => return Ok(()), // send_error already written (e.g. 413 / 400)
+    };
+
+    // Build the origin-form request bytes: rewritten request line +
+    // proxy-header-stripped header block + optional Content-Length +
+    // terminating CRLF.
     let origin_line = rewrite_absolute_to_origin_form(first_line)?;
     let inbound_path = origin_line
         .split_whitespace()
@@ -2105,18 +2117,14 @@ async fn handle_forward_http(
             }
             _ => (strip_proxy_headers(header_bytes), false),
         };
-    let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 2);
+
+    let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 64);
     request_bytes.extend_from_slice(origin_line.as_bytes());
     request_bytes.extend_from_slice(&filtered_headers);
+    if !body.is_empty() {
+        request_bytes.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
+    }
     request_bytes.extend_from_slice(b"\r\n");
-
-    // Read the request body honoring Content-Length. `buffered` holds any
-    // bytes the BufReader already read past the header terminator.
-    let content_length = reverse::extract_content_length(header_bytes);
-    let body = match reverse::read_request_body(stream, content_length, buffered).await? {
-        Some(body) => body,
-        None => return Ok(()), // send_error already written (e.g. 413)
-    };
 
     // 4. Choose the upstream strategy: chain through the external/enterprise
     //    proxy when configured (unless the host is a bypass host), else

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1234,11 +1234,11 @@ where
         filtered_headers.retain(|(name, _)| !name.eq_ignore_ascii_case("accept-encoding"));
         filtered_headers.push(("Accept-Encoding".to_string(), "identity".to_string()));
     }
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
     let body = if let Some(endpoint) = oauth_endpoint {
         ctx.oauth_capture_store
             .rewrite_request_body(endpoint, &body)?
@@ -1511,11 +1511,11 @@ where
 
     let strip_header = inject_header.as_deref().unwrap_or("");
     let filtered_headers = reverse::filter_headers(&req.header_bytes, strip_header);
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
 
     let upstream_authority = reverse::format_host_header(UpstreamScheme::Https, ctx.host, ctx.port);
     let mut request = Zeroizing::new(format!(
@@ -1661,11 +1661,11 @@ where
     let mut filtered_headers = reverse::filter_headers(&req.header_bytes, "");
     filtered_headers.retain(|(name, _)| !crate::aws::sign::is_aws_auth_header(name));
 
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
 
     // --- Resolve upstream IPs (DNS-rebind-safe via filter) ---
     let resolved_addrs = match resolve_upstream_or_deny(

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1234,11 +1234,11 @@ where
         filtered_headers.retain(|(name, _)| !name.eq_ignore_ascii_case("accept-encoding"));
         filtered_headers.push(("Accept-Encoding".to_string(), "identity".to_string()));
     }
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
     let body = if let Some(endpoint) = oauth_endpoint {
         ctx.oauth_capture_store
             .rewrite_request_body(endpoint, &body)?
@@ -1512,11 +1512,11 @@ where
 
     let strip_header = inject_header.as_deref().unwrap_or("");
     let filtered_headers = reverse::filter_headers(&req.header_bytes, strip_header);
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
 
     let upstream_authority = reverse::format_host_header(UpstreamScheme::Https, ctx.host, ctx.port);
     let mut request = Zeroizing::new(format!(
@@ -1685,11 +1685,11 @@ where
     let mut filtered_headers = reverse::filter_headers(&req.header_bytes, "");
     filtered_headers.retain(|(name, _)| !crate::aws::sign::is_aws_auth_header(name));
 
-    let content_length = reverse::extract_content_length(&req.header_bytes);
-    let body = match reverse::read_request_body(tls_stream, content_length, &req.buffered).await? {
-        Some(b) => b,
-        None => return Ok(()),
-    };
+    let body =
+        match reverse::read_request_body(tls_stream, &req.header_bytes, &req.buffered).await? {
+            Some(b) => b,
+            None => return Ok(()),
+        };
 
     // --- Resolve upstream IPs (DNS-rebind-safe via filter) ---
     let resolved_addrs = match resolve_upstream_or_deny(


### PR DESCRIPTION
## Summary

- Decode `Transfer-Encoding: chunked` request bodies in `read_request_body` so L7 plaintext HTTP forward no longer hangs when clients omit `Content-Length` (e.g. Go `net/http` streaming readers).
- Strip `Transfer-Encoding` from forwarded headers and re-frame upstream requests with a computed `Content-Length`.
- Fail closed on malformed chunk framing (400 Bad Request / 413 Payload Too Large) instead of silently deadlocking.

Closes #1635

## Approach

1. **`reverse.rs`**: When headers declare chunked encoding, read and decode the body from the client stream (bounded by existing `MAX_REQUEST_BODY` = 16 MiB), using the same line-bounded reading pattern as `tls_intercept/http1.rs::relay_chunked` on the response side.
2. **`filter_headers` / `filter_headers_multi`**: Strip `Transfer-Encoding` alongside `Content-Length` so upstream never receives `Transfer-Encoding: chunked` with zero chunks.
3. **`server.rs` forward path**: Read body before building upstream headers; strip body-framing headers in `strip_proxy_headers` / `strip_and_redeem_proxy_headers`; append `Content-Length` after decode.

CONNECT blind-tunnel path is unchanged.

## Test plan

- [x] `cargo test -p nono-proxy` — 493 unit/integration tests pass
- [x] `cargo clippy -p nono-proxy -- -D warnings -D clippy::unwrap_used`
- [x] `make fmt-check`
- [x] New unit tests:
  - chunked body decode (normal + buffered prefix)
  - empty chunked body (`0\r\n\r\n`)
  - malformed chunk → 400, no hang
  - Content-Length regression
  - `has_chunked_transfer_encoding` + header stripping
- [ ] Manual: Linux `curl` chunked POST through proxy allow-list (issue repro steps)

## Conflict note (#1683)

PR #1683 (`fix(proxy): decode Basic auth for basic_auth phantom validation`) also touches `reverse.rs` but is **still open / not merged**. This branch is based on current `origin/main` (post v0.74.0). Overlap is limited to unrelated areas of `reverse.rs`; rebasing after #1683 merges may require a trivial conflict resolution.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1635)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (chunked line-reading pattern from `tls_intercept/http1.rs::relay_chunked`)
- [x] I did not use forbidden patterns such as unwrap/expect (production code)
- [x] I used NonoError/ProxyError where required
- [x] I validated and canonicalized all relevant paths (N/A — no new path grants)
- [x] This PR matches the approved or disclosed issue scope

**Contributor disclosure:** This PR was prepared by an AI coding agent (Cursor).


Made with [Cursor](https://cursor.com)