### PR TITLE
fix(cli): preserve file permissions on write_file wiring copy

### DIFF
--- a/crates/nono-cli/src/legacy_cleanup.rs
+++ b/crates/nono-cli/src/legacy_cleanup.rs
@@ -303,7 +303,7 @@ fn strip_settings_entries(path: &Path, home: &Path) -> Result<Vec<(String, Strin
     let serialized = serde_json::to_string_pretty(&settings)
         .map_err(|e| NonoError::HookInstall(format!("serialize {}: {e}", path.display())))?;
     let tmp = path.with_extension("json.nono-tmp");
-    fs::write(&tmp, format!("{serialized}\n")).map_err(NonoError::Io)?;
+    crate::wiring::write_tmp_file(&tmp, format!("{serialized}\n").as_bytes(), None)?;
     fs::rename(&tmp, path).map_err(NonoError::Io)?;
 
     Ok(removed)

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -958,7 +958,8 @@ fn install_manifest_artifact(
 fn copy_instruction_to_project(artifact: &ArtifactEntry, source_path: &Path) -> Result<()> {
     let cwd = std::env::current_dir().map_err(NonoError::Io)?;
     let path = cwd.join(file_name(&artifact.path)?);
-    if path.exists() {
+    // symlink_metadata, not exists() — a dangling symlink must count as occupied.
+    if path.symlink_metadata().is_ok() {
         return Ok(());
     }
     copy_path(source_path, &path)
@@ -1296,5 +1297,50 @@ mod tests {
 
         assert_eq!(prerelease_vs_stable, Ordering::Less);
         assert_eq!(stable_vs_prerelease, Ordering::Greater);
+    }
+
+    #[test]
+    fn copy_instruction_to_project_refuses_dangling_symlink_at_dest() {
+        use crate::test_env::ENV_LOCK;
+        use std::os::unix::fs as unix_fs;
+
+        let _g = match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let original_cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir.path()).expect("chdir into tempdir");
+
+        let victim = dir.path().join("victim");
+        fs::write(&victim, "sensitive").expect("seed victim");
+        // A dangling symlink: exists() is false for it, but it still
+        // occupies the path and must not be written through.
+        unix_fs::symlink(
+            dir.path().join("does-not-exist"),
+            dir.path().join("CLAUDE.md"),
+        )
+        .expect("plant dangling symlink");
+
+        let source = dir.path().join("source.md");
+        fs::write(&source, "pack instructions").expect("seed source");
+        let artifact = ArtifactEntry {
+            artifact_type: ArtifactType::Instruction,
+            path: "CLAUDE.md".to_string(),
+            install_as: None,
+            placement: None,
+            prefix: None,
+            aliases: Vec::new(),
+        };
+
+        let result = copy_instruction_to_project(&artifact, &source);
+        std::env::set_current_dir(original_cwd).expect("restore cwd");
+
+        result.expect("must not error, just skip");
+        assert_eq!(
+            fs::read_to_string(&victim).expect("victim readable"),
+            "sensitive",
+            "victim must never be written through the dangling symlink"
+        );
     }
 }

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -377,7 +377,15 @@ fn execute_one(
             //     changes and we mustn't clobber them).
             //   - In pack_owned_files and content matches → overwrite
             //     freely (true idempotent re-pull).
-            if dest_path.exists() {
+            if let Ok(dest_meta) = fs::symlink_metadata(&dest_path) {
+                if !dest_meta.is_file() {
+                    return Err(NonoError::PackageInstall(format!(
+                        "write_file: refusing to write '{}' — occupied by a \
+                         symlink or special file, not a regular file. Remove \
+                         it manually then re-pull.",
+                        dest_path.display()
+                    )));
+                }
                 let recorded_hash = pack_owned_files.get(&dest_path);
                 let current_hash = match fs::read(&dest_path) {
                     Ok(b) => hash_bytes(&b),
@@ -544,7 +552,17 @@ fn reverse_one(record: &WiringRecord) -> Result<()> {
             // we wrote — otherwise the user has modified it and we
             // leave it alone (security review fix).
             let path = Path::new(dest);
-            if !path.exists() {
+            let meta = match fs::symlink_metadata(path) {
+                Ok(m) => m,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(e) => return Err(NonoError::Io(e)),
+            };
+            if !meta.is_file() {
+                tracing::info!(
+                    "write_file: leaving '{}' in place — occupied by a \
+                     symlink or special file, not the regular file we wrote.",
+                    path.display()
+                );
                 return Ok(());
             }
             let bytes = fs::read(path).map_err(NonoError::Io)?;
@@ -745,10 +763,11 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
     let source_bytes = fs::read(source).map_err(NonoError::Io)?;
     let source_perms = safe_perms(fs::metadata(source).map_err(NonoError::Io)?.permissions());
     let sha256 = hash_bytes(&source_bytes);
-    // Skip-no-op only if existing content matches exactly. Caller has
-    // already enforced the conflict policy (only owned files reach
-    // here when dest exists), so a hash match is a real no-op re-pull.
-    if let Ok(existing) = fs::read(dest)
+    // No-op only on a hash match against a plain dest file — never read
+    // or chmod through a symlink (caller already enforced ownership).
+    let dest_is_plain_file = fs::symlink_metadata(dest).is_ok_and(|m| m.is_file());
+    if dest_is_plain_file
+        && let Ok(existing) = fs::read(dest)
         && existing == source_bytes
     {
         sync_permissions(dest, &source_perms)?;
@@ -758,7 +777,7 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
         });
     }
     let tmp = dest.with_extension("nono-tmp");
-    write_tmp_file(&tmp, &source_bytes, &source_perms)?;
+    write_tmp_file(&tmp, &source_bytes, Some(&source_perms))?;
     fs::rename(&tmp, dest).map_err(NonoError::Io)?;
     Ok(CopyOutcome {
         mutated: true,
@@ -766,25 +785,32 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
     })
 }
 
-/// Creates `tmp` fresh with `perms` set at creation, so it never exists at a
-/// looser mode and never writes through a pre-planted symlink. Retries once
-/// past a leftover tmp file from an interrupted prior run.
-fn write_tmp_file(tmp: &Path, bytes: &[u8], perms: &std::fs::Permissions) -> Result<()> {
+/// Creates `tmp` fresh (mode set at creation, default `0o644`), refusing to
+/// follow a pre-planted symlink. Shared by every `.nono-tmp`-then-rename site.
+pub(crate) fn write_tmp_file(
+    tmp: &Path,
+    bytes: &[u8],
+    perms: Option<&std::fs::Permissions>,
+) -> Result<()> {
     for _ in 0..2 {
         #[cfg(unix)]
         let opened = {
             use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            let mode = perms.map_or(0o644, std::fs::Permissions::mode);
             fs::OpenOptions::new()
                 .create_new(true)
                 .write(true)
-                .mode(perms.mode())
+                .mode(mode)
                 .open(tmp)
         };
         #[cfg(not(unix))]
-        let opened = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(tmp);
+        let opened = {
+            let _ = perms;
+            fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(tmp)
+        };
 
         match opened {
             Ok(mut file) => {
@@ -1101,7 +1127,7 @@ fn write_json(path: &Path, value: &Value) -> Result<()> {
     let pretty = serde_json::to_string_pretty(value)
         .map_err(|e| NonoError::PackageInstall(format!("serialize {}: {e}", path.display())))?;
     let tmp = path.with_extension("json.nono-tmp");
-    fs::write(&tmp, format!("{pretty}\n")).map_err(NonoError::Io)?;
+    write_tmp_file(&tmp, format!("{pretty}\n").as_bytes(), None)?;
     fs::rename(&tmp, path).map_err(NonoError::Io)?;
     Ok(())
 }
@@ -1398,7 +1424,7 @@ fn write_yaml(path: &Path, value: &Value) -> Result<()> {
     let serialized = yaml::to_string(&yaml_val)
         .map_err(|e| NonoError::PackageInstall(format!("serialize {}: {e}", path.display())))?;
     let tmp = path.with_extension("yaml.nono-tmp");
-    fs::write(&tmp, &serialized).map_err(NonoError::Io)?;
+    write_tmp_file(&tmp, serialized.as_bytes(), None)?;
     fs::rename(&tmp, path).map_err(NonoError::Io)?;
     Ok(())
 }
@@ -1516,7 +1542,7 @@ fn upsert_toml_block(file: &Path, marker_id: &str, body: &str) -> Result<bool> {
         fs::create_dir_all(parent).map_err(NonoError::Io)?;
     }
     let tmp = file.with_extension("toml.nono-tmp");
-    fs::write(&tmp, &updated).map_err(NonoError::Io)?;
+    write_tmp_file(&tmp, updated.as_bytes(), None)?;
     fs::rename(&tmp, file).map_err(NonoError::Io)?;
     Ok(true)
 }
@@ -1537,7 +1563,7 @@ fn strip_toml_block(file: &Path, marker_id: &str) -> Result<()> {
         out.pop();
     }
     let tmp = file.with_extension("toml.nono-tmp");
-    fs::write(&tmp, &out).map_err(NonoError::Io)?;
+    write_tmp_file(&tmp, out.as_bytes(), None)?;
     fs::rename(&tmp, file).map_err(NonoError::Io)?;
     Ok(())
 }
@@ -2132,6 +2158,31 @@ mod tests {
     }
 
     #[test]
+    fn write_file_refuses_to_write_when_dest_is_symlink() {
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(pack.join("file"), "pack content").expect("seed source");
+            let victim = home.join("victim");
+            fs::write(&victim, "sensitive").expect("seed victim");
+            unix_fs::symlink(&victim, home.join("dest")).expect("plant symlink at dest");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::WriteFile {
+                source: "file".to_string(),
+                dest: "$HOME/dest".to_string(),
+            }];
+
+            let result = exec(&directives, &ctx);
+            assert!(result.is_err(), "must refuse a dest occupied by a symlink");
+            assert_eq!(
+                fs::read_to_string(&victim).expect("victim readable"),
+                "sensitive",
+                "victim must never be read or chmod'd through the symlink"
+            );
+        });
+    }
+
+    #[test]
     fn write_file_refuses_to_overwrite_unmanaged_file() {
         with_fake_home(|home| {
             let pack = home.join("pack");
@@ -2376,6 +2427,38 @@ mod tests {
             assert_eq!(
                 fs::read_to_string(home.join("dest")).expect("read"),
                 "user edited",
+            );
+        });
+    }
+
+    #[test]
+    fn write_file_reverse_leaves_symlinked_dest_alone() {
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(pack.join("file"), "from-pack").expect("seed source");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::WriteFile {
+                source: "file".to_string(),
+                dest: "$HOME/dest".to_string(),
+            }];
+            let r1 = exec(&directives, &ctx).expect("install");
+
+            let victim = home.join("victim");
+            fs::write(&victim, "sensitive").expect("seed victim");
+            fs::remove_file(home.join("dest")).expect("remove installed file");
+            unix_fs::symlink(&victim, home.join("dest")).expect("plant symlink at dest");
+
+            rev(&r1.records);
+
+            assert!(
+                home.join("dest").is_symlink(),
+                "reverse must not blindly remove a symlink at dest"
+            );
+            assert_eq!(
+                fs::read_to_string(&victim).expect("victim readable"),
+                "sensitive",
+                "victim must never be read through the symlink during reverse"
             );
         });
     }

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -743,6 +743,7 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
         fs::create_dir_all(parent).map_err(NonoError::Io)?;
     }
     let source_bytes = fs::read(source).map_err(NonoError::Io)?;
+    let source_perms = safe_perms(fs::metadata(source).map_err(NonoError::Io)?.permissions());
     let sha256 = hash_bytes(&source_bytes);
     // Skip-no-op only if existing content matches exactly. Caller has
     // already enforced the conflict policy (only owned files reach
@@ -750,18 +751,87 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
     if let Ok(existing) = fs::read(dest)
         && existing == source_bytes
     {
+        sync_permissions(dest, &source_perms)?;
         return Ok(CopyOutcome {
             mutated: false,
             sha256,
         });
     }
     let tmp = dest.with_extension("nono-tmp");
-    fs::write(&tmp, &source_bytes).map_err(NonoError::Io)?;
+    write_tmp_file(&tmp, &source_bytes, &source_perms)?;
     fs::rename(&tmp, dest).map_err(NonoError::Io)?;
     Ok(CopyOutcome {
         mutated: true,
         sha256,
     })
+}
+
+/// Creates `tmp` fresh with `perms` set at creation, so it never exists at a
+/// looser mode and never writes through a pre-planted symlink. Retries once
+/// past a leftover tmp file from an interrupted prior run.
+fn write_tmp_file(tmp: &Path, bytes: &[u8], perms: &std::fs::Permissions) -> Result<()> {
+    for _ in 0..2 {
+        #[cfg(unix)]
+        let opened = {
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(perms.mode())
+                .open(tmp)
+        };
+        #[cfg(not(unix))]
+        let opened = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(tmp);
+
+        match opened {
+            Ok(mut file) => {
+                use std::io::Write;
+                return file.write_all(bytes).map_err(NonoError::Io);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                fs::remove_file(tmp).map_err(NonoError::Io)?;
+            }
+            Err(e) => return Err(NonoError::Io(e)),
+        }
+    }
+    Err(NonoError::Io(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!("could not create fresh temp file at {}", tmp.display()),
+    )))
+}
+
+/// Strips setuid/setgid/sticky bits, keeping only rwxrwxrwx — a pack must
+/// never be able to plant a setuid/setgid file via `write_file`.
+fn safe_perms(perms: std::fs::Permissions) -> std::fs::Permissions {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::Permissions::from_mode(perms.mode() & 0o777)
+    }
+    #[cfg(not(unix))]
+    {
+        perms
+    }
+}
+
+/// Reapplies source permissions to an already-up-to-date dest (no-op re-pull path).
+fn sync_permissions(dest: &Path, source_perms: &std::fs::Permissions) -> Result<()> {
+    let dest_perms = fs::metadata(dest).map_err(NonoError::Io)?.permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if dest_perms.mode() != source_perms.mode() {
+            fs::set_permissions(dest, source_perms.clone()).map_err(NonoError::Io)?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (dest_perms, source_perms);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1950,6 +2020,114 @@ mod tests {
 
             rev(&r1.records);
             assert!(!home.join("dest").exists());
+        });
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_file_atomic_preserves_executable_bit() {
+        use std::os::unix::fs::PermissionsExt;
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            let source = pack.join("hook.sh");
+            fs::write(&source, "#!/bin/sh\necho hi").expect("seed source");
+            fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).expect("chmod source");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::WriteFile {
+                source: "hook.sh".to_string(),
+                dest: "$HOME/dest.sh".to_string(),
+            }];
+            let r1 = exec(&directives, &ctx).expect("first");
+            let dest_mode = fs::metadata(home.join("dest.sh"))
+                .expect("dest metadata")
+                .permissions()
+                .mode();
+            assert_eq!(dest_mode & 0o777, 0o755, "exec bit must survive the copy");
+
+            // Re-pull with identical content must still sync perms (fast no-op path).
+            fs::set_permissions(home.join("dest.sh"), fs::Permissions::from_mode(0o644))
+                .expect("simulate stripped perms");
+            let prior_sha = match &r1.records[0] {
+                WiringRecord::WriteFile { sha256, .. } => sha256.clone(),
+                other => panic!("expected WriteFile, got {other:?}"),
+            };
+            let mut owned: HashMap<PathBuf, String> = HashMap::new();
+            owned.insert(home.join("dest.sh"), prior_sha);
+            execute(&directives, &ctx, &owned).expect("second");
+            let dest_mode = fs::metadata(home.join("dest.sh"))
+                .expect("dest metadata")
+                .permissions()
+                .mode();
+            assert_eq!(dest_mode & 0o777, 0o755, "re-pull must restore exec bit");
+        });
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_file_atomic_strips_setuid_bit() {
+        use std::os::unix::fs::PermissionsExt;
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            let source = pack.join("hook.sh");
+            fs::write(&source, "#!/bin/sh\necho hi").expect("seed source");
+            // A pack source should never be able to plant a setuid/setgid file.
+            fs::set_permissions(&source, fs::Permissions::from_mode(0o4755)).expect("chmod source");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::WriteFile {
+                source: "hook.sh".to_string(),
+                dest: "$HOME/dest.sh".to_string(),
+            }];
+            exec(&directives, &ctx).expect("first");
+            let dest_mode = fs::metadata(home.join("dest.sh"))
+                .expect("dest metadata")
+                .permissions()
+                .mode();
+            assert_eq!(
+                dest_mode & 0o7000,
+                0,
+                "setuid/setgid/sticky must never be copied"
+            );
+            assert_eq!(dest_mode & 0o777, 0o755, "regular perms still preserved");
+        });
+    }
+
+    #[test]
+    fn write_file_atomic_refuses_to_follow_preplanted_tmp_symlink() {
+        with_fake_home(|home| {
+            let pack = home.join("pack");
+            fs::create_dir_all(&pack).expect("mkdir pack");
+            fs::write(pack.join("file"), "pack content").expect("seed source");
+            let victim = home.join("victim");
+            fs::write(&victim, "sensitive").expect("seed victim");
+            let ctx = ctx_in(home, pack);
+            let directives = vec![WiringDirective::WriteFile {
+                source: "file".to_string(),
+                dest: "$HOME/dest".to_string(),
+            }];
+
+            // Attacker pre-plants the tmp path as a symlink to a file the
+            // process can otherwise write, before the wiring directive runs.
+            let tmp = home.join("dest.nono-tmp");
+            unix_fs::symlink(&victim, &tmp).expect("plant symlink");
+
+            exec(&directives, &ctx).expect("write_file must not fail outright");
+
+            assert_eq!(
+                fs::read_to_string(&victim).expect("victim readable"),
+                "sensitive",
+                "victim file must be untouched"
+            );
+            assert!(
+                !tmp.is_symlink(),
+                "planted symlink must be replaced, not written through"
+            );
+            assert_eq!(
+                fs::read_to_string(home.join("dest")).expect("dest readable"),
+                "pack content",
+                "dest must contain the actual pack content, not a redirected symlink"
+            );
         });
     }
 


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1803 

## Summary

copy_file_atomic used fs::write for the destination, which always creates the file at the default mode, silently dropping the source files executable bit. Packs that ship scripts via write_file (e.g. Claude Code hook scripts) landed non-executable, breaking every hook invocation.

Now reads and applies the source permissions, masked to plain rwx bits so a pack can never plant a setuid/setgid/sticky file. The temp file is created with create_new and the final mode set at creation time, closing a pre-existing symlink-preplant and loose-transient-mode window on the same code path.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
