### PR TITLE
fix(cli): route tracing warnings to stderr, not stdout

### DIFF
--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -169,6 +169,7 @@ pub(crate) fn init_tracing(cli: &Cli) {
                 tracing_subscriber::fmt()
                     .with_env_filter(tracing_filter(cli))
                     .with_target(false)
+                    .with_writer(io::stderr)
                     .init();
             }
         },
@@ -176,6 +177,7 @@ pub(crate) fn init_tracing(cli: &Cli) {
             tracing_subscriber::fmt()
                 .with_env_filter(tracing_filter(cli))
                 .with_target(false)
+                .with_writer(io::stderr)
                 .init();
         }
     }


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1777

## Summary

init_tracing()s default and log-file-fallback branches omitted .with_writer(io::stderr), so tracing_subscriber fell back to its stdout default. Warnings (e.g. invalid XDG_CONFIG_HOME) leaked into piped stdout, corrupting output like `nono completion fish > foo.fish`.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
