### PR TITLE
fix(policy): remove blanket /Volumes read grant from system_read_macos

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -179,7 +179,6 @@
           "/Applications",
           "/cores",
           "/opt",
-          "/Volumes",
           "/run",
           "/nix"
         ]

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -4327,4 +4327,30 @@ mod tests {
 
         assert_eq!(result, vec![root.join("weird{name}.json")]);
     }
+
+    #[test]
+    fn test_system_read_macos_does_not_grant_plain_volumes() {
+        // Regression for the overbroad grant reported in discussion #1482:
+        // `/Volumes` is where external drives, disk images, and network
+        // shares mount, and unlike `/System/Volumes` (needed only to match
+        // APFS firmlink-resolved paths, see docs/cli/internals/seatbelt.mdx),
+        // no executable needs it to function. Granting it by default handed
+        // every sandboxed process read access to the contents of any mounted
+        // volume, regardless of what the invocation actually touches.
+        let policy = load_embedded_policy().expect("load embedded policy");
+        let group = policy
+            .groups
+            .get("system_read_macos")
+            .expect("system_read_macos group must exist");
+        let read_paths = &group.allow.as_ref().expect("allow ops").read;
+
+        assert!(
+            !read_paths.iter().any(|p| p == "/Volumes"),
+            "system_read_macos must not grant plain /Volumes: {read_paths:?}"
+        );
+        assert!(
+            read_paths.iter().any(|p| p == "/System/Volumes"),
+            "system_read_macos should still grant /System/Volumes for firmlink resolution: {read_paths:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #727 
Ref https://github.com/nolabs-ai/nono/discussions/1482

## Summary

The system_read_macos group granted read access to the entire /Volumes mount namespace (all external drives, disk images, and network shares), described only as paths "required for executables to function." No executable or system path resolution actually needs this — unlike /System/Volumes, which stays in the list because its required to match APFS firmlink-resolved paths (see docs/cli/internals/seatbelt.mdx).

This mirrors the fix already applied to the macOS runtime baseline in a9263ed3, which removed an analogous overbroad /System/Volumes grant for the same reason: it could inadvertently expose user data. The system_read_macos policy group never got the same scrutiny.

Reported in discussion #1482, where an external drives contents were readable by every sandboxed process by default with no way to opt out short of a custom deny + --bypass-protection workaround.

Adds a regression test asserting /Volumes is absent from system_read_macos while /System/Volumes remains present.


<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
