### PR TITLE
fix(cli): hint at CAP_SYS_PTRACE on pidfd_getfd EPERM, fix doubled error prefix

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1501,9 +1501,14 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
                                 Err(e) => {
                                     let _ = signal::kill(child, Signal::SIGKILL);
                                     let _ = waitpid(child, None);
+                                    // Unwrap to avoid doubling the "Sandbox
+                                    // initialization failed: " prefix.
+                                    let detail = match e {
+                                        NonoError::SandboxInit(msg) => msg,
+                                        other => other.to_string(),
+                                    };
                                     return Err(NonoError::SandboxInit(format!(
-                                        "Failed to acquire required network seccomp notify fd from child: {}",
-                                        e
+                                        "failed to acquire required network seccomp notify fd from child: {detail}"
                                     )));
                                 }
                             }
@@ -3847,10 +3852,16 @@ fn acquire_fd_from_child(
     let new_fd_raw =
         unsafe { libc::syscall(libc::SYS_pidfd_getfd, pidfd.as_raw_fd(), child_fd, 0_u32) };
     if new_fd_raw < 0 {
+        let err = std::io::Error::last_os_error();
+        let hint = if err.raw_os_error() == Some(libc::EPERM) {
+            " (this commonly happens inside a container: pidfd_getfd requires \
+             CAP_SYS_PTRACE, which container runtimes drop by default -- retry with \
+             `docker run --cap-add=SYS_PTRACE ...` or the equivalent for your runtime)"
+        } else {
+            ""
+        };
         return Err(NonoError::SandboxInit(format!(
-            "pidfd_getfd failed for child fd {}: {}",
-            child_fd,
-            std::io::Error::last_os_error()
+            "pidfd_getfd failed for child fd {child_fd}: {err}{hint}"
         )));
     }
     // SAFETY: pidfd_getfd returned a fresh owned fd duplicated from the child.

--- a/docs/cli/internals/containers.mdx
+++ b/docs/cli/internals/containers.mdx
@@ -151,6 +151,8 @@ This gives you:
 - **Path-level control** from nono -- the agent can only touch `/work`, even though the container filesystem is larger
 - **Credential blocking** from nono -- sensitive paths are denied automatically, even if a home directory is mounted in
 
+If you use domain filtering (`--allow-domain`) inside the container, add `--cap-add=SYS_PTRACE` to the `docker run` invocation -- nono's seccomp-based network proxy needs it to hand a file descriptor across the fork boundary, and Docker drops that capability by default. See [Troubleshooting](/cli/usage/troubleshooting#running-inside-docker-podman) for details.
+
 ## Threat Model Comparison
 
 ### What nono Protects Against

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -410,6 +410,22 @@ This reports the detected kernel version, Landlock ABI, WSL2 detection status, a
 
 ---
 
+## Running Inside Docker/Podman
+
+### `pidfd_getfd failed ... Operation not permitted`
+
+**Symptom:** `Sandbox initialization failed: Failed to acquire required network seccomp notify fd from child: pidfd_getfd failed for child fd N: Operation not permitted (os error 1)` when using `--allow-domain` (or any other capability that falls back to the seccomp proxy) inside a container.
+
+**Cause:** The proxy fallback hands the network-notify file descriptor across the fork boundary with `pidfd_getfd(2)`, which requires `CAP_SYS_PTRACE`. Docker (and most container runtimes) drop that capability by default, so the call returns `EPERM`.
+
+**Solution:** Add the capability back when starting the container:
+
+```bash
+docker run --cap-add=SYS_PTRACE ...
+```
+
+or the equivalent in your Compose file / Kubernetes `securityContext.capabilities.add: ["SYS_PTRACE"]`. This doesn't weaken the container boundary in a way relevant to nono's threat model -- it only lets nono's own parent process duplicate a file descriptor from its own sandboxed child.
+
 ## Getting Help
 
 If you're still stuck:


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1716 

## Summary

Docker and most container runtimes drop CAP_SYS_PTRACE by default, which makes the seccomp-proxy fallbacks pidfd_getfd() call fail with EPERM, surfacing as an opaque "Operation not permitted" error (#1716). Detect that specific errno and point at `--cap-add=SYS_PTRACE`. Also fixes the caller re-wrapping an already-prefixed SandboxInit error, which doubled "Sandbox initialization failed: " in the message. Adds a matching troubleshooting doc entry.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
