### PR TITLE
fix: allow fire-and-forget child processes

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -2137,6 +2137,7 @@ fn wait_for_child_with_pty(
         }
         let in_band_detach_requested = pty.take_detach_request();
         handle_pty_detach_request(Some(pty), pause_requested, in_band_detach_requested);
+        handle_pty_signal_relay(Some(pty));
         handle_pty_suspension(Some(pty), child);
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
@@ -2271,6 +2272,25 @@ static PTY_MASTER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI3
 static PAUSE_PIPE_WRITE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
 static PAUSE_PIPE_READ: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
 
+/// Serializes reads of `PTY_MASTER_FD` against the teardown.
+static PTY_MASTER_FD_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// The current foreground process group of the pty nono created for its own
+/// direct child.
+#[cfg(target_os = "macos")]
+pub(crate) fn pty_foreground_pgid() -> Option<Pid> {
+    let _guard = PTY_MASTER_FD_GUARD.lock().ok()?;
+    let fd = PTY_MASTER_FD.load(std::sync::atomic::Ordering::SeqCst);
+    if fd < 0 {
+        return None;
+    }
+    // SAFETY: borrowed only for this call, and the fd is still open for its
+    // duration. `SignalForwardingGuard` is declared after the `PtyProxy` local,
+    // so it drops first.
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+    nix::unistd::tcgetpgrp(fd).ok()
+}
+
 fn create_pause_pipe() -> i32 {
     let mut fds = [0i32; 2];
     let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
@@ -2330,6 +2350,13 @@ extern "C" fn forward_signal(sig: libc::c_int) {
                 }
             }
         } else {
+            let relay_fd = crate::tool_sandbox::signal_relay_write_fd();
+            if relay_fd >= 0 {
+                let byte = [sig as u8];
+                unsafe {
+                    libc::write(relay_fd, byte.as_ptr().cast(), 1);
+                }
+            }
             unsafe {
                 libc::kill(child_raw, sig);
             }
@@ -2353,7 +2380,16 @@ extern "C" fn forward_signal(sig: libc::c_int) {
 
 fn clear_signal_forwarding_target() {
     CHILD_PID.store(0, std::sync::atomic::Ordering::SeqCst);
-    PTY_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+    // Before the pty fd is dropped below: a relayed signal still in the pipe is
+    // delivered from the relay thread, which resolves its target through
+    // `pty_foreground_pgid`.
+    crate::tool_sandbox::stop_signal_relay();
+    {
+        // Held so a relay-thread `pty_foreground_pgid` cannot be mid-`tcgetpgrp`
+        // on the fd the owning `PtyProxy` is about to close.
+        let _guard = PTY_MASTER_FD_GUARD.lock();
+        PTY_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+    }
     close_pause_pipe();
 }
 
@@ -2432,6 +2468,20 @@ fn signal_pty_foreground_group(pty: &crate::pty_proxy::PtyProxy, child: Pid, sig
     }
 }
 
+/// Relay a Ctrl-C or Ctrl-\ intercepted by the PtyProxy to mediated
+/// tool-sandbox children.
+fn handle_pty_signal_relay(pty: Option<&mut crate::pty_proxy::PtyProxy>) {
+    let Some(pty) = pty else {
+        return;
+    };
+    if let Some(pgid) = pty.take_interrupt_request() {
+        crate::tool_sandbox::signal_active_children_in_pgroup(pgid, Signal::SIGINT);
+    }
+    if let Some(pgid) = pty.take_quit_request() {
+        crate::tool_sandbox::signal_active_children_in_pgroup(pgid, Signal::SIGQUIT);
+    }
+}
+
 /// Handle a Ctrl-Z suspension request intercepted by the PtyProxy.
 ///
 /// The handling depends on whether the PTY foreground group is nono's direct
@@ -2457,10 +2507,9 @@ fn handle_pty_suspension(pty: Option<&mut crate::pty_proxy::PtyProxy>, child: Pi
         Some(pgid) => pgid.as_raw() == child.as_raw(),
         None => true,
     };
-
     // Nested job: forward SIGTSTP and let the inner shell handle it. Do not
     // waitpid() — the stopped job is not our child, and the inner shell is
-    // already blocked waiting on it, so waiting here would hang.
+    // already blocked waiting on it, so waiting here would hang..
     if !child_is_foreground {
         if let Some(pgid) = fg_pgid {
             let _ = signal::kill(Pid::from_raw(-pgid.as_raw()), Signal::SIGTSTP);
@@ -2471,6 +2520,7 @@ fn handle_pty_suspension(pty: Option<&mut crate::pty_proxy::PtyProxy>, child: Pi
     // Direct child (orphaned PG): SIGSTOP is uncatchable, unlike SIGTSTP which
     // an interactive bash ignores, so it forces the stopped state immediately.
     signal_pty_foreground_group(pty, child, Signal::SIGSTOP);
+    let stopped_mediated = crate::tool_sandbox::stop_active_children_in_pgroup(child);
 
     loop {
         match waitpid(child, Some(WaitPidFlag::WUNTRACED)) {
@@ -2479,10 +2529,14 @@ fn handle_pty_suspension(pty: Option<&mut crate::pty_proxy::PtyProxy>, child: Pi
                 break;
             }
             Ok(WaitStatus::Exited(..) | WaitStatus::Signaled(..)) => {
+                crate::tool_sandbox::resume_mediated_children(&stopped_mediated);
                 return;
             }
             Err(nix::errno::Errno::EINTR) => continue,
-            Err(_) => return,
+            Err(_) => {
+                crate::tool_sandbox::resume_mediated_children(&stopped_mediated);
+                return;
+            }
             _ => {}
         }
     }
@@ -2521,6 +2575,7 @@ fn handle_pty_suspension(pty: Option<&mut crate::pty_proxy::PtyProxy>, child: Pi
     pty.reenter_screen_for_resume();
 
     signal_pty_foreground_group(pty, child, Signal::SIGCONT);
+    crate::tool_sandbox::resume_mediated_children(&stopped_mediated);
 
     // SIGSTOP doesn't give the child a chance to clean up its terminal state.
     // When resumed, TUI apps (opencode, vim, htop) don't know they need to
@@ -2743,6 +2798,7 @@ fn run_supervisor_loop(
             pause_requested,
             in_band_detach_requested,
         );
+        handle_pty_signal_relay(pty.as_deref_mut());
         handle_pty_suspension(pty.as_deref_mut(), child);
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
@@ -3133,6 +3189,7 @@ fn run_supervisor_loop(
             pause_requested,
             in_band_detach_requested,
         );
+        handle_pty_signal_relay(pty.as_deref_mut());
         handle_pty_suspension(pty.as_deref_mut(), child);
 
         // Drain reparented orphans; if the primary child was among them,

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -18,6 +18,8 @@
 use nix::libc;
 use nix::pty::{OpenptyResult, Winsize, openpty};
 use nix::sys::signal::{self, SigHandler, Signal};
+use nix::sys::termios::{LocalFlags, SpecialCharacterIndices, Termios, tcgetattr};
+use nix::unistd::{Pid, tcgetpgrp};
 use nono::{NonoError, Result};
 use std::collections::VecDeque;
 use std::io::{Read, Write};
@@ -191,6 +193,28 @@ impl AttachedClient {
     }
 }
 
+struct PtySignalChars {
+    interrupt: Option<u8>,
+    quit: Option<u8>,
+}
+
+impl PtySignalChars {
+    fn from_termios(termios: &Termios) -> Option<Self> {
+        if !termios.local_flags.contains(LocalFlags::ISIG) {
+            return None;
+        }
+        Some(Self {
+            interrupt: enabled_control_char(termios, SpecialCharacterIndices::VINTR),
+            quit: enabled_control_char(termios, SpecialCharacterIndices::VQUIT),
+        })
+    }
+}
+
+fn enabled_control_char(termios: &Termios, index: SpecialCharacterIndices) -> Option<u8> {
+    let byte = termios.control_chars[index as usize];
+    (byte != libc::_POSIX_VDISABLE).then_some(byte)
+}
+
 struct ScreenState {
     parser: vt100::Parser,
 }
@@ -265,6 +289,12 @@ pub struct PtyProxy {
     detach_requested: bool,
     /// Ctrl-Z suspension requested from a terminal client.
     suspension_requested: bool,
+    /// The pty's foreground process group as of an interrupt byte its line
+    /// discipline will act on..
+    interrupt_requested: Option<Pid>,
+    /// A quit byte, recorded and forwarded on exactly the same terms as
+    /// `interrupt_requested`.
+    quit_requested: Option<Pid>,
 }
 
 /// Open a PTY pair, inheriting the current terminal's window size.
@@ -394,6 +424,8 @@ impl PtyProxy {
             pending_detach_escape: Vec::new(),
             detach_requested: false,
             suspension_requested: false,
+            interrupt_requested: None,
+            quit_requested: None,
         })
     }
 
@@ -888,6 +920,15 @@ impl PtyProxy {
         std::mem::take(&mut self.suspension_requested)
     }
 
+    /// The process group to relay a seen interrupt to, once.
+    pub fn take_interrupt_request(&mut self) -> Option<Pid> {
+        std::mem::take(&mut self.interrupt_requested)
+    }
+
+    pub fn take_quit_request(&mut self) -> Option<Pid> {
+        std::mem::take(&mut self.quit_requested)
+    }
+
     /// Temporarily restore the local terminal so the parent can prompt.
     ///
     /// Child output must be relayed before the parent writes its prompt; otherwise
@@ -1224,7 +1265,28 @@ impl PtyProxy {
 
             forwarded.push(byte);
         }
+        // Recorded and then forwarded.
+        if let Some(chars) = self.pty_signal_chars() {
+            let interrupt = chars
+                .interrupt
+                .is_some_and(|byte| forwarded.contains(&byte));
+            let quit = chars.quit.is_some_and(|byte| forwarded.contains(&byte));
+            if interrupt || quit {
+                let pgid = tcgetpgrp(&self.master).ok();
+                if interrupt {
+                    self.interrupt_requested = self.interrupt_requested.or(pgid);
+                }
+                if quit {
+                    self.quit_requested = self.quit_requested.or(pgid);
+                }
+            }
+        }
         forwarded
+    }
+
+    /// The interrupt and quit bytes the pty will act on.
+    fn pty_signal_chars(&self) -> Option<PtySignalChars> {
+        PtySignalChars::from_termios(&tcgetattr(&self.master).ok()?)
     }
 
     fn should_start_enhanced_detach_match(&self, byte: u8) -> bool {
@@ -2680,6 +2742,8 @@ mod tests {
     };
     use nix::libc;
     use nix::pty::{OpenptyResult, Winsize, openpty};
+    use nix::sys::termios::{LocalFlags, SpecialCharacterIndices, Termios, tcgetattr};
+    use nix::unistd::tcgetpgrp;
     use std::collections::VecDeque;
     use std::io::{Read, Write};
     use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
@@ -2837,6 +2901,8 @@ mod tests {
             pending_detach_escape: Vec::new(),
             detach_requested: false,
             suspension_requested: false,
+            interrupt_requested: None,
+            quit_requested: None,
         }
     }
 
@@ -2854,6 +2920,34 @@ mod tests {
             libc::STDOUT_FILENO,
         ));
         proxy
+    }
+
+    /// A proxy over a real pty.
+    fn build_test_proxy_over_pty(sequence: &[u8]) -> (PtyProxy, OwnedFd) {
+        let OpenptyResult { master, slave } = openpty(None, None).expect("openpty");
+        (build_test_proxy_with_master(master, sequence), slave)
+    }
+
+    fn build_test_proxy_over_pty_with_terminal(sequence: &[u8]) -> (PtyProxy, OwnedFd) {
+        let (mut proxy, slave) = build_test_proxy_over_pty(sequence);
+        proxy.client = Some(AttachedClient::terminal(
+            libc::STDIN_FILENO,
+            libc::STDOUT_FILENO,
+        ));
+        (proxy, slave)
+    }
+
+    /// The peer end is dropped.
+    fn attach_socket_client(proxy: &mut PtyProxy) {
+        let (client, _) = UnixStream::pair().expect("socketpair");
+        proxy.client = Some(AttachedClient::socket(OwnedFd::from(client)));
+    }
+
+    fn edit_slave_termios(slave: &OwnedFd, edit: impl FnOnce(&mut Termios)) {
+        let mut attrs = tcgetattr(slave).expect("tcgetattr slave");
+        edit(&mut attrs);
+        nix::sys::termios::tcsetattr(slave, nix::sys::termios::SetArg::TCSANOW, &attrs)
+            .expect("tcsetattr slave");
     }
 
     #[test]
@@ -3380,6 +3474,121 @@ mod tests {
 
         assert!(!proxy.resume_terminal_after_prompt());
         assert!(proxy.saved_termios.is_none());
+    }
+
+    #[test]
+    fn filter_client_input_raw_ctrl_c_from_terminal_sets_interrupt_and_forwards() {
+        let (mut proxy, _slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        let forwarded = proxy.filter_client_input(b"\x03");
+        assert_eq!(
+            forwarded, b"\x03",
+            "the byte must still reach the pty, whose line discipline raises SIGINT \
+             on the foreground job"
+        );
+        assert!(proxy.take_interrupt_request().is_some());
+    }
+
+    #[test]
+    fn filter_client_input_records_the_signalled_pgroup_with_the_interrupt() {
+        let (mut proxy, _slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        // Off the master: the slave is not this process's controlling terminal,
+        // so tcgetpgrp on it fails with ENOTTY.
+        let foreground = tcgetpgrp(&proxy.master).expect("tcgetpgrp");
+
+        proxy.filter_client_input(b"\x03");
+
+        assert_eq!(
+            proxy.take_interrupt_request(),
+            Some(foreground),
+            "the relay must target the job the line discipline signalled, not whichever \
+             job holds the terminal by the time the supervisor gets round to relaying"
+        );
+    }
+
+    #[test]
+    fn filter_client_input_ctrl_c_from_socket_client_sets_interrupt() {
+        let (mut proxy, _slave) = build_test_proxy_over_pty(&DEFAULT_DETACH_SEQUENCE);
+        attach_socket_client(&mut proxy);
+        let forwarded = proxy.filter_client_input(b"\x03");
+        assert_eq!(forwarded, b"\x03");
+        assert!(
+            proxy.take_interrupt_request().is_some(),
+            "a reattached client's interrupt reaches the same line discipline the local \
+             terminal's does, so it kills the foreground job and must be relayed too"
+        );
+    }
+
+    #[test]
+    fn filter_client_input_raw_ctrl_backslash_from_terminal_sets_quit_and_forwards() {
+        let (mut proxy, _slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        let forwarded = proxy.filter_client_input(b"\x1c");
+        assert_eq!(
+            forwarded, b"\x1c",
+            "the byte must still reach the pty, whose line discipline raises SIGQUIT \
+             on the foreground job"
+        );
+        assert!(proxy.take_quit_request().is_some());
+    }
+
+    #[test]
+    fn filter_client_input_requests_nothing_while_the_pty_has_isig_off() {
+        let (mut proxy, slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        edit_slave_termios(&slave, |attrs| attrs.local_flags.remove(LocalFlags::ISIG));
+
+        let forwarded = proxy.filter_client_input(b"\x03\x1c");
+
+        assert_eq!(forwarded, b"\x03\x1c");
+        assert!(
+            proxy.take_interrupt_request().is_none() && proxy.take_quit_request().is_none(),
+            "with ISIG off the line discipline raises nothing for either byte, so a relay \
+             would signal mediated children the kernel signalled nothing for"
+        );
+    }
+
+    #[test]
+    fn filter_client_input_follows_a_remapped_interrupt_char() {
+        let (mut proxy, slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        edit_slave_termios(&slave, |attrs| {
+            attrs.control_chars[SpecialCharacterIndices::VINTR as usize] = 0x07;
+        });
+
+        assert!(
+            !proxy.filter_client_input(b"\x03").is_empty()
+                && proxy.take_interrupt_request().is_none(),
+            "0x03 is ordinary input once VINTR points elsewhere"
+        );
+        proxy.filter_client_input(b"\x07");
+        assert!(
+            proxy.take_interrupt_request().is_some(),
+            "the byte the line discipline actually raises SIGINT for must be the one relayed"
+        );
+    }
+
+    #[test]
+    fn filter_client_input_requests_no_interrupt_when_the_intr_char_is_disabled() {
+        let (mut proxy, slave) = build_test_proxy_over_pty_with_terminal(&DEFAULT_DETACH_SEQUENCE);
+        edit_slave_termios(&slave, |attrs| {
+            attrs.control_chars[SpecialCharacterIndices::VINTR as usize] = libc::_POSIX_VDISABLE;
+        });
+
+        proxy.filter_client_input(&[0x03, libc::_POSIX_VDISABLE]);
+
+        assert!(
+            proxy.take_interrupt_request().is_none(),
+            "a disabled VINTR raises no SIGINT, and its sentinel value is not itself a key"
+        );
+    }
+
+    #[test]
+    fn filter_client_input_ctrl_c_consumed_by_the_detach_sequence_requests_no_interrupt() {
+        let (mut proxy, _slave) = build_test_proxy_over_pty_with_terminal(b"\x03");
+        let forwarded = proxy.filter_client_input(b"\x03");
+        assert!(forwarded.is_empty(), "the detach match swallows the byte");
+        assert!(proxy.take_detach_request());
+        assert!(
+            proxy.take_interrupt_request().is_none(),
+            "a byte the pty never sees raises no SIGINT there, so it must relay none"
+        );
     }
 
     // --- Ctrl-Z suspension detection ---

--- a/crates/nono-cli/src/tool-sandbox/mod.rs
+++ b/crates/nono-cli/src/tool-sandbox/mod.rs
@@ -27,6 +27,29 @@ pub(crate) fn record_main_start() {}
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub(crate) fn log_main_total() {}
 
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn signal_active_children_in_pgroup(
+    _pgid: nix::unistd::Pid,
+    _sig: nix::sys::signal::Signal,
+) {
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn stop_active_children_in_pgroup(_pgid: nix::unistd::Pid) -> Vec<u32> {
+    Vec::new()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn resume_mediated_children(_pids: &[u32]) {}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn signal_relay_write_fd() -> i32 {
+    -1
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn stop_signal_relay() {}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod audit_context;
 // Unconditional: readers of an event log classify decisions on every platform,
@@ -490,5 +513,6 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub(crate) use macos::{
     PreparedToolSandboxRuntime, log_main_total, maybe_run_internal_tool_sandbox_entrypoint,
-    record_main_start,
+    record_main_start, resume_mediated_children, signal_active_children_in_pgroup,
+    signal_relay_write_fd, stop_active_children_in_pgroup, stop_signal_relay,
 };

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -2615,7 +2615,7 @@ fn resolve_url_open_command(
             return Ok(Some(found));
         }
     }
-    Ok(None)
+    Ok(session_id_of(peer_pid).and_then(|sid| state.session_lineage.resolve_sid(sid)))
 }
 
 fn is_pid_alive_with_start(pid: u32, expected_start_usec: u64) -> bool {
@@ -7244,6 +7244,39 @@ mod tests {
         let blocked = resolve_caller_with(pid, UNRELATED_ROOT, &state, "child", |_| None);
 
         assert!(matches!(blocked, Err(NonoError::BlockedCommand { .. })));
+    }
+
+    #[test]
+    fn resolve_url_open_command_resolves_ordinary_orphan_via_session_lineage() -> Result<()> {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+        state.session_lineage.record(
+            leader.sid(),
+            "parent",
+            &Caller::Session,
+            Some(leader.identity()),
+        );
+
+        let found = resolve_url_open_command(leader.sid(), &state)?;
+
+        assert!(
+            matches!(found, Some((name, Caller::Session)) if name == "parent"),
+            "a severed caller's URL-open request must still resolve via session lineage, \
+             the same fallback resolve_caller_with already gets"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_url_open_command_denies_when_no_session_record() -> Result<()> {
+        let state = test_state();
+        let pid = std::process::id();
+
+        // Fail-closed: nothing recorded this pid's session, and no active_children match.
+        let found = resolve_url_open_command(pid, &state)?;
+
+        assert!(found.is_none());
+        Ok(())
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -25,6 +25,8 @@ use crate::tool_sandbox::protocol::{
     send_frame_ack, send_stdio_fds, validate_ipc_request, write_frame, write_response,
 };
 use nix::libc;
+use nix::sys::signal::{self, Signal};
+use nix::unistd::{Pid, getpgid};
 use nono::supervisor::ApprovalRequest;
 use nono::{
     AccessMode, CapabilitySet, FsCapability, NetworkMode, NonoError, Result, Sandbox,
@@ -42,8 +44,8 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, trace, warn};
 use zeroize::Zeroizing;
@@ -110,6 +112,7 @@ struct ShimIdentity {
     id: FileId,
 }
 
+#[derive(Clone)]
 struct ActiveChild {
     command: String,
     /// The caller this command was launched under (its policy edge). A URL-open
@@ -120,6 +123,14 @@ struct ActiveChild {
     /// Monotonic start time (pbi_start_tvsec * 1_000_000 + pbi_start_tvusec)
     /// used to detect stale pid map entries.
     start_usec: u64,
+    /// pid of the shim that requested this launch.
+    requester_pid: u32,
+    /// The requester's process group at request time.
+    requester_pgid: Option<Pid>,
+    /// The requester's kernel identity at request time..
+    requester_identity: Option<DaemonIdentity>,
+    /// The requester's session at request time.
+    requester_sid: Option<u32>,
 }
 
 struct ChildLaunchResult {
@@ -349,6 +360,7 @@ impl PreparedToolSandboxRuntime {
             listener: Arc::new(listener),
             url_listener,
         };
+        register_active_tool_sandbox_state(&runtime.inner);
         cleanup.disarm();
         Ok(runtime)
     }
@@ -481,6 +493,7 @@ impl PreparedToolSandboxRuntime {
         session_id: &str,
         audit_recorder: Option<Arc<Mutex<crate::audit_integrity::AuditRecorder>>>,
     ) -> Result<()> {
+        start_signal_relay_thread();
         self.spawn_url_listener(session_root_pid, session_id, audit_recorder.clone());
         let state = Arc::clone(&self.inner);
         let listener = Arc::clone(&self.listener);
@@ -1411,7 +1424,14 @@ fn handle_shim_stream_inner(
         }
         let result = (|| {
             let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
-            launch_child_with_capture(state, &request.command, &caller, launch, stdio)
+            launch_child_with_capture(
+                state,
+                &request.command,
+                &caller,
+                auth.peer_pid,
+                launch,
+                stdio,
+            )
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
         return match result {
@@ -1501,7 +1521,14 @@ fn handle_shim_stream_inner(
         }
         let result = (|| {
             let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
-            launch_child_with_capture(state, &request.command, &caller, launch, stdio)
+            launch_child_with_capture(
+                state,
+                &request.command,
+                &caller,
+                auth.peer_pid,
+                launch,
+                stdio,
+            )
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
         return match result {
@@ -1584,7 +1611,14 @@ fn handle_shim_stream_inner(
                 false,
                 &caller,
             )?;
-            launch_child(state, &request.command, &caller, launch, stdio)
+            launch_child(
+                state,
+                &request.command,
+                &caller,
+                auth.peer_pid,
+                launch,
+                stdio,
+            )
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
         return match result {
@@ -1663,7 +1697,14 @@ fn handle_shim_stream_inner(
     }
     let result = (|| {
         let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
-        launch_child(state, &request.command, &caller, launch, stdio)
+        launch_child(
+            state,
+            &request.command,
+            &caller,
+            auth.peer_pid,
+            launch,
+            stdio,
+        )
     })();
     state.active_count.fetch_sub(1, Ordering::SeqCst);
     match result {
@@ -2578,6 +2619,11 @@ fn resolve_url_open_command(
 }
 
 fn is_pid_alive_with_start(pid: u32, expected_start_usec: u64) -> bool {
+    tracked_pid_start_usec(pid) == Some(expected_start_usec)
+}
+
+/// `pid`'s BSD start time.
+fn tracked_pid_start_usec(pid: u32) -> Option<u64> {
     let mut info: ProcBsdInfo = unsafe { std::mem::zeroed() };
     let size = std::mem::size_of::<ProcBsdInfo>() as i32;
     // SAFETY: same as parent_pid.
@@ -2591,10 +2637,20 @@ fn is_pid_alive_with_start(pid: u32, expected_start_usec: u64) -> bool {
         )
     };
     if ret != size {
-        return false;
+        return None;
     }
-    let start_usec = info.pbi_start_tvsec * 1_000_000 + info.pbi_start_tvusec as u64;
-    start_usec == expected_start_usec
+    Some(info.pbi_start_tvsec * 1_000_000 + info.pbi_start_tvusec as u64)
+}
+
+/// Whether a signal sent to the process group `pid` leads can still reach
+/// something that belongs to this tracked child.
+fn pgroup_may_be_reachable(pid: u32, expected_start_usec: u64) -> bool {
+    match tracked_pid_start_usec(pid) {
+        Some(start_usec) => start_usec == expected_start_usec,
+        // Signal 0: an existence probe, which succeeds while the group still has
+        // any member.
+        None => signal::kill(Pid::from_raw(-(pid as i32)), None).is_ok(),
+    }
 }
 
 fn track_child(
@@ -2602,20 +2658,28 @@ fn track_child(
     child_pid: u32,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
 ) -> Result<()> {
     let identity = daemon_identity(child_pid);
     let start_usec = identity.map_or(0, |identity| identity.start_usec);
+    let requester_pgid = getpgid(Some(Pid::from_raw(requester_pid as i32))).ok();
+    let requester_identity = daemon_identity(requester_pid);
+    let requester_sid = session_id_of(requester_pid);
     let mut map = state
         .active_children
         .lock()
         .map_err(|_| NonoError::SandboxInit("tool-sandbox pid map lock poisoned".to_string()))?;
-    map.retain(|pid, child| is_pid_alive_with_start(*pid, child.start_usec));
+    map.retain(|pid, child| pgroup_may_be_reachable(*pid, child.start_usec));
     map.insert(
         child_pid,
         ActiveChild {
             command: command_name.to_string(),
             launch_caller: launch_caller.clone(),
             start_usec,
+            requester_pid,
+            requester_pgid,
+            requester_identity,
+            requester_sid,
         },
     );
     drop(map);
@@ -2632,6 +2696,292 @@ fn untrack_child(state: &ToolSandboxState, child_pid: u32) -> Result<()> {
         .map_err(|_| NonoError::SandboxInit("tool-sandbox pid map lock poisoned".to_string()))?;
     map.remove(&child_pid);
     Ok(())
+}
+
+static ACTIVE_TOOL_SANDBOX_STATE: Mutex<Option<Weak<ToolSandboxState>>> = Mutex::new(None);
+
+fn register_active_tool_sandbox_state(state: &Arc<ToolSandboxState>) {
+    if let Ok(mut slot) = ACTIVE_TOOL_SANDBOX_STATE.lock() {
+        *slot = Some(Arc::downgrade(state));
+    }
+}
+
+fn active_tool_sandbox_state() -> Option<Arc<ToolSandboxState>> {
+    ACTIVE_TOOL_SANDBOX_STATE.lock().ok()?.as_ref()?.upgrade()
+}
+
+/// Send `sig` to every mediated child whose requesting shim currently belongs
+/// to process group `pgid`..
+pub(crate) fn signal_active_children_in_pgroup(pgid: Pid, sig: Signal) {
+    let Some(state) = active_tool_sandbox_state() else {
+        return;
+    };
+    signal_children_in_pgroup_for_state(&state, pgid, sig);
+}
+
+/// `SIGSTOP` the mediated children of the job whose process group is `pgid`.
+pub(crate) fn stop_active_children_in_pgroup(pgid: Pid) -> Vec<u32> {
+    let Some(state) = active_tool_sandbox_state() else {
+        return Vec::new();
+    };
+    signal_children_in_pgroup_for_state(&state, pgid, Signal::SIGSTOP)
+}
+
+/// `SIGCONT` the mediated children named by a preceding
+/// [`stop_active_children_in_pgroup`].
+pub(crate) fn resume_mediated_children(pids: &[u32]) {
+    let Some(state) = active_tool_sandbox_state() else {
+        return;
+    };
+    resume_children_for_state(&state, pids);
+}
+
+/// Core of [`resume_mediated_children`], taking the state explicitly rather
+/// than through the process-global registration.
+fn resume_children_for_state(state: &ToolSandboxState, pids: &[u32]) {
+    // Recycle guard, on the same terms as the relay that stopped them: a child
+    // that died since could have handed its pid to an unrelated process group.
+    let tracked: Vec<(u32, u64)> = {
+        let Ok(map) = state.active_children.lock() else {
+            return;
+        };
+        pids.iter()
+            .filter_map(|&pid| map.get(&pid).map(|child| (pid, child.start_usec)))
+            .collect()
+    };
+    for (pid, start_usec) in tracked {
+        if pgroup_may_be_reachable(pid, start_usec) {
+            let _ = signal::kill(Pid::from_raw(-(pid as i32)), Signal::SIGCONT);
+        }
+    }
+}
+
+/// One tracked child resolved for a single relay pass.
+struct RelayTarget {
+    pid: u32,
+    /// Whether it was launched from the job being signalled.
+    in_pgroup: bool,
+    /// The session its requesting shim belongs to, for the nesting walk.
+    requester_session: Option<u32>,
+}
+
+/// Core of the per-job signal paths ([`signal_active_children_in_pgroup`],
+/// [`stop_active_children_in_pgroup`], and the relay), taking the state
+/// explicitly rather than through the process-global registration. Returns the
+/// pids signalled.
+fn signal_children_in_pgroup_for_state(
+    state: &ToolSandboxState,
+    pgid: Pid,
+    sig: Signal,
+) -> Vec<u32> {
+    let tracked: Vec<(u32, ActiveChild)> = {
+        let Ok(map) = state.active_children.lock() else {
+            return Vec::new();
+        };
+        map.iter()
+            .map(|(&pid, child)| (pid, child.clone()))
+            .collect()
+    };
+    let targets: Vec<RelayTarget> = tracked
+        .into_iter()
+        .filter(|(pid, child)| pgroup_may_be_reachable(*pid, child.start_usec))
+        .map(|(pid, child)| {
+            let requester_live = requester_is_live(&child);
+            RelayTarget {
+                pid,
+                in_pgroup: requester_in_pgroup(&child, pgid, requester_live),
+                requester_session: requester_session(&child, requester_live),
+            }
+        })
+        .collect();
+
+    let mut matched: HashSet<u32> = targets
+        .iter()
+        .filter(|target| target.in_pgroup)
+        .map(|target| target.pid)
+        .collect();
+
+    loop {
+        let mut grew = false;
+        for target in &targets {
+            if matched.contains(&target.pid) {
+                continue;
+            }
+            if target
+                .requester_session
+                .is_some_and(|sid| matched.contains(&sid))
+            {
+                matched.insert(target.pid);
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    let signalled: Vec<u32> = matched.into_iter().collect();
+    for &pid in &signalled {
+        let _ = signal::kill(Pid::from_raw(-(pid as i32)), sig);
+    }
+    signalled
+}
+
+/// Whether `child` was launched from the job whose process group is `pgid`.
+fn requester_in_pgroup(child: &ActiveChild, pgid: Pid, requester_live: bool) -> bool {
+    if requester_live {
+        return getpgid(Some(Pid::from_raw(child.requester_pid as i32)))
+            .is_ok_and(|requester_pgid| requester_pgid == pgid);
+    }
+    child.requester_pgid == Some(pgid)
+}
+
+/// The session `child`'s requesting shim belongs to.
+fn requester_session(child: &ActiveChild, requester_live: bool) -> Option<u32> {
+    if requester_live {
+        return session_id_of(child.requester_pid);
+    }
+    child.requester_sid
+}
+
+/// Whether the process at `requester_pid` is still the shim that made the
+/// request.
+fn requester_is_live(child: &ActiveChild) -> bool {
+    child
+        .requester_identity
+        .is_some_and(|recorded| daemon_identity(child.requester_pid) == Some(recorded))
+}
+
+/// Deliver one relayed signal to mediated children.
+fn relay_signal_for_state(state: &ToolSandboxState, sig: Signal, foreground_pgid: Option<Pid>) {
+    if sig == Signal::SIGHUP {
+        signal_all_children_for_state(state, sig);
+        return;
+    }
+    match foreground_pgid {
+        Some(pgid) => {
+            signal_children_in_pgroup_for_state(state, pgid, sig);
+        }
+        None => signal_all_children_for_state(state, sig),
+    }
+}
+
+/// Send `sig` to every live mediated child regardless of which job launched it.
+fn signal_all_children_for_state(state: &ToolSandboxState, sig: Signal) {
+    let tracked: Vec<(u32, u64)> = {
+        let Ok(map) = state.active_children.lock() else {
+            return;
+        };
+        map.iter()
+            .map(|(&pid, child)| (pid, child.start_usec))
+            .collect()
+    };
+    for (pid, start_usec) in tracked {
+        if !pgroup_may_be_reachable(pid, start_usec) {
+            continue;
+        }
+        let _ = signal::kill(Pid::from_raw(-(pid as i32)), sig);
+    }
+}
+
+static TOOL_SANDBOX_SIGNAL_RELAY_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+
+/// Join handle for the thread [`start_signal_relay_thread`] spawns, so
+/// [`stop_signal_relay`] can wait for it to finish the bytes already in the pipe.
+static TOOL_SANDBOX_SIGNAL_RELAY_THREAD: Mutex<Option<std::thread::JoinHandle<()>>> =
+    Mutex::new(None);
+
+/// Write end of the pipe `exec_strategy::forward_signal` writes a signal byte
+/// into from async-signal-safe context.
+pub(crate) fn signal_relay_write_fd() -> i32 {
+    TOOL_SANDBOX_SIGNAL_RELAY_WRITE_FD.load(Ordering::SeqCst)
+}
+
+/// Start the ordinary thread that turns a relayed signal byte into a
+/// foreground-scoped `signal_active_children_in_pgroup` call.
+fn start_signal_relay_thread() {
+    let mut fds = [-1i32; 2];
+    // SAFETY: `fds` is a valid 2-element buffer for pipe(2) to fill.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        warn!(
+            "tool-sandbox signal relay disabled, pipe(2) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+    // SAFETY: fcntl on freshly created, still process-local fds. O_NONBLOCK on
+    // the write end keeps `forward_signal` from ever blocking inside a signal
+    // handler behind a full pipe.
+    unsafe {
+        libc::fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC);
+        libc::fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC);
+        libc::fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK);
+    }
+    TOOL_SANDBOX_SIGNAL_RELAY_WRITE_FD.store(fds[1], Ordering::SeqCst);
+    let read_fd = fds[0];
+    let handle = std::thread::spawn(move || {
+        loop {
+            let mut byte = [0u8; 1];
+            // SAFETY: read_fd is a valid, owned pipe read end for the life of
+            // this process; the buffer is a stack-allocated single byte.
+            let n = unsafe { libc::read(read_fd, byte.as_mut_ptr().cast(), 1) };
+            if n <= 0 {
+                if n < 0
+                    && std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted
+                {
+                    continue;
+                }
+                break;
+            }
+            let Ok(sig) = Signal::try_from(byte[0] as i32) else {
+                continue;
+            };
+            let Some(state) = active_tool_sandbox_state() else {
+                continue;
+            };
+            relay_signal_for_state(&state, sig, terminal_foreground_pgid());
+        }
+        // SAFETY: the loop is done with it and this thread is its only owner.
+        unsafe { libc::close(read_fd) };
+    });
+    if let Ok(mut slot) = TOOL_SANDBOX_SIGNAL_RELAY_THREAD.lock() {
+        *slot = Some(handle);
+    }
+}
+
+/// Close the relay pipe's write end and wait for the relay thread to deliver
+/// whatever is already queued in it.
+pub(crate) fn stop_signal_relay() {
+    let write_fd = TOOL_SANDBOX_SIGNAL_RELAY_WRITE_FD.swap(-1, Ordering::SeqCst);
+    if write_fd >= 0 {
+        // SAFETY: the swap above makes this the only close of the only write
+        // end; a `forward_signal` that already loaded the number can at worst
+        // write to a closed fd, the same exposure `close_pause_pipe` carries.
+        unsafe { libc::close(write_fd) };
+    }
+    let handle = TOOL_SANDBOX_SIGNAL_RELAY_THREAD
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take());
+    if let Some(handle) = handle {
+        let _ = handle.join();
+    }
+}
+
+/// The current foreground process group of the terminal the requesting shims
+/// run under.
+fn terminal_foreground_pgid() -> Option<Pid> {
+    if let Some(pgid) = crate::exec_strategy::pty_foreground_pgid() {
+        return Some(pgid);
+    }
+    [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO]
+        .into_iter()
+        .find_map(|fd| {
+            // SAFETY: the standard fds outlive this call; tcgetpgrp fails
+            // cleanly (ENOTTY) on a redirected one.
+            let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+            nix::unistd::tcgetpgrp(fd).ok()
+        })
 }
 
 fn file_id(metadata: &fs::Metadata) -> FileId {
@@ -3506,6 +3856,7 @@ fn filter_child_env(
     Ok(result)
 }
 
+/// Give the launched command its own POSIX session, pre-exec, so `track_child`'s
 /// `session_lineage` record stays resolvable after this process exits..
 fn install_session_lineage(command: &mut Command) {
     // SAFETY: runs post-fork/pre-exec, so must be async-signal-safe; setsid(2)
@@ -3541,12 +3892,20 @@ fn launch_child(
     state: &ToolSandboxState,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
     spec: ToolSandboxChildLaunchSpec,
     stdio: StdioFds,
 ) -> Result<ChildLaunchResult> {
     let spec_path = write_launch_spec(&state.runtime_dir, &spec)?;
-    let result =
-        launch_child_with_direct_fds(state, command_name, launch_caller, &spec_path, &spec, stdio);
+    let result = launch_child_with_direct_fds(
+        state,
+        command_name,
+        launch_caller,
+        requester_pid,
+        &spec_path,
+        &spec,
+        stdio,
+    );
     remove_launch_spec(&spec_path);
     result
 }
@@ -3555,6 +3914,7 @@ fn launch_child_with_direct_fds(
     state: &ToolSandboxState,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
     spec_path: &Path,
     spec: &ToolSandboxChildLaunchSpec,
     stdio: StdioFds,
@@ -3564,6 +3924,7 @@ fn launch_child_with_direct_fds(
             state,
             command_name,
             launch_caller,
+            requester_pid,
             spec_path,
             spec,
             stdio,
@@ -3575,7 +3936,13 @@ fn launch_child_with_direct_fds(
         .stdout(Stdio::from(File::from(stdio.stdout)))
         .stderr(Stdio::from(File::from(stdio.stderr)));
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
-    let exit_code = wait_for_tracked_child(state, command_name, launch_caller, &mut child)?;
+    let exit_code = wait_for_tracked_child(
+        state,
+        command_name,
+        launch_caller,
+        requester_pid,
+        &mut child,
+    )?;
     Ok(ChildLaunchResult {
         exit_code,
         stdio: None,
@@ -3587,6 +3954,7 @@ fn launch_child_with_brokered_stdio(
     state: &ToolSandboxState,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
     spec_path: &Path,
     spec: &ToolSandboxChildLaunchSpec,
     stdio: StdioFds,
@@ -3610,7 +3978,13 @@ fn launch_child_with_brokered_stdio(
 
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
-    track_child(state, child.id(), command_name, launch_caller)?;
+    track_child(
+        state,
+        child.id(),
+        command_name,
+        launch_caller,
+        requester_pid,
+    )?;
 
     let exceeded = Arc::new(AtomicBool::new(false));
     let stdout_exceeded = exceeded.clone();
@@ -3848,6 +4222,7 @@ fn launch_child_with_capture(
     state: &ToolSandboxState,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
     spec: ToolSandboxChildLaunchSpec,
     stdio: StdioFds,
 ) -> Result<(i32, Vec<u8>)> {
@@ -3871,7 +4246,13 @@ fn launch_child_with_capture(
 
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
-    track_child(state, child.id(), command_name, launch_caller)?;
+    track_child(
+        state,
+        child.id(),
+        command_name,
+        launch_caller,
+        requester_pid,
+    )?;
 
     let mut captured = Vec::new();
     let mut pipe_reader =
@@ -3899,9 +4280,16 @@ fn wait_for_tracked_child(
     state: &ToolSandboxState,
     command_name: &str,
     launch_caller: &Caller,
+    requester_pid: u32,
     child: &mut Child,
 ) -> Result<i32> {
-    track_child(state, child.id(), command_name, launch_caller)?;
+    track_child(
+        state,
+        child.id(),
+        command_name,
+        launch_caller,
+        requester_pid,
+    )?;
     let status = child.wait().map_err(NonoError::CommandExecution);
     untrack_child(state, child.id())?;
     status.map(exit_status_code)
@@ -6508,7 +6896,7 @@ mod tests {
     fn resolve_caller_prefers_active_command_for_peer_pid() -> Result<()> {
         let state = test_state();
         let pid = std::process::id();
-        track_child(&state, pid, "git", &Caller::Session)?;
+        track_child(&state, pid, "git", &Caller::Session, pid)?;
 
         let caller = resolve_caller(pid, pid, &state, "ssh")?;
 
@@ -6520,7 +6908,7 @@ mod tests {
     fn resolve_caller_uses_launch_caller_for_self_invocation() -> Result<()> {
         let state = test_state();
         let pid = std::process::id();
-        track_child(&state, pid, "git", &Caller::Session)?;
+        track_child(&state, pid, "git", &Caller::Session, pid)?;
 
         let caller = resolve_caller(pid, pid, &state, "git")?;
 
@@ -6539,7 +6927,7 @@ mod tests {
             },
         );
         let pid = std::process::id();
-        track_child(&state, pid, "git", &Caller::Session)?;
+        track_child(&state, pid, "git", &Caller::Session, pid)?;
 
         let caller = resolve_caller(pid, pid, &state, "git")?;
 
@@ -6818,7 +7206,7 @@ mod tests {
             return Ok(());
         }
 
-        track_child(&state, launcher_pid, "parent", &Caller::Session)?;
+        track_child(&state, launcher_pid, "parent", &Caller::Session, 1)?;
 
         assert!(
             matches!(state.session_lineage.resolve_sid(launcher_pid), Some((name, _)) if name == "parent"),
@@ -7526,6 +7914,481 @@ mod tests {
             matches!(caller, Caller::Command { name } if name == "parent"),
             "an ordinary orphan must attribute to the command that self-assigned its session"
         );
+    }
+
+    #[test]
+    fn active_tool_sandbox_state_upgrades_only_while_registered() {
+        let state = Arc::new(test_state());
+        register_active_tool_sandbox_state(&state);
+        assert!(
+            active_tool_sandbox_state().is_some(),
+            "must resolve while the runtime's Arc is still alive"
+        );
+        drop(state);
+        assert!(
+            active_tool_sandbox_state().is_none(),
+            "must go stale once the runtime's Arc is dropped, so a torn-down \
+             tool-sandbox runtime can't receive a stray relayed signal"
+        );
+    }
+
+    #[test]
+    fn stop_signal_relay_closes_the_pipe_and_joins_the_thread() {
+        start_signal_relay_thread();
+        let write_fd = signal_relay_write_fd();
+        assert!(write_fd >= 0, "the relay pipe must be open");
+        // SAFETY: one byte into the relay pipe's write end, exactly as
+        // `exec_strategy::forward_signal` writes it.
+        let written = unsafe { libc::write(write_fd, [Signal::SIGHUP as u8].as_ptr().cast(), 1) };
+        assert_eq!(written, 1, "the queued byte is what teardown must drain");
+
+        stop_signal_relay();
+
+        assert_eq!(
+            signal_relay_write_fd(),
+            -1,
+            "a torn-down relay must not accept further signal bytes"
+        );
+        assert!(
+            TOOL_SANDBOX_SIGNAL_RELAY_THREAD
+                .lock()
+                .is_ok_and(|slot| slot.is_none()),
+            "the thread must have been joined, not left racing nono's exit"
+        );
+    }
+
+    fn spawn_setsid_sleep() -> std::process::Child {
+        let mut command = std::process::Command::new("sleep");
+        command.arg("20");
+        install_session_lineage(&mut command);
+        command.spawn().expect("spawn sleep")
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_children_in_pgroup_only_signals_the_foreground_job() {
+        use nix::sys::wait::{WaitStatus, waitpid};
+
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        // Reaped below via `nix::sys::wait::waitpid` directly (not
+        // `Child::wait`), so clippy can't see it's collected.
+        #[allow(clippy::zombie_processes)]
+        let foreground_child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            foreground_child.id(),
+            "sleep",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child foreground");
+
+        // A distinct, unrelated pgroup standing in for a backgrounded job's
+        // shim.
+        let mut background_requester = spawn_setsid_sleep();
+        let mut background_child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            background_child.id(),
+            "sleep",
+            &Caller::Session,
+            background_requester.id(),
+        )
+        .expect("track_child background");
+
+        signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGTERM);
+
+        match waitpid(Pid::from_raw(foreground_child.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!("expected the foreground-pgroup child to be SIGTERM'd, got {other:?}"),
+        }
+
+        // Long enough for a wrongly-delivered SIGTERM to have taken effect.
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            background_child.try_wait().expect("try_wait"),
+            None,
+            "a child whose requester is outside the target pgroup must not be signaled"
+        );
+
+        let _ = background_child.kill();
+        let _ = background_child.wait();
+
+        // A dead requester must not break scoping.
+        #[allow(clippy::zombie_processes)]
+        let orphaned_child = spawn_setsid_sleep();
+        let orphaned_pgid = getpgid(Some(Pid::from_raw(background_requester.id() as i32)))
+            .expect("getpgid of the live requester");
+        track_child(
+            &state,
+            orphaned_child.id(),
+            "sleep",
+            &Caller::Session,
+            background_requester.id(),
+        )
+        .expect("track_child orphaned");
+        let _ = background_requester.kill();
+        let _ = background_requester.wait(); // reaped: the live getpgid lookup now fails
+
+        signal_children_in_pgroup_for_state(&state, orphaned_pgid, Signal::SIGTERM);
+
+        match waitpid(Pid::from_raw(orphaned_child.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!(
+                "expected the dead-requester child to be SIGTERM'd via the snapshot pgid, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_children_in_pgroup_reaches_a_chained_mediated_child() {
+        use nix::sys::wait::{WaitStatus, waitpid};
+
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        #[allow(clippy::zombie_processes)]
+        let outer = spawn_setsid_sleep();
+        track_child(
+            &state,
+            outer.id(),
+            "sleep",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child outer");
+
+        #[allow(clippy::zombie_processes)]
+        let inner = spawn_setsid_sleep();
+        track_child(&state, inner.id(), "sleep", &Caller::Session, outer.id())
+            .expect("track_child inner");
+
+        signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGTERM);
+
+        match waitpid(Pid::from_raw(outer.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!("expected the first-tier child to be SIGTERM'd, got {other:?}"),
+        }
+        match waitpid(Pid::from_raw(inner.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!(
+                "a mediated child requested from inside another mediated child's session must \
+                 still be reached by the relay, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_children_in_pgroup_reaches_a_chained_child_whose_shim_died() -> Result<()> {
+        use nix::sys::wait::{WaitStatus, waitpid};
+
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        let dir = test_tempdir()?;
+        let pid_file = dir.path().join("shim.pid");
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg(format!(
+            "sleep 20 & echo $! > {}; sleep 20",
+            pid_file.display()
+        ));
+        install_session_lineage(&mut command);
+        #[allow(clippy::zombie_processes)]
+        let outer = command.spawn().map_err(NonoError::CommandExecution)?;
+        let shim = read_pid_file(&pid_file).expect("the script writes the pid before sleeping");
+        track_child(
+            &state,
+            outer.id(),
+            "sh",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child outer");
+
+        #[allow(clippy::zombie_processes)]
+        let inner = spawn_setsid_sleep();
+        track_child(&state, inner.id(), "sleep", &Caller::Session, shim)
+            .expect("track_child inner");
+
+        signal::kill(Pid::from_raw(shim as i32), Signal::SIGKILL).expect("kill the shim");
+        assert!(
+            wait_until(|| daemon_identity(shim).is_none()),
+            "the shim must read as dead before the relay runs"
+        );
+
+        signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGTERM);
+
+        match waitpid(Pid::from_raw(inner.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!(
+                "a mediated child whose requesting shim died before the relay must still be \
+                 reached through the session recorded at request time, got {other:?}"
+            ),
+        }
+        let _ = waitpid(Pid::from_raw(outer.id() as i32), None);
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_children_in_pgroup_reaches_a_pgroup_behind_a_zombie_leader() -> Result<()> {
+        use nix::sys::wait::waitpid;
+
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        // The leader exits at once, leaving `sleep` running in its process
+        // group, and is not reaped until the end so it stays a zombie.
+        let dir = test_tempdir()?;
+        let pid_file = dir.path().join("descendant.pid");
+        let mut command = std::process::Command::new("sh");
+        command
+            .arg("-c")
+            .arg(format!("sleep 20 & echo $! > {}", pid_file.display()));
+        install_session_lineage(&mut command);
+        #[allow(clippy::zombie_processes)]
+        let leader = command.spawn().map_err(NonoError::CommandExecution)?;
+        let descendant =
+            read_pid_file(&pid_file).expect("the script writes the pid before exiting");
+        track_child(
+            &state,
+            leader.id(),
+            "sh",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child");
+        let start_usec = state
+            .active_children
+            .lock()
+            .expect("lock active_children")
+            .get(&leader.id())
+            .expect("tracked child")
+            .start_usec;
+
+        assert!(
+            wait_until(|| !is_pid_alive_with_start(leader.id(), start_usec)),
+            "precondition: an unreaped exit must make the leader read back as gone"
+        );
+        assert!(
+            pgroup_may_be_reachable(leader.id(), start_usec),
+            "its process group still holds a live descendant"
+        );
+
+        signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGTERM);
+
+        assert!(
+            wait_until(|| daemon_identity(descendant).is_none()),
+            "a descendant left running in the exited child's process group must still be \
+             reached by the relay"
+        );
+        let _ = waitpid(Pid::from_raw(leader.id() as i32), None);
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_children_in_pgroup_ignores_a_recycled_requester_pid() {
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        let mut child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            child.id(),
+            "sleep",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child");
+        {
+            let mut map = state.active_children.lock().expect("lock active_children");
+            let entry = map.get_mut(&child.id()).expect("tracked child");
+            entry.requester_identity = Some(DaemonIdentity {
+                uniqueid: u64::MAX,
+                start_usec: u64::MAX,
+            });
+            entry.requester_pgid = Some(Pid::from_raw(-1));
+        }
+
+        signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGTERM);
+
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            child.try_wait().expect("try_wait"),
+            None,
+            "a child whose requester identity no longer matches must not be signaled"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// `SSTOP` from `<sys/proc.h>`.
+    const PROC_STATUS_STOPPED: u32 = 4;
+
+    fn process_is_stopped(pid: u32) -> bool {
+        let mut info: ProcBsdInfo = unsafe { std::mem::zeroed() };
+        let size = std::mem::size_of::<ProcBsdInfo>() as i32;
+        // SAFETY: same call shape as `is_pid_alive_with_start`.
+        let ret = unsafe {
+            proc_pidinfo(
+                pid as i32,
+                PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                size,
+            )
+        };
+        ret == size && info.pbi_status == PROC_STATUS_STOPPED
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_resume_lifts_only_the_children_the_stop_relay_stopped() {
+        let state = test_state();
+        let target_pgid = getpgid(None).expect("getpgid(self)");
+
+        // Reaped below via `nix::sys::wait::waitpid` directly.
+        #[allow(clippy::zombie_processes)]
+        let mut foreground_child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            foreground_child.id(),
+            "sleep",
+            &Caller::Session,
+            std::process::id(),
+        )
+        .expect("track_child foreground");
+
+        let mut background_requester = spawn_setsid_sleep();
+        #[allow(clippy::zombie_processes)]
+        let mut background_child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            background_child.id(),
+            "sleep",
+            &Caller::Session,
+            background_requester.id(),
+        )
+        .expect("track_child background");
+        let _ = background_requester.kill();
+        let _ = background_requester.wait();
+        signal::kill(
+            Pid::from_raw(-(background_child.id() as i32)),
+            Signal::SIGSTOP,
+        )
+        .expect("stop the unrelated job's child");
+        assert!(
+            wait_until(|| process_is_stopped(background_child.id())),
+            "precondition: the unrelated child must be stopped before the resume runs"
+        );
+
+        let stopped = signal_children_in_pgroup_for_state(&state, target_pgid, Signal::SIGSTOP);
+
+        assert_eq!(
+            stopped,
+            vec![foreground_child.id()],
+            "only the foreground job's child may be reported stopped"
+        );
+        assert!(wait_until(|| process_is_stopped(foreground_child.id())));
+
+        resume_children_for_state(&state, &stopped);
+
+        assert!(
+            wait_until(|| !process_is_stopped(foreground_child.id())),
+            "the stopped child must be resumed even though nothing live still ties it \
+             to the job it was launched from"
+        );
+        assert!(
+            process_is_stopped(background_child.id()),
+            "a deliberately-stopped child of an unrelated job must not be resumed by \
+             another job's Ctrl-Z resume"
+        );
+
+        let _ = foreground_child.kill();
+        let _ = foreground_child.wait();
+        let _ = signal::kill(
+            Pid::from_raw(-(background_child.id() as i32)),
+            Signal::SIGKILL,
+        );
+        let _ = background_child.wait();
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_signal_all_children_reaches_a_backgrounded_job() {
+        use nix::sys::wait::{WaitStatus, waitpid};
+
+        let state = test_state();
+
+        let mut background_requester = spawn_setsid_sleep();
+        // Reaped below via `nix::sys::wait::waitpid` directly.
+        #[allow(clippy::zombie_processes)]
+        let mut background_child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            background_child.id(),
+            "sleep",
+            &Caller::Session,
+            background_requester.id(),
+        )
+        .expect("track_child background");
+
+        let foreground_pgid = getpgid(None).expect("getpgid(self)");
+        signal_children_in_pgroup_for_state(&state, foreground_pgid, Signal::SIGHUP);
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            background_child.try_wait().ok().flatten(),
+            None,
+            "precondition: the foreground-scoped relay must not reach a background job"
+        );
+
+        signal_all_children_for_state(&state, Signal::SIGHUP);
+
+        match waitpid(Pid::from_raw(background_child.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGHUP, _)) => {}
+            other => panic!("expected a backgrounded job's child to be SIGHUP'd, got {other:?}"),
+        }
+
+        let _ = background_requester.kill();
+        let _ = background_requester.wait();
+    }
+
+    #[test]
+    #[ignore = "spawns and signals real processes; run with --ignored"]
+    fn live_relay_without_a_terminal_reaches_every_mediated_child() {
+        use nix::sys::wait::{WaitStatus, waitpid};
+
+        let state = test_state();
+        let mut requester = spawn_setsid_sleep();
+        // Reaped below via `nix::sys::wait::waitpid` directly.
+        #[allow(clippy::zombie_processes)]
+        let child = spawn_setsid_sleep();
+        track_child(
+            &state,
+            child.id(),
+            "sleep",
+            &Caller::Session,
+            requester.id(),
+        )
+        .expect("track_child");
+
+        relay_signal_for_state(&state, Signal::SIGTERM, None);
+
+        match waitpid(Pid::from_raw(child.id() as i32), None) {
+            Ok(WaitStatus::Signaled(_, Signal::SIGTERM, _)) => {}
+            other => panic!(
+                "expected a mediated child to be SIGTERM'd when no terminal resolves, got {other:?}"
+            ),
+        }
+
+        let _ = requester.kill();
+        let _ = requester.wait();
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -39,8 +39,9 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -160,6 +161,7 @@ struct ToolSandboxState {
     /// Attributes severed-ancestry callers to their spawning command. See the
     /// daemon-lineage section below.
     lineage: LineageMarker,
+    session_lineage: SessionLineage,
     active_count: AtomicUsize,
     queued_requests: AtomicUsize,
     emitted_error_response: AtomicBool,
@@ -336,6 +338,7 @@ impl PreparedToolSandboxRuntime {
                 proxy_trust_bundle_paths: proxy_trust_bundle_paths.to_vec(),
                 active_children: Mutex::new(HashMap::new()),
                 lineage,
+                session_lineage: SessionLineage::default(),
                 active_count: AtomicUsize::new(0),
                 queued_requests: AtomicUsize::new(0),
                 emitted_error_response: AtomicBool::new(false),
@@ -1861,8 +1864,23 @@ fn resolve_caller_with(
             Err(_) => break,
         };
     }
-    // Walk stopped short of the root: an ancestor daemonized (reparented to pid 1).
-    // Fail closed unless the marker verifies `last_non_init` by pid identity.
+    // Walk stopped short of the root: an ancestor exited before this connection
+    // was mediated.
+    let peer_sid = session_id_of(peer_pid);
+    if let Some((name, launch_caller)) =
+        peer_sid.and_then(|sid| state.session_lineage.resolve_sid(sid))
+    {
+        if name == command_name
+            && !has_explicit_self_invocation_entry(&state.plan.config, command_name)
+        {
+            return Ok(launch_caller);
+        }
+        return Ok(Caller::Command { name });
+    }
+    if peer_sid == Some(session_root_pid) {
+        return Ok(Caller::Session);
+    }
+    // A genuine daemon calls its own setsid().
     if let Some(caller) = resolve_severed(last_non_init) {
         return Ok(caller);
     }
@@ -1870,6 +1888,111 @@ fn resolve_caller_with(
         command: "unknown".to_string(),
         reason: "caller ancestry did not reach session root".to_string(),
     })
+}
+
+// `install_session_lineage` puts every mediated launch in its own POSIX
+// session pre-exec. `setsid()` can't join another session, so this is
+// unforgeable (unlike pgid). Orphans keep their sid across reparenting, so
+// `resolve` finds them after `resolve_caller`'s ancestry walk breaks. Real
+// daemons (double-fork + own `setsid()`) get an untracked session and still
+// need the `daemon_pid_source` fallback.
+
+const MAX_SESSION_LINEAGE_ENTRIES: usize = 4096;
+
+#[derive(Default)]
+struct SessionLineage {
+    owners: Mutex<SessionLineageOwners>,
+}
+
+#[derive(Clone)]
+struct SessionLineageEntry {
+    command: String,
+    launch_caller: Caller,
+    identity: Option<DaemonIdentity>,
+    used: u64,
+}
+
+#[derive(Default)]
+struct SessionLineageOwners {
+    by_sid: HashMap<u32, SessionLineageEntry>,
+    next_used: u64,
+}
+
+impl SessionLineageOwners {
+    /// Drop the least-recently-used entries until at most `MAX_SESSION_LINEAGE_ENTRIES`
+    /// remain.
+    fn evict_to_cap(&mut self) {
+        while self.by_sid.len() > MAX_SESSION_LINEAGE_ENTRIES {
+            let Some(stalest) = self
+                .by_sid
+                .iter()
+                .min_by_key(|(_, entry)| entry.used)
+                .map(|(&sid, _)| sid)
+            else {
+                break;
+            };
+            self.by_sid.remove(&stalest);
+        }
+    }
+
+    fn remove(&mut self, sid: u32) {
+        self.by_sid.remove(&sid);
+    }
+
+    /// Stamp `sid` as most recently used.
+    fn touch(&mut self, sid: u32) {
+        let used = self.next_used;
+        self.next_used = self.next_used.saturating_add(1);
+        if let Some(entry) = self.by_sid.get_mut(&sid) {
+            entry.used = used;
+        }
+    }
+}
+
+impl SessionLineage {
+    /// Record `sid` as owned by `command`, pinned by `identity` when one could
+    /// be read.
+    fn record(
+        &self,
+        sid: u32,
+        command: &str,
+        launch_caller: &Caller,
+        identity: Option<DaemonIdentity>,
+    ) {
+        let Ok(mut owners) = self.owners.lock() else {
+            return;
+        };
+        let used = owners.next_used;
+        owners.next_used = owners.next_used.saturating_add(1);
+        owners.by_sid.insert(
+            sid,
+            SessionLineageEntry {
+                command: command.to_string(),
+                launch_caller: launch_caller.clone(),
+                identity,
+                used,
+            },
+        );
+        owners.evict_to_cap();
+    }
+
+    fn resolve_sid(&self, sid: u32) -> Option<(String, Caller)> {
+        let mut owners = self.owners.lock().ok()?;
+        let entry = owners.by_sid.get(&sid)?.clone();
+        let (name, launch_caller, recorded_identity) =
+            (entry.command, entry.launch_caller, entry.identity);
+
+        let stale = match recorded_identity {
+            Some(recorded) => daemon_identity(sid).is_some_and(|current| current != recorded),
+            None => true,
+        };
+        if stale && session_id_of(sid) == Some(sid) {
+            owners.remove(sid);
+            return None;
+        }
+        owners.touch(sid);
+        Some((name, launch_caller))
+    }
 }
 
 // ── Daemon lineage ─────────────────────────────────────────────────────────
@@ -2107,6 +2230,11 @@ fn daemon_identity(pid: u32) -> Option<DaemonIdentity> {
         uniqueid: uinfo.p_uniqueid,
         start_usec: binfo.pbi_start_tvsec * 1_000_000 + binfo.pbi_start_tvusec,
     })
+}
+
+fn session_id_of(pid: u32) -> Option<u32> {
+    let sid = nix::unistd::getsid(Some(nix::unistd::Pid::from_raw(pid as i32))).ok()?;
+    u32::try_from(sid.as_raw()).ok().filter(|sid| *sid > 0)
 }
 
 /// Bumped only on an incompatible change to the helper's JSON input.
@@ -2475,23 +2603,8 @@ fn track_child(
     command_name: &str,
     launch_caller: &Caller,
 ) -> Result<()> {
-    let mut info: ProcBsdInfo = unsafe { std::mem::zeroed() };
-    let size = std::mem::size_of::<ProcBsdInfo>() as i32;
-    // SAFETY: same as parent_pid.
-    let ret = unsafe {
-        proc_pidinfo(
-            child_pid as i32,
-            PROC_PIDTBSDINFO,
-            0,
-            &mut info as *mut _ as *mut libc::c_void,
-            size,
-        )
-    };
-    let start_usec = if ret == size {
-        info.pbi_start_tvsec * 1_000_000 + info.pbi_start_tvusec as u64
-    } else {
-        0
-    };
+    let identity = daemon_identity(child_pid);
+    let start_usec = identity.map_or(0, |identity| identity.start_usec);
     let mut map = state
         .active_children
         .lock()
@@ -2505,6 +2618,10 @@ fn track_child(
             start_usec,
         },
     );
+    drop(map);
+    state
+        .session_lineage
+        .record(child_pid, command_name, launch_caller, identity);
     Ok(())
 }
 
@@ -3389,6 +3506,37 @@ fn filter_child_env(
     Ok(result)
 }
 
+/// `session_lineage` record stays resolvable after this process exits..
+fn install_session_lineage(command: &mut Command) {
+    // SAFETY: runs post-fork/pre-exec, so must be async-signal-safe; setsid(2)
+    // is on the POSIX async-signal-safe list. _exit(126)s on failure (fail
+    // closed) rather than launching without the marker in place.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                libc::_exit(126);
+            }
+            Ok(())
+        });
+    }
+}
+
+/// SIGKILL the mediated child and every descendant still in its process group.
+fn kill_mediated_child_group(child: &mut std::process::Child) {
+    // SAFETY: kill(2) takes plain integers, no pointers. The negated pid
+    // addresses the child's whole process group.
+    unsafe { libc::kill(-(child.id() as i32), libc::SIGKILL) };
+    // Fallback for a child that does not lead its own group, for which the
+    // group kill above is an ESRCH no-op.
+    let _ = child.kill();
+}
+
+fn prepare_mediated_command(spec_path: &Path) -> Result<Command> {
+    let mut command = prepare_launcher_command(spec_path)?;
+    install_session_lineage(&mut command);
+    Ok(command)
+}
+
 fn launch_child(
     state: &ToolSandboxState,
     command_name: &str,
@@ -3421,7 +3569,7 @@ fn launch_child_with_direct_fds(
             stdio,
         );
     }
-    let mut command = prepare_launcher_command(spec_path)?;
+    let mut command = prepare_mediated_command(spec_path)?;
     command
         .stdin(Stdio::from(File::from(stdio.stdin)))
         .stdout(Stdio::from(File::from(stdio.stdout)))
@@ -3454,7 +3602,7 @@ fn launch_child_with_brokered_stdio(
         stderr,
     } = stdio;
 
-    let mut command = prepare_launcher_command(spec_path)?;
+    let mut command = prepare_mediated_command(spec_path)?;
     command
         .stdin(Stdio::from(File::from(stdin)))
         .stdout(Stdio::from(File::from(stdout_write)))
@@ -3478,7 +3626,7 @@ fn launch_child_with_brokered_stdio(
 
     let status = loop {
         if exceeded.load(Ordering::SeqCst) {
-            let _ = child.kill();
+            kill_mediated_child_group(&mut child);
             break child.wait().map_err(NonoError::CommandExecution)?;
         }
         if let Some(status) = child.try_wait().map_err(NonoError::CommandExecution)? {
@@ -3714,7 +3862,7 @@ fn launch_child_with_capture(
     let pipe_write = unsafe { File::from_raw_fd(pipe_fds[1]) };
 
     let spec_path = write_launch_spec(&state.runtime_dir, &spec)?;
-    let mut command = prepare_launcher_command(&spec_path)?;
+    let mut command = prepare_mediated_command(&spec_path)?;
     command
         .stdin(Stdio::from(File::from(stdio.stdin)))
         .stdout(Stdio::from(pipe_write))
@@ -5008,6 +5156,7 @@ mod tests {
             proxy_trust_bundle_paths: Vec::new(),
             active_children: Mutex::new(HashMap::new()),
             lineage: LineageMarker::Disabled,
+            session_lineage: SessionLineage::default(),
             active_count: AtomicUsize::new(0),
             queued_requests: AtomicUsize::new(0),
             emitted_error_response: AtomicBool::new(false),
@@ -5147,6 +5296,29 @@ mod tests {
             path: PathBuf::from("/tmp"),
             source,
         })
+    }
+
+    /// Poll `ready` every 10ms for up to two seconds; false if it never held.
+    fn wait_until(mut ready: impl FnMut() -> bool) -> bool {
+        for _ in 0..200 {
+            if ready() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        false
+    }
+
+    /// The pid a spawned script wrote to `path`, waiting for it to appear.
+    fn read_pid_file(path: &Path) -> Option<u32> {
+        let mut pid = None;
+        wait_until(|| {
+            pid = fs::read_to_string(path)
+                .ok()
+                .and_then(|text| text.trim().parse::<u32>().ok());
+            pid.is_some()
+        });
+        pid
     }
 
     fn create_dir(path: &Path) -> Result<()> {
@@ -6267,6 +6439,33 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "spawns and kills real processes; run with --ignored"]
+    fn live_kill_mediated_child_group_reaches_a_descendant() -> Result<()> {
+        let dir = test_tempdir()?;
+        let pid_file = dir.path().join("descendant.pid");
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg(format!(
+            "sleep 30 & echo $! > {}; sleep 30",
+            pid_file.display()
+        ));
+        install_session_lineage(&mut command);
+        let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
+        let descendant =
+            read_pid_file(&pid_file).expect("the script writes the pid before sleeping");
+        let identity = daemon_identity(descendant).expect("the descendant is still live");
+
+        kill_mediated_child_group(&mut child);
+        let _ = child.wait();
+
+        let gone = wait_until(|| daemon_identity(descendant) != Some(identity));
+        assert!(
+            gone,
+            "the descendant outlived the stdio-limit kill, in a session nothing can reach"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn verify_binary_identity_accepts_unchanged_binary() -> Result<()> {
         let dir = test_tempdir()?;
         let path = dir.path().join("multitool");
@@ -6368,6 +6567,109 @@ mod tests {
         config
     }
 
+    /// A live child that leads its own POSIX session, so `getsid` and
+    /// `daemon_identity` reads on the session leader pid both succeed. The test
+    /// process's own session leader is not a substitute: on a CI runner it can be
+    /// launchd or an already-exited login process, whose identity is unreadable.
+    struct SessionLeaderChild {
+        child: std::process::Child,
+    }
+
+    impl SessionLeaderChild {
+        fn spawn() -> Self {
+            let mut command = std::process::Command::new("/bin/sleep");
+            command.arg("30");
+            install_session_lineage(&mut command);
+            let leader = Self {
+                child: command.spawn().expect("spawning /bin/sleep must succeed"),
+            };
+            let sid = leader.sid();
+            for _ in 0..200 {
+                // SAFETY: getsid is a pure syscall wrapper; the pid is a plain integer.
+                if unsafe { libc::getsid(sid as libc::pid_t) } == sid as libc::pid_t
+                    && daemon_identity(sid).is_some()
+                {
+                    return leader;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            panic!("install_session_lineage must make the child an identifiable session leader");
+        }
+
+        fn identity(&self) -> DaemonIdentity {
+            daemon_identity(self.sid()).expect("a live session leader's identity stays readable")
+        }
+
+        fn sid(&self) -> u32 {
+            self.child.id()
+        }
+    }
+
+    impl Drop for SessionLeaderChild {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    struct SeveredSessionRootOrphan {
+        root: std::process::Child,
+        orphan_pid: u32,
+    }
+
+    impl SeveredSessionRootOrphan {
+        fn spawn() -> Self {
+            use std::io::BufRead;
+
+            let mut command = std::process::Command::new("/bin/sh");
+            command
+                .arg("-c")
+                // The inner shell exits right after backgrounding `sleep`, severing
+                // the orphan's walk; `exec` keeps the outer shell's pid, and with it
+                // the session it leads, on the surviving process.
+                .arg(r#"sh -c 'sleep 30 & printf "%s\n" "$!"'; exec sleep 30"#)
+                .stdout(std::process::Stdio::piped());
+            install_session_lineage(&mut command);
+            let mut root = command.spawn().expect("spawning /bin/sh must succeed");
+            let stdout = root.stdout.take().expect("stdout is piped above");
+            let mut line = String::new();
+            std::io::BufReader::new(stdout)
+                .read_line(&mut line)
+                .expect("the launcher prints the backgrounded pid before it exits");
+            let orphan_pid = line
+                .trim()
+                .parse()
+                .expect("`$!` is a pid, so the printed line parses");
+            let severed = Self { root, orphan_pid };
+            for _ in 0..200 {
+                if parent_pid(orphan_pid).ok() == Some(1) {
+                    assert_eq!(
+                        session_id_of(orphan_pid),
+                        Some(severed.root_pid()),
+                        "the orphan must stay in the session its root leads"
+                    );
+                    return severed;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            panic!("the backgrounded command must reparent to 1 once its launcher exits");
+        }
+
+        fn root_pid(&self) -> u32 {
+            self.root.id()
+        }
+    }
+
+    impl Drop for SeveredSessionRootOrphan {
+        fn drop(&mut self) {
+            // SAFETY: kill(2) takes plain integers, no pointers. The orphan belongs to
+            // init now, so it can only be signalled here, never waited for.
+            unsafe { libc::kill(self.orphan_pid as libc::pid_t, libc::SIGKILL) };
+            let _ = self.root.kill();
+            let _ = self.root.wait();
+        }
+    }
+
     fn test_context(candidate_pid: u32) -> DaemonHelperContext {
         DaemonHelperContext {
             schema_version: DAEMON_HELPER_SCHEMA_VERSION,
@@ -6401,6 +6703,318 @@ mod tests {
         let blocked = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| None);
         assert!(matches!(blocked, Err(NonoError::BlockedCommand { .. })));
         Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_resolves_ordinary_orphan_via_session_lineage() -> Result<()> {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+        state.session_lineage.record(
+            leader.sid(),
+            "parent",
+            &Caller::Session,
+            Some(leader.identity()),
+        );
+
+        let caller = resolve_caller_with(leader.sid(), UNRELATED_ROOT, &state, "child", |_| None)?;
+
+        assert!(matches!(caller, Caller::Command { name } if name == "parent"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_session_lineage_uses_launch_caller_for_self_invocation() -> Result<()> {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+        state.session_lineage.record(
+            leader.sid(),
+            "git",
+            &Caller::Session,
+            Some(leader.identity()),
+        );
+
+        let caller = resolve_caller_with(leader.sid(), UNRELATED_ROOT, &state, "git", |_| None)?;
+
+        assert!(matches!(caller, Caller::Session));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_attributes_a_severed_session_root_descendant_to_the_session() -> Result<()> {
+        let state = test_state();
+        let severed = SeveredSessionRootOrphan::spawn();
+
+        let caller = resolve_caller_with(
+            severed.orphan_pid,
+            severed.root_pid(),
+            &state,
+            "child",
+            |_| None,
+        )?;
+
+        assert!(
+            matches!(caller, Caller::Session),
+            "an orphan of an unmediated launcher must keep the session's policy edge"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_blocks_a_severed_orphan_of_another_session() {
+        let state = test_state();
+        let severed = SeveredSessionRootOrphan::spawn();
+
+        // A session root that does not lead the orphan's session: that session is one
+        // nono never created (e.g. the user's terminal, shared with processes outside
+        // the sandboxed tree), so membership proves no descent from the session root.
+        let blocked =
+            resolve_caller_with(severed.orphan_pid, UNRELATED_ROOT, &state, "child", |_| {
+                None
+            });
+
+        assert!(
+            matches!(blocked, Err(NonoError::BlockedCommand { .. })),
+            "only the session nono created may stand in for the ancestry walk"
+        );
+    }
+
+    #[test]
+    fn session_lineage_resolves_entry_recorded_without_an_identity_pin() {
+        let state = test_state();
+        let mut probe = std::process::Command::new("/usr/bin/true")
+            .spawn()
+            .expect("spawning /usr/bin/true must succeed");
+        let dead_sid = probe.id();
+        probe.wait().expect("reaping the probe must succeed");
+        // SAFETY: getsid is a pure syscall wrapper; the pid is a plain integer.
+        if unsafe { libc::getsid(dead_sid as libc::pid_t) } >= 0 {
+            return;
+        }
+
+        state
+            .session_lineage
+            .record(dead_sid, "parent", &Caller::Session, None);
+
+        assert!(
+            matches!(state.session_lineage.resolve_sid(dead_sid), Some((name, Caller::Session)) if name == "parent"),
+            "an unpinned entry must still resolve while no live leader holds its pid"
+        );
+    }
+
+    #[test]
+    fn track_child_records_session_lineage_for_an_already_exited_launcher() -> Result<()> {
+        let state = test_state();
+        let mut launcher = std::process::Command::new("/usr/bin/true")
+            .spawn()
+            .expect("spawning /usr/bin/true must succeed");
+        let launcher_pid = launcher.id();
+        launcher.wait().expect("reaping the launcher must succeed");
+        assert!(
+            daemon_identity(launcher_pid).is_none(),
+            "an exited launcher must have no readable identity"
+        );
+        // SAFETY: getsid is a pure syscall wrapper; the pid is a plain integer.
+        if unsafe { libc::getsid(launcher_pid as libc::pid_t) } >= 0 {
+            return Ok(());
+        }
+
+        track_child(&state, launcher_pid, "parent", &Caller::Session)?;
+
+        assert!(
+            matches!(state.session_lineage.resolve_sid(launcher_pid), Some((name, _)) if name == "parent"),
+            "the orphan's session must stay attributable to its launcher"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn session_lineage_evicts_unpinned_entry_whose_leader_pid_was_recycled() {
+        let state = test_state();
+        let squatter = SessionLeaderChild::spawn();
+        let sid = squatter.sid();
+
+        state
+            .session_lineage
+            .record(sid, "parent", &Caller::Session, None);
+
+        assert!(
+            state.session_lineage.resolve_sid(sid).is_none(),
+            "an unpinned entry must fail closed once a live session leader holds its pid"
+        );
+        assert!(
+            state.session_lineage.resolve_sid(sid).is_none(),
+            "the stale entry must have been evicted, not merely rejected once"
+        );
+    }
+
+    #[test]
+    fn resolve_caller_denies_severed_caller_with_no_session_record() {
+        let state = test_state();
+        let pid = std::process::id();
+
+        // Fail-closed: nothing recorded this pid's session, and no daemon match either.
+        let blocked = resolve_caller_with(pid, UNRELATED_ROOT, &state, "child", |_| None);
+
+        assert!(matches!(blocked, Err(NonoError::BlockedCommand { .. })));
+    }
+
+    #[test]
+    fn resolve_caller_denies_stale_session_after_pid_reuse() {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+
+        // Simulate a stale record left behind by a long-exited command whose
+        // session id was later recycled by the live leader spawned above.
+        {
+            let mut owners = state.session_lineage.owners.lock().expect("lock owners");
+            owners.by_sid.insert(
+                leader.sid(),
+                SessionLineageEntry {
+                    command: "stale-command".to_string(),
+                    launch_caller: Caller::Session,
+                    identity: Some(DaemonIdentity {
+                        uniqueid: 0,
+                        start_usec: 0,
+                    }),
+                    used: 0,
+                },
+            );
+        }
+
+        let blocked = resolve_caller_with(leader.sid(), UNRELATED_ROOT, &state, "child", |_| None);
+
+        assert!(matches!(blocked, Err(NonoError::BlockedCommand { .. })));
+    }
+
+    #[test]
+    fn session_lineage_survives_innocent_leader_pid_reuse() {
+        let state = test_state();
+
+        let mut bystander = std::process::Command::new("sleep")
+            .arg("20")
+            .spawn()
+            .expect("spawn sleep");
+        let sid = bystander.id();
+        state.session_lineage.record(
+            sid,
+            "parent",
+            &Caller::Session,
+            Some(DaemonIdentity {
+                uniqueid: 0,
+                start_usec: 0,
+            }),
+        );
+
+        let resolved = state.session_lineage.resolve_sid(sid);
+        assert!(
+            matches!(&resolved, Some((name, _)) if name == "parent"),
+            "innocent reuse of the dead leader's pid must not break attribution, got {resolved:?}"
+        );
+        assert!(
+            state.session_lineage.resolve_sid(sid).is_some(),
+            "the entry must also survive (not be evicted) for later requests"
+        );
+
+        let _ = bystander.kill();
+        let _ = bystander.wait();
+    }
+
+    #[test]
+    fn session_lineage_re_record_after_eviction_outlives_older_fillers() {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+        let sid = leader.sid();
+        let real_identity = leader.identity();
+
+        // Fabricate a stale record under our own live sid so `resolve` evicts
+        // it via the identity-mismatch path, exactly as in the test above.
+        {
+            let mut owners = state.session_lineage.owners.lock().expect("lock owners");
+            owners.by_sid.insert(
+                sid,
+                SessionLineageEntry {
+                    command: "stale-command".to_string(),
+                    launch_caller: Caller::Session,
+                    identity: Some(DaemonIdentity {
+                        uniqueid: 0,
+                        start_usec: 0,
+                    }),
+                    used: 0,
+                },
+            );
+        }
+        assert!(
+            state.session_lineage.resolve_sid(sid).is_none(),
+            "identity mismatch must evict the stale record"
+        );
+
+        // Re-record that same sid as a legitimate fresh session (the number
+        // was reused) behind a full cap of older fillers, then cross the cap.
+        // The fresh entry is the newest of all of them, so every filler is a
+        // better eviction victim; an evicted sid must leave nothing behind
+        // that outranks it.
+        for i in 0..MAX_SESSION_LINEAGE_ENTRIES - 1 {
+            let filler_sid = 1_000_000 + i as u32;
+            state.session_lineage.record(
+                filler_sid,
+                "filler",
+                &Caller::Session,
+                Some(real_identity),
+            );
+        }
+        state
+            .session_lineage
+            .record(sid, "fresh-command", &Caller::Session, Some(real_identity));
+        state.session_lineage.record(
+            1_000_000 + MAX_SESSION_LINEAGE_ENTRIES as u32,
+            "filler",
+            &Caller::Session,
+            Some(real_identity),
+        );
+
+        let resolved = state.session_lineage.resolve_sid(sid);
+        assert!(
+            matches!(&resolved, Some((name, _)) if name == "fresh-command"),
+            "fresh record for a reused sid must survive cap eviction (only fillers are actually oldest), got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn session_lineage_resolve_refreshes_recency_for_lru_eviction() {
+        let state = test_state();
+        let leader = SessionLeaderChild::spawn();
+        let sid = leader.sid();
+        let identity = leader.identity();
+
+        // Oldest entry: the session a long-lived orphan keeps resolving through.
+        state
+            .session_lineage
+            .record(sid, "parent", &Caller::Session, Some(identity));
+        for i in 0..MAX_SESSION_LINEAGE_ENTRIES - 1 {
+            state.session_lineage.record(
+                1_000_000 + i as u32,
+                "filler",
+                &Caller::Session,
+                Some(identity),
+            );
+        }
+        assert!(
+            state.session_lineage.resolve_sid(sid).is_some(),
+            "entry must still resolve at exactly the cap"
+        );
+
+        // Under FIFO this launch would evict the orphan's entry (the first
+        // recorded); the resolve above must have refreshed it so the stalest
+        // filler goes instead.
+        state
+            .session_lineage
+            .record(2_000_000, "filler", &Caller::Session, Some(identity));
+
+        let resolved = state.session_lineage.resolve_sid(sid);
+        assert!(
+            matches!(&resolved, Some((name, _)) if name == "parent"),
+            "an actively-resolving session must not be the eviction victim, got {resolved:?}"
+        );
     }
 
     #[test]
@@ -6767,10 +7381,6 @@ mod tests {
         assert_eq!(cache.len(), 1);
     }
 
-    /// LIVE: the property the marker exists for. A real setsid+double-fork daemon
-    /// reparented to pid 1, named by a `daemon_pid_source` helper, resolves to
-    /// `Command{tmux}`; an unnamed reparented daemon is denied. `#[ignore]`: forks
-    /// real processes; run with --ignored.
     #[test]
     #[ignore = "forks real reparented daemons; run with --ignored"]
     fn live_severed_daemon_attributed_to_its_command() {
@@ -6849,6 +7459,73 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[ignore = "forks real reparented processes; run with --ignored"]
+    fn live_ordinary_orphan_attributed_via_session_lineage() {
+        use nix::sys::wait::waitpid;
+        use nix::unistd::{ForkResult, fork};
+
+        fn spawn_ordinary_orphan(state: &ToolSandboxState) -> u32 {
+            let mut fds = [0i32; 2];
+            assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe");
+            let [read_fd, write_fd] = fds;
+            // SAFETY: post-fork children use only async-signal-safe libc calls.
+            match unsafe { fork() }.expect("fork") {
+                ForkResult::Child => {
+                    unsafe { libc::setsid() };
+                    match unsafe { fork() }.expect("fork") {
+                        ForkResult::Child => {
+                            let pid = unsafe { libc::getpid() };
+                            let bytes = pid.to_ne_bytes();
+                            unsafe {
+                                libc::write(write_fd, bytes.as_ptr().cast(), bytes.len());
+                                libc::usleep(800_000);
+                                libc::_exit(0);
+                            }
+                        }
+                        // The launching process exits immediately without waiting,
+                        // exactly like `parent`'s script ending right after `child &`.
+                        ForkResult::Parent { .. } => unsafe { libc::_exit(0) },
+                    }
+                }
+                ForkResult::Parent { child } => {
+                    unsafe { libc::close(write_fd) };
+                    // What `track_child` records once `install_session_lineage`'s
+                    // setsid() has made the launched command its own session leader.
+                    let identity = daemon_identity(child.as_raw() as u32)
+                        .expect("setsid-ing process is still queryable pre-reap");
+                    state.session_lineage.record(
+                        child.as_raw() as u32,
+                        "parent",
+                        &Caller::Session,
+                        Some(identity),
+                    );
+                    let _ = waitpid(child, None); // reap the setsid-ing process
+                    let mut buf = [0u8; 4];
+                    let n = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+                    assert_eq!(n, 4, "expected the orphan's pid");
+                    unsafe { libc::close(read_fd) };
+                    i32::from_ne_bytes(buf) as u32
+                }
+            }
+        }
+
+        let state = test_state();
+        let orphan = spawn_ordinary_orphan(&state);
+        assert_eq!(
+            parent_pid(orphan).ok(),
+            Some(1),
+            "backgrounded descendant must reparent to 1 once its launcher exits"
+        );
+
+        let caller = resolve_caller_with(orphan, UNRELATED_ROOT, &state, "child", |_| None)
+            .expect("resolve_caller_with");
+        assert!(
+            matches!(caller, Caller::Command { name } if name == "parent"),
+            "an ordinary orphan must attribute to the command that self-assigned its session"
+        );
     }
 
     #[test]

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -304,6 +304,17 @@ The macOS helper is declared as `{ "argv": [...], "env": [...] }`. nono passes t
 
 The helper runs **unsandboxed** in the supervisor. It MUST only read and emit a single pid (for example, the pid file the daemon writes) and MUST NOT execute workspace-controlled code. nono hardens the launch — the `argv` program is expanded (`~`, `$WORKDIR`, `$TMPDIR`, `$UID`, XDG) and must then be an absolute path, its environment is cleared to a minimal set, its working directory is neutral, and it is killed if it exceeds a short timeout — but cannot vet what the declared helper itself does.
 
+### macOS: mediated commands run in their own session
+
+To make that marker work for an ordinary orphan — a `child &` whose parent exits immediately, rather than a deliberate daemon — macOS Tool Sandbox puts **every** mediated launch in its own POSIX session (`setsid`) before exec. A session id cannot be joined after the fact, only created, which is what makes it unforgeable; a descendant keeps it across reparenting, so nono can still attribute a request whose ancestry walk has run off the top of the process tree.
+
+The cost is that a mediated command has **no controlling terminal**, and cannot reacquire one (the session's pty already belongs to the direct child's session, so `TIOCSCTTY` is refused):
+
+- `open("/dev/tty")` fails with `ENXIO`. A command that reads a secret straight from the terminal — `ssh` asking for a passphrase, `git` with a terminal credential helper — fails instead of prompting. Supply those through `credentials`, an `askpass` helper, or an agent socket rather than an interactive prompt.
+- The kernel delivers it no terminal job-control signals. nono relays Ctrl-C, Ctrl-\\, Ctrl-Z and terminal hangup to mediated commands itself, so interrupting and suspending a session still reaches them, but a mediated command cannot read or set the terminal's foreground process group.
+
+nono's own interactive prompts (command approval, profile save) run in the supervisor, which keeps the terminal, and are unaffected.
+
 ## Examples
 
 ### Minimal Direct Tool

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -282,6 +282,10 @@ Tool Sandbox authorizes a request by walking the caller's process ancestry to th
 
 Either way a severed caller resolves only to the command that spawned it, never the session, and is denied on any mismatch.
 
+macOS adds one case where the session is the answer: a launcher nono never mediated — a plain fork of the session root, such as an agent's status-line script that backgrounds a command and returns — leaves no marker naming it. nono then accepts the orphan under the **session** policy when it is a member of the session nono created for its direct child. Membership is proof of descent: a session can only be created, never joined.
+
+That session exists only when nono allocated a pty for the direct child, which it does when stdin, stdout and stderr are all a terminal. With any of them redirected — a piped or CI run — the direct child inherits nono's own session, shared with every other process in the user's terminal session, so membership proves nothing and such a caller is denied.
+
 The macOS helper is declared as `{ "argv": [...], "env": [...] }`. nono passes the daemon's context as a single JSON object on **stdin**:
 
 ```json

--- a/tests/integration/test_child_tool_boundaries.sh
+++ b/tests/integration/test_child_tool_boundaries.sh
@@ -455,6 +455,121 @@ else
 fi
 
 # =============================================================================
+# Fire-and-forget from an unmediated launcher
+# =============================================================================
+
+echo ""
+echo "--- Unmediated Fire-and-forget Launcher ---"
+
+UNMEDIATED_DIR="$TMPDIR/unmediated-fire-forget"
+mkdir -p "$UNMEDIATED_DIR"
+UNMEDIATED_PROFILE="$UNMEDIATED_DIR/profile.json"
+
+# The launcher is a plain fork of the session root, so nothing mediated it and
+# no per-command lineage marker names it. Attribution then rests on the session
+# nono created for its direct child, which exists only when nono allocated a pty
+# (all three stdio a terminal), hence the python pty harness below. On Linux the
+# cgroup marker attributes severed callers to commands only, never the session,
+# so the scenario still fails closed there.
+if [[ "$(uname)" == "Darwin" ]] && command_exists python3; then
+
+cat > "$UNMEDIATED_DIR/launcher.sh" <<'EOF'
+#!/bin/sh
+set -eu
+echo "launcher: firing child (fire & forget)"
+child &
+EOF
+chmod 755 "$UNMEDIATED_DIR/launcher.sh"
+
+cat > "$UNMEDIATED_DIR/child" <<'EOF'
+#!/bin/sh
+set -eu
+echo "child: writing file"
+echo "written by child at $(date)" > out.txt
+EOF
+chmod 755 "$UNMEDIATED_DIR/child"
+
+# fs_write_file only grants an existing file, so pre-create it empty; the poll
+# below waits for it to become non-empty, so this can't pass vacuously.
+printf "" > "$UNMEDIATED_DIR/out.txt"
+
+# pty.spawn's stdin copy loop never sees EOF under the suite's stdio, so drive
+# the pty directly and drain it until the child closes the slave.
+cat > "$UNMEDIATED_DIR/pty_run.py" <<'EOF'
+import os
+import pty
+import select
+import sys
+import time
+
+pid, master = pty.fork()
+if pid == 0:
+    os.execvp(sys.argv[1], sys.argv[1:])
+
+deadline = time.time() + 60
+while time.time() < deadline:
+    readable, _, _ = select.select([master], [], [], 0.2)
+    if readable:
+        try:
+            if not os.read(master, 4096):
+                break
+        except OSError:
+            break
+    reaped, status = os.waitpid(pid, os.WNOHANG)
+    if reaped:
+        sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)
+
+_, status = os.waitpid(pid, 0)
+sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)
+EOF
+
+# `launcher.sh` is deliberately absent from `commands`: an unmediated launcher is
+# the shape this case is about. Same group exclusions as the block above.
+cat > "$UNMEDIATED_PROFILE" <<EOF
+{
+  "meta": { "name": "integration-unmediated-fire-and-forget" },
+  "workdir": { "access": "read" },
+  "groups": { "exclude": ["system_write_linux", "system_write_macos"] },
+  "command_policies": {
+    "executable_dirs": ["."],
+    "commands": {
+      "child": {
+        "can_use": ["date"],
+        "from": {
+          "session": {
+            "sandbox": {
+              "fs_read": ["\$WORKDIR"],
+              "fs_write_file": ["\$WORKDIR/out.txt"]
+            }
+          }
+        }
+      },
+      "date": { "from": { "child": { "sandbox": {} } } },
+      "sleep": { "from": { "session": { "sandbox": {} } } }
+    }
+  }
+}
+EOF
+
+expect_success "outer session survives an unmediated fire-and-forget launcher (#1274)" \
+    run_in_dir "$UNMEDIATED_DIR" python3 "$UNMEDIATED_DIR/pty_run.py" \
+    "$NONO_BIN" run --silent --no-audit --profile "$UNMEDIATED_PROFILE" --allow-cwd -- \
+    sh -c './launcher.sh
+i=0
+while [ ! -s out.txt ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+done'
+
+expect_file_contains "unmediated launcher's orphan was authorized under the session policy (#1274)" \
+    "$UNMEDIATED_DIR/out.txt" "written by child at"
+
+else
+    skip_test "unmediated fire-and-forget launcher (#1274)" \
+        "session-lineage attribution is macOS-only and needs python3 for a pty"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/tests/integration/test_child_tool_boundaries.sh
+++ b/tests/integration/test_child_tool_boundaries.sh
@@ -324,6 +324,17 @@ expect_file_content "tool sandbox directory write reached host file" \
 expect_file_content "tool sandbox single-file write reached host file" \
     "$TMPDIR/tool-write-file.txt" "tool-file-write"
 
+# --trust-override skips the trust scan, which is what otherwise leaves the
+# aws-lc-rs pool threads behind and puts the supervised fork in
+# ThreadingContext::CryptoExpected. Without it the fork runs under Strict,
+# where a single stray thread started while preparing the tool-sandbox runtime
+# aborts the run before the child ever execs.
+expect_output_payload "tool sandbox forks under strict threading (--trust-override)" \
+    "strict-threading-ok" \
+    run_in_dir "$TMPDIR" "$NONO_BIN" run --profile "$TOOL_PROFILE" --silent --no-audit \
+    --allow-cwd --trust-override -- \
+    sh -c 'printf "%s" "strict-threading-ok"'
+
 if is_macos; then
     skip_test "tool sandbox does not inherit outer --allow directory" "macOS temp path denial is host-dependent"
     skip_test "tool sandbox raw-file credential requires use_credentials" "macOS temp path denial is host-dependent"

--- a/tests/integration/test_child_tool_boundaries.sh
+++ b/tests/integration/test_child_tool_boundaries.sh
@@ -238,6 +238,30 @@ run_in_dir() {
     cd "$dir" && "$@"
 }
 
+expect_file_contains() {
+    local name="$1"
+    local path="$2"
+    local expected="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ -f "$path" ]] && grep -q "$expected" "$path"; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected file '$path' to contain: '$expected'"
+    if [[ -f "$path" ]]; then
+        echo "       Actual content: '$(<"$path")'"
+    else
+        echo "       File does not exist"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 0
+}
+
 # =============================================================================
 # Primary Child Sandbox
 # =============================================================================
@@ -312,6 +336,122 @@ else
     expect_failure "tool sandbox raw-file credential requires use_credentials" \
         run_in_dir "$TMPDIR" "$NONO_BIN" run --profile "$TOOL_NO_CREDENTIAL_USE_PROFILE" --silent --no-audit --allow-cwd -- \
         sh -c 'IFS= read -r value < "$1" || exit 77; printf "%s" "$value"' sh "$TMPDIR/tool-raw-secret.txt"
+fi
+
+# =============================================================================
+# Fire-and-forget chaining
+# =============================================================================
+
+echo ""
+echo "--- Fire-and-forget Chaining ---"
+
+FIRE_FORGET_DIR="$TMPDIR/fire-forget"
+mkdir -p "$FIRE_FORGET_DIR"
+FIRE_FORGET_PROFILE="$FIRE_FORGET_DIR/profile.json"
+
+# Severed-caller attribution needs a platform lineage mechanism: session
+# lineage on macOS, the cgroup marker on Linux — which requires a writable
+# cgroup v2 base (mirrors lineage_cgroup::probe_writable_base). Without one,
+# nono correctly fails closed and denies the orphaned child, so the scenario
+# below cannot pass in e.g. a container with a read-only /sys/fs/cgroup.
+fire_forget_lineage_available() {
+    if [[ "$(uname)" != "Linux" ]]; then
+        return 0
+    fi
+    local rel dir
+    rel=$(sed -n 's/^0:://p' /proc/self/cgroup 2>/dev/null)
+    dir="/sys/fs/cgroup${rel%/}"
+    while [[ "$dir" == /sys/fs/cgroup* ]]; do
+        if mkdir "$dir/nono-it-probe.$$" 2>/dev/null; then
+            rmdir "$dir/nono-it-probe.$$" 2>/dev/null
+            return 0
+        fi
+        [[ "$dir" == "/sys/fs/cgroup" ]] && return 1
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
+
+if fire_forget_lineage_available; then
+
+# `parent` backgrounds `child` and exits immediately, so by the time `child`'s
+# launch request is mediated, `parent` (its authorizing ancestor) has already
+# been reaped and `child` is reparented to init. `child` must still resolve to
+# `parent`'s policy edge rather than being denied as an unattributable caller.
+cat > "$FIRE_FORGET_DIR/parent" <<'EOF'
+#!/bin/sh
+set -eu
+echo "parent: launching child (fire & forget)"
+child &
+EOF
+chmod 755 "$FIRE_FORGET_DIR/parent"
+
+# Writes to the CWD (the workdir the shim forwards), not $(dirname "$0"):
+# the Linux launcher execs the script through /dev/fd, so $0 is not a
+# workdir-relative path there.
+cat > "$FIRE_FORGET_DIR/child" <<'EOF'
+#!/bin/sh
+set -eu
+echo "child: writing file"
+echo "written by child at $(date)" > out.txt
+EOF
+chmod 755 "$FIRE_FORGET_DIR/child"
+
+# Landlock can only grant write on an existing file, so pre-create it empty;
+# the poll below waits for it to become non-empty, so this can't pass vacuously.
+printf "" > "$FIRE_FORGET_DIR/out.txt"
+
+# The system_write groups grant session write on /tmp and \$TMPDIR, where this
+# suite's test dir lives; executable_dirs refuses any directory the session can
+# write (the agent could swap the policied binaries). Excluding them here keeps
+# the fixture under \$TMPDIR while matching the issue's real-world shape: a
+# project directory the session cannot write.
+cat > "$FIRE_FORGET_PROFILE" <<EOF
+{
+  "meta": { "name": "integration-fire-and-forget" },
+  "workdir": { "access": "read" },
+  "groups": { "exclude": ["system_write_linux", "system_write_macos"] },
+  "command_policies": {
+    "executable_dirs": ["."],
+    "commands": {
+      "parent": {
+        "can_use": ["child"],
+        "from": { "session": { "sandbox": { "fs_read": ["\$WORKDIR"] } } }
+      },
+      "child": {
+        "can_use": ["date"],
+        "from": {
+          "parent": {
+            "sandbox": {
+              "fs_read": ["\$WORKDIR"],
+              "fs_write_file": ["\$WORKDIR/out.txt"]
+            }
+          }
+        }
+      },
+      "date": { "from": { "child": { "sandbox": {} } } }
+    }
+  }
+}
+EOF
+
+# `child` itself launches further mediated subprocesses (`date`, `dirname`)
+# before it writes out.txt, so poll for the file instead of guessing a fixed
+# delay for the whole chain to finish; bounded to 5s total.
+expect_success "outer session survives a fire-and-forget child launch (#1274)" \
+    run_in_dir "$FIRE_FORGET_DIR" "$NONO_BIN" run --silent --no-audit --profile "$FIRE_FORGET_PROFILE" --allow-cwd -- \
+    sh -c 'parent
+i=0
+while [ ! -s out.txt ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+done'
+
+expect_file_contains "fire-and-forget child was authorized under parent's policy edge (#1274)" \
+    "$FIRE_FORGET_DIR/out.txt" "written by child at"
+
+else
+    skip_test "fire-and-forget chaining (#1274)" "no writable cgroup v2 base for lineage attribution"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1274

## Summary
 - Records the session ID of 'fire and forget' calls so they can be resolved to the command that launched them, meaning they be 'allow'ed
 - Forwards ^Z/^C to the detached child processes
 
 MacOS only, as Linux doesn't detach these children.

## Test Plan
New integration test
Steps to reproduce

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates