### PR TITLE
fix(cgroup): skip control files when sweeping stale lineage sessions

### DIFF
--- a/crates/nono-cli/src/lineage_cgroup.rs
+++ b/crates/nono-cli/src/lineage_cgroup.rs
@@ -304,7 +304,15 @@ fn sweep_stale_sessions(base: &Path) {
 fn teardown_session_tree(session_dir: &Path) {
     if let Ok(entries) = fs::read_dir(session_dir) {
         for entry in entries.flatten() {
-            remove_cgroup(&entry.path());
+            // Skip session_dir's own control files (memory.events, pids.peak, ...);
+            // only cmd_* are child cgroups rmdir can remove.
+            let is_cmd_dir = entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(CMD_PREFIX));
+            if is_cmd_dir {
+                remove_cgroup(&entry.path());
+            }
         }
     }
     let _ = fs::remove_dir(session_dir);


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1793 

## Summary

teardown_session_tree read_dir a session cgroup dir and rmdir every entry, including the cgroups own control/pseudo-files (memory.events, pids.peak, io.latency, ...), not just the cmd_* child cgroups it meant to remove. rmdir on those files fails with ENOTDIR, logging spurious "could not remove cgroup leaf" warnings on every stale-session sweep.

Filter to cmd_-prefixed entries only, matching CMD_PREFIX used elsewhere in this file.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
