### PR TITLE
chore(github): remove triage label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something isn't working as expected
-labels: ["bug", "triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest something for nono to support or do better
-labels: ["enhancement", "triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/onboarding_issue.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding_issue.yml
@@ -1,6 +1,6 @@
 name: Onboarding / setup issue
 description: You couldn't get nono installed or running for the first time
-labels: ["onboarding", "triage"]
+labels: ["onboarding"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Remove the automatic `triage` label assignment across all GitHub issue templates, including bug reports, feature requests, and onboarding issues.

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

