### PR TITLE
fix(hooks): expand $WORKDIR/$HOME/etc. in session hook script paths

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -2433,7 +2433,7 @@
       "properties": {
         "script": {
           "type": "string",
-          "description": "Absolute path to the hook script. Must be an executable regular file owned by the current user or root, not located in a world-writable directory. Validated at execution time."
+          "description": "Path to the hook script. Supports variable expansion ($HOME, $WORKDIR, $TMPDIR, $XDG_*, $NONO_CONFIG, $NONO_PACKAGES) so shared profiles don't need a hardcoded per-machine path; the expanded result must be an absolute path. Must be an executable regular file owned by the current user or root, not located in a world-writable directory. Expanded and validated at execution time."
         },
         "timeout_secs": {
           "type": "integer",

--- a/crates/nono-cli/src/hook_runtime.rs
+++ b/crates/nono-cli/src/hook_runtime.rs
@@ -9,6 +9,11 @@
 //!
 //! # Security
 //!
+//! - Script paths support the same `$WORKDIR`/`$HOME`/`$TMPDIR`/XDG/etc.
+//!   variable expansion as other profile paths (see `profile::expand_vars`),
+//!   so a shared profile need not hardcode a per-machine absolute path.
+//!   Expansion happens first; the result must still resolve to an absolute
+//!   path.
 //! - Script paths are validated before every execution
 //!   (absolute, canonical, regular file, executable, owned by user, not world-writable)
 //! - Hooks run as subprocesses
@@ -65,7 +70,8 @@ pub(crate) fn execute_before_hook(
     session_id: &str,
     workdir: &Path,
 ) -> Result<Vec<(String, String)>> {
-    let script_path = validate_hook_script(&hook.script)?;
+    let expanded = profile::expand_vars(&hook.script.to_string_lossy(), workdir)?;
+    let script_path = validate_hook_script(&expanded)?;
     let env_file = EnvFileGuard::create(session_id)?;
 
     let mut cmd = build_hook_command(
@@ -123,7 +129,8 @@ pub(crate) fn execute_after_hook(
     workdir: &Path,
     child_exit_code: i32,
 ) -> Result<()> {
-    let script_path = validate_hook_script(&hook.script)?;
+    let expanded = profile::expand_vars(&hook.script.to_string_lossy(), workdir)?;
+    let script_path = validate_hook_script(&expanded)?;
     let mut cmd = build_hook_command(
         &script_path,
         session_id,
@@ -534,6 +541,29 @@ mod tests {
         assert!(result.contains(&("CUSTOM_VAR".into(), "hello".into())));
         assert!(!result.iter().any(|(k, _)| k == "LD_PRELOAD"));
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_execute_before_hook_expands_workdir() {
+        let (_lock, _env, _home) = isolated_home();
+
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("hook.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'CUSTOM_VAR=hello' > \"$NONO_ENV_FILE\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let hook = profile::SessionHook {
+            script: PathBuf::from("$WORKDIR/hook.sh"),
+            timeout_secs: Some(5),
+            source_pack: None,
+        };
+
+        let result = execute_before_hook(&hook, "test-expand", dir.path()).unwrap();
+        assert!(result.contains(&("CUSTOM_VAR".into(), "hello".into())));
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1998,8 +1998,11 @@ pub struct HooksConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SessionHook {
-    /// Absolute path to the hook script.
-    /// Must be an executable regular file. Validated at execution time.
+    /// Path to the hook script.
+    /// Supports the same `$WORKDIR`/`$HOME`/`$TMPDIR`/XDG/etc. variable
+    /// expansion as other profile paths (see `expand_vars`); the expanded
+    /// result must be an absolute path. Must be an executable regular file.
+    /// Expanded and validated at execution time.
     pub script: PathBuf,
 
     /// Optional timeout in seconds.


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1700

## Summary

Session hook scripts required a hardcoded, per-machine absolute path, making them unusable in profiles shared across a team or checked into a project repo (#1700). resolve_store_pack_session_hooks already expanded $PACK_DIR for registry-pack hooks, but plain profiles had no equivalent.

Run session_hooks.{before,after}.script through the existing profile::expand_vars ($WORKDIR, $HOME, $TMPDIR, XDG_*, $NONO_CONFIG, $NONO_PACKAGES, ~) before validate_hook_script, so expansion happens first and every existing check (absolute, canonicalize, regular file, executable, owned by user/root, not world-writable) still runs unconditionally on the resolved path.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
