### PR TITLE
fix(why): evaluate network.deny_domain in nono why host queries

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -2260,6 +2260,18 @@ pub struct WhyArgs {
     #[arg(long, default_value = "443", help_heading = "QUERY")]
     pub port: u16,
 
+    /// Add a domain to the proxy allowlist for this query (repeatable)
+    #[arg(
+        long = "allow-domain",
+        value_name = "DOMAIN_OR_URL",
+        help_heading = "QUERY"
+    )]
+    pub allow_proxy: Vec<String>,
+
+    /// Block a domain through the proxy for this query (repeatable)
+    #[arg(long = "deny-domain", value_name = "DOMAIN", help_heading = "QUERY")]
+    pub deny_proxy: Vec<String>,
+
     /// Output JSON instead of human-readable format
     #[arg(long, help_heading = "OPTIONS")]
     pub json: bool,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -318,6 +318,20 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     } else {
         plain_domain_strs
     };
+    // Expand `deny_domain` the same way for `nono why --self`.
+    let denied_domain_strs: Vec<String> = domain_filter
+        .map(|d| d.deny_domain.as_slice())
+        .map(|deny_domain| {
+            let policy_json = config::embedded::embedded_network_policy_json();
+            match network_policy::load_network_policy(policy_json) {
+                Ok(net_policy) => network_policy::expand_proxy_deny(&net_policy, deny_domain),
+                Err(e) => {
+                    warn!("failed to load network policy for sandbox state: {e}");
+                    deny_domain.to_vec()
+                }
+            }
+        })
+        .unwrap_or_default();
     let domain_endpoints: Vec<sandbox_state::DomainEndpointState> = all_domain_entries
         .iter()
         .filter_map(|e| match e {
@@ -343,6 +357,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         &flags.bypass_protection_paths,
         &deny_paths,
         &allowed_domain_strs,
+        &denied_domain_strs,
         &domain_endpoints,
         flags.silent,
     );
@@ -820,6 +835,7 @@ fn write_capability_state_file(
     bypass_protection_paths: &[std::path::PathBuf],
     deny_paths: &[std::path::PathBuf],
     allowed_domains: &[String],
+    denied_domains: &[String],
     domain_endpoints: &[sandbox_state::DomainEndpointState],
     silent: bool,
 ) -> Option<std::path::PathBuf> {
@@ -828,6 +844,7 @@ fn write_capability_state_file(
         bypass_protection_paths,
         deny_paths,
         allowed_domains,
+        denied_domains,
         domain_endpoints,
     );
 

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -212,17 +212,37 @@ pub fn query_path(
     })
 }
 
+/// Check host:port then bare host against the deny list, so a port-scoped
+/// `deny_domain` entry isn't shadowed by a wildcard allowlist. Mirrors
+/// `ProxyFilter::check_host_result` (`nono-proxy/src/filter.rs`) minus DNS.
+fn check_domain_deny(
+    filter: &nono::net_filter::HostFilter,
+    domain: &str,
+    port: u16,
+) -> Option<nono::net_filter::FilterResult> {
+    let normalized_domain = nono::net_filter::HostFilter::normalize_authority_host(domain);
+    // Bracket IPv6 literals so their colons aren't mistaken for the port separator.
+    let host_port = if normalized_domain.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{normalized_domain}]:{port}")
+    } else {
+        format!("{normalized_domain}:{port}")
+    };
+    filter
+        .check_deny(&host_port)
+        .or_else(|| filter.check_deny(domain))
+}
+
 /// Query whether network access is permitted.
 ///
-/// `allowed_domains` contains the resolved proxy allowlist (from profile
-/// `allow_domain`, network profile hosts, and CLI `--allow-domain`).
-/// When the network mode is `ProxyOnly`, delegates to `HostFilter` for
-/// consistent matching with the proxy (including cloud metadata deny list).
+/// `allowed_domains`/`denied_domains` are the resolved proxy allow/deny
+/// lists (profile config + CLI `--allow-domain`/`--deny-domain`); deny is
+/// evaluated before allow, matching real proxy precedence.
 pub fn query_network(
     host: &str,
     port: u16,
     caps: &CapabilitySet,
     allowed_domains: &[String],
+    denied_domains: &[String],
     domain_endpoints: &[crate::sandbox_state::DomainEndpointState],
 ) -> QueryResult {
     let (domain, url_path) = parse_host_input(host);
@@ -244,9 +264,12 @@ pub fn query_network(
                 nono::net_filter::HostFilter::allow_all()
             } else {
                 nono::net_filter::HostFilter::new(allowed_domains)
-            };
+            }
+            .with_denied_hosts(denied_domains);
             // Pass empty IPs: DNS resolution happens at proxy time, not query time.
-            match filter.check_host(&domain, &[]) {
+            let check_result = check_domain_deny(&filter, &domain, port)
+                .unwrap_or_else(|| filter.check_host(&domain, &[]));
+            match check_result {
                 nono::net_filter::FilterResult::Allow => {
                     let matching_endpoints = domain_endpoints
                         .iter()
@@ -321,6 +344,19 @@ pub fn query_network(
                         },
                     }
                 }
+                deny_result @ nono::net_filter::FilterResult::DenyHost { .. } => {
+                    QueryResult::Denied {
+                        reason: "domain_deny".to_string(),
+                        details: Some(format!(
+                            "Host is blocked by network.deny_domain. {}",
+                            deny_result.reason()
+                        )),
+                        policy_source: Some("proxy domain filter (deny_domain)".to_string()),
+                        matching_capability: None,
+                        suggested_flag: None,
+                        endpoint_rules: None,
+                    }
+                }
                 deny => QueryResult::Denied {
                     reason: "proxy_filtered".to_string(),
                     details: Some(format!("Domain filtering is active. {}", deny.reason())),
@@ -332,12 +368,18 @@ pub fn query_network(
             }
         }
         nono::NetworkMode::AllowAll => {
-            // OS-level network is unrestricted, but a proxy domain filter may still
-            // apply. When allowed_domains is non-empty the proxy is active with
-            // default-deny semantics — check it the same way ProxyOnly does.
-            if !allowed_domains.is_empty() {
-                let filter = nono::net_filter::HostFilter::new(allowed_domains);
-                match filter.check_host(&domain, &[]) {
+            // OS-level network is unrestricted, but a domain filter is active
+            // whenever either list is non-empty — check it like ProxyOnly does.
+            if !allowed_domains.is_empty() || !denied_domains.is_empty() {
+                let filter = if allowed_domains.is_empty() {
+                    nono::net_filter::HostFilter::allow_all()
+                } else {
+                    nono::net_filter::HostFilter::new(allowed_domains)
+                }
+                .with_denied_hosts(denied_domains);
+                let check_result = check_domain_deny(&filter, &domain, port)
+                    .unwrap_or_else(|| filter.check_host(&domain, &[]));
+                match check_result {
                     nono::net_filter::FilterResult::Allow => {
                         let matching_endpoints = domain_endpoints
                             .iter()
@@ -402,6 +444,17 @@ pub fn query_network(
                             },
                         }
                     }
+                    nono::net_filter::FilterResult::DenyHost { .. } => QueryResult::Denied {
+                        reason: "domain_deny".to_string(),
+                        details: Some(format!(
+                            "Host is blocked by network.deny_domain. {}",
+                            check_result.reason()
+                        )),
+                        policy_source: Some("proxy domain filter (deny_domain)".to_string()),
+                        matching_capability: None,
+                        suggested_flag: None,
+                        endpoint_rules: None,
+                    },
                     deny => QueryResult::Denied {
                         reason: "proxy_filtered".to_string(),
                         details: Some(format!("Domain filtering is active. {}", deny.reason())),
@@ -1068,14 +1121,14 @@ mod tests {
     #[test]
     fn test_query_network_allowed() {
         let caps = CapabilitySet::new();
-        let result = query_network("example.com", 443, &caps, &[], &[]);
+        let result = query_network("example.com", 443, &caps, &[], &[], &[]);
         assert!(matches!(result, QueryResult::Allowed { .. }));
     }
 
     #[test]
     fn test_query_network_blocked() {
         let caps = CapabilitySet::new().block_network();
-        let result = query_network("example.com", 443, &caps, &[], &[]);
+        let result = query_network("example.com", 443, &caps, &[], &[], &[]);
         assert!(matches!(result, QueryResult::Denied { .. }));
     }
 
@@ -1107,10 +1160,10 @@ mod tests {
         });
         let allowed = vec!["api.example.com".to_string()];
 
-        let result = query_network("api.example.com", 443, &caps, &allowed, &[]);
+        let result = query_network("api.example.com", 443, &caps, &allowed, &[], &[]);
         assert!(matches!(result, QueryResult::Allowed { .. }));
 
-        match query_network("evil.com", 443, &caps, &allowed, &[]) {
+        match query_network("evil.com", 443, &caps, &allowed, &[], &[]) {
             QueryResult::Denied {
                 reason,
                 suggested_flag,
@@ -1132,12 +1185,12 @@ mod tests {
         let allowed = vec!["*.example.com".to_string()];
 
         assert!(matches!(
-            query_network("sub.example.com", 443, &caps, &allowed, &[]),
+            query_network("sub.example.com", 443, &caps, &allowed, &[], &[]),
             QueryResult::Allowed { .. }
         ));
         // *.example.com must NOT match bare example.com (mirrors HostFilter)
         assert!(matches!(
-            query_network("example.com", 443, &caps, &allowed, &[]),
+            query_network("example.com", 443, &caps, &allowed, &[], &[]),
             QueryResult::Denied { .. }
         ));
     }
@@ -1149,7 +1202,7 @@ mod tests {
             bind_ports: vec![],
         });
         assert!(matches!(
-            query_network("anything.com", 443, &caps, &[], &[]),
+            query_network("anything.com", 443, &caps, &[], &[], &[]),
             QueryResult::Allowed { .. }
         ));
     }
@@ -1162,14 +1215,35 @@ mod tests {
         });
         // Cloud metadata endpoints are denied even with an empty allowlist
         assert!(matches!(
-            query_network("169.254.169.254", 80, &caps, &[], &[]),
+            query_network("169.254.169.254", 80, &caps, &[], &[], &[]),
             QueryResult::Denied { .. }
         ));
         // Also denied even if explicitly in the allowlist
         let allowed = vec!["169.254.169.254".to_string()];
         assert!(matches!(
-            query_network("169.254.169.254", 80, &caps, &allowed, &[]),
+            query_network("169.254.169.254", 80, &caps, &allowed, &[], &[]),
             QueryResult::Denied { .. }
+        ));
+    }
+
+    /// A port-scoped deny entry must bracket an IPv6 literal (`[::1]:8975`),
+    /// not naively append `:port` (ambiguous `::1:8975`).
+    #[test]
+    fn test_query_network_port_scoped_deny_matches_ipv6_literal() {
+        let caps = CapabilitySet::new().set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        });
+        let allowed = vec!["*".to_string()];
+        let denied = vec!["[::1]:8975".to_string()];
+        assert!(matches!(
+            query_network("::1", 8975, &caps, &allowed, &denied, &[]),
+            QueryResult::Denied { reason, .. } if reason == "domain_deny"
+        ));
+        // Different port on the same host is unaffected by a port-scoped deny.
+        assert!(matches!(
+            query_network("::1", 8787, &caps, &allowed, &denied, &[]),
+            QueryResult::Allowed { .. }
         ));
     }
 
@@ -1182,7 +1256,14 @@ mod tests {
         let allowed = vec!["github.com".to_string()];
         // Full URL should extract domain and match
         assert!(matches!(
-            query_network("https://github.com/some/repo", 443, &caps, &allowed, &[]),
+            query_network(
+                "https://github.com/some/repo",
+                443,
+                &caps,
+                &allowed,
+                &[],
+                &[]
+            ),
             QueryResult::Allowed { .. }
         ));
     }
@@ -1213,6 +1294,7 @@ mod tests {
             443,
             &caps,
             &allowed,
+            &[],
             &endpoints,
         );
         assert!(matches!(result, QueryResult::Allowed { .. }));
@@ -1238,6 +1320,7 @@ mod tests {
             443,
             &caps,
             &allowed,
+            &[],
             &endpoints,
         );
         match result {
@@ -1276,7 +1359,7 @@ mod tests {
             }],
         }];
         // Bare domain (no path) shows allowed with endpoint rules
-        let result = query_network("github.com", 443, &caps, &allowed, &endpoints);
+        let result = query_network("github.com", 443, &caps, &allowed, &[], &endpoints);
         match result {
             QueryResult::Allowed {
                 endpoint_rules,

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -44,6 +44,9 @@ pub struct SandboxState {
     /// Proxy domain allowlist at sandbox creation time
     #[serde(default)]
     pub allowed_domains: Vec<String>,
+    /// Proxy domain denylist (`network.deny_domain`) at sandbox creation time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_domains: Vec<String>,
     /// Endpoint-restricted domains with method+path rules
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub domain_endpoints: Vec<DomainEndpointState>,
@@ -133,6 +136,7 @@ impl SandboxState {
             bypass_protection_paths,
             &[],
             allowed_domains,
+            &[],
             domain_endpoints,
         )
     }
@@ -143,6 +147,7 @@ impl SandboxState {
         bypass_protection_paths: &[PathBuf],
         deny_paths: &[PathBuf],
         allowed_domains: &[String],
+        denied_domains: &[String],
         domain_endpoints: &[DomainEndpointState],
     ) -> Self {
         Self {
@@ -175,6 +180,7 @@ impl SandboxState {
                 .collect(),
             deny_paths: deny_paths.iter().map(|p| p.display().to_string()).collect(),
             allowed_domains: allowed_domains.to_vec(),
+            denied_domains: denied_domains.to_vec(),
             domain_endpoints: domain_endpoints.to_vec(),
             resource_limits: caps.resource_limits().copied(),
         }
@@ -655,7 +661,7 @@ mod tests {
     fn test_sandbox_state_roundtrip_preserves_deny_paths() {
         let caps = CapabilitySet::new();
         let deny_paths = vec![PathBuf::from("/workspace/blocked.txt")];
-        let state = SandboxState::from_caps_with_denies(&caps, &[], &deny_paths, &[], &[]);
+        let state = SandboxState::from_caps_with_denies(&caps, &[], &deny_paths, &[], &[], &[]);
 
         let json = serde_json::to_string(&state).expect("serialize state");
         let restored: SandboxState = serde_json::from_str(&json).expect("deserialize state");
@@ -871,6 +877,7 @@ mod tests {
             bypass_protection_paths: vec![],
             deny_paths: vec![],
             allowed_domains: vec![],
+            denied_domains: vec![],
             domain_endpoints: vec![],
             resource_limits: None,
         };

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -12,6 +12,7 @@ struct WhyContext {
     deny_paths: Vec<std::path::PathBuf>,
     overridden_paths: Vec<std::path::PathBuf>,
     allowed_domains: Vec<String>,
+    denied_domains: Vec<String>,
     domain_endpoints: Vec<sandbox_state::DomainEndpointState>,
     command_policies: Option<CommandPoliciesConfig>,
 }
@@ -50,6 +51,41 @@ fn resolve_allowed_domains(profile: &profile::Profile) -> Result<Vec<String>> {
         &plain_entries,
     ));
 
+    Ok(domains)
+}
+
+/// Resolve the proxy domain denylist from a profile's network config.
+fn resolve_denied_domains(profile: &profile::Profile) -> Result<Vec<String>> {
+    let policy_json = crate::config::embedded::embedded_network_policy_json();
+    let net_policy = network_policy::load_network_policy(policy_json)?;
+    Ok(network_policy::expand_proxy_deny(
+        &net_policy,
+        &profile.network.deny_domain,
+    ))
+}
+
+/// Merge `--allow-domain` overrides into a resolved allowlist.
+fn merge_cli_allow_domains(
+    mut domains: Vec<String>,
+    cli_entries: &[String],
+) -> Result<Vec<String>> {
+    if cli_entries.is_empty() {
+        return Ok(domains);
+    }
+    let policy_json = crate::config::embedded::embedded_network_policy_json();
+    let net_policy = network_policy::load_network_policy(policy_json)?;
+    domains.extend(network_policy::expand_proxy_allow(&net_policy, cli_entries));
+    Ok(domains)
+}
+
+/// Merge `--deny-domain` overrides into a resolved denylist.
+fn merge_cli_deny_domains(mut domains: Vec<String>, cli_entries: &[String]) -> Result<Vec<String>> {
+    if cli_entries.is_empty() {
+        return Ok(domains);
+    }
+    let policy_json = crate::config::embedded::embedded_network_policy_json();
+    let net_policy = network_policy::load_network_policy(policy_json)?;
+    domains.extend(network_policy::expand_proxy_deny(&net_policy, cli_entries));
     Ok(domains)
 }
 
@@ -114,6 +150,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
                     deny_paths: state.deny_paths_as_paths(),
                     overridden_paths: paths,
                     allowed_domains: state.allowed_domains.clone(),
+                    denied_domains: state.denied_domains.clone(),
                     domain_endpoints,
                     command_policies: None,
                 }
@@ -165,7 +202,10 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             }
         }
 
-        let allowed_domains = resolve_allowed_domains(&profile)?;
+        let allowed_domains =
+            merge_cli_allow_domains(resolve_allowed_domains(&profile)?, &args.allow_proxy)?;
+        let denied_domains =
+            merge_cli_deny_domains(resolve_denied_domains(&profile)?, &args.deny_proxy)?;
         let domain_endpoints = resolve_domain_endpoints(&profile);
         let command_policies = profile.command_policies.clone();
 
@@ -179,6 +219,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             deny_paths: prepared.deny_paths,
             overridden_paths: override_paths,
             allowed_domains,
+            denied_domains,
             domain_endpoints,
             command_policies,
         }
@@ -204,7 +245,8 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             caps,
             deny_paths: prepared.deny_paths,
             overridden_paths: vec![],
-            allowed_domains: vec![],
+            allowed_domains: merge_cli_allow_domains(Vec::new(), &args.allow_proxy)?,
+            denied_domains: merge_cli_deny_domains(Vec::new(), &args.deny_proxy)?,
             domain_endpoints: vec![],
             command_policies: None,
         }
@@ -252,6 +294,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             args.port,
             &ctx.caps,
             &ctx.allowed_domains,
+            &ctx.denied_domains,
             &ctx.domain_endpoints,
         )
     } else if let Some(ref scope) = args.scope {
@@ -684,6 +727,7 @@ mod tests {
             443,
             &caps,
             &resolve_allowed_domains(&profile).expect("resolve allowlist"),
+            &resolve_denied_domains(&profile).expect("resolve denylist"),
             &resolve_domain_endpoints(&profile),
         )
     }
@@ -765,6 +809,58 @@ mod tests {
     fn profile_without_network_config_reports_allowed() {
         let result = why_profile_host(r#"{}"#, "anything.example.com");
         assert_eq!(reason_of(&result), "network_allowed");
+    }
+
+    /// #1742: deny_domain must win over allow_domain for the same host.
+    #[test]
+    fn profile_deny_domain_beats_allow_domain() {
+        let config =
+            r#"{"network":{"allow_domain":["pypi.org","example.com"],"deny_domain":["pypi.org"]}}"#;
+        assert_eq!(
+            reason_of(&why_profile_host(config, "pypi.org")),
+            "domain_deny"
+        );
+        // Control: a host in allow_domain but not deny_domain stays allowed.
+        assert_eq!(
+            reason_of(&why_profile_host(config, "example.com")),
+            "proxy_allowed"
+        );
+    }
+
+    /// deny_domain also wins under a `network_profile` allowlist.
+    #[test]
+    fn profile_deny_domain_beats_network_profile() {
+        let config =
+            r#"{"network":{"network_profile":"claude-code","deny_domain":["api.anthropic.com"]}}"#;
+        assert_eq!(
+            reason_of(&why_profile_host(config, "api.anthropic.com")),
+            "domain_deny"
+        );
+    }
+
+    /// deny_domain alone (no allowlist) still denies its listed hosts.
+    #[test]
+    fn profile_deny_domain_alone_still_denies() {
+        let config = r#"{"network":{"deny_domain":["evil.example.com"]}}"#;
+        assert_eq!(
+            reason_of(&why_profile_host(config, "evil.example.com")),
+            "domain_deny"
+        );
+        assert_eq!(
+            reason_of(&why_profile_host(config, "anything-else.example.com")),
+            "proxy_allowed"
+        );
+    }
+
+    /// Wildcard deny_domain entries are enforced too.
+    #[test]
+    fn profile_wildcard_deny_domain_matches_subdomains() {
+        let config =
+            r#"{"network":{"allow_domain":["*.npmjs.org"],"deny_domain":["*.npmjs.org"]}}"#;
+        assert_eq!(
+            reason_of(&why_profile_host(config, "registry.npmjs.org")),
+            "domain_deny"
+        );
     }
 
     #[test]


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1742

## Summary

query_network only built a HostFilter from the allowlist and never consulted deny_domain, so a host blocked by the proxy at runtime was still reported ALLOWED by nono why. Fixes #1742.

- Check deny_domain before the allowlist in both ProxyOnly and AllowAll modes, including deny-only profiles (previously skipped domain filtering entirely).
- Add a domain_deny reason, distinct from proxy_filtered.
- Add --allow-domain/--deny-domain to nono why for parity with run.
- Store denied_domains in SandboxState so why --self sees it too.
- Bracket IPv6 literals in the port-scoped deny check.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
