### PR TITLE
fix(policy): make unmatched deny-glob warning platform-accurate

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -362,12 +362,7 @@ pub(crate) fn expand_glob_path(pattern: &str) -> Result<Vec<PathBuf>> {
 /// returned path and denies both forms.
 pub(crate) fn expand_glob_deny_paths(pattern: &str) -> Result<Vec<PathBuf>> {
     let (mut matches, escaped) = expand_glob_path_impl(pattern)?;
-    if matches.is_empty() && escaped.is_empty() {
-        warn!(
-            "Glob pattern {pattern:?} matched no existing paths; \
-             the rule will have no effect until matching files are created"
-        );
-    }
+    // No warning on an empty match here — the caller logs platform-appropriately.
     matches.extend(escaped);
     matches.sort();
     matches.dedup();
@@ -1011,8 +1006,24 @@ pub(crate) fn add_glob_deny_rules(
     caps: &mut CapabilitySet,
     deny_paths: &mut Vec<PathBuf>,
 ) -> Result<()> {
-    for path in expand_glob_deny_paths(pattern)? {
+    let expanded = expand_glob_deny_paths(pattern)?;
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    let matched_existing = !expanded.is_empty();
+    for path in expanded {
         add_deny_access_rules(path_to_utf8(&path)?, caps, deny_paths)?;
+    }
+
+    // Landlock is allow-list only, so an unmatched deny glob leaves later-created
+    // matches uncovered — warn so the profile can be scoped accordingly.
+    #[cfg(target_os = "linux")]
+    if !matched_existing {
+        warn!(
+            "Glob deny {pattern:?} matched no existing paths at sandbox start; \
+             Landlock has no deny semantics, so files matching this pattern \
+             created after startup will NOT be denied. Scope deny globs to \
+             paths that already exist, or enable capability_elevation for \
+             runtime enforcement."
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -1041,13 +1052,6 @@ pub(crate) fn add_glob_deny_rules(
         // Unix socket connect(2) is mediated as network-outbound, not file I/O.
         caps.add_platform_rule(format!("(deny network-outbound (regex #\"{re}\"))"))?;
     }
-
-    #[cfg(target_os = "linux")]
-    debug!(
-        "Glob deny {pattern:?}: pattern is expanded at sandbox start — files created \
-         after the sandbox is applied are not covered. Enable capability_elevation \
-         for runtime enforcement."
-    );
 
     Ok(())
 }
@@ -2136,6 +2140,31 @@ mod tests {
             assert!(rules.contains("allow file-read-metadata"));
         } else {
             // On Linux, no platform rules (Landlock has no deny semantics)
+            assert!(caps.platform_rules().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_add_glob_deny_rules_unmatched_pattern_still_covers_future_files_on_macos() {
+        // #1735: an unmatched deny glob still enforces prospectively on macOS
+        // (Seatbelt regex rule), but not on Linux (Landlock is allow-list only).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pattern = format!("{}/**/.env", dir.path().display());
+
+        let mut caps = CapabilitySet::new();
+        let mut deny_paths = Vec::new();
+        add_glob_deny_rules(&pattern, &mut caps, &mut deny_paths).expect("add_glob_deny_rules");
+
+        // No existing file matched, so nothing was carved out of the allow-list.
+        assert!(deny_paths.is_empty());
+
+        if cfg!(target_os = "macos") {
+            // The regex-based rule still denies future-created matches.
+            let rules = caps.platform_rules().join("\n");
+            assert!(rules.contains("deny file-write*"));
+            assert!(rules.contains("deny file-read-data"));
+        } else {
+            // Landlock has no deny semantics; nothing to enforce prospectively.
             assert!(caps.platform_rules().is_empty());
         }
     }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -341,8 +341,8 @@ pub(crate) fn expand_glob_path(pattern: &str) -> Result<Vec<PathBuf>> {
     let (matches, _escaped) = expand_glob_path_impl(pattern)?;
     if matches.is_empty() {
         warn!(
-            "Glob pattern {pattern:?} matched no existing paths; \
-             the rule will have no effect until matching files are created"
+            "Glob pattern {pattern:?} matched no existing paths; allow globs are \
+             evaluated once at sandbox start, so files created later will NOT be granted access"
         );
     }
     Ok(matches)
@@ -1000,31 +1000,26 @@ fn resolve_parent_symlinks(path: &Path) -> Result<Option<PathBuf>> {
 /// sandbox start are covered at the kernel level. The literal path prefix is
 /// canonicalized before generating the regex so it matches the kernel's view.
 ///
-/// On Linux, emits a debug-level note that coverage is build-time only.
+/// On Linux, always warns that coverage is build-time only (Landlock has no
+/// deny semantics, so matches created after sandbox start are never covered —
+/// this holds regardless of whether other matches already existed at start).
 pub(crate) fn add_glob_deny_rules(
     pattern: &str,
     caps: &mut CapabilitySet,
     deny_paths: &mut Vec<PathBuf>,
 ) -> Result<()> {
     let expanded = expand_glob_deny_paths(pattern)?;
-    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
-    let matched_existing = !expanded.is_empty();
     for path in expanded {
         add_deny_access_rules(path_to_utf8(&path)?, caps, deny_paths)?;
     }
 
-    // Landlock is allow-list only, so an unmatched deny glob leaves later-created
-    // matches uncovered — warn so the profile can be scoped accordingly.
     #[cfg(target_os = "linux")]
-    if !matched_existing {
-        warn!(
-            "Glob deny {pattern:?} matched no existing paths at sandbox start; \
-             Landlock has no deny semantics, so files matching this pattern \
-             created after startup will NOT be denied. Scope deny globs to \
-             paths that already exist, or enable capability_elevation for \
-             runtime enforcement."
-        );
-    }
+    warn!(
+        "Glob deny {pattern:?}: Landlock has no deny semantics, so this pattern is only \
+         enforced against paths that existed at sandbox start — files matching it created \
+         afterward will NOT be denied. Scope deny globs to paths that already exist, or \
+         enable capability_elevation for runtime enforcement."
+    );
 
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1735 

## Summary

On macOS, an unmatched filesystem.deny glob still enforces prospectively via the compiled Seatbelt regex rule, so the old warning claiming "the rule will have no effect" was false — verified with the reporters repro on both macOS (write blocked, no warning needed) and Linux (write succeeds, warning is accurate).

On Linux, Landlock is allow-list only, so an unmatched glob is a real gap: nothing exists to carve out of the allow-list, and files created after sandbox start arent covered. Reworded that warning to say so explicitly and suggest scoping globs or using capability_elevation.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
