### PR TITLE
fix(macos): renew the trusted proxy CA before and during a session

### DIFF
--- a/crates/nono-cli/src/macos_ca_renewal.rs
+++ b/crates/nono-cli/src/macos_ca_renewal.rs
@@ -1,0 +1,273 @@
+//! Keeps a running session's interception CA usable across its own expiry, which
+//! would otherwise kill every intercepted route until a restart.
+//!
+//! Adopting a certificate another launch already renewed is preferred over renewing
+//! here, because only the latter writes to the trust store and prompts.
+
+use crate::macos_trust::{self, CertValidity};
+use nono_proxy::tls_intercept::InterceptCaRotator;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+/// Each check is a Keychain read, and a 7-day certificate needs nothing tighter.
+const MAX_CHECK_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Floor, so a misconfigured tiny `ca_validity` can't spin.
+const MIN_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// After a declined prompt or failed trust write: re-prompting hourly would be
+/// worse than the expiry.
+const BACKOFF_AFTER_FAILURE: Duration = Duration::from_secs(6 * 3600);
+
+/// Watch the live interception CA and keep it renewed for the life of the process.
+///
+/// A plain thread, not a tokio task: every step is a blocking Security.framework
+/// call, and it must outlive the caller's stack frame.
+pub(crate) fn spawn_supervisor(rotator: Arc<InterceptCaRotator>, validity: Duration) {
+    let interval = check_interval(validity);
+    std::thread::Builder::new()
+        .name("nono-ca-renewal".to_string())
+        .spawn(move || {
+            let mut delay = interval;
+            loop {
+                std::thread::sleep(delay);
+                delay = match supervise_once(&rotator, validity) {
+                    Ok(Outcome::Deferred) => BACKOFF_AFTER_FAILURE,
+                    Ok(_) => interval,
+                    Err(e) => {
+                        warn!("Proxy CA renewal check failed: {e}");
+                        BACKOFF_AFTER_FAILURE
+                    }
+                };
+            }
+        })
+        .map(|_| ())
+        .unwrap_or_else(|e| warn!("Could not start proxy CA renewal supervisor: {e}"));
+}
+
+/// Several checks per headroom, so the renewal window is never missed however
+/// short the configured validity is.
+fn check_interval(validity: Duration) -> Duration {
+    let headroom = macos_trust::renewal_headroom(validity.as_secs().min(i64::MAX as u64) as i64);
+    (headroom / 2).clamp(MIN_CHECK_INTERVAL, MAX_CHECK_INTERVAL)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    /// Live certificate has life left and nothing newer is stored.
+    NothingToDo,
+    /// Swapped in a certificate another process had already renewed.
+    Adopted,
+    /// Re-issued and installed a certificate ourselves.
+    Renewed,
+    /// Renewal was needed but couldn't be completed; still serving the old cert.
+    Deferred,
+}
+
+fn supervise_once(rotator: &InterceptCaRotator, validity: Duration) -> nono::Result<Outcome> {
+    let live = rotator
+        .current_cert_pem()
+        .map_err(|e| nono::NonoError::SandboxInit(format!("{e}")))?;
+
+    if let Some(outcome) = try_adopt(rotator, &live)? {
+        return Ok(outcome);
+    }
+    if macos_trust::cert_validity(&live)? == CertValidity::Valid {
+        return Ok(Outcome::NothingToDo);
+    }
+
+    // Renewal writes to the trust store and prompts; one winner per machine.
+    let Some(_lock) = RenewalLock::acquire()? else {
+        debug!("another process is renewing the proxy CA; deferring");
+        return Ok(Outcome::Deferred);
+    };
+    // It may have finished while we waited for the lock.
+    if let Some(outcome) = try_adopt(rotator, &live)? {
+        return Ok(outcome);
+    }
+
+    match macos_trust::renew_shared_ca(validity)? {
+        Some(renewed) => {
+            install(rotator, &renewed.key_der, &renewed.cert_pem)?;
+            info!("Proxy CA renewed mid-session; no restart needed");
+            Ok(Outcome::Renewed)
+        }
+        None => {
+            warn!(
+                "Proxy CA could not be renewed (authentication declined or trust write failed). \
+                 Still serving the current certificate; will retry later. Intercepted routes will \
+                 fail once it expires — restart the agent to recover."
+            );
+            Ok(Outcome::Deferred)
+        }
+    }
+}
+
+/// Swap in the stored CA if it supersedes what we're serving.
+fn try_adopt(rotator: &InterceptCaRotator, live: &str) -> nono::Result<Option<Outcome>> {
+    let Some((key_der, cert_pem)) = macos_trust::read_shared_ca()? else {
+        return Ok(None);
+    };
+    if !worth_adopting(&cert_pem, live)? {
+        return Ok(None);
+    }
+    if !macos_trust::stored_cert_is_trusted(&cert_pem)? {
+        debug!("stored proxy CA is newer but not trusted; not adopting");
+        return Ok(None);
+    }
+    install(rotator, &key_der, &cert_pem)?;
+    info!("Adopted renewed proxy CA from Keychain");
+    Ok(Some(Outcome::Adopted))
+}
+
+fn worth_adopting(stored: &str, live: &str) -> nono::Result<bool> {
+    Ok(stored != live && macos_trust::supersedes(stored, live)?)
+}
+
+fn install(rotator: &InterceptCaRotator, key_der: &[u8], cert_pem: &str) -> nono::Result<PathBuf> {
+    rotator
+        .rotate(key_der, cert_pem)
+        .map_err(|e| nono::NonoError::SandboxInit(format!("failed to install renewed CA: {e}")))
+}
+
+/// Advisory lock so two sessions renewing at once produce one prompt, and one
+/// Keychain write, rather than two.
+struct RenewalLock {
+    _lock: nix::fcntl::Flock<std::fs::File>,
+}
+
+impl RenewalLock {
+    fn acquire() -> nono::Result<Option<Self>> {
+        let dir = crate::state_paths::user_state_dir()?;
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            nono::NonoError::SandboxInit(format!(
+                "cannot create state dir '{}': {e}",
+                dir.display()
+            ))
+        })?;
+        let path = dir.join("proxy-ca-renewal.lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)
+            .map_err(|e| {
+                nono::NonoError::SandboxInit(format!(
+                    "cannot open renewal lock '{}': {e}",
+                    path.display()
+                ))
+            })?;
+        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+            Ok(lock) => Ok(Some(Self { _lock: lock })),
+            Err((_, nix::errno::Errno::EWOULDBLOCK)) => Ok(None),
+            Err((_, e)) => Err(nono::NonoError::SandboxInit(format!(
+                "cannot lock '{}': {e}",
+                path.display()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use nono_proxy::tls_intercept::{CertCache, EphemeralCa};
+
+    fn rotator_with(ca: EphemeralCa, dir: &std::path::Path) -> InterceptCaRotator {
+        InterceptCaRotator::new(
+            Arc::new(CertCache::new(Arc::new(ca))),
+            dir.to_path_buf(),
+            "intercept-ca.pem",
+            None,
+        )
+    }
+
+    #[test]
+    fn the_check_interval_fits_inside_the_renewal_headroom() {
+        // 7 days: 24h headroom, so hourly is the cap that bites.
+        assert_eq!(
+            check_interval(Duration::from_secs(7 * 86400)),
+            MAX_CHECK_INTERVAL
+        );
+        // 120s: 30s headroom, so checks must be far tighter than hourly or the
+        // window closes unnoticed.
+        assert_eq!(
+            check_interval(Duration::from_secs(120)),
+            Duration::from_secs(15)
+        );
+        assert_eq!(check_interval(Duration::from_secs(1)), MIN_CHECK_INTERVAL);
+    }
+
+    #[test]
+    fn only_a_longer_lived_stored_cert_is_worth_adopting() {
+        let key =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(3600)).unwrap();
+        let live = key.cert_pem().to_string();
+        let renewed = EphemeralCa::reissue_with_cn(
+            key.key_der(),
+            "nono-proxy-ca",
+            Duration::from_secs(86400),
+        )
+        .unwrap();
+
+        assert!(worth_adopting(renewed.cert_pem(), &live).unwrap());
+        assert!(
+            !worth_adopting(&live, &live).unwrap(),
+            "the cert we already serve is not an upgrade"
+        );
+        assert!(
+            !worth_adopting(&live, renewed.cert_pem()).unwrap(),
+            "a shorter-lived cert must never displace a renewed one"
+        );
+    }
+
+    #[test]
+    fn a_rotation_replaces_the_live_cert_and_the_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(3600)).unwrap();
+        let old = ca.cert_pem().to_string();
+        let key_der = ca.key_der().to_vec();
+        let r = rotator_with(ca, dir.path());
+
+        let renewed =
+            EphemeralCa::reissue_with_cn(&key_der, "nono-proxy-ca", Duration::from_secs(7 * 86400))
+                .unwrap();
+        let bundle = install(&r, &key_der, renewed.cert_pem()).unwrap();
+
+        assert_eq!(r.current_cert_pem().unwrap(), renewed.cert_pem());
+        assert_ne!(r.current_cert_pem().unwrap(), old);
+        assert!(
+            std::fs::read_to_string(&bundle)
+                .unwrap()
+                .contains(renewed.cert_pem()),
+            "the bundle a child reads must carry the renewed anchor"
+        );
+    }
+
+    #[test]
+    fn the_lock_is_exclusive_across_holders() {
+        let home = tempfile::tempdir().unwrap();
+        let _env_lock = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::EnvVarGuard::set_all(&[(
+            "XDG_STATE_HOME",
+            &home.path().display().to_string(),
+        )]);
+
+        let first = RenewalLock::acquire().unwrap();
+        assert!(first.is_some(), "first acquisition must succeed");
+        assert!(
+            RenewalLock::acquire().unwrap().is_none(),
+            "a second holder must be turned away, so concurrent sessions prompt once"
+        );
+        drop(first);
+        assert!(
+            RenewalLock::acquire().unwrap().is_some(),
+            "the lock must be released with its holder"
+        );
+    }
+}

--- a/crates/nono-cli/src/macos_trust.rs
+++ b/crates/nono-cli/src/macos_trust.rs
@@ -53,11 +53,12 @@ pub(crate) fn load_or_generate_proxy_ca(validity: Duration) -> Option<PreloadedC
 fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
     match load_existing_ca()? {
         Some((key_der, cert_pem)) => {
-            if !cert_pem_is_valid(&cert_pem)? {
-                debug!("stored proxy CA has expired; regenerating");
-                remove_cert_from_keychain(&cert_pem);
-                delete_existing_ca();
-                return generate_and_trust_new_ca(validity);
+            match cert_validity(&cert_pem)? {
+                CertValidity::Valid => {}
+                state => {
+                    debug!("stored proxy CA needs renewal ({state:?}); re-issuing over stored key");
+                    return rotate_ca(&key_der, &cert_pem, validity, state);
+                }
             }
 
             let cert_der = pem_to_der(&cert_pem)?;
@@ -93,6 +94,46 @@ fn try_ensure_trusted_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
     }
 }
 
+/// The CA shared through Keychain, as `(key DER, cert PEM)`.
+pub(crate) fn read_shared_ca() -> Result<Option<(Zeroizing<Vec<u8>>, String)>> {
+    load_existing_ca()
+}
+
+/// Re-issue the shared CA over its stored key and retire the previous certificate.
+///
+/// `Ok(None)` means nothing changed: no stored CA, or a declined trust prompt.
+pub(crate) fn renew_shared_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
+    let Some((key_der, cert_pem)) = load_existing_ca()? else {
+        return Ok(None);
+    };
+    let state = cert_validity(&cert_pem)?;
+    match rotate_ca(&key_der, &cert_pem, validity, state)? {
+        Some(ca) if ca.cert_pem != cert_pem => Ok(Some(ca)),
+        _ => Ok(None),
+    }
+}
+
+/// Whether adopting `candidate` gains runway over `current`.
+pub(crate) fn supersedes(candidate: &str, current: &str) -> Result<bool> {
+    Ok(not_after_of(candidate)? > not_after_of(current)?)
+}
+
+pub(crate) fn stored_cert_is_trusted(cert_pem: &str) -> Result<bool> {
+    let der = pem_to_der(cert_pem)?;
+    let cert = SecCertificate::from_der(&der)
+        .map_err(|e| NonoError::SandboxInit(format!("failed to parse stored CA cert: {e}")))?;
+    Ok(is_cert_trusted(&cert))
+}
+
+fn not_after_of(cert_pem: &str) -> Result<i64> {
+    let (_, pem) = parse_x509_pem(cert_pem.as_bytes())
+        .map_err(|e| NonoError::SandboxInit(format!("failed to parse CA cert PEM: {e}")))?;
+    let cert = pem
+        .parse_x509()
+        .map_err(|e| NonoError::SandboxInit(format!("failed to parse X.509 from PEM: {e}")))?;
+    Ok(cert.validity().not_after.timestamp())
+}
+
 fn load_existing_ca() -> Result<Option<(Zeroizing<Vec<u8>>, String)>> {
     let bundle = match passwords::get_generic_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT) {
         Ok(data) => data,
@@ -103,6 +144,81 @@ fn load_existing_ca() -> Result<Option<(Zeroizing<Vec<u8>>, String)>> {
     nono_proxy::tls_intercept::ca::split_key_cert_pem(&combined)
         .map(Some)
         .map_err(|e| NonoError::SandboxInit(format!("{e}")))
+}
+
+/// Re-issue the CA certificate over the stored key and hand the new one over.
+///
+/// Trust the new cert before retiring the old, so nothing fails mid-swap. The key is
+/// unchanged, so leaves minted under the old cert still chain to the new one.
+fn rotate_ca(
+    key_der: &Zeroizing<Vec<u8>>,
+    old_cert_pem: &str,
+    validity: Duration,
+    state: CertValidity,
+) -> Result<Option<PreloadedCa>> {
+    let ca = match nono_proxy::tls_intercept::ca::EphemeralCa::reissue_with_cn(
+        key_der,
+        "nono-proxy-ca",
+        validity,
+    ) {
+        Ok(ca) => ca,
+        Err(e) => {
+            // No usable stored key: only a whole new anchor can recover.
+            warn!("Cannot re-issue over the stored proxy CA key ({e}); generating a new CA.");
+            remove_cert_from_keychain(old_cert_pem);
+            delete_existing_ca();
+            return generate_and_trust_new_ca(validity);
+        }
+    };
+    let cert_pem = ca.cert_pem().to_string();
+
+    let cert_der = pem_to_der(&cert_pem)?;
+    let sec_cert = SecCertificate::from_der(&cert_der)
+        .map_err(|e| NonoError::SandboxInit(format!("failed to create SecCertificate: {e}")))?;
+
+    info!("Renewing proxy CA (you may be prompted for authentication)...");
+    if let Err(e) = trust_cert(&sec_cert) {
+        match e {
+            TrustCertError::UserCancelled => {
+                // The old cert is untouched, so declining costs nothing until it expires.
+                if state == CertValidity::RenewDue {
+                    warn!(
+                        "Proxy CA renewal cancelled; continuing on the current \
+                         certificate. It will be retried next launch."
+                    );
+                    return Ok(Some(PreloadedCa {
+                        key_der: key_der.clone(),
+                        cert_pem: old_cert_pem.to_string(),
+                    }));
+                }
+                warn!(
+                    "Proxy CA renewal cancelled and the stored certificate has \
+                     expired. Falling back to ephemeral CA; Go CLI tools won't \
+                     validate proxy certs."
+                );
+                return Ok(None);
+            }
+            TrustCertError::Other(err) => return Err(err),
+        }
+    }
+
+    let key_pem = ca.key_pem();
+    let combined = Zeroizing::new(format!("{}{}", *key_pem, cert_pem));
+    passwords::set_generic_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, combined.as_bytes())
+        .map_err(|e| {
+            NonoError::SandboxInit(format!(
+                "failed to store renewed CA bundle in Keychain: {e}"
+            ))
+        })?;
+
+    remove_cert_from_keychain(old_cert_pem);
+    flush_trust_cache();
+
+    info!("Proxy CA renewed");
+    Ok(Some(PreloadedCa {
+        key_der: Zeroizing::new(ca.key_der().to_vec()),
+        cert_pem,
+    }))
 }
 
 fn generate_and_trust_new_ca(validity: Duration) -> Result<Option<PreloadedCa>> {
@@ -303,18 +419,63 @@ fn delete_existing_ca() {
     let _ = passwords::delete_generic_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
 }
 
-fn cert_pem_is_valid(cert_pem: &str) -> Result<bool> {
+/// Remaining life below which the CA is renewed at launch, so every session starts
+/// with runway.
+const RENEWAL_HEADROOM: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CertValidity {
+    Valid,
+    RenewDue,
+    Expired,
+}
+
+pub(crate) fn cert_validity(cert_pem: &str) -> Result<CertValidity> {
     let (_, pem) = parse_x509_pem(cert_pem.as_bytes())
         .map_err(|e| NonoError::SandboxInit(format!("failed to parse stored CA cert PEM: {e}")))?;
     let cert = pem.parse_x509().map_err(|e| {
         NonoError::SandboxInit(format!("failed to parse X.509 from stored PEM: {e}"))
     })?;
-    let not_after = cert.validity().not_after.timestamp();
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| NonoError::SandboxInit(format!("system clock before UNIX epoch: {e}")))?
         .as_secs() as i64;
-    Ok(now < not_after)
+    let not_before = cert.validity().not_before.timestamp();
+    let not_after = cert.validity().not_after.timestamp();
+    Ok(classify_validity(
+        not_after,
+        now,
+        renewal_headroom(not_after.saturating_sub(not_before)),
+    ))
+}
+
+/// Proportional, so a 7-day cert prompts at most weekly and a short-lived one still
+/// gets warning.
+pub(crate) fn renewal_headroom(lifetime_secs: i64) -> Duration {
+    let quarter = Duration::from_secs(lifetime_secs.max(0) as u64 / 4);
+    quarter.min(RENEWAL_HEADROOM)
+}
+
+fn classify_validity(not_after: i64, now: i64, headroom: Duration) -> CertValidity {
+    if now >= not_after {
+        CertValidity::Expired
+    } else if not_after - now <= headroom.as_secs() as i64 {
+        CertValidity::RenewDue
+    } else {
+        CertValidity::Valid
+    }
+}
+
+/// Trust settings live in a data vault with no cache-invalidation API, so restarting
+/// `trustd` is the only reliable flush. Best-effort: a stale cache only delays.
+fn flush_trust_cache() {
+    match std::process::Command::new("/usr/bin/killall")
+        .args(["-q", "trustd"])
+        .status()
+    {
+        Ok(status) => debug!("trustd flush exited with {status}"),
+        Err(e) => debug!("could not run killall to flush trustd: {e}"),
+    }
 }
 
 fn pem_to_der(cert_pem: &str) -> Result<Vec<u8>> {
@@ -351,14 +512,63 @@ mod tests {
     }
 
     #[test]
-    fn cert_pem_is_valid_returns_true_for_fresh_cert() {
-        let ca = generate_test_ca();
-        assert!(cert_pem_is_valid(ca.cert_pem()).unwrap());
+    fn cert_validity_sees_a_week_old_cert_as_valid() {
+        let ca =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(7 * 86400)).unwrap();
+        assert_eq!(cert_validity(ca.cert_pem()).unwrap(), CertValidity::Valid);
     }
 
     #[test]
-    fn cert_pem_is_valid_rejects_garbage() {
-        assert!(cert_pem_is_valid("not a cert").is_err());
+    fn cert_validity_scales_the_headroom_to_a_short_lived_cert() {
+        // A 120s cert must not be born renew-due, or every launch rotates.
+        let ca = EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(120)).unwrap();
+        assert_eq!(cert_validity(ca.cert_pem()).unwrap(), CertValidity::Valid);
+
+        let not_after = not_after_of(ca.cert_pem()).unwrap();
+        assert_eq!(
+            classify_validity(not_after, not_after - 20, renewal_headroom(120)),
+            CertValidity::RenewDue,
+            "20s of life left on a 120s cert is inside the 30s headroom"
+        );
+    }
+
+    #[test]
+    fn renewal_headroom_is_a_quarter_of_life_capped_at_a_day() {
+        assert_eq!(renewal_headroom(120), Duration::from_secs(30));
+        assert_eq!(
+            renewal_headroom(7 * 86400),
+            Duration::from_secs(24 * 60 * 60),
+            "a week-long cert renews a day out, not 42 hours out"
+        );
+        assert_eq!(renewal_headroom(-1), Duration::ZERO);
+    }
+
+    #[test]
+    fn cert_validity_rejects_garbage() {
+        assert!(cert_validity("not a cert").is_err());
+    }
+
+    #[test]
+    fn classify_validity_boundaries() {
+        let headroom = Duration::from_secs(86400);
+        // not_after exactly now, and one second past it, are both expired.
+        assert_eq!(
+            classify_validity(1_000, 1_000, headroom),
+            CertValidity::Expired
+        );
+        assert_eq!(
+            classify_validity(1_000, 1_001, headroom),
+            CertValidity::Expired
+        );
+        // Exactly one headroom of life left still counts as due.
+        assert_eq!(
+            classify_validity(1_000 + 86_400, 1_000, headroom),
+            CertValidity::RenewDue
+        );
+        assert_eq!(
+            classify_validity(1_000 + 86_401, 1_000, headroom),
+            CertValidity::Valid
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -38,6 +38,8 @@ mod legacy_cleanup;
 #[cfg(target_os = "linux")]
 mod lineage_cgroup;
 #[cfg(target_os = "macos")]
+mod macos_ca_renewal;
+#[cfg(target_os = "macos")]
 mod macos_trust;
 mod migration;
 mod network_policy;

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2960,6 +2960,22 @@ pub(crate) fn start_proxy_runtime(
     if !proxy_diagnostics.is_empty() {
         crate::output::print_proxy_diagnostics(proxy_diagnostics);
     }
+
+    // A session-lifecycle CA is neither shared nor able to outlive its session.
+    #[cfg(target_os = "macos")]
+    if proxy
+        .tls_intercept
+        .as_ref()
+        .is_some_and(|t| t.trust_proxy_ca)
+        && let Some(rotator) = handle.intercept_rotator()
+    {
+        let validity = proxy
+            .tls_intercept
+            .as_ref()
+            .and_then(|t| t.ca_validity)
+            .unwrap_or(nono_proxy::tls_intercept::ca::CA_VALIDITY_DEFAULT);
+        crate::macos_ca_renewal::spawn_supervisor(rotator, validity);
+    }
     caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
         port,
         bind_ports: proxy.allow_bind_ports.clone(),

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -267,6 +267,8 @@ pub struct ProxyHandle {
     intercept_ca_path: Option<PathBuf>,
     /// Environment variables that should point at `intercept_ca_path`.
     intercept_ca_env_vars: Vec<String>,
+    /// `None` when interception is not active.
+    intercept_rotator: Option<Arc<tls_intercept::InterceptCaRotator>>,
     /// Credential load warnings collected at startup.
     diagnostics: Vec<crate::diagnostic::ProxyDiagnostic>,
 }
@@ -281,6 +283,21 @@ impl ProxyHandle {
     #[must_use]
     pub fn drain_audit_events(&self) -> Vec<nono::undo::NetworkAuditEvent> {
         audit::drain_audit_events(&self.audit_log)
+    }
+
+    /// For callers that outlive this handle, i.e. the renewal supervisor. `None` when
+    /// interception is not active.
+    #[must_use]
+    pub fn intercept_rotator(&self) -> Option<Arc<tls_intercept::InterceptCaRotator>> {
+        self.intercept_rotator.as_ref().map(Arc::clone)
+    }
+
+    /// Install a renewed interception CA without restarting the proxy.
+    pub fn rotate_intercept_ca(&self, key_der: &[u8], cert_pem: &str) -> Result<PathBuf> {
+        let rotator = self.intercept_rotator.as_ref().ok_or_else(|| {
+            ProxyError::Config("TLS interception is not active; nothing to rotate".to_string())
+        })?;
+        rotator.rotate(key_der, cert_pem)
     }
 
     /// Path to the TLS-intercept trust bundle, when interception is active.
@@ -1234,6 +1251,16 @@ pub async fn start_with_nonce_resolver(
 
     let enable_h2 = config.enable_h2;
     let intercept_ca_env_vars = config.intercept_ca_env_vars.clone();
+    // Holds its own Arc on the cache so the renewal supervisor can outlive the handle.
+    let intercept_rotator = match (&cert_cache, &config.intercept_ca_dir) {
+        (Some(cache), Some(dir)) => Some(Arc::new(tls_intercept::InterceptCaRotator::new(
+            Arc::clone(cache),
+            dir.clone(),
+            "intercept-ca.pem",
+            config.intercept_parent_ca_pems.clone(),
+        ))),
+        _ => None,
+    };
     let state = Arc::new(ProxyState {
         filter,
         session_token: session_token.clone(),
@@ -1273,6 +1300,7 @@ pub async fn start_with_nonce_resolver(
         canonical_no_proxy_hosts,
         intercept_ca_path,
         intercept_ca_env_vars,
+        intercept_rotator,
         diagnostics: proxy_diagnostics,
     })
 }
@@ -2707,6 +2735,7 @@ mod tests {
                 canonical_no_proxy_hosts: Vec::new(),
                 intercept_ca_path: None,
                 intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+                intercept_rotator: None,
                 diagnostics: vec![],
             };
         }
@@ -3341,6 +3370,7 @@ mod tests {
                 "::1".to_string(),
             ],
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             intercept_ca_path: None,
             diagnostics: Vec::new(),
         };
@@ -3413,6 +3443,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config = ProxyConfig {
@@ -3477,6 +3508,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config = ProxyConfig {
@@ -3546,6 +3578,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config = ProxyConfig {
@@ -3636,6 +3669,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config = ProxyConfig {
@@ -3698,6 +3732,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
 
@@ -3800,6 +3835,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config_no_env_var = ProxyConfig {
@@ -3850,6 +3886,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
         let config_fixed = ProxyConfig {
@@ -3907,6 +3944,7 @@ mod tests {
             ],
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
 
@@ -3940,6 +3978,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
 
@@ -3965,6 +4004,7 @@ mod tests {
             canonical_no_proxy_hosts: Vec::new(),
             intercept_ca_path: None,
             intercept_ca_env_vars: crate::config::default_intercept_ca_env_vars(),
+            intercept_rotator: None,
             diagnostics: vec![],
         };
 

--- a/crates/nono-proxy/src/tls_intercept/bundle.rs
+++ b/crates/nono-proxy/src/tls_intercept/bundle.rs
@@ -143,18 +143,10 @@ pub fn write_bundle(inputs: BundleInputs<'_>) -> Result<PathBuf> {
 fn write_with_restrictive_perms(path: &Path, contents: &[u8]) -> Result<()> {
     use std::io::Write;
 
-    // Remove any pre-existing file so we don't inherit permissions from a
-    // previous session (defence in depth — the parent dir should be 0o700
-    // anyway).
-    if path.exists() {
-        std::fs::remove_file(path).map_err(|e| {
-            ProxyError::Config(format!(
-                "tls_intercept: cannot remove stale bundle '{}': {}",
-                path.display(),
-                e
-            ))
-        })?;
-    }
+    // Rename over the target: a child reading SSL_CERT_FILE during a mid-session
+    // rewrite must never see a missing or partial bundle.
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
 
     #[cfg(unix)]
     {
@@ -163,18 +155,18 @@ fn write_with_restrictive_perms(path: &Path, contents: &[u8]) -> Result<()> {
             .write(true)
             .create_new(true)
             .mode(0o400)
-            .open(path)
+            .open(&tmp)
             .map_err(|e| {
                 ProxyError::Config(format!(
                     "tls_intercept: cannot create bundle '{}': {}",
-                    path.display(),
+                    tmp.display(),
                     e
                 ))
             })?;
         file.write_all(contents).map_err(|e| {
             ProxyError::Config(format!(
                 "tls_intercept: cannot write bundle '{}': {}",
-                path.display(),
+                tmp.display(),
                 e
             ))
         })?;
@@ -182,14 +174,23 @@ fn write_with_restrictive_perms(path: &Path, contents: &[u8]) -> Result<()> {
     }
     #[cfg(not(unix))]
     {
-        std::fs::write(path, contents).map_err(|e| {
+        std::fs::write(&tmp, contents).map_err(|e| {
             ProxyError::Config(format!(
                 "tls_intercept: cannot write bundle '{}': {}",
-                path.display(),
+                tmp.display(),
                 e
             ))
         })?;
     }
+
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        ProxyError::Config(format!(
+            "tls_intercept: cannot install bundle '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
     Ok(())
 }
 

--- a/crates/nono-proxy/src/tls_intercept/ca.rs
+++ b/crates/nono-proxy/src/tls_intercept/ca.rs
@@ -128,27 +128,38 @@ impl EphemeralCa {
             ProxyError::Config(format!("failed to generate ephemeral CA key pair: {}", e))
         })?;
         let key_pkcs8_der = Zeroizing::new(key_pair.serialize_der());
-
-        let mut params = CertificateParams::default();
-        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        params.key_usages = vec![
-            KeyUsagePurpose::KeyCertSign,
-            KeyUsagePurpose::CrlSign,
-            KeyUsagePurpose::DigitalSignature,
-        ];
-
-        let now = SystemTime::now();
-        let not_after = now + validity;
-        params.not_before = system_time_to_offset(now)?;
-        params.not_after = system_time_to_offset(not_after)?;
-
-        let mut dn = DistinguishedName::new();
-        dn.push(DnType::CommonName, cn);
-        params.distinguished_name = dn;
+        let (params, not_after) = ca_params(cn, validity)?;
 
         let self_signed = params
             .self_signed(&key_pair)
             .map_err(|e| ProxyError::Config(format!("failed to self-sign ephemeral CA: {}", e)))?;
+        let cert_pem = self_signed.pem();
+        let cert_der = self_signed.der().to_vec();
+        let issuer = Issuer::new(params, key_pair);
+
+        Ok(Self {
+            key_pkcs8_der,
+            issuer,
+            cert_der,
+            cert_pem,
+            not_after,
+        })
+    }
+
+    /// Re-issue a certificate over an existing CA key, with a fresh validity window.
+    ///
+    /// Subject, key and the key-derived authority key id are unchanged, so leaves
+    /// minted under the old cert still chain to the new one.
+    pub fn reissue_with_cn(key_der: &[u8], cn: &str, validity: Duration) -> Result<Self> {
+        let pkcs8 = PrivatePkcs8KeyDer::from(key_der);
+        let key_pair = KeyPair::from_der_and_sign_algo(&pkcs8.into(), &PKCS_ECDSA_P256_SHA256)
+            .map_err(|e| ProxyError::Config(format!("failed to load CA key for re-issue: {e}")))?;
+        let key_pkcs8_der = Zeroizing::new(key_der.to_vec());
+        let (params, not_after) = ca_params(cn, validity)?;
+
+        let self_signed = params
+            .self_signed(&key_pair)
+            .map_err(|e| ProxyError::Config(format!("failed to self-sign re-issued CA: {e}")))?;
         let cert_pem = self_signed.pem();
         let cert_der = self_signed.der().to_vec();
         let issuer = Issuer::new(params, key_pair);
@@ -306,6 +317,29 @@ pub fn split_key_cert_pem(combined: &str) -> Result<(Zeroizing<Vec<u8>>, String)
 }
 
 /// Convert `SystemTime` to the `time::OffsetDateTime` that `rcgen` expects.
+/// Shared by fresh generation and re-issue, so a re-issued cert differs from its
+/// predecessor only in its validity window.
+fn ca_params(cn: &str, validity: Duration) -> Result<(CertificateParams, SystemTime)> {
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+
+    let now = SystemTime::now();
+    let not_after = now + validity;
+    params.not_before = system_time_to_offset(now)?;
+    params.not_after = system_time_to_offset(not_after)?;
+
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, cn);
+    params.distinguished_name = dn;
+
+    Ok((params, not_after))
+}
+
 fn system_time_to_offset(t: SystemTime) -> Result<OffsetDateTime> {
     OffsetDateTime::from_unix_timestamp(
         t.duration_since(SystemTime::UNIX_EPOCH)
@@ -394,6 +428,68 @@ mod tests {
             original_der.as_ref(),
             "cert_der() must return the original cert DER, not the re-signed reconstruction"
         );
+    }
+
+    #[test]
+    fn reissue_keeps_key_and_subject_but_extends_validity() {
+        let original =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(60)).unwrap();
+        let reissued = EphemeralCa::reissue_with_cn(
+            original.key_der(),
+            "nono-proxy-ca",
+            Duration::from_secs(7 * 24 * 60 * 60),
+        )
+        .unwrap();
+
+        assert_eq!(reissued.key_der(), original.key_der());
+        assert!(reissued.not_after() > original.not_after());
+        assert_ne!(reissued.cert_pem(), original.cert_pem());
+
+        // Same public key: the re-issued cert is an interchangeable anchor.
+        let spki = |der: &[u8]| {
+            let (_, c) = x509_parser::parse_x509_certificate(der).unwrap();
+            c.public_key().subject_public_key.data.to_vec()
+        };
+        assert_eq!(spki(reissued.cert_der()), spki(original.cert_der()));
+    }
+
+    #[test]
+    fn reissued_ca_verifies_leaves_minted_under_the_old_cert() {
+        use crate::tls_intercept::CertCache;
+        use std::sync::Arc;
+
+        let original =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(3600)).unwrap();
+        let leaf = CertCache::new(Arc::new(
+            EphemeralCa::from_existing(original.key_der(), original.cert_pem()).unwrap(),
+        ))
+        .get_or_mint("api.github.com")
+        .unwrap();
+
+        let reissued = EphemeralCa::reissue_with_cn(
+            original.key_der(),
+            "nono-proxy-ca",
+            Duration::from_secs(7 * 24 * 60 * 60),
+        )
+        .unwrap();
+
+        // Issuer name and authority key id must match, or the old leaf stops chaining.
+        let (_, leaf_x509) = x509_parser::parse_x509_certificate(leaf.cert[0].as_ref()).unwrap();
+        let (_, new_ca) = x509_parser::parse_x509_certificate(reissued.cert_der()).unwrap();
+        assert_eq!(leaf_x509.issuer(), new_ca.subject());
+        leaf_x509
+            .verify_signature(Some(new_ca.public_key()))
+            .expect("leaf minted under the previous cert must verify against the re-issued CA");
+    }
+
+    #[test]
+    fn reissue_rejects_a_key_it_cannot_load() {
+        let result = EphemeralCa::reissue_with_cn(
+            b"not-a-pkcs8-key",
+            "nono-proxy-ca",
+            Duration::from_secs(60),
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/nono-proxy/src/tls_intercept/cert_cache.rs
+++ b/crates/nono-proxy/src/tls_intercept/cert_cache.rs
@@ -30,14 +30,16 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, SystemTime};
 use time::OffsetDateTime;
 use tracing::{debug, warn};
 
 /// Per-hostname leaf certificate cache backed by the session's [`EphemeralCa`].
 pub struct CertCache {
-    ca: Arc<EphemeralCa>,
+    /// Swappable so a session can adopt a renewed CA without a restart. Always locked
+    /// *after* `cache`, to keep one lock order.
+    ca: RwLock<Arc<EphemeralCa>>,
     leaf_validity: Option<Duration>,
     /// Hostname → minted leaf. Kept behind a `Mutex` because rustls' cert
     /// resolver is invoked from sync handshake context.
@@ -54,7 +56,7 @@ impl CertCache {
     #[must_use]
     pub fn new_with_leaf_validity(ca: Arc<EphemeralCa>, leaf_validity: Option<Duration>) -> Self {
         Self {
-            ca,
+            ca: RwLock::new(ca),
             leaf_validity,
             cache: Mutex::new(HashMap::new()),
         }
@@ -87,10 +89,37 @@ impl CertCache {
         if let Some(existing) = cache.get(hostname) {
             return Ok(Arc::clone(existing));
         }
-        let minted = mint_leaf(self.ca.as_ref(), hostname, self.leaf_validity)?;
+        let ca = self
+            .ca
+            .read()
+            .map_err(|_| ProxyError::Config("tls_intercept CA lock poisoned".to_string()))?;
+        let minted = mint_leaf(ca.as_ref(), hostname, self.leaf_validity)?;
         cache.insert(hostname.to_string(), Arc::clone(&minted));
         debug!("tls_intercept: minted leaf certificate for {}", hostname);
         Ok(minted)
+    }
+
+    /// Swap in a renewed CA, discarding every cached leaf: leaves embed the previous
+    /// CA's DER and are clamped to its `not_after`, so each host must re-mint.
+    pub fn replace_ca(&self, ca: Arc<EphemeralCa>) -> Result<()> {
+        let mut cache = self.cache.lock().map_err(|_| {
+            ProxyError::Config("tls_intercept cert cache mutex poisoned".to_string())
+        })?;
+        let mut current = self
+            .ca
+            .write()
+            .map_err(|_| ProxyError::Config("tls_intercept CA lock poisoned".to_string()))?;
+        *current = ca;
+        cache.clear();
+        Ok(())
+    }
+
+    /// The CA currently backing this cache.
+    pub fn current_ca(&self) -> Result<Arc<EphemeralCa>> {
+        self.ca
+            .read()
+            .map(|ca| Arc::clone(&ca))
+            .map_err(|_| ProxyError::Config("tls_intercept CA lock poisoned".to_string()))
     }
 }
 
@@ -99,7 +128,7 @@ impl std::fmt::Debug for CertCache {
         let len = self.cache.lock().map(|g| g.len()).unwrap_or(0);
         f.debug_struct("CertCache")
             .field("entries", &len)
-            .field("ca", &self.ca)
+            .field("ca", &self.ca.try_read().ok().map(|ca| format!("{ca:?}")))
             .finish()
     }
 }

--- a/crates/nono-proxy/src/tls_intercept/mod.rs
+++ b/crates/nono-proxy/src/tls_intercept/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod h2_forward;
 pub(crate) mod h2_probe;
 pub mod handle;
 pub(crate) mod http1;
+pub mod rotate;
 pub(crate) mod websocket;
 
 pub use acceptor::build_server_config;
@@ -49,3 +50,4 @@ pub use ca::EphemeralCa;
 pub use cert_cache::CertCache;
 pub(crate) use h2_probe::UpstreamH2Cache;
 pub use handle::{InterceptCtx, InterceptUpstreamProxy, handle_intercept_connect};
+pub use rotate::InterceptCaRotator;

--- a/crates/nono-proxy/src/tls_intercept/rotate.rs
+++ b/crates/nono-proxy/src/tls_intercept/rotate.rs
@@ -1,0 +1,147 @@
+//! Mid-session replacement of the interception CA, for sessions that outlive the
+//! certificate they started with. A cert re-issued over the same key is an
+//! interchangeable anchor, so only the presented chain and the bundle change.
+
+use crate::error::Result;
+use crate::tls_intercept::ca::EphemeralCa;
+use crate::tls_intercept::cert_cache::CertCache;
+use crate::tls_intercept::{BundleInputs, write_bundle};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tracing::info;
+
+/// Everything needed to install a renewed CA into a running proxy.
+pub struct InterceptCaRotator {
+    cache: Arc<CertCache>,
+    bundle_dir: PathBuf,
+    bundle_filename: &'static str,
+    parent_ca_pems: Option<Vec<u8>>,
+}
+
+impl InterceptCaRotator {
+    #[must_use]
+    pub fn new(
+        cache: Arc<CertCache>,
+        bundle_dir: PathBuf,
+        bundle_filename: &'static str,
+        parent_ca_pems: Option<Vec<u8>>,
+    ) -> Self {
+        Self {
+            cache,
+            bundle_dir,
+            bundle_filename,
+            parent_ca_pems,
+        }
+    }
+
+    /// PEM of the certificate currently presented as the interception anchor.
+    pub fn current_cert_pem(&self) -> Result<String> {
+        Ok(self.cache.current_ca()?.cert_pem().to_string())
+    }
+
+    /// `not_after` of the certificate currently in use.
+    pub fn current_not_after(&self) -> Result<SystemTime> {
+        Ok(self.cache.current_ca()?.not_after())
+    }
+
+    /// Install `cert_pem` (signed by `key_der`) as the live interception CA.
+    ///
+    /// Rejects a key/cert pair that doesn't agree, so a torn write to whatever
+    /// store the caller read from cannot take the proxy down.
+    pub fn rotate(&self, key_der: &[u8], cert_pem: &str) -> Result<PathBuf> {
+        let ca = Arc::new(EphemeralCa::from_existing(key_der, cert_pem)?);
+        self.cache.replace_ca(ca)?;
+        let path = write_bundle(BundleInputs {
+            dir: &self.bundle_dir,
+            filename: self.bundle_filename,
+            parent_ssl_cert_file: self.parent_ca_pems.as_deref(),
+            ephemeral_ca_pem: cert_pem,
+        })?;
+        info!(
+            "tls_intercept: adopted renewed CA; trust bundle rewritten at {}",
+            path.display()
+        );
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn rotator(ca: Arc<EphemeralCa>, dir: &std::path::Path) -> InterceptCaRotator {
+        InterceptCaRotator::new(
+            Arc::new(CertCache::new(ca)),
+            dir.to_path_buf(),
+            "intercept-ca.pem",
+            None,
+        )
+    }
+
+    #[test]
+    fn rotate_installs_the_new_cert_and_rewrites_the_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let original =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(60)).unwrap();
+        let key_der = original.key_der().to_vec();
+        let r = rotator(Arc::new(original), dir.path());
+
+        let renewed =
+            EphemeralCa::reissue_with_cn(&key_der, "nono-proxy-ca", Duration::from_secs(86_400))
+                .unwrap();
+        let path = r.rotate(&key_der, renewed.cert_pem()).unwrap();
+
+        assert_eq!(r.current_cert_pem().unwrap(), renewed.cert_pem());
+        assert!(r.current_not_after().unwrap() > SystemTime::now() + Duration::from_secs(3600));
+        let bundle = std::fs::read_to_string(&path).unwrap();
+        assert!(bundle.contains(renewed.cert_pem()));
+    }
+
+    #[test]
+    fn rotate_serves_leaves_under_the_new_cert() {
+        let dir = tempfile::tempdir().unwrap();
+        let original =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(60)).unwrap();
+        let key_der = original.key_der().to_vec();
+        let cache = Arc::new(CertCache::new(Arc::new(original)));
+        let r = InterceptCaRotator::new(
+            Arc::clone(&cache),
+            dir.path().to_path_buf(),
+            "intercept-ca.pem",
+            None,
+        );
+
+        let before = cache.get_or_mint("api.github.com").unwrap();
+        let renewed =
+            EphemeralCa::reissue_with_cn(&key_der, "nono-proxy-ca", Duration::from_secs(86_400))
+                .unwrap();
+        r.rotate(&key_der, renewed.cert_pem()).unwrap();
+        let after = cache.get_or_mint("api.github.com").unwrap();
+
+        // Re-minted, and the chain now carries the renewed anchor.
+        assert_ne!(before.cert[0], after.cert[0]);
+        assert_eq!(after.cert[1].as_ref(), renewed.cert_der());
+    }
+
+    #[test]
+    fn rotate_rejects_a_cert_that_does_not_match_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let original =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(60)).unwrap();
+        let key_der = original.key_der().to_vec();
+        let cert_pem = original.cert_pem().to_string();
+        let r = rotator(Arc::new(original), dir.path());
+
+        let unrelated =
+            EphemeralCa::generate_with_cn("nono-proxy-ca", Duration::from_secs(86_400)).unwrap();
+        assert!(r.rotate(&key_der, unrelated.cert_pem()).is_err());
+        assert_eq!(
+            r.current_cert_pem().unwrap(),
+            cert_pem,
+            "a rejected rotation must leave the live CA untouched"
+        );
+    }
+}

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -532,11 +532,12 @@ Without `--proxy-port`, nono uses an OS-assigned ephemeral port and sets environ
 nono run --allow-cwd --credential github --trust-proxy-ca -- gh api /user
 ```
 
-The CA is persisted in macOS Keychain and shared across sessions. It regenerates automatically when expired (default: 1 day, configurable via `--proxy-ca-validity`):
+The CA is persisted in macOS Keychain and shared across sessions. It renews automatically as it nears expiry (validity default: 1 day, configurable via `--proxy-ca-validity`):
 
 - **First run**: Generates a new ECDSA P-256 CA, stores it in Keychain, and adds it to the user trust store (one biometric/password prompt)
 - **Subsequent runs**: Loads from Keychain with zero prompts
-- **After expiry**: Removes the expired CA and regenerates
+- **Nearing expiry**: Re-issues the certificate over the same key, trusts and stores it, then retires the superseded one (one prompt). Certificates already minted for intercepted hosts keep working, because the key — and so the anchor — is unchanged
+- **Mid-session**: A running session picks up a certificate another session renewed with no prompt at all, and renews itself only if nothing newer is available. If renewal cannot complete, the session keeps using its current certificate rather than re-prompting
 
 <Note>
 This flag has no effect without `--credential` (or another TLS-intercepting route). If no credential routes are configured, nono warns and skips CA generation.


### PR DESCRIPTION
## Linked Issue

Closes #1681

## Summary

An expired interception CA killed every intercepted route until the agent restarted: `mint_leaf` refuses past `not_after`, cached leaves are clamped to it and expire with it, and the certificate was only ever checked at launch.

The root of it is that the key and the certificate were treated as one object — the expired branch discarded the private key and minted a whole new anchor, which is why renewal could only happen at launch. Renewal now re-issues over the key already in the Keychain, so subject, SPKI and the key-derived AKI are unchanged and leaves minted under the old certificate still chain to the new one.

That makes the live anchor swappable, so a running session can pick up a renewal without a restart. A supervisor prefers adopting a certificate another launch already renewed — no prompt and no trust-store write — and renews itself only when nothing newer exists, under a cross-process lock. Validity is tri-state, so launch rotates while the old certificate is still valid and a declined prompt costs nothing. If renewal cannot complete, the session keeps serving its current certificate and backs off.

Renewal and its trust-settings handling are macOS-only. The misleading "agent likely pins certs" WARN that triage flagged is not addressed here.

## Agent Disclosure

This PR was prepared by an AI coding agent acting on my behalf. Files and sections consulted: `AGENTS.md` (Coding Agent Contribution Policy, error-handling and forbidden-pattern rules), `CLAUDE.md`, `crates/nono-cli/src/macos_trust.rs`, `crates/nono-proxy/src/tls_intercept/*`, `crates/nono-cli/src/proxy_runtime.rs`. Intent, approach and limitations were disclosed in #1681 before implementation, and this PR matches that scope.

## Test Plan

`make ci` on this branch.

Unit tests cover re-issue producing the same SPKI with a later `not_after`, rejection of a mismatched key/cert pair, `replace_ca` clearing the leaf cache, the rotator swapping both the live certificate and the bundle, tri-state validity and headroom boundaries, and lock exclusivity across holders.

Verified live on macOS with a short `ca_validity` so a session outlives its certificate:

- Mid-session renewal without a restart — an already-expired CA (`no server certificate chain resolved` on every handshake), renewed in place, next request to a fresh host succeeded.
- Adoption — a second session minted a new anchor; the running session logged `Adopted renewed proxy CA from Keychain` with no prompt, rewrote its bundle, and continued serving freshly minted leaves.
- No CA key material reaches the on-disk bundle before or after a rotation.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
