### PR TITLE
fix(proxy): load declarative credentials from profiles

### DIFF
--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -231,6 +231,14 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
         .map(|p| p.credential_capture.clone())
         .unwrap_or_default();
     let command_policies = loaded.as_ref().and_then(|p| p.command_policies.clone());
+    let credential_providers = loaded
+        .as_ref()
+        .map(|p| p.credential_providers.clone())
+        .unwrap_or_default();
+    let credential_routes = loaded
+        .as_ref()
+        .map(|p| p.credential_routes.clone())
+        .unwrap_or_default();
 
     let upstream_proxy_addr = args
         .external_proxy
@@ -359,6 +367,8 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
         proxy_leaf_validity: tls_options.leaf_validity,
         command_policies,
         credential_capture,
+        credential_providers,
+        credential_routes,
         session_id: crate::session::generate_session_id(),
         enable_h2,
         ..ProxyLaunchOptions::default()
@@ -531,6 +541,8 @@ mod tests {
         let args = parse_args(&[]);
         let opts = build_launch_options(&args).expect("empty args are valid");
         assert!(opts.credential_capture.is_empty());
+        assert!(opts.credential_providers.is_empty());
+        assert!(opts.credential_routes.is_empty());
         assert!(opts.command_policies.is_none());
         // A session id is always minted so the capture backend can scope caches.
         assert!(!opts.session_id.is_empty());
@@ -675,6 +687,109 @@ mod tests {
             .get("github")
             .expect("github capture entry carried through");
         assert_eq!(entry.command, vec!["true", "auth", "github"]);
+    }
+
+    #[test]
+    fn profile_credential_provider_and_route_carry_through()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let _lock = ENV_LOCK
+            .lock()
+            .map_err(|_| std::io::Error::other("env lock poisoned"))?;
+        let _env = cleared_env();
+        let dir = tempfile::tempdir()?;
+        let profile_path = dir.path().join("provider.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "provider-test" },
+                "credential_providers": {
+                    "example": {
+                        "type": "oauth_capture",
+                        "token_endpoints": [{
+                            "host": "https://auth.example.com",
+                            "path": "/oauth/token",
+                            "response_fields": [{ "path": "access_token" }]
+                        }],
+                        "api_hosts": ["https://api.example.com"]
+                    }
+                },
+                "credential_routes": [{
+                    "name": "example",
+                    "provider": "example",
+                    "env_var": "EXAMPLE_TOKEN",
+                    "base_url_env_var": "EXAMPLE_BASE_URL"
+                }]
+            }"#,
+        )?;
+
+        let profile_path_arg = profile_path.to_string_lossy();
+        let args = parse_args(&["--profile", profile_path_arg.as_ref()]);
+        let opts = build_launch_options(&args)?;
+
+        assert!(opts.credential_providers.contains_key("example"));
+        assert_eq!(opts.credential_routes.len(), 1);
+        assert_eq!(opts.credential_routes[0].name, "example");
+        assert_eq!(opts.credential_routes[0].provider, "example");
+
+        let config = build_proxy_config_from_flags(&opts)?;
+        assert_eq!(config.oauth_capture.len(), 1);
+        assert_eq!(config.oauth_capture[0].provider, "example");
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(config.routes[0].prefix, "example");
+        assert_eq!(config.routes[0].upstream, "https://api.example.com");
+        Ok(())
+    }
+
+    #[test]
+    fn profile_extends_carries_credential_provider_and_route_through()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let _lock = ENV_LOCK
+            .lock()
+            .map_err(|_| std::io::Error::other("env lock poisoned"))?;
+        let _env = cleared_env();
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("oauth-base.json"),
+            r#"{
+                "meta": { "name": "oauth-base" },
+                "credential_providers": {
+                    "example": {
+                        "type": "oauth_capture",
+                        "token_endpoints": [{
+                            "host": "https://auth.example.com",
+                            "path": "/oauth/token",
+                            "response_fields": [{ "path": "access_token" }]
+                        }],
+                        "api_hosts": ["https://api.example.com"]
+                    }
+                },
+                "credential_routes": [{
+                    "name": "example",
+                    "provider": "example"
+                }]
+            }"#,
+        )?;
+        let child_path = dir.path().join("oauth-child.json");
+        std::fs::write(
+            &child_path,
+            r#"{
+                "meta": { "name": "oauth-child" }
+            }"#,
+        )?;
+
+        let child_path_arg = child_path.to_string_lossy();
+        let args = parse_args(&[
+            "--profile",
+            child_path_arg.as_ref(),
+            "--extends",
+            "oauth-base",
+        ]);
+        let opts = build_launch_options(&args)?;
+
+        assert!(opts.credential_providers.contains_key("example"));
+        assert_eq!(opts.credential_routes.len(), 1);
+        assert_eq!(opts.credential_routes[0].provider, "example");
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1788

## Summary

- Project top-level `credential_providers` and `credential_routes` from the resolved profile into the standalone proxy's `ProxyLaunchOptions`.
- Reuse the existing `build_proxy_config_from_flags` and declarative OAuth synthesis path unchanged.
- Cover direct profiles, `--extends` inheritance, the generated OAuth capture/reverse-route config, and the no-profile default.

This restores the profile parity intended by #1260 without adding a profile field, CLI flag, credential protocol, or cross-process store-sharing behavior.

## Agent Disclosure

This pull request was generated by an OpenAI Codex coding agent acting for @Haoxincode.

The agent reviewed `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `neps/README.md`, issue #1260, `crates/nono-cli/src/proxy_command.rs`, `crates/nono-cli/src/profile_runtime.rs`, `crates/nono-cli/src/launch_runtime.rs`, and `crates/nono-cli/src/proxy_runtime.rs` before preparing the change.

No external code was copied or adapted. The implementation only wires resolved profile fields into existing project-owned interfaces and continues to use the existing `synthesize_credential_provider_proxy_config` behavior. This scoped bug fix does not change the library/CLI security boundary and does not require a NEP under `neps/README.md`.

The contribution follows the repository's coding, security, DCO, and agent-contribution requirements.

## Test Plan

- `make ci`
  - workspace Clippy with `-D warnings -D clippy::unwrap_used`
  - formatting
  - all `nono`, `nono-cli`, and `nono-ffi` tests
  - RustSec audit (no vulnerabilities; the existing allowed `chacha20 0.10.1` yanked warning remains)
  - alias inventory and docs lint
- `nono profile validate --strict <minimal-oauth-profile>`
- Started `nono proxy --profile <minimal-oauth-profile>` and verified that the standalone process generated a TLS interception trust bundle.
- The focused test also verifies one synthesized OAuth capture provider and one reverse route targeting the declared API origin.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates (not applicable; this restores already-declared profile behavior)
- [x] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked (not applicable; scoped CLI projection bug fix)

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no external code; existing project functions are identified above)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used `NonoError` where required (the production change introduces no new error path)
- [x] I validated and canonicalized all relevant paths (the change introduces no path input; existing profile loading/validation is retained)
- [x] This PR matches the approved or disclosed issue scope
