### PR TITLE
fix(cli): make profile promote work for existing profiles

### DIFF
--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -2611,7 +2611,7 @@ pub(crate) fn cmd_promote(args: ProfilePromoteArgs) -> Result<()> {
     }
 
     if let Some(current) = current_bytes.as_deref() {
-        verify_base_hash(&base_path, current)?;
+        verify_or_infer_base_hash(&base_path, current)?;
     }
 
     print_promote_diff(&args.name, current_bytes.as_deref(), &draft_bytes);
@@ -2687,6 +2687,25 @@ fn reserved_profile_source(name: &str) -> Result<Option<&'static str>> {
         return Ok(Some("installed pack"));
     }
     Ok(None)
+}
+
+fn verify_or_infer_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<()> {
+    match regular_file_exists(base_path, "profile draft base hash")? {
+        true => verify_base_hash(base_path, current_bytes),
+        false => {
+            // Agents often write only the draft JSON. Infer the baseline from
+            // the live profile so promote can still show a diff; staleness
+            // relative to an older draft-time snapshot cannot be proven.
+            eprintln!(
+                "{} missing {}; treating the current profile as the draft baseline. \
+                 Concurrent edits to the live profile since the draft was written cannot be detected. \
+                 To pin a baseline next time, write the live profile SHA-256 hex to that path.",
+                prefix(),
+                base_path.display()
+            );
+            Ok(())
+        }
+    }
 }
 
 fn verify_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<()> {
@@ -4134,6 +4153,49 @@ mod tests {
     }
 
     #[test]
+    fn promote_existing_profile_infers_missing_base_hash() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("config");
+        std::fs::create_dir_all(&xdg).expect("create xdg");
+        let xdg_str = xdg.to_str().expect("utf8 xdg");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", xdg_str)]);
+
+        let profiles_dir = profile::user_profile_dir().expect("profile dir");
+        let draft_dir = profile::user_profile_draft_dir().expect("draft dir");
+        std::fs::create_dir_all(&profiles_dir).expect("create profiles");
+        std::fs::create_dir_all(&draft_dir).expect("create drafts");
+
+        let target = profile::get_user_profile_path("agent-local").expect("target path");
+        let old = b"{\n  \"meta\": { \"name\": \"agent-local\" },\n  \"filesystem\": { \"read\": [\"/tmp\"] }\n}\n";
+        std::fs::write(&target, old).expect("write target");
+        let draft = profile::get_user_profile_draft_path("agent-local").expect("draft path");
+        std::fs::write(
+            &draft,
+            "{\n  \"meta\": { \"name\": \"agent-local\" },\n  \"filesystem\": { \"read\": [\"/var/tmp\"] }\n}\n",
+        )
+        .expect("write draft");
+
+        // No .base file: promote should still succeed using the live profile as baseline.
+        let result = cmd_promote(ProfilePromoteArgs {
+            name: "agent-local".to_string(),
+            diff: false,
+            yes: true,
+            help: None,
+        });
+        assert!(
+            result.is_ok(),
+            "promote without .base should succeed: {result:?}"
+        );
+        let promoted = std::fs::read_to_string(&target).expect("read promoted");
+        assert!(promoted.contains("/var/tmp"));
+        assert!(!draft.exists(), "draft should be removed after promote");
+    }
+
+    #[test]
     fn promote_existing_profile_requires_matching_base_hash() {
         let _guard = match crate::test_env::ENV_LOCK.lock() {
             Ok(guard) => guard,
@@ -4160,19 +4222,23 @@ mod tests {
         )
         .expect("write draft");
 
-        let missing_base = cmd_promote(ProfilePromoteArgs {
+        let base = profile::get_user_profile_draft_base_path("agent-local").expect("base path");
+        std::fs::write(&base, "0".repeat(64)).expect("write mismatched base");
+        let mismatched = cmd_promote(ProfilePromoteArgs {
             name: "agent-local".to_string(),
             diff: false,
             yes: true,
             help: None,
         });
-        assert!(
-            missing_base.is_err(),
-            "existing profile promote must require .base"
-        );
+        assert!(mismatched.is_err(), "mismatched .base must still fail");
 
-        let base = profile::get_user_profile_draft_base_path("agent-local").expect("base path");
-        std::fs::write(&base, sha256_hex(old)).expect("write base");
+        std::fs::write(&base, sha256_hex(old)).expect("write matching base");
+        // Re-write draft (previous promote attempt did not consume it on error).
+        std::fs::write(
+            &draft,
+            "{\n  \"meta\": { \"name\": \"agent-local\" },\n  \"filesystem\": { \"read\": [\"/var/tmp\"] }\n}\n",
+        )
+        .expect("rewrite draft");
         let result = cmd_promote(ProfilePromoteArgs {
             name: "agent-local".to_string(),
             diff: false,

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -2690,9 +2690,13 @@ fn reserved_profile_source(name: &str) -> Result<Option<&'static str>> {
 }
 
 fn verify_or_infer_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<()> {
-    match regular_file_exists(base_path, "profile draft base hash")? {
-        true => verify_base_hash(base_path, current_bytes),
-        false => {
+    // Single open: do not exists-check then read. A concurrent swap to a
+    // symlink, or a vanish between check and use, must fail closed.
+    match read_regular_file(base_path, "profile draft base hash") {
+        Ok(base_bytes) => verify_base_hash_bytes(base_path, &base_bytes, current_bytes),
+        Err(NonoError::ProfileRead { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
             // Agents often write only the draft JSON. Infer the baseline from
             // the live profile so promote can still show a diff; staleness
             // relative to an older draft-time snapshot cannot be proven.
@@ -2705,12 +2709,12 @@ fn verify_or_infer_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<(
             );
             Ok(())
         }
+        Err(err) => Err(err),
     }
 }
 
-fn verify_base_hash(base_path: &Path, current_bytes: &[u8]) -> Result<()> {
-    let base_bytes = read_regular_file(base_path, "profile draft base hash")?;
-    let provided = std::str::from_utf8(&base_bytes)
+fn verify_base_hash_bytes(base_path: &Path, base_bytes: &[u8], current_bytes: &[u8]) -> Result<()> {
+    let provided = std::str::from_utf8(base_bytes)
         .map_err(|e| NonoError::ProfileParse(format!("base hash is not UTF-8: {e}")))?
         .trim();
     if provided.len() != 64 || !provided.chars().all(|c| c.is_ascii_hexdigit()) {
@@ -2737,10 +2741,9 @@ fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
     {
         options.custom_flags(nix::libc::O_NOFOLLOW);
     }
-    let mut file = options.open(path).map_err(|e| NonoError::ProfileRead {
-        path: path.to_path_buf(),
-        source: e,
-    })?;
+    let mut file = options
+        .open(path)
+        .map_err(|e| profile_file_open_error(path, label, e))?;
     let metadata = file.metadata().map_err(|e| NonoError::ProfileRead {
         path: path.to_path_buf(),
         source: e,
@@ -2758,6 +2761,20 @@ fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
             source: e,
         })?;
     Ok(bytes)
+}
+
+fn profile_file_open_error(path: &Path, label: &str, error: std::io::Error) -> NonoError {
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(nix::libc::ELOOP) {
+        return NonoError::ProfileParse(format!(
+            "{label} must not be a symlink: {}",
+            path.display()
+        ));
+    }
+    NonoError::ProfileRead {
+        path: path.to_path_buf(),
+        source: error,
+    }
 }
 
 fn regular_file_exists(path: &Path, label: &str) -> Result<bool> {
@@ -4248,6 +4265,40 @@ mod tests {
         assert!(result.is_ok(), "promote should succeed: {result:?}");
         let promoted = std::fs::read_to_string(&target).expect("read promoted");
         assert!(promoted.contains("/var/tmp"));
+    }
+
+    #[test]
+    fn verify_or_infer_base_hash_infers_when_file_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("agent-local.base");
+        let result = verify_or_infer_base_hash(&missing, b"current-profile");
+        assert!(
+            result.is_ok(),
+            "missing base file should infer the live profile: {result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_or_infer_base_hash_rejects_symlink() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let referent = dir.path().join("real.base");
+        std::fs::write(&referent, "0".repeat(64)).expect("write referent");
+        let link = dir.path().join("agent-local.base");
+        std::os::unix::fs::symlink(&referent, &link).expect("symlink");
+        let err = verify_or_infer_base_hash(&link, b"current-profile")
+            .expect_err("symlink base must fail closed");
+        let msg = err.to_string();
+        assert!(msg.contains("symlink"), "expected symlink error, got {msg}");
+    }
+
+    #[test]
+    fn verify_or_infer_base_hash_accepts_matching_regular_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let current = b"live-profile-bytes";
+        let base = dir.path().join("agent-local.base");
+        std::fs::write(&base, sha256_hex(current)).expect("write hash");
+        verify_or_infer_base_hash(&base, current).expect("matching regular file should pass");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `nono profile promote` over an existing profile no longer fails with a cryptic `ProfileRead` / "No such file or directory" when `profile-drafts/<name>.base` is missing.
- Missing `.base` now treats the live profile as the draft baseline, prints a clear stderr note about undetectable concurrent edits, and continues the normal diff / confirm flow.
- Invalid or mismatched `.base` files still fail with the existing `NonoError::ProfileParse` messages.

Closes #1421

## Approach

Agents typically write only `profile-drafts/<name>.json`. The `.base` SHA-256 file is a staleness guard for concurrent live-profile edits, but requiring it blocked the common promote path. When the target exists and `.base` is absent, infer the baseline from current live bytes (equivalent to a correctly written current hash) and warn; when `.base` is present, keep strict verification.

## Test plan

- [x] `cargo test -p nono-cli --bin nono promote_existing_profile` — missing `.base` succeeds; mismatched still fails; matching still succeeds
- [x] `make ci` — full green locally

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1421)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (extends existing `cmd_promote` / `verify_base_hash`)
- [x] I did not use forbidden patterns such as unwrap/expect (test `.expect()` follows existing test conventions)
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (reuses existing regular-file checks)
- [x] This PR matches the approved or disclosed issue scope

**Contributor disclosure:** This PR was prepared by an AI coding agent (Cursor) acting as a contribution assistant for Frankie-Xu.

## References

- Issue: #1421
- Disclosure: https://github.com/nolabs-ai/nono/issues/1421#issuecomment-5366143930
- Docs note: authoring guide still recommends writing `.base` for stronger concurrency detection; promote now works without it

Made with [Cursor](https://cursor.com)