### PR TITLE
feat(tool-sandbox): support Git fsmonitor socket via unix_socket_bind

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -2040,6 +2040,11 @@
           "items": { "type": "string" },
           "description": "Exact file write grants for the selected child-tool-sandbox policy."
         },
+        "unix_socket_bind": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "AF_UNIX socket bind grants for the selected child-tool-sandbox policy."
+        },
         "use_credentials": {
           "type": "array",
           "items": { "$ref": "#/$defs/CommandPolicyIdentifier" },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -123,6 +123,8 @@ tool-sandbox policies live under `command_policies`. Use `commands.<name>.execut
 
 Command sandbox path lists (`fs_read`, `fs_write`, `fs_read_file`, `fs_write_file`) may use dynamic provider tokens. `@git:config-files` expands to trusted global/system Git config files, Git file settings (attributes, excludes, commit templates), and the declared target of every `include.path` and `includeIf.*.path` directive — including conditional includes that do not currently fire. `@git:hooks-path` expands to trusted global/system `core.hooksPath` directories. `@git:common-dir` expands to the git common directory (`.git` in a regular repo, or the absolute path to the main repo's `.git` in a worktree). `@git:worktree` expands to the main worktree root (empty in a regular repo). `@git:toplevel` expands to the current checkout root. `@git:toplevel-parent` expands to the parent of the current checkout root. These tokens are opt-in per profile and ignore repo-local/worktree Git config so a checkout cannot grant itself extra host filesystem access.
 
+`unix_socket_bind` (command sandbox only) grants `connect(2)`/`bind(2)` on named pathname AF_UNIX sockets, with the same implied filesystem coupling as the agent-level field of the same name. It also accepts the `@git:fsmonitor-socket` dynamic token, which expands to `fsmonitor--daemon.ipc` under the current worktree's private git-dir — resolved by a pure filesystem walk (no `git` process spawn), so an attacker-controlled working directory cannot influence resolution through `.git/config`.
+
 ```json
 {
   "command_policies": {

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -820,6 +820,12 @@ pub struct CommandSandboxConfig {
     /// tools like `git` that re-exec their own helpers by absolute path.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exec_paths: Vec<String>,
+    /// Exact-file Unix domain socket grants this command may `connect` or
+    /// `bind` to (e.g. a daemon's IPC socket it starts on demand). Mirrors
+    /// the agent-level `filesystem.unix_socket_bind` field but scoped to a
+    /// single command. Supports dynamic-provider tokens.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unix_socket_bind: Vec<String>,
 }
 
 impl CommandSandboxConfig {
@@ -848,6 +854,7 @@ impl CommandSandboxConfig {
                 &child.unsafe_macos_seatbelt_rules,
             ),
             exec_paths: dedup_append(&self.exec_paths, &child.exec_paths),
+            unix_socket_bind: dedup_append(&self.unix_socket_bind, &child.unix_socket_bind),
         }
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
+++ b/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
@@ -108,7 +108,13 @@ pub(super) mod git {
         if raw.is_empty() {
             return None;
         }
-        let backlink = PathBuf::from(raw).canonicalize().ok()?;
+        let backlink_raw = PathBuf::from(raw);
+        let backlink_path = if backlink_raw.is_absolute() {
+            backlink_raw
+        } else {
+            canonical_candidate.join(backlink_raw)
+        };
+        let backlink = backlink_path.canonicalize().ok()?;
         let expected = dot_git.canonicalize().ok()?;
         (backlink == expected).then_some(canonical_candidate)
     }
@@ -1431,6 +1437,45 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
             result.is_empty(),
             "must not resolve when the backlink names a different .git file, got {:?}",
             result
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_accepts_gitdir_pointer_with_relative_backlink() {
+        // The private gitdir's own `gitdir` backlink file is resolved
+        // relative to the private gitdir itself, not the process cwd, so a
+        // valid relative backlink (as a real repository may write) must
+        // still verify.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let checkout = tmp.path().join("checkout");
+        std::fs::create_dir(&checkout).expect("mkdir checkout");
+        let private = tmp.path().join("repo/.git/worktrees/wt");
+        std::fs::create_dir_all(&private).expect("mkdir private gitdir");
+
+        std::fs::write(
+            checkout.join(".git"),
+            format!("gitdir: {}\n", private.display()),
+        )
+        .expect("write .git file");
+        // Relative from `private` (tmp/repo/.git/worktrees/wt) back up to
+        // `checkout/.git`.
+        std::fs::write(private.join("gitdir"), "../../../../checkout/.git\n")
+            .expect("write relative backlink");
+
+        let result = git::read_fsmonitor_socket_in(&checkout).expect("read_fsmonitor_socket");
+        assert_eq!(
+            result.len(),
+            1,
+            "a valid relative backlink must still resolve, got {:?}",
+            result
+        );
+        let socket = std::path::Path::new(&result[0]);
+        assert_eq!(
+            socket,
+            private
+                .canonicalize()
+                .expect("canonicalize")
+                .join("fsmonitor--daemon.ipc"),
         );
     }
 

--- a/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
+++ b/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
@@ -72,14 +72,13 @@ pub(super) mod git {
         }
     }
 
-    /// Resolve the git-dir for the repo/worktree rooted at `worktree_root`.
-    /// A `.git` directory resolves to itself; a `.git` file (linked worktree)
-    /// is followed via its `gitdir: <path>` line. Never spawns a process.
+    /// Resolves a `.git` file's `gitdir:` pointer with backlink verification
+    /// (agent-controlled), pre-canonicalized to avoid a TOCTOU re-resolve.
     fn resolve_git_dir(worktree_root: &Path) -> Option<PathBuf> {
         let dot_git = worktree_root.join(".git");
         let meta = std::fs::symlink_metadata(&dot_git).ok()?;
         if meta.is_dir() {
-            return Some(dot_git);
+            return dot_git.canonicalize().ok();
         }
         let contents = std::fs::read_to_string(&dot_git).ok()?;
         let raw = contents
@@ -92,19 +91,30 @@ pub(super) mod git {
             return None;
         }
         let pointed = PathBuf::from(raw);
-        Some(if pointed.is_absolute() {
+        let candidate = if pointed.is_absolute() {
             pointed
         } else {
             worktree_root.join(pointed)
-        })
+        };
+        verify_worktree_backlink(&candidate, &dot_git)
     }
 
-    /// Resolve the git *common* directory for the repo/worktree rooted at
-    /// `worktree_root` — the main repo's `.git` even when called from a
-    /// linked worktree. Follows the `commondir` file git itself writes
-    /// inside a linked worktree's private gitdir (pointing back at the main
-    /// repo's `.git`, relative to that private gitdir) if present. Never
-    /// spawns a process.
+    /// Rejects a forged `gitdir:` pointer lacking the real worktree's
+    /// backlink to `dot_git`.
+    fn verify_worktree_backlink(candidate: &Path, dot_git: &Path) -> Option<PathBuf> {
+        let canonical_candidate = candidate.canonicalize().ok()?;
+        let contents = std::fs::read_to_string(canonical_candidate.join("gitdir")).ok()?;
+        let raw = contents.lines().next()?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        let backlink = PathBuf::from(raw).canonicalize().ok()?;
+        let expected = dot_git.canonicalize().ok()?;
+        (backlink == expected).then_some(canonical_candidate)
+    }
+
+    /// Resolves `commondir` with backlink verification, or a writable `.git`
+    /// could grant itself write access anywhere via `@git:common-dir`.
     fn resolve_common_dir(worktree_root: &Path) -> Option<PathBuf> {
         let git_dir = resolve_git_dir(worktree_root)?;
         let commondir_file = git_dir.join("commondir");
@@ -116,11 +126,22 @@ pub(super) mod git {
             return Some(git_dir);
         }
         let pointed = PathBuf::from(raw);
-        Some(if pointed.is_absolute() {
+        let candidate = if pointed.is_absolute() {
             pointed
         } else {
             git_dir.join(pointed)
-        })
+        };
+        verify_common_dir_backlink(&candidate, &git_dir)
+    }
+
+    /// Rejects a forged `commondir` pointer lacking the real common-dir's
+    /// `worktrees/<name>` backlink to `git_dir`.
+    fn verify_common_dir_backlink(candidate: &Path, git_dir: &Path) -> Option<PathBuf> {
+        let canonical_candidate = candidate.canonicalize().ok()?;
+        let name = git_dir.file_name()?;
+        let expected_link = canonical_candidate.join("worktrees").join(name);
+        let backlink = expected_link.canonicalize().ok()?;
+        (backlink == git_dir).then_some(canonical_candidate)
     }
 
     /// Run `git rev-parse --show-toplevel` from `cwd` (or the process cwd when
@@ -218,6 +239,38 @@ pub(super) mod git {
         run_main_worktree(Some(cwd))
     }
 
+    /// Uses the per-worktree git-dir, not the common dir, since the fsmonitor
+    /// daemon watches one working directory.
+    pub(crate) fn read_fsmonitor_socket(workdir: Option<&Path>) -> Result<Vec<String>> {
+        run_fsmonitor_socket(workdir)
+    }
+
+    fn run_fsmonitor_socket(cwd: Option<&Path>) -> Result<Vec<String>> {
+        let start = match cwd {
+            Some(d) => d.to_path_buf(),
+            None => match std::env::current_dir() {
+                Ok(d) => d,
+                Err(_) => return Ok(vec![]),
+            },
+        };
+        let Some(toplevel) = find_git_toplevel(&start) else {
+            return Ok(vec![]);
+        };
+        let Some(git_dir) = resolve_git_dir(&toplevel) else {
+            return Ok(vec![]);
+        };
+        let Some(path) = git_dir.to_str() else {
+            return Ok(vec![]);
+        };
+        Ok(vec![format!("{path}/fsmonitor--daemon.ipc")])
+    }
+
+    /// Test seam: run the fsmonitor-socket provider from a specific directory.
+    #[cfg(test)]
+    pub(super) fn read_fsmonitor_socket_in(cwd: &Path) -> Result<Vec<String>> {
+        run_fsmonitor_socket(Some(cwd))
+    }
+
     /// Return the absolute path of the current git checkout root
     /// (`git rev-parse --show-toplevel`).
     ///
@@ -303,7 +356,10 @@ pub(super) mod git {
             return Ok(vec![]);
         };
 
-        let is_regular_dot_git = common_dir == toplevel.join(".git");
+        // `common_dir` is canonical, so compare against a canonical
+        // `toplevel/.git` or a symlinked cwd (e.g. /tmp) misses the match.
+        let canonical_dot_git = toplevel.join(".git").canonicalize().ok();
+        let is_regular_dot_git = canonical_dot_git.as_deref() == Some(common_dir.as_path());
         let started_at_toplevel = match (start.canonicalize(), toplevel.canonicalize()) {
             (Ok(a), Ok(b)) => a == b,
             _ => false,
@@ -312,10 +368,7 @@ pub(super) mod git {
             return Ok(vec![".git".to_string()]);
         }
 
-        let Ok(canonical) = common_dir.canonicalize() else {
-            return Ok(vec![]);
-        };
-        let Some(path) = canonical.to_str() else {
+        let Some(path) = common_dir.to_str() else {
             return Ok(vec![]);
         };
         Ok(vec![path.to_string()])
@@ -502,6 +555,7 @@ fn dispatch_token(
             "worktree" => git::read_main_worktree(workdir),
             "toplevel" => git::read_toplevel(workdir),
             "toplevel-parent" => git::read_toplevel_parent(workdir),
+            "fsmonitor-socket" => git::read_fsmonitor_socket(workdir),
             other => Err(NonoError::ProfileParse(format!(
                 "unknown git provider query '{other}'"
             ))),
@@ -1079,6 +1133,78 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
     }
 
     #[test]
+    fn git_read_common_dir_rejects_forged_commondir_pointer_in_regular_repo() {
+        // A forged `commondir` pointing at an arbitrary directory must not
+        // resolve — that directory lacks the real worktrees/<name> backlink.
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+        let victim = tmp.path().join("victim");
+        std::fs::create_dir(&victim).expect("mkdir victim");
+
+        std::fs::write(
+            repo.join(".git").join("commondir"),
+            format!("{}\n", victim.display()),
+        )
+        .expect("write forged commondir file");
+
+        let result = git::read_common_dir_in(&repo).expect("read_common_dir");
+        assert!(
+            result.is_empty(),
+            "must not resolve a commondir: pointer lacking the real worktrees/<name> backlink, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn git_read_common_dir_rejects_commondir_pointer_with_mismatched_backlink() {
+        // A worktrees/<name> entry that resolves to the wrong git-dir must
+        // not count as a valid backlink.
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+        let victim = tmp.path().join("victim");
+        let repo_git_name = repo
+            .join(".git")
+            .canonicalize()
+            .expect("canonicalize")
+            .file_name()
+            .expect("file_name")
+            .to_owned();
+        std::fs::create_dir_all(victim.join("worktrees")).expect("mkdir victim/worktrees");
+        let unrelated = tmp.path().join("unrelated-gitdir");
+        std::fs::create_dir(&unrelated).expect("mkdir unrelated");
+        std::os::unix::fs::symlink(&unrelated, victim.join("worktrees").join(&repo_git_name))
+            .expect("symlink victim/worktrees/<name> to unrelated dir");
+
+        std::fs::write(
+            repo.join(".git").join("commondir"),
+            format!("{}\n", victim.display()),
+        )
+        .expect("write forged commondir file");
+
+        let result = git::read_common_dir_in(&repo).expect("read_common_dir");
+        assert!(
+            result.is_empty(),
+            "must not resolve when victim/worktrees/<name> resolves to a different directory than this repo's git-dir, got {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn git_read_main_worktree_returns_empty_in_regular_repo() {
         use std::process::Command;
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1163,6 +1289,147 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
         assert!(
             result.is_empty(),
             "expected empty outside repo, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_returns_path_under_dot_git_in_regular_repo() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+
+        let result = git::read_fsmonitor_socket_in(&repo).expect("read_fsmonitor_socket");
+        assert_eq!(result.len(), 1, "expected one entry, got {:?}", result);
+        let socket = std::path::Path::new(&result[0]);
+        assert_eq!(
+            socket,
+            repo.join(".git")
+                .canonicalize()
+                .expect("canonicalize")
+                .join("fsmonitor--daemon.ipc"),
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_returns_path_under_private_worktree_gitdir() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+        let commit = Command::new("git")
+            .args([
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "user.email=t@t.com",
+                "-c",
+                "user.name=T",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git commit");
+        assert!(commit.success(), "git commit failed: {commit}");
+
+        let wt = tmp.path().join("worktree");
+        let worktree_add = Command::new("git")
+            .args(["worktree", "add", wt.to_str().expect("utf8")])
+            .current_dir(&repo)
+            .status()
+            .expect("git worktree add");
+        assert!(
+            worktree_add.success(),
+            "git worktree add failed: {worktree_add}"
+        );
+
+        let result = git::read_fsmonitor_socket_in(&wt).expect("read_fsmonitor_socket in worktree");
+        assert_eq!(result.len(), 1, "expected one entry, got {:?}", result);
+        let socket = std::path::Path::new(&result[0]);
+        assert_eq!(
+            socket,
+            repo.join(".git")
+                .join("worktrees")
+                .join("worktree")
+                .canonicalize()
+                .expect("canonicalize")
+                .join("fsmonitor--daemon.ipc"),
+            "fsmonitor socket must live under the worktree's own private git-dir, not the common dir"
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_returns_empty_outside_git_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = git::read_fsmonitor_socket_in(tmp.path()).expect("read_fsmonitor_socket");
+        assert!(
+            result.is_empty(),
+            "expected empty outside repo, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_rejects_gitdir_pointer_without_backlink() {
+        // A forged `gitdir:` pointer at an arbitrary directory must not
+        // resolve — that directory lacks the real gitdir backlink.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let checkout = tmp.path().join("checkout");
+        std::fs::create_dir(&checkout).expect("mkdir checkout");
+        let victim = tmp.path().join("victim");
+        std::fs::create_dir(&victim).expect("mkdir victim");
+
+        std::fs::write(
+            checkout.join(".git"),
+            format!("gitdir: {}\n", victim.display()),
+        )
+        .expect("write forged .git file");
+
+        let result = git::read_fsmonitor_socket_in(&checkout).expect("read_fsmonitor_socket");
+        assert!(
+            result.is_empty(),
+            "must not resolve a gitdir: pointer lacking the real backlink, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn git_read_fsmonitor_socket_rejects_gitdir_pointer_with_mismatched_backlink() {
+        // A `gitdir` backlink naming the wrong `.git` file must not count.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let checkout = tmp.path().join("checkout");
+        std::fs::create_dir(&checkout).expect("mkdir checkout");
+        let victim = tmp.path().join("victim");
+        std::fs::create_dir(&victim).expect("mkdir victim");
+        let unrelated = tmp.path().join("unrelated.git");
+        std::fs::write(&unrelated, "").expect("write unrelated file");
+
+        std::fs::write(
+            checkout.join(".git"),
+            format!("gitdir: {}\n", victim.display()),
+        )
+        .expect("write forged .git file");
+        std::fs::write(victim.join("gitdir"), format!("{}\n", unrelated.display()))
+            .expect("write mismatched backlink");
+
+        let result = git::read_fsmonitor_socket_in(&checkout).expect("read_fsmonitor_socket");
+        assert!(
+            result.is_empty(),
+            "must not resolve when the backlink names a different .git file, got {:?}",
             result
         );
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3830,7 +3830,10 @@ fn add_policy_unix_sockets(
         .unwrap_or_else(|_| super::lexically_normalize(cwd));
     let write_access = |path: &Path| {
         let normalized = super::lexically_normalize(path);
-        if normalized.starts_with(&canonical_cwd)
+        // `normalized` is only lexically cleaned, not canonicalized, so it
+        // must be compared against both the raw and canonical cwd or a
+        // symlinked cwd bypasses the downgrade below.
+        if (normalized.starts_with(cwd) || normalized.starts_with(&canonical_cwd))
             && !super::agent_can_write(&normalized, policy_root, outer_caps, deny_paths)
         {
             AccessMode::Read
@@ -6894,6 +6897,53 @@ mod tests {
             AccessMode::Read,
             "socket under a cwd the agent cannot write must be downgraded to \
              Read even when cwd resolves through a symlink"
+        );
+        Ok(())
+    }
+
+    /// A literal (non-`@git:`) relative `unix_socket_bind` entry is resolved
+    /// against the raw `cwd`, so `normalized` is never canonicalized even
+    /// when `cwd` resolves through a symlink. The downgrade check must still
+    /// catch it by also comparing against the raw `cwd`.
+    #[test]
+    fn add_policy_unix_sockets_downgrades_to_read_for_literal_relative_socket_under_symlinked_cwd()
+    -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+
+        // policy_root (the agent's own --workdir) is a sibling of the repo,
+        // so the agent itself has no write authority under the repo.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["my.sock".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        // `repo` is passed raw (un-canonicalized), exactly as a real
+        // command's `cwd` would be.
+        add_policy_unix_sockets(&mut caps, &policy, &policy_root, &repo, &outer_caps, &[])?;
+
+        let canonical_repo =
+            repo.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.clone(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_repo)
+            .expect("implied parent-dir fs grant for the socket missing");
+        assert_eq!(
+            parent_grant.access,
+            AccessMode::Read,
+            "a literal relative socket path under a cwd the agent cannot \
+             write must be downgraded to Read even when cwd resolves \
+             through a symlink"
         );
         Ok(())
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3544,6 +3544,14 @@ fn build_child_caps(
         &state.outer_caps,
         &state.deny_paths,
     )?;
+    add_policy_unix_sockets(
+        &mut caps,
+        policy,
+        &state.policy_root,
+        cwd,
+        &state.outer_caps,
+        &state.deny_paths,
+    )?;
     add_policy_network(&mut caps, policy)?;
     add_policy_proxy_network(&mut caps, state, request, policy)?;
     add_proxy_trust_bundle_caps(&mut caps, state, policy)?;
@@ -3804,6 +3812,71 @@ fn add_policy_fs(
         }
     }
     Ok(())
+}
+
+fn add_policy_unix_sockets(
+    caps: &mut CapabilitySet,
+    policy: &CommandSandboxConfig,
+    policy_root: &Path,
+    cwd: &Path,
+    outer_caps: &CapabilitySet,
+    deny_paths: &[PathBuf],
+) -> Result<()> {
+    use super::dynamic_providers::expand_dynamic_tokens;
+    // Must canonicalize cwd to match dynamic-token providers, or a symlinked
+    // cwd escapes the write non-escalation downgrade.
+    let canonical_cwd = cwd
+        .canonicalize()
+        .unwrap_or_else(|_| super::lexically_normalize(cwd));
+    let write_access = |path: &Path| {
+        let normalized = super::lexically_normalize(path);
+        if normalized.starts_with(&canonical_cwd)
+            && !super::agent_can_write(&normalized, policy_root, outer_caps, deny_paths)
+        {
+            AccessMode::Read
+        } else {
+            AccessMode::ReadWrite
+        }
+    };
+    for entry in &expand_dynamic_tokens(&policy.unix_socket_bind, Some(cwd), outer_caps)? {
+        let path = resolve_policy_path(entry, policy_root, cwd)?;
+        let access = write_access(&path);
+        add_optional_unix_socket_bind(caps, path, access)?;
+    }
+    Ok(())
+}
+
+fn add_optional_unix_socket_bind(
+    caps: &mut CapabilitySet,
+    path: PathBuf,
+    access: AccessMode,
+) -> Result<()> {
+    // Dangling-symlink guard: bind(2) would punch through to the link
+    // target, so reject rather than silently skip.
+    if path.symlink_metadata().is_ok() && !path.exists() {
+        return Err(NonoError::SandboxInit(format!(
+            "unix_socket_bind rejects dangling symlink (bind would punch \
+             through to the link target): '{}'",
+            path.display()
+        )));
+    }
+    match UnixSocketCapability::new_file(&path, UnixSocketMode::ConnectBind) {
+        Ok(capability) => {
+            caps.add_unix_socket(capability);
+            // bind(2) creates the socket if absent, so grant the parent dir
+            // when it doesn't exist yet, or the exact file when it does.
+            if path.exists() {
+                caps.add_fs(FsCapability::new_file(&path, access)?);
+            } else if let Some(parent) = path.parent()
+                && !crate::query_ext::is_sensitive_root(parent)
+            {
+                add_optional_dir(caps, parent.to_path_buf(), access)?;
+            }
+            Ok(())
+        }
+        Err(NonoError::PathNotFound(_)) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn add_optional_dir(caps: &mut CapabilitySet, path: PathBuf, access: AccessMode) -> Result<()> {
@@ -6641,6 +6714,274 @@ mod tests {
         assert_eq!(restored_cap.original, link);
         assert_eq!(restored_cap.resolved, resolved);
 
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_rejects_dangling_symlink() -> Result<()> {
+        let temp = test_tempdir()?;
+        let link = temp.path().join("dangling.sock");
+        let missing_target = temp.path().join("does-not-exist");
+        symlink_path(&missing_target, &link)?;
+
+        let mut caps = CapabilitySet::new();
+        let err = add_optional_unix_socket_bind(&mut caps, link, AccessMode::ReadWrite)
+            .expect_err("dangling symlink must be rejected");
+        assert!(
+            format!("{err}").contains("dangling symlink"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_accepts_nonexistent_path_and_widens_fs_to_parent() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        let pending = temp.path().join("future.sock");
+        assert!(!pending.exists(), "test precondition: path must not exist");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending.clone(), AccessMode::ReadWrite)?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+
+        let canonical_parent =
+            temp.path()
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: temp.path().to_path_buf(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_parent)
+            .expect("implied parent-dir fs grant missing");
+        assert_eq!(parent_grant.access, AccessMode::ReadWrite);
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_existing_grants_readwrite_fs() -> Result<()> {
+        let temp = test_tempdir()?;
+        let sock = temp.path().join("existing.sock");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, sock.clone(), AccessMode::ReadWrite)?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+
+        let canonical_sock =
+            sock.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: sock.clone(),
+                    source,
+                })?;
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.is_file && c.resolved == canonical_sock)
+            .expect("implied fs grant not found");
+        assert_eq!(fs_match.access, AccessMode::ReadWrite);
+        Ok(())
+    }
+
+    #[test]
+    fn add_policy_unix_sockets_expands_git_fsmonitor_socket_token() -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        assert!(
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(&repo)
+                .status()
+                .expect("run git init")
+                .success()
+        );
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["@git:fsmonitor-socket".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        add_policy_unix_sockets(&mut caps, &policy, &repo, &repo, &outer_caps, &[])?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(
+            socks[0].resolved.ends_with("fsmonitor--daemon.ipc"),
+            "expected fsmonitor socket path, got {:?}",
+            socks[0].resolved
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_policy_unix_sockets_grants_none_when_undeclared() -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+
+        let policy = CommandSandboxConfig::default();
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        add_policy_unix_sockets(&mut caps, &policy, &repo, &repo, &outer_caps, &[])?;
+
+        assert!(
+            caps.unix_socket_capabilities().is_empty(),
+            "a command with no unix_socket_bind entries must get no socket capability"
+        );
+        Ok(())
+    }
+
+    /// A symlinked `cwd` must not escape the write non-escalation check.
+    /// Mirrors the macOS parity test.
+    #[test]
+    fn add_policy_unix_sockets_downgrades_to_read_when_cwd_resolves_through_symlink() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        assert!(
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(&repo)
+                .status()
+                .expect("run git init")
+                .success()
+        );
+
+        // policy_root (the agent's own --workdir) is a sibling of the repo,
+        // so the agent itself has no write authority under the repo.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["@git:fsmonitor-socket".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        // `repo` is passed raw (un-canonicalized), exactly as a real
+        // command's `cwd` would be.
+        add_policy_unix_sockets(&mut caps, &policy, &policy_root, &repo, &outer_caps, &[])?;
+
+        let canonical_git_dir =
+            repo.join(".git")
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.join(".git"),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_git_dir)
+            .expect("implied parent-dir fs grant for the socket missing");
+        assert_eq!(
+            parent_grant.access,
+            AccessMode::Read,
+            "socket under a cwd the agent cannot write must be downgraded to \
+             Read even when cwd resolves through a symlink"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_sensitive_root_parent_skips_fs_widening() -> Result<()> {
+        let _guard = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let temp = test_tempdir()?;
+        let home = temp.path().join("home");
+        create_dir(&home)?;
+        // is_sensitive_root compares against a canonicalized $HOME, so match it.
+        let home = home
+            .canonicalize()
+            .map_err(|source| NonoError::PathCanonicalization {
+                path: home.clone(),
+                source,
+            })?;
+        let home_str = home.to_string_lossy().into_owned();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("HOME", home_str.as_str())]);
+
+        let pending = home.join("fsmonitor--daemon.ipc");
+        assert!(!pending.exists(), "test precondition: path must not exist");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending, AccessMode::ReadWrite)?;
+
+        assert_eq!(
+            caps.unix_socket_capabilities().len(),
+            1,
+            "socket capability itself must still be granted"
+        );
+        assert!(
+            caps.fs_capabilities().is_empty(),
+            "must not widen a filesystem grant onto a sensitive root like $HOME"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_downgrades_to_read_outside_agent_write_authority() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        // policy_root is a sibling of cwd, so the agent has no write
+        // authority under cwd — mirrors a cwd outside the writable root.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        let pending = repo.join("future.sock");
+
+        // Mirrors add_policy_fs's write non-escalation check: a path under
+        // cwd that the agent itself cannot write is downgraded to Read.
+        let outer_caps = CapabilitySet::new();
+        let write_access = |path: &Path| {
+            let normalized = crate::tool_sandbox::lexically_normalize(path);
+            if normalized.starts_with(&repo)
+                && !crate::tool_sandbox::agent_can_write(
+                    &normalized,
+                    &policy_root,
+                    &outer_caps,
+                    &[],
+                )
+            {
+                AccessMode::Read
+            } else {
+                AccessMode::ReadWrite
+            }
+        };
+        let access = write_access(&pending);
+        assert_eq!(access, AccessMode::Read);
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending, access)?;
+
+        let canonical_parent =
+            repo.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.clone(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_parent)
+            .expect("implied parent-dir fs grant missing");
+        assert_eq!(parent_grant.access, AccessMode::Read);
         Ok(())
     }
 

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -3127,6 +3127,14 @@ fn build_child_caps(
         &state.outer_caps,
         &state.deny_paths,
     )?;
+    add_policy_unix_sockets(
+        &mut caps,
+        policy,
+        &state.policy_root,
+        cwd,
+        &state.outer_caps,
+        &state.deny_paths,
+    )?;
     // When the command was granted a keychain DB file (e.g. login.keychain-db),
     // reuse the main-path keychain mechanism: add the WAL/SHM/`.fl`/`user.kb`
     // sibling-file exceptions the Security framework touches. The library
@@ -3589,6 +3597,71 @@ fn add_policy_fs(
         }
     }
     Ok(())
+}
+
+fn add_policy_unix_sockets(
+    caps: &mut CapabilitySet,
+    policy: &CommandSandboxConfig,
+    policy_root: &Path,
+    cwd: &Path,
+    outer_caps: &CapabilitySet,
+    deny_paths: &[PathBuf],
+) -> Result<()> {
+    use super::dynamic_providers::expand_dynamic_tokens;
+    // Must canonicalize cwd to match dynamic-token providers, or a symlinked
+    // cwd (e.g. /tmp) escapes the write non-escalation downgrade.
+    let canonical_cwd = cwd
+        .canonicalize()
+        .unwrap_or_else(|_| super::lexically_normalize(cwd));
+    let write_access = |path: &Path| {
+        let normalized = super::lexically_normalize(path);
+        if normalized.starts_with(&canonical_cwd)
+            && !super::agent_can_write(&normalized, policy_root, outer_caps, deny_paths)
+        {
+            AccessMode::Read
+        } else {
+            AccessMode::ReadWrite
+        }
+    };
+    for entry in &expand_dynamic_tokens(&policy.unix_socket_bind, Some(cwd), outer_caps)? {
+        let path = resolve_policy_path(entry, policy_root, cwd)?;
+        let access = write_access(&path);
+        add_optional_unix_socket_bind(caps, path, access)?;
+    }
+    Ok(())
+}
+
+fn add_optional_unix_socket_bind(
+    caps: &mut CapabilitySet,
+    path: PathBuf,
+    access: AccessMode,
+) -> Result<()> {
+    // Dangling-symlink guard: bind(2) would punch through to the link
+    // target, so reject rather than silently skip.
+    if path.symlink_metadata().is_ok() && !path.exists() {
+        return Err(NonoError::SandboxInit(format!(
+            "unix_socket_bind rejects dangling symlink (bind would punch \
+             through to the link target): '{}'",
+            path.display()
+        )));
+    }
+    match UnixSocketCapability::new_file(&path, UnixSocketMode::ConnectBind) {
+        Ok(capability) => {
+            caps.add_unix_socket(capability);
+            // bind(2) creates the socket if absent, so grant the parent dir
+            // when it doesn't exist yet, or the exact file when it does.
+            if path.exists() {
+                caps.add_fs(FsCapability::new_file(&path, access)?);
+            } else if let Some(parent) = path.parent()
+                && !crate::query_ext::is_sensitive_root(parent)
+            {
+                add_optional_dir(caps, parent.to_path_buf(), access)?;
+            }
+            Ok(())
+        }
+        Err(NonoError::PathNotFound(_)) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn add_optional_dir(caps: &mut CapabilitySet, path: PathBuf, access: AccessMode) -> Result<()> {
@@ -5861,6 +5934,275 @@ mod tests {
             resolve_policy_path("/etc/hosts", workdir, cwd)?,
             PathBuf::from("/etc/hosts")
         );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_optional_unix_socket_bind_rejects_dangling_symlink() -> Result<()> {
+        let temp = test_tempdir()?;
+        let link = temp.path().join("dangling.sock");
+        let missing_target = temp.path().join("does-not-exist");
+        std::os::unix::fs::symlink(&missing_target, &link).expect("create dangling symlink");
+
+        let mut caps = CapabilitySet::new();
+        let err = add_optional_unix_socket_bind(&mut caps, link, AccessMode::ReadWrite)
+            .expect_err("dangling symlink must be rejected");
+        assert!(
+            format!("{err}").contains("dangling symlink"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_accepts_nonexistent_path_and_widens_fs_to_parent() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        let pending = temp.path().join("future.sock");
+        assert!(!pending.exists(), "test precondition: path must not exist");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending.clone(), AccessMode::ReadWrite)?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+
+        let canonical_parent =
+            temp.path()
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: temp.path().to_path_buf(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_parent)
+            .expect("implied parent-dir fs grant missing");
+        assert_eq!(parent_grant.access, AccessMode::ReadWrite);
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_existing_grants_readwrite_fs() -> Result<()> {
+        let temp = test_tempdir()?;
+        let sock = temp.path().join("existing.sock");
+        std::os::unix::net::UnixListener::bind(&sock).expect("create socket");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, sock.clone(), AccessMode::ReadWrite)?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+
+        let canonical_sock =
+            sock.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: sock.clone(),
+                    source,
+                })?;
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.is_file && c.resolved == canonical_sock)
+            .expect("implied fs grant not found");
+        assert_eq!(fs_match.access, AccessMode::ReadWrite);
+        Ok(())
+    }
+
+    #[test]
+    fn add_policy_unix_sockets_expands_git_fsmonitor_socket_token() -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        assert!(
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(&repo)
+                .status()
+                .expect("run git init")
+                .success()
+        );
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["@git:fsmonitor-socket".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        add_policy_unix_sockets(&mut caps, &policy, &repo, &repo, &outer_caps, &[])?;
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(
+            socks[0].resolved.ends_with("fsmonitor--daemon.ipc"),
+            "expected fsmonitor socket path, got {:?}",
+            socks[0].resolved
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_policy_unix_sockets_grants_none_when_undeclared() -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+
+        let policy = CommandSandboxConfig::default();
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        add_policy_unix_sockets(&mut caps, &policy, &repo, &repo, &outer_caps, &[])?;
+
+        assert!(
+            caps.unix_socket_capabilities().is_empty(),
+            "a command with no unix_socket_bind entries must get no socket capability"
+        );
+        Ok(())
+    }
+
+    /// A symlinked `cwd` (e.g. `/tmp` -> `/private/tmp`) must not escape the
+    /// write non-escalation check.
+    #[test]
+    fn add_policy_unix_sockets_downgrades_to_read_when_cwd_resolves_through_symlink() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        assert!(
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(&repo)
+                .status()
+                .expect("run git init")
+                .success()
+        );
+
+        // policy_root (the agent's own --workdir) is a sibling of the repo,
+        // so the agent itself has no write authority under the repo.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["@git:fsmonitor-socket".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        // `repo` is passed raw (un-canonicalized), exactly as a real
+        // command's `cwd` would be.
+        add_policy_unix_sockets(&mut caps, &policy, &policy_root, &repo, &outer_caps, &[])?;
+
+        let canonical_git_dir =
+            repo.join(".git")
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.join(".git"),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_git_dir)
+            .expect("implied parent-dir fs grant for the socket missing");
+        assert_eq!(
+            parent_grant.access,
+            AccessMode::Read,
+            "socket under a cwd the agent cannot write must be downgraded to \
+             Read even when cwd resolves through a symlink"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_sensitive_root_parent_skips_fs_widening() -> Result<()> {
+        let _guard = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let temp = test_tempdir()?;
+        let home = temp.path().join("home");
+        create_dir(&home)?;
+        // is_sensitive_root compares against a canonicalized $HOME, so match it.
+        let home = home
+            .canonicalize()
+            .map_err(|source| NonoError::PathCanonicalization {
+                path: home.clone(),
+                source,
+            })?;
+        let home_str = home.to_string_lossy().into_owned();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("HOME", home_str.as_str())]);
+
+        let pending = home.join("fsmonitor--daemon.ipc");
+        assert!(!pending.exists(), "test precondition: path must not exist");
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending, AccessMode::ReadWrite)?;
+
+        assert_eq!(
+            caps.unix_socket_capabilities().len(),
+            1,
+            "socket capability itself must still be granted"
+        );
+        assert!(
+            caps.fs_capabilities().is_empty(),
+            "must not widen a filesystem grant onto a sensitive root like $HOME"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn add_optional_unix_socket_bind_downgrades_to_read_outside_agent_write_authority() -> Result<()>
+    {
+        let temp = test_tempdir()?;
+        // policy_root is a sibling of cwd, so the agent has no write
+        // authority under cwd — mirrors a cwd outside the writable root.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+        let pending = repo.join("future.sock");
+
+        // Mirrors add_policy_fs's write non-escalation check: a path under
+        // cwd that the agent itself cannot write is downgraded to Read.
+        let outer_caps = CapabilitySet::new();
+        let write_access = |path: &Path| {
+            let normalized = crate::tool_sandbox::lexically_normalize(path);
+            if normalized.starts_with(&repo)
+                && !crate::tool_sandbox::agent_can_write(
+                    &normalized,
+                    &policy_root,
+                    &outer_caps,
+                    &[],
+                )
+            {
+                AccessMode::Read
+            } else {
+                AccessMode::ReadWrite
+            }
+        };
+        let access = write_access(&pending);
+        assert_eq!(access, AccessMode::Read);
+
+        let mut caps = CapabilitySet::new();
+        add_optional_unix_socket_bind(&mut caps, pending, access)?;
+
+        let canonical_parent =
+            repo.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.clone(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_parent)
+            .expect("implied parent-dir fs grant missing");
+        assert_eq!(parent_grant.access, AccessMode::Read);
         Ok(())
     }
 

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -3615,7 +3615,10 @@ fn add_policy_unix_sockets(
         .unwrap_or_else(|_| super::lexically_normalize(cwd));
     let write_access = |path: &Path| {
         let normalized = super::lexically_normalize(path);
-        if normalized.starts_with(&canonical_cwd)
+        // `normalized` is only lexically cleaned, not canonicalized, so it
+        // must be compared against both the raw and canonical cwd or a
+        // symlinked cwd bypasses the downgrade below.
+        if (normalized.starts_with(cwd) || normalized.starts_with(&canonical_cwd))
             && !super::agent_can_write(&normalized, policy_root, outer_caps, deny_paths)
         {
             AccessMode::Read
@@ -6115,6 +6118,53 @@ mod tests {
             AccessMode::Read,
             "socket under a cwd the agent cannot write must be downgraded to \
              Read even when cwd resolves through a symlink"
+        );
+        Ok(())
+    }
+
+    /// A literal (non-`@git:`) relative `unix_socket_bind` entry is resolved
+    /// against the raw `cwd`, so `normalized` is never canonicalized even
+    /// when `cwd` resolves through a symlink. The downgrade check must still
+    /// catch it by also comparing against the raw `cwd`.
+    #[test]
+    fn add_policy_unix_sockets_downgrades_to_read_for_literal_relative_socket_under_symlinked_cwd()
+    -> Result<()> {
+        let temp = test_tempdir()?;
+        let repo = temp.path().join("repo");
+        create_dir(&repo)?;
+
+        // policy_root (the agent's own --workdir) is a sibling of the repo,
+        // so the agent itself has no write authority under the repo.
+        let policy_root = temp.path().join("agent-workdir");
+        create_dir(&policy_root)?;
+
+        let policy = CommandSandboxConfig {
+            unix_socket_bind: vec!["my.sock".to_string()],
+            ..Default::default()
+        };
+        let outer_caps = CapabilitySet::new();
+        let mut caps = CapabilitySet::new();
+        // `repo` is passed raw (un-canonicalized), exactly as a real
+        // command's `cwd` would be.
+        add_policy_unix_sockets(&mut caps, &policy, &policy_root, &repo, &outer_caps, &[])?;
+
+        let canonical_repo =
+            repo.canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: repo.clone(),
+                    source,
+                })?;
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_repo)
+            .expect("implied parent-dir fs grant for the socket missing");
+        assert_eq!(
+            parent_grant.access,
+            AccessMode::Read,
+            "a literal relative socket path under a cwd the agent cannot \
+             write must be downgraded to Read even when cwd resolves \
+             through a symlink"
         );
         Ok(())
     }

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -664,6 +664,7 @@ fn test_schema_command_policies_match_tool_sandbox_guide_shape() {
             "open_urls",
             "resources",
             "stdio",
+            "unix_socket_bind",
             "unsafe_macos_seatbelt_rules",
             "use_credentials",
         ],

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -96,6 +96,7 @@ The selected `sandbox` object describes what the child receives:
 | `allow_launch_services` | boolean | macOS-only direct LaunchServices URL opening. |
 | `allow_raw_file_credentials_in_chained_policy` | boolean | Required before non-session callers can receive raw-file credentials. |
 | `unsafe_macos_seatbelt_rules` | string array | macOS-only escape hatch: raw Seatbelt rules appended to this command's child profile after the deny gate (last-match-wins). Mirrors the top-level `unsafe_macos_seatbelt_rules` but scoped to one command/intercept. Use sparingly — e.g. to let a command exec + read a binary it forks by absolute path. Honoured only for **user-authored profiles** (same trust boundary as `binary` — see below); pack and built-in profiles have these rules stripped with a warning. |
+| `unix_socket_bind` | path array | Grant `connect(2)` and `bind(2)` on the named pathname AF_UNIX socket files (supports the dynamic tokens below). Implied filesystem grant is ReadWrite on the file if it already exists, otherwise ReadWrite on its parent directory (so `bind(2)` can create it) — mirrors the agent-level `unix_socket_bind` field, see [AF_UNIX Socket Grants](/cli/features/profiles-groups#af-unix-socket-grants). A path that resolves to an existing dangling symlink is rejected. |
 
 ### Per-Intercept Sandbox Override
 
@@ -170,6 +171,7 @@ Supported tokens:
 | `@git:worktree` | `fs_read`, `fs_write` | The main worktree root (parent of `@git:common-dir`). Empty in a regular repo; in a linked worktree it is the absolute path to the main repo root. `git worktree add` changes CWD to the main repo root, so without this `getcwd()` fails with EPERM. |
 | `@git:toplevel` | `fs_read`, `fs_write` | Absolute path of the current checkout root (`git rev-parse --show-toplevel`). In a linked worktree this is the worktree's own root, not the main repo. |
 | `@git:toplevel-parent` | `fs_write` | Parent directory of `@git:toplevel`. Required for `git worktree add ../sibling`, where the new worktree is created adjacent to the current checkout. |
+| `@git:fsmonitor-socket` | `unix_socket_bind` | Path to `fsmonitor--daemon.ipc` under the current worktree's private git-dir (not the shared common dir — each worktree runs its own fsmonitor daemon). Pair with `unix_socket_bind` to let `core.fsmonitor=true` reach the daemon's socket. |
 
 Example:
 
@@ -192,6 +194,8 @@ Example:
 The Git provider reads `git config --list --show-origin --show-scope` and keeps only `global` and `system` scoped paths. It ignores `local` and `worktree` scopes so a repository cannot grant itself additional host filesystem access through `.git/config`. If `git` is unavailable or returns no matching paths, the token expands to no paths.
 
 The `@git:common-dir` token runs `git rev-parse --git-common-dir` from nono's working directory at sandbox-prepare time. In a regular repo it returns `.git` (relative, resolved against `$WORKDIR`). In a worktree it returns the absolute path to the main repo's `.git`. If git is unavailable or the process is not inside a repo, the token expands to no paths. The `@git:worktree`, `@git:toplevel`, and `@git:toplevel-parent` tokens are derived from the same git invocations and behave the same way when git is unavailable.
+
+`@git:fsmonitor-socket` is resolved without spawning `git`: it walks the filesystem from the current working directory to find the checkout (reading `.git`, then following a `gitdir:`/`commondir` pointer file when present) and appends `fsmonitor--daemon.ipc` to the private per-worktree git-dir. This mirrors the no-process-spawn approach the other path-resolution tokens use internally, so a working directory with an attacker-controlled `.git/config` cannot influence resolution through `core.pager` or similar. If the process is not inside a git repo, the token expands to no paths.
 
 `@git:config-files` expands to the config files git reads in the current context, plus the declared target of every `include.path` and `includeIf.*.path` directive in trusted `global` and `system` scopes — including conditional includes whose condition does not currently fire (e.g. a `hasconfig:remote.*.url` rule that only matches certain repositories). A conditional include that is false now is still grantable because a later git operation — such as `git worktree add` for a repo with a matching remote — may make the condition fire. Like the other git tokens it keeps only `global` and `system` scopes; per-repo `.git/config` entries are not trusted.
 


### PR DESCRIPTION
## Linked Issue

Closes #1779

## Summary

Adds a `unix_socket_bind` command-sandbox field for connect(2)/bind(2) grants on named AF_UNIX sockets, plus the `@git:fsmonitor-socket` token so a command running with `core.fsmonitor=true` can reach the per-worktree fsmonitor daemon's IPC socket without a broader filesystem grant.

## Test Plan

- `make ci` (fmt, clippy -D warnings, full test suite)
- `nono why --profile <profile> --command git --path <repo>/.git/fsmonitor--daemon.ipc --op readwrite --workdir <repo>` against a real git worktree, confirming the token resolves to the exact daemon socket path and the grant is allowed

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

## Agent Compliance Check (Required for AI/Automated PRs)
- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
