### PR TITLE
fix(cli): use CLAUDE_CONFIG_DIR instead of ~/.claude.json symlink redirects

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -21,8 +21,6 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 #[cfg(unix)]
-use std::io::Write;
-#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
@@ -36,75 +34,6 @@ fn print_allow_domain_port_warnings(entries: &[String], context: &str, silent: b
 
     for warning in network_policy::collect_allow_domain_port_warnings(entries, context) {
         output::print_warning(&warning);
-    }
-}
-
-#[cfg(unix)]
-fn initialize_claude_json(path: &Path) -> std::io::Result<()> {
-    let mut file = match std::fs::OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .mode(0o600)
-        .open(path)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let metadata = std::fs::symlink_metadata(path)?;
-            if !metadata.file_type().is_file() || metadata.len() != 0 {
-                return Ok(());
-            }
-            std::fs::OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(path)?
-        }
-        Err(error) => return Err(error),
-    };
-    file.write_all(b"{}\n")
-}
-
-#[cfg(unix)]
-fn prepare_claude_json_redirect(home_path: &Path) {
-    let claude_json = home_path.join(".claude.json");
-    let claude_dir = home_path.join(".claude");
-    let redirect_target = claude_dir.join("claude.json");
-
-    if let Err(error) = std::fs::create_dir_all(&claude_dir) {
-        warn!("Failed to create ~/.claude: {error}");
-        return;
-    }
-
-    if claude_json.is_symlink() {
-        if std::fs::read_link(&claude_json)
-            .is_ok_and(|target| target == Path::new(".claude/claude.json"))
-            && let Err(error) = initialize_claude_json(&redirect_target)
-        {
-            warn!(
-                "Failed to initialize redirected Claude configuration {}: {error}",
-                redirect_target.display()
-            );
-        }
-        return;
-    }
-
-    if claude_json.exists() {
-        // Preserve an existing configuration by moving it behind the redirect.
-        if let Err(error) = std::fs::rename(&claude_json, &redirect_target) {
-            warn!("Failed to move ~/.claude.json to ~/.claude/claude.json: {error}");
-            return;
-        }
-    } else if let Err(error) = initialize_claude_json(&redirect_target) {
-        warn!(
-            "Failed to initialize redirected Claude configuration {}: {error}",
-            redirect_target.display()
-        );
-        return;
-    }
-
-    if let Err(error) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
-        && error.kind() != std::io::ErrorKind::AlreadyExists
-    {
-        warn!("Failed to create ~/.claude.json symlink: {error}");
     }
 }
 
@@ -1561,7 +1490,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allowed_env_vars: profile_allowed_env_vars,
         denied_env_vars: profile_denied_env_vars,
         case_insensitive_env_vars: profile_case_insensitive_env_vars,
-        set_vars: profile_set_vars,
+        set_vars: mut profile_set_vars,
         resolved_command_binaries: profile_resolved_command_binaries,
     } = prepared_profile;
 
@@ -1625,19 +1554,27 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             }
         };
 
-        precreate(&home_path.join(".claude.json.lock"), false);
         precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
 
-        // Claude Code writes ~/.claude.json atomically via temp files named
-        // ~/.claude.json.tmp.<pid>.<timestamp>.  Landlock/Seatbelt cannot
-        // grant permission for these dynamically-named files in ~/, so token
-        // refreshes silently fail and the user is logged out.
-        //
-        // Redirect ~/.claude.json to ~/.claude/claude.json via a
-        // symlink.  Claude Code resolves symlinks before computing the temp
-        // file path, so temp files land in ~/.claude/ (already readwrite)
-        // instead of ~/ (not writable inside the sandbox).
-        prepare_claude_json_redirect(home_path);
+        // Claude Code writes its config atomically via temp files named
+        // <config>.tmp.<pid>.<timestamp> next to the config file itself.
+        // Landlock/Seatbelt cannot grant permission for these
+        // dynamically-named files in ~/, so token refreshes would silently
+        // fail there. Point Claude Code at ~/.claude (already readwrite)
+        // via CLAUDE_CONFIG_DIR instead of leaving its config at
+        // ~/.claude.json, so the config and its temp siblings both land
+        // inside a directory nono already grants.
+        let claude_dir = home_path.join(".claude");
+        if let Err(error) = std::fs::create_dir_all(&claude_dir) {
+            warn!("Failed to create ~/.claude: {error}");
+        } else if !std::env::var_os("CLAUDE_CONFIG_DIR").is_some() {
+            profile_set_vars
+                .get_or_insert_with(Vec::new)
+                .push((
+                    "CLAUDE_CONFIG_DIR".to_string(),
+                    claude_dir.to_string_lossy().into_owned(),
+                ));
+        }
     }
 
     let prepared = if let Some(ref profile) = loaded_profile {
@@ -2030,81 +1967,6 @@ mod tests {
             result, None,
             "a nonexistent keychain entry via the real /usr/bin/security must return None, \
              not the trojan's fake output"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn claude_redirect_initializes_valid_private_json_for_fresh_home() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempdir().expect("tmpdir");
-        let home = dir.path().join("home");
-        fs::create_dir_all(&home).expect("mkdir home");
-
-        prepare_claude_json_redirect(&home);
-
-        let link = home.join(".claude.json");
-        let target = home.join(".claude/claude.json");
-        assert_eq!(
-            fs::read_link(&link).expect("read Claude redirect"),
-            Path::new(".claude/claude.json")
-        );
-        let contents = fs::read(&target).expect("read Claude configuration");
-        serde_json::from_slice::<serde_json::Value>(&contents)
-            .expect("fresh Claude configuration must be valid JSON");
-        assert_eq!(contents, b"{}\n");
-        assert_eq!(
-            fs::metadata(target)
-                .expect("Claude metadata")
-                .permissions()
-                .mode()
-                & 0o777,
-            0o600
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn claude_redirect_repairs_only_zero_byte_target() {
-        let dir = tempdir().expect("tmpdir");
-        let home = dir.path().join("home");
-        let claude_dir = home.join(".claude");
-        fs::create_dir_all(&claude_dir).expect("mkdir Claude home");
-        fs::write(claude_dir.join("claude.json"), b"").expect("write empty target");
-        std::os::unix::fs::symlink(".claude/claude.json", home.join(".claude.json"))
-            .expect("create Claude redirect");
-
-        prepare_claude_json_redirect(&home);
-        assert_eq!(
-            fs::read(claude_dir.join("claude.json")).expect("read repaired target"),
-            b"{}\n"
-        );
-
-        fs::write(claude_dir.join("claude.json"), b"{\"existing\":true}\n")
-            .expect("write existing configuration");
-        prepare_claude_json_redirect(&home);
-        assert_eq!(
-            fs::read(claude_dir.join("claude.json")).expect("read existing configuration"),
-            b"{\"existing\":true}\n"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn claude_redirect_preserves_existing_root_configuration() {
-        let dir = tempdir().expect("tmpdir");
-        let home = dir.path().join("home");
-        fs::create_dir_all(&home).expect("mkdir home");
-        fs::write(home.join(".claude.json"), b"{\"existing\":true}\n")
-            .expect("write existing configuration");
-
-        prepare_claude_json_redirect(&home);
-
-        assert!(home.join(".claude.json").is_symlink());
-        assert_eq!(
-            fs::read(home.join(".claude/claude.json")).expect("read moved configuration"),
-            b"{\"existing\":true}\n"
         );
     }
 

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1568,12 +1568,10 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         if let Err(error) = std::fs::create_dir_all(&claude_dir) {
             warn!("Failed to create ~/.claude: {error}");
         } else if !std::env::var_os("CLAUDE_CONFIG_DIR").is_some() {
-            profile_set_vars
-                .get_or_insert_with(Vec::new)
-                .push((
-                    "CLAUDE_CONFIG_DIR".to_string(),
-                    claude_dir.to_string_lossy().into_owned(),
-                ));
+            profile_set_vars.get_or_insert_with(Vec::new).push((
+                "CLAUDE_CONFIG_DIR".to_string(),
+                claude_dir.to_string_lossy().into_owned(),
+            ));
         }
     }
 
@@ -1832,7 +1830,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
     use std::fs;
     use tempfile::tempdir;
 


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1817

@simple10 Tested locally and worked, would appreciate if you could give it a run. This seems a much cleaner solution which is nice. Alongside https://github.com/nolabs-ai/nono/pull/1807 it should fix the claude issues

## Summary

Claude Code does not reliably resolve the ~/.claude.json symlink before renaming its atomic config saves, so a save can replace the redirect with a plain file. This desyncs sandbox state and makes `nono why --self` hard-fail with "sandbox state path drifted at reload" for the rest of the session (#1817).

Set CLAUDE_CONFIG_DIR to <home>/.claude for profiles that select Claude Code instead of maintaining the redirect symlink. Claude Code writes its config and temp files directly inside the granted directory, so there is no symlink left for an atomic rename to break.

Removes prepare_claude_json_redirect and initialize_claude_json and their tests.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
