### PR TITLE
fix(sandbox): use capturing group in ** deny-glob Seatbelt regex

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -675,8 +675,9 @@ fn push_glob_as_seatbelt_regex(glob: &str, out: &mut String) -> Result<()> {
                     i += 2;
                     if i < chars.len() && chars[i] == '/' {
                         // **/ → optional path prefix so **/foo matches both
-                        // foo and subdir/foo at any depth.
-                        out.push_str("(?:.*/)?");
+                        // foo and subdir/foo at any depth. Must be a capturing
+                        // group: Seatbelt's regex matcher silently ignores `(?:...)`.
+                        out.push_str("(.*/)?");
                         i += 1;
                     } else {
                         // ** at end or before a non-slash: match anything
@@ -4043,13 +4044,13 @@ mod tests {
         #[test]
         fn test_glob_regex_double_star_slash_prefix() {
             let re = glob_to_seatbelt_regex("**/appsettings.json").expect("ok");
-            assert_eq!(re, r"^(?:.*/)?appsettings\.json$");
+            assert_eq!(re, r"^(.*/)?appsettings\.json$");
         }
 
         #[test]
         fn test_glob_regex_double_star_mid_pattern() {
             let re = glob_to_seatbelt_regex("/repo/**/appsettings.json").expect("ok");
-            assert_eq!(re, r"^/repo/(?:.*/)?appsettings\.json$");
+            assert_eq!(re, r"^/repo/(.*/)?appsettings\.json$");
         }
 
         #[test]
@@ -4074,13 +4075,13 @@ mod tests {
         #[test]
         fn test_glob_regex_double_star_with_prefix_wildcard() {
             let re = glob_to_seatbelt_regex("/repo/**/appsettings*.json").expect("ok");
-            assert_eq!(re, r"^/repo/(?:.*/)?appsettings[^/]*\.json$");
+            assert_eq!(re, r"^/repo/(.*/)?appsettings[^/]*\.json$");
         }
 
         #[test]
         fn test_glob_regex_dot_env_wildcard() {
             let re = glob_to_seatbelt_regex("**/.env.*").expect("ok");
-            assert_eq!(re, r"^(?:.*/)?\.env\.[^/]*$");
+            assert_eq!(re, r"^(.*/)?\.env\.[^/]*$");
         }
 
         #[test]

--- a/crates/nono-cli/tests/glob_access_run.rs
+++ b/crates/nono-cli/tests/glob_access_run.rs
@@ -1,0 +1,101 @@
+//! Kernel-level checks that `filesystem.read`/`write`/`bypass_protection`
+//! globs match existing files correctly, with proper read/write separation.
+
+use nono_test_support::{Argv, nono_test};
+use std::fs;
+
+#[test]
+fn read_glob_grants_read_not_write() {
+    let t = nono_test!("glob-read-mode");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("logs")).expect("create logs dir");
+    let target = workspace.join("logs").join("app.log");
+    fs::write(&target, "content\n").expect("write log");
+
+    let profile = t.write_profile(
+        "glob-read-mode",
+        &format!(
+            r#"{{"meta":{{"name":"t"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"read":["{}/logs/*.log"]}}}}"#,
+            workspace.display()
+        ),
+    );
+
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new("/bin/cat").arg(&target))
+        .assert_stdout_contains("content");
+
+    t.run()
+        .profile(&profile)
+        .exec(
+            Argv::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("echo x > {}", target.display())),
+        )
+        .assert_failure("read-only glob must not grant write");
+}
+
+#[test]
+fn write_glob_grants_write_not_read() {
+    let t = nono_test!("glob-write-mode");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("out")).expect("create out dir");
+    let target = workspace.join("out").join("result.txt");
+    fs::write(&target, "original\n").expect("write file");
+
+    let profile = t.write_profile(
+        "glob-write-mode",
+        &format!(
+            r#"{{"meta":{{"name":"t"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"write":["{}/out/*.txt"]}}}}"#,
+            workspace.display()
+        ),
+    );
+
+    t.run()
+        .profile(&profile)
+        .exec(
+            Argv::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("echo new > {}", target.display())),
+        )
+        .assert_success("write-only glob must grant write");
+    assert_eq!(fs::read_to_string(&target).expect("read back"), "new\n");
+
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new("/bin/cat").arg(&target))
+        .assert_failure("write-only glob must not grant read");
+}
+
+#[test]
+fn bypass_protection_glob_requires_paired_allow() {
+    let t = nono_test!("glob-bypass-requires-allow");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("creds")).expect("create creds dir");
+    let target = workspace.join("creds").join("service.token");
+    fs::write(&target, "secret\n").expect("write token");
+
+    let pattern = format!("{}/creds/*.token", workspace.display());
+
+    let no_allow = t.write_profile(
+        "glob-bypass-no-allow",
+        &format!(
+            r#"{{"meta":{{"name":"t"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"deny":["{pattern}"],"bypass_protection":["{pattern}"]}}}}"#
+        ),
+    );
+    t.run()
+        .profile(&no_allow)
+        .exec(Argv::new("/bin/cat").arg(&target))
+        .assert_failure("bypass_protection without a paired allow must not grant access");
+
+    let with_allow = t.write_profile(
+        "glob-bypass-with-allow",
+        &format!(
+            r#"{{"meta":{{"name":"t"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"allow":["{pattern}"],"deny":["{pattern}"],"bypass_protection":["{pattern}"]}}}}"#
+        ),
+    );
+    t.run()
+        .profile(&with_allow)
+        .exec(Argv::new("/bin/cat").arg(&target))
+        .assert_stdout_contains("secret");
+}

--- a/crates/nono-cli/tests/glob_deny_after_start_run.rs
+++ b/crates/nono-cli/tests/glob_deny_after_start_run.rs
@@ -1,0 +1,243 @@
+//! Kernel-enforcement tests for `filesystem.deny` glob patterns on macOS: a
+//! file matching a deny-glob must stay denied even when created, deleted, or
+//! recreated after the sandbox starts. Unlike the string-level unit tests in
+//! `policy.rs`, these run a real `sandbox_init()` via the `nono` binary — see
+//! https://github.com/nolabs-ai/nono/issues/1763.
+
+#![cfg(target_os = "macos")]
+
+use nono_test_support::{Argv, NonoTest, Profile, nono_test};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+/// Delay before the late write, must clear `nono`'s own startup or the file
+/// would exist at policy-load time and get caught by a literal deny instead.
+const WRITE_DELAY: Duration = Duration::from_secs(2);
+/// How long the sandboxed child waits before reading.
+const READ_DELAY_SECS: u64 = 3;
+
+/// Serializes tests so concurrent CPU contention can't push `nono` startup
+/// past `WRITE_DELAY` and cause a flaky false result.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
+    SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn write_deny_glob_profile(t: &NonoTest, name: &str, deny_pattern: &str) -> Profile {
+    let workspace = t.workspace().to_path_buf();
+    t.write_profile(
+        name,
+        &format!(
+            r#"{{
+            "meta": {{ "name": "{name}" }},
+            "workdir": {{ "access": "readwrite" }},
+            "filesystem": {{
+                "allow": ["{workspace}"],
+                "deny": ["{deny_pattern}"]
+            }}
+        }}"#,
+            workspace = workspace.display(),
+        ),
+    )
+}
+
+/// Writes `SECRET\n` to `secret_path` after `WRITE_DELAY`, then `cat`s it in
+/// the sandbox and asserts the read is denied.
+fn assert_deny_glob_blocks_read_after_start(t: &NonoTest, profile: &Profile, secret_path: &Path) {
+    let write_path = secret_path.to_path_buf();
+    thread::spawn(move || {
+        thread::sleep(WRITE_DELAY);
+        if let Some(parent) = write_path.parent() {
+            fs::create_dir_all(parent).expect("create parent dirs for late write");
+        }
+        fs::write(&write_path, "SECRET\n").expect("write secret after sandbox start");
+    });
+
+    t.run()
+        .profile(profile)
+        .exec(Argv::new("/bin/sh").arg("-c").arg(format!(
+            "sleep {READ_DELAY_SECS}; cat {}",
+            secret_path.display()
+        )))
+        .assert_failure("deny glob must cover a file created after sandbox start")
+        .assert_stdout_lacks("SECRET");
+}
+
+#[test]
+fn double_star_prefix_blocks_file_created_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-prefix");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("deep")).expect("create deep dir");
+    let secret_path = workspace.join("deep").join(".env");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-prefix",
+        &format!("{}/**/.env", workspace.display()),
+    );
+    assert_deny_glob_blocks_read_after_start(&t, &profile, &secret_path);
+}
+
+#[test]
+fn mid_pattern_double_star_blocks_file_created_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-mid");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("a").join("b")).expect("create nested dir");
+    let secret_path = workspace.join("a").join("b").join("secret.log");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-mid",
+        &format!("{}/a/**/secret.log", workspace.display()),
+    );
+    assert_deny_glob_blocks_read_after_start(&t, &profile, &secret_path);
+}
+
+#[test]
+fn single_star_within_segment_blocks_file_created_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-star");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("logs")).expect("create logs dir");
+    let secret_path = workspace.join("logs").join("token.secret");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-star",
+        &format!("{}/logs/*.secret", workspace.display()),
+    );
+    assert_deny_glob_blocks_read_after_start(&t, &profile, &secret_path);
+}
+
+#[test]
+fn trailing_double_star_blocks_file_created_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-trailing");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("private").join("nested")).expect("create private dir");
+    let secret_path = workspace.join("private").join("nested").join("leak.txt");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-trailing",
+        &format!("{}/private/**", workspace.display()),
+    );
+    assert_deny_glob_blocks_read_after_start(&t, &profile, &secret_path);
+}
+
+/// Deny globs must also block writes, not just reads.
+#[test]
+fn double_star_prefix_blocks_write_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-write-after-start");
+    let workspace = t.workspace().to_path_buf();
+    fs::create_dir_all(workspace.join("deep")).expect("create deep dir");
+    let target = workspace.join("deep").join(".env");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-write",
+        &format!("{}/**/.env", workspace.display()),
+    );
+
+    t.run()
+        .profile(&profile)
+        .exec(
+            Argv::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("echo pwned > {}", target.display())),
+        )
+        .assert_failure("a **-glob deny must block writes to a newly created matching path");
+
+    assert!(
+        !target.exists(),
+        "deny glob must prevent the file from being created at all"
+    );
+}
+
+/// A file deleted and recreated under the same name must stay denied —
+/// isolates the regex-based deny from the literal-expansion deny, which
+/// stops applying once the original match is gone.
+#[test]
+fn deleted_and_recreated_file_stays_denied() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-deny-delete-recreate");
+    let workspace = t.workspace().to_path_buf();
+    let deep_dir = workspace.join("deep");
+    fs::create_dir_all(&deep_dir).expect("create deep dir");
+    let secret_path: PathBuf = deep_dir.join(".env");
+    fs::write(&secret_path, "ORIGINAL\n").expect("write original secret");
+
+    let profile = write_deny_glob_profile(
+        &t,
+        "glob-deny-delete-recreate",
+        &format!("{}/**/.env", workspace.display()),
+    );
+
+    fs::remove_file(&secret_path).expect("delete original secret");
+    let write_path = secret_path.clone();
+    thread::spawn(move || {
+        thread::sleep(WRITE_DELAY);
+        fs::write(&write_path, "RECREATED\n").expect("recreate secret after sandbox start");
+    });
+
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new("/bin/sh").arg("-c").arg(format!(
+            "sleep {READ_DELAY_SECS}; cat {}",
+            secret_path.display()
+        )))
+        .assert_failure("a deleted-and-recreated file must still be covered by the deny glob")
+        .assert_stdout_lacks("RECREATED");
+}
+
+/// Not a bug: `filesystem.allow` globs are a load-time snapshot with no
+/// regex-based runtime rule, unlike `filesystem.deny`. A file matching an
+/// allow-glob but created after sandbox start must NOT be granted.
+#[test]
+fn allow_glob_does_not_cover_file_created_after_start() {
+    let _guard = serial_guard();
+    let t = nono_test!("glob-allow-after-start");
+    let workspace = t.workspace().to_path_buf();
+    let data_dir = workspace.join("data");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    let late_path = data_dir.join("late.json");
+
+    let profile = t.write_profile(
+        "glob-allow-after-start",
+        &format!(
+            r#"{{
+            "meta": {{ "name": "glob-allow-after-start" }},
+            "workdir": {{ "access": "readwrite" }},
+            "filesystem": {{
+                "allow": ["{workspace}/data/*.json"]
+            }}
+        }}"#,
+            workspace = workspace.display()
+        ),
+    );
+
+    let write_path = late_path.clone();
+    thread::spawn(move || {
+        thread::sleep(WRITE_DELAY);
+        fs::write(&write_path, "{}").expect("write file after sandbox start");
+    });
+
+    t.run()
+        .profile(&profile)
+        .exec(Argv::new("/bin/sh").arg("-c").arg(format!(
+            "sleep {READ_DELAY_SECS}; cat {}",
+            late_path.display()
+        )))
+        .assert_failure(
+            "an allow-glob snapshot at policy load must not cover a file created afterward",
+        );
+}


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1763

## Summary

Apples Seatbelt regex matcher silently ignores non-capturing groups, so **/ deny-glob rules on macOS never matched anything: a file created after sandbox start under a filesystem.deny glob was readable and writable despite the rule. (?:.*/)? -> (.*/)?  fixes it.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
