### PR TITLE
fix(cli): warn when a draft profile cannot resolve its extends chain

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3271,10 +3271,20 @@ pub(crate) fn parse_profile_bytes(content: &[u8]) -> Result<Profile> {
 
 /// Load a profile from a JSON file, resolving inheritance. The parent
 /// directory is passed as context so `extends` can resolve sibling profiles.
+///
+/// Exception: files under `profile-drafts/` do **not** use the drafts directory
+/// as sibling context. Draft sibling lookup can shadow a same-named user/pack
+/// base and make `show`/`validate` disagree with post-`promote` resolution
+/// (#1565). Drafts resolve `extends` the same way as `resolve_and_finalize_profile`
+/// (user profiles → packs → builtins).
 fn load_from_file(path: &Path, cli_extends: &[String]) -> Result<Profile> {
     let (mut profile, source_path) = parse_file_backed_profile(path)?;
     prepend_cli_extends(&mut profile, cli_extends);
-    let context_dir = source_path.parent();
+    let context_dir = if is_under_user_profile_draft_dir(&source_path) {
+        None
+    } else {
+        source_path.parent()
+    };
     resolve_extends(profile, &mut Vec::new(), 0, context_dir, Some(&source_path))
 }
 
@@ -3925,6 +3935,25 @@ pub fn display_trust_policy_path() -> String {
 
 pub(crate) fn user_profile_draft_dir() -> Result<PathBuf> {
     Ok(crate::package::nono_config_dir()?.join("profile-drafts"))
+}
+
+/// True when `path` is inside the user profile-drafts directory.
+///
+/// Uses canonicalized [`Path::starts_with`] (not string prefix matching) so
+/// lookalike paths such as `profile-drafts-evil/` cannot match.
+pub(crate) fn is_under_user_profile_draft_dir(path: &Path) -> bool {
+    let Ok(drafts) = user_profile_draft_dir() else {
+        return false;
+    };
+    let Ok(drafts_canon) = drafts.canonicalize() else {
+        // Drafts dir missing or unreadable → nothing can be under it.
+        return false;
+    };
+    let canon = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => path.to_path_buf(),
+    };
+    canon.starts_with(&drafts_canon)
 }
 
 pub(crate) fn get_user_profile_draft_path(name: &str) -> Result<PathBuf> {
@@ -4666,6 +4695,106 @@ mod tests {
                 .contains(&"deny_credentials".to_string())
         );
         assert!(profile.groups.include.contains(&"node_runtime".to_string()));
+    }
+
+    /// Regression for https://github.com/nolabs-ai/nono/issues/1565:
+    /// a draft sibling must not shadow a same-named user profile base.
+    #[test]
+    fn draft_extends_skips_draft_sibling_shadow_of_user_base() {
+        with_config_env(|config_dir| {
+            let profiles = config_dir.join("nono").join("profiles");
+            let drafts = config_dir.join("nono").join("profile-drafts");
+            std::fs::create_dir_all(&profiles).expect("profiles dir");
+            std::fs::create_dir_all(&drafts).expect("drafts dir");
+
+            std::fs::write(
+                profiles.join("base-grants.json"),
+                r#"{
+                    "meta": { "name": "base-grants" },
+                    "filesystem": {
+                        "read": ["/tmp/gh-nono", "/tmp/nono-ssh", "/tmp/agent.sock", "/tmp/extra"]
+                    }
+                }"#,
+            )
+            .expect("write user base");
+            // Incomplete draft sibling with the same name as the intended base.
+            std::fs::write(
+                drafts.join("base-grants.json"),
+                r#"{
+                    "meta": { "name": "base-grants" }
+                }"#,
+            )
+            .expect("write draft sibling");
+
+            let draft_path = drafts.join("claude-harness-config.json");
+            std::fs::write(
+                &draft_path,
+                r#"{
+                    "extends": "base-grants",
+                    "meta": { "name": "claude-harness-config" },
+                    "filesystem": { "read": ["/tmp/child-only"] }
+                }"#,
+            )
+            .expect("write draft child");
+
+            let from_draft = load_profile_from_path(&draft_path).expect("load draft");
+            assert!(
+                from_draft
+                    .filesystem
+                    .read
+                    .iter()
+                    .any(|p| p.contains("gh-nono")),
+                "draft must resolve the user-profile base, not the empty draft sibling; got {:?}",
+                from_draft.filesystem.read
+            );
+            assert!(
+                from_draft
+                    .filesystem
+                    .read
+                    .iter()
+                    .any(|p| p.contains("child-only")),
+                "child grants must still merge"
+            );
+        });
+    }
+
+    /// Draft-only extends targets (no user/pack/builtin) must fail closed
+    /// rather than silently resolving via draft siblings (#1565).
+    #[test]
+    fn draft_extends_draft_only_base_fails_closed() {
+        with_config_env(|config_dir| {
+            let drafts = config_dir.join("nono").join("profile-drafts");
+            std::fs::create_dir_all(&drafts).expect("drafts dir");
+            std::fs::write(
+                drafts.join("draft-only-base.json"),
+                r#"{
+                    "meta": { "name": "draft-only-base" },
+                    "filesystem": { "read": ["/tmp/should-not-merge"] }
+                }"#,
+            )
+            .expect("write draft-only base");
+            let draft_path = drafts.join("child.json");
+            std::fs::write(
+                &draft_path,
+                r#"{
+                    "extends": "draft-only-base",
+                    "meta": { "name": "child" }
+                }"#,
+            )
+            .expect("write draft child");
+
+            let err =
+                load_profile_from_path(&draft_path).expect_err("must not resolve draft sibling");
+            assert!(
+                matches!(err, NonoError::ProfileInheritance(_)),
+                "expected inheritance error, got {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("draft-only-base") && msg.contains("not found"),
+                "error should name the missing base: {msg}"
+            );
+        });
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3939,8 +3939,10 @@ pub(crate) fn user_profile_draft_dir() -> Result<PathBuf> {
 
 /// True when `path` is inside the user profile-drafts directory.
 ///
-/// Uses canonicalized [`Path::starts_with`] (not string prefix matching) so
-/// lookalike paths such as `profile-drafts-evil/` cannot match.
+/// `path` must already be canonical. The only caller, `load_from_file`,
+/// passes the path returned by `parse_file_backed_profile`.
+/// Uses [`Path::starts_with`] (not string prefix matching) so lookalike
+/// paths such as `profile-drafts-evil/` cannot match.
 pub(crate) fn is_under_user_profile_draft_dir(path: &Path) -> bool {
     let Ok(drafts) = user_profile_draft_dir() else {
         return false;
@@ -3949,11 +3951,7 @@ pub(crate) fn is_under_user_profile_draft_dir(path: &Path) -> bool {
         // Drafts dir missing or unreadable → nothing can be under it.
         return false;
     };
-    let canon = match path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => path.to_path_buf(),
-    };
-    canon.starts_with(&drafts_canon)
+    path.starts_with(&drafts_canon)
 }
 
 pub(crate) fn get_user_profile_draft_path(name: &str) -> Result<PathBuf> {
@@ -4793,6 +4791,68 @@ mod tests {
             assert!(
                 msg.contains("draft-only-base") && msg.contains("not found"),
                 "error should name the missing base: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn is_under_user_profile_draft_dir_matches_canonical_path() {
+        with_config_env(|config_dir| {
+            let drafts = config_dir.join("nono").join("profile-drafts");
+            std::fs::create_dir_all(&drafts).expect("drafts dir");
+            let file = drafts.join("child.json");
+            std::fs::write(&file, "{}").expect("write");
+            let canon = file.canonicalize().expect("canonicalize");
+            assert!(
+                is_under_user_profile_draft_dir(&canon),
+                "canonical draft path must match"
+            );
+        });
+    }
+
+    #[test]
+    fn is_under_user_profile_draft_dir_rejects_relative_path() {
+        with_config_env(|config_dir| {
+            let drafts = config_dir.join("nono").join("profile-drafts");
+            std::fs::create_dir_all(&drafts).expect("drafts dir");
+            std::fs::write(drafts.join("child.json"), "{}").expect("write");
+            let relative = Path::new("profile-drafts").join("child.json");
+            assert!(
+                !is_under_user_profile_draft_dir(&relative),
+                "relative path must not match; callers canonicalize first"
+            );
+        });
+    }
+
+    #[test]
+    fn draft_loaded_via_lexical_path_still_skips_sibling_context() {
+        with_config_env(|config_dir| {
+            let drafts = config_dir.join("nono").join("profile-drafts");
+            std::fs::create_dir_all(drafts.join("nested")).expect("drafts dir");
+            std::fs::write(
+                drafts.join("draft-only-base.json"),
+                r#"{
+                    "meta": { "name": "draft-only-base" },
+                    "filesystem": { "read": ["/tmp/should-not-merge"] }
+                }"#,
+            )
+            .expect("write draft-only base");
+            std::fs::write(
+                drafts.join("child.json"),
+                r#"{
+                    "extends": "draft-only-base",
+                    "meta": { "name": "child" }
+                }"#,
+            )
+            .expect("write draft child");
+
+            // `..` is not canonical; parse_file_backed_profile canonicalizes
+            // before draft-dir detection, so sibling lookup must stay skipped.
+            let lexical = drafts.join("nested").join("..").join("child.json");
+            let err = load_profile_from_path(&lexical).expect_err("must not resolve draft sibling");
+            assert!(
+                matches!(err, NonoError::ProfileInheritance(_)),
+                "expected inheritance error, got {err:?}"
             );
         });
     }


### PR DESCRIPTION
## Summary

- Stop using `profile-drafts/` as sibling `extends` context so draft `show`/`validate` match post-`promote` resolution.
- Same-named incomplete draft siblings no longer silently shadow user/pack/builtin bases (#1565).
- Draft-only extends targets now fail closed with `ProfileInheritance` instead of quietly merging empty draft siblings.

Closes #1565

## Approach

`load_from_file` always passed the file's parent directory as sibling context. For drafts that meant `profile-drafts/` was searched before user `profiles/`. When an agent stages several related drafts, an incomplete `{base}.json` in drafts wins and the real user base is never consulted — `validate`/`show` succeed with no warning because inheritance "resolved".

Fix: if the canonicalized source path is under `user_profile_draft_dir()` (`Path::starts_with` after canonicalize), clear sibling context and resolve like `resolve_and_finalize_profile` / promote (user profiles → packs → builtins).

## Test plan

- [x] `cargo test -p nono-cli --bin nono draft_extends_` — shadow fixture + draft-only fail-closed
- [x] `make check` (clippy + fmt)
- [x] `make audit` / `lint-aliases` / `lint-docs`
- [x] `make test-cli` — 1986 passed; one unrelated flaky (`shell_dry_run_rejects_block_net_with_upstream_proxy`) fails under full parallel suite when TMPDIR under `/var/folders` overlaps `system_read_macos` `/private/var` grant; passes in isolation (same flake noted on #1686)

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1565)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (extends existing `load_from_file` / draft-dir helpers)
- [x] I did not use forbidden patterns such as unwrap/expect (test `.expect()` follows existing test conventions)
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (`Path::starts_with` after canonicalize)
- [x] This PR matches the approved or disclosed issue scope

**Contributor disclosure:** This PR was prepared by an AI coding agent (Cursor) acting as a contribution assistant for Frankie-Xu.

## References

- Issue: #1565
- Disclosure: https://github.com/nolabs-ai/nono/issues/1565#issuecomment-5366143680
- Related: sibling context design in `load_from_file` / `load_base_profile_raw`

Made with [Cursor](https://cursor.com)