### PR TITLE
feat(cli): use CLONE_FILES bootstrap for network-notification sessions

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -10,6 +10,8 @@
 //! until `exec()`. This module carefully prepares all data in the parent (where
 //! allocation is safe) and uses only raw libc calls in the child.
 
+#[cfg(target_os = "linux")]
+mod clone_files;
 pub(crate) mod env_sanitization;
 #[cfg(target_os = "linux")]
 mod supervisor_linux;
@@ -238,8 +240,8 @@ impl SeccompPolicy {
         self.proxy_fallback || self.af_unix_mediation
     }
 
-    /// Whether the child must be made dumpable so the supervisor can use
-    /// `pidfd_getfd` to steal the network notify fd.
+    /// Whether the child must remain dumpable for the supervisor to read
+    /// syscall arguments through procfs during notification mediation.
     pub fn child_requires_dumpable(self) -> bool {
         self.needs_openat_notify() || self.needs_network_notify()
     }
@@ -473,18 +475,22 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
 ///
 /// # Sandbox Application in Child
 ///
-/// The child calls `Sandbox::apply_auto()` after fork, which allocates memory (generating
-/// Seatbelt profile strings on macOS, opening Landlock PathFds on Linux). This is safe
-/// because we validate threading context before fork — known-safe thread contexts
-/// (keyring workers, crypto pool) are idle and not holding allocator locks.
+/// Linux network-notification sessions use a short `CLONE_FILES` bootstrap.
+/// The parent prepares the kernel ruleset against the known child's procfs
+/// entries; the child installs a single, optionally combined notification
+/// filter, detaches its descriptor table, and applies the ruleset before exec.
+/// That child path uses no allocator or locks, including on failure.
+/// Other sessions retain the fork path, whose allocating sandbox setup relies
+/// on the threading-context validation below.
 ///
 /// # Process Flow
 ///
 /// 1. Prepare all data for exec in parent (CString conversion)
 /// 2. Verify threading context allows fork
-/// 3. Fork into parent and child
-/// 4. Child: apply Landlock, install seccomp-notify, close inherited FDs, exec
-/// 5. Parent: apply PR_SET_DUMPABLE(0) + PT_DENY_ATTACH, receive seccomp fd, run supervisor loop
+/// 3. Fork, or raw clone for Linux network notifications
+/// 4. Harden parent and complete any listener handoff before running untrusted code
+/// 5. Child: apply restrictions, close inherited FDs in its private table, exec
+/// 6. Parent: run the existing supervisor loop
 ///
 /// When a PTY pair is provided, the child runs behind the PTY proxy so the
 /// parent can capture terminal output for diagnostics while the child still sees
@@ -582,7 +588,17 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
     let needs_child_ipc = supervisor.is_some();
 
     let socket_pair = if needs_child_ipc {
-        Some(SupervisorSocket::pair()?)
+        let pair = SupervisorSocket::pair()?;
+        #[cfg(target_os = "linux")]
+        let pair = if config.seccomp_policy.needs_network_notify() {
+            (
+                clone_files::promote_supervisor_socket(pair.0)?,
+                clone_files::promote_supervisor_socket(pair.1)?,
+            )
+        } else {
+            pair
+        };
+        Some(pair)
     } else {
         None
     };
@@ -878,9 +894,60 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
     // Clear any stale forwarding target before forking.
     clear_signal_forwarding_target();
 
-    // SAFETY: fork() is safe here because we validated threading context.
-    // Child will call Sandbox::apply_auto() which allocates, but this is safe
-    // because the child is single-threaded (validated above).
+    // Serialize notification listener ownership, including destruction, across
+    // shared-table bootstraps. Ordinary proxy I/O threads remain concurrent.
+    #[cfg(target_os = "linux")]
+    let _listener_ownership_guard = if config.seccomp_policy.child_requires_dumpable() {
+        Some(clone_files::lock_listener_ownership()?)
+    } else {
+        None
+    };
+    #[cfg(target_os = "linux")]
+    let mut clone_bootstrap = if config.seccomp_policy.needs_network_notify() {
+        if !supervisor.is_some_and(|sup| sup.seccomp_policy == config.seccomp_policy) {
+            return Err(NonoError::SandboxInit(
+                "Network notifications require a supervisor with matching notification policy"
+                    .into(),
+            ));
+        }
+        let mut caps = config.caps.clone();
+        caps.widen_procfs_self_to_proc();
+        if let Some(ref path) = url_listener_socket_path {
+            caps.add_unix_socket(UnixSocketCapability::new_file(
+                path,
+                UnixSocketMode::Connect,
+            )?);
+        }
+        Some(clone_files::spawn(
+            config,
+            clone_files::Command {
+                program: &program_c,
+                argv: &argv_ptrs,
+                envp: &envp_ptrs,
+                cwd: &current_dir_c,
+                supervisor_fd: child_sock_fd,
+                pty_slave: pty_slave_fd,
+                resource_procs: resource_procs_fd,
+                #[cfg(test)]
+                fault: clone_files::Fault::None,
+            },
+            &caps,
+            Sandbox::detect_abi()?,
+        )?)
+    } else {
+        None
+    };
+    #[cfg(target_os = "linux")]
+    let fork_result = if let Some(ref bootstrap) = clone_bootstrap {
+        Ok(ForkResult::Parent {
+            child: bootstrap.child,
+        })
+    } else {
+        // SAFETY: legacy path's threading context was checked above.
+        unsafe { fork() }
+    };
+    #[cfg(not(target_os = "linux"))]
+    // SAFETY: legacy path's threading context was checked above.
     let fork_result = unsafe { fork() };
 
     match fork_result {
@@ -1158,135 +1225,8 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
                     }
                 }
 
-                // If the parent determined that network seccomp-notify is
-                // needed, install exactly one connect/bind notify filter and
-                // tell the parent its fd number.
-                //
-                // Ordering is critical: the filter is installed AFTER the
-                // notify fd number is sent to the parent. This means no
-                // fd-based exemption is needed in the filter — the filter is
-                // a pure allowlist. The parent uses pidfd_getfd to acquire
-                // the fd from this process after reading the number.
-                //
-                // The notify fd is kept alive in `proxy_notify_fd_keep` past
-                // close_inherited_fds so the parent can call pidfd_getfd
-                // before the fd is closed. It is O_CLOEXEC and closes at exec.
-                let install_network_notify = config.seccomp_policy.needs_network_notify();
-                let mut proxy_notify_fd_keep: Option<std::os::fd::OwnedFd> = None;
-                if install_network_notify && nono::sandbox::is_wsl2() {
-                    let msg =
-                        b"nono: WSL2 detected, seccomp network notify required but unavailable\n";
-                    unsafe {
-                        libc::write(
-                            libc::STDERR_FILENO,
-                            msg.as_ptr().cast::<libc::c_void>(),
-                            msg.len(),
-                        );
-                        libc::_exit(126);
-                    }
-                } else if install_network_notify && let Some(fd) = child_sock_fd {
-                    let notify_result = if config.seccomp_policy.proxy_fallback {
-                        let has_bind = match effective_caps.network_mode() {
-                            nono::NetworkMode::ProxyOnly { bind_ports, .. } => {
-                                !bind_ports.is_empty()
-                            }
-                            _ => false,
-                        };
-                        nono::sandbox::install_seccomp_proxy_filter(has_bind)
-                    } else {
-                        nono::sandbox::install_seccomp_af_unix_filter()
-                    };
-
-                    match notify_result {
-                        Ok(proxy_notify_fd) => {
-                            // Write the raw fd number via write() — not intercepted
-                            // by the BPF filter (which only traps connect/bind/send*).
-                            // The parent reads this number and calls pidfd_getfd.
-                            let fd_num = proxy_notify_fd.as_raw_fd();
-                            let fd_bytes = fd_num.to_ne_bytes();
-                            let written = loop {
-                                // SAFETY: fd is a valid socket fd; fd_bytes is
-                                // a valid 4-byte buffer.
-                                let n = unsafe {
-                                    libc::write(
-                                        fd,
-                                        fd_bytes.as_ptr().cast::<libc::c_void>(),
-                                        fd_bytes.len(),
-                                    )
-                                };
-                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
-                                    continue;
-                                }
-                                break n;
-                            };
-                            if written < 0 {
-                                let detail = format!(
-                                    "nono: failed to write proxy seccomp notify fd number: {}\n",
-                                    std::io::Error::last_os_error()
-                                );
-                                let msg = detail.as_bytes();
-                                unsafe {
-                                    libc::write(
-                                        libc::STDERR_FILENO,
-                                        msg.as_ptr().cast::<libc::c_void>(),
-                                        msg.len(),
-                                    );
-                                    libc::_exit(126);
-                                }
-                            }
-                            // Block until the parent acks that it has called
-                            // pidfd_getfd. This prevents exec (and O_CLOEXEC
-                            // closing the notify fd) before the parent acquires
-                            // its own copy. read() is not trapped by the BPF
-                            // filter (only connect/bind/send* are), so this
-                            // does not deadlock. Loop on EINTR so a signal
-                            // cannot cause the child to proceed prematurely.
-                            let mut ack = [0u8; 1];
-                            loop {
-                                // SAFETY: fd is a valid socket fd; ack is a
-                                // valid 1-byte buffer.
-                                let n = unsafe {
-                                    libc::read(fd, ack.as_mut_ptr().cast::<libc::c_void>(), 1)
-                                };
-                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
-                                    continue;
-                                }
-                                break;
-                            }
-                            // Keep alive past close_inherited_fds so the parent
-                            // can call pidfd_getfd. O_CLOEXEC closes it at exec.
-                            proxy_notify_fd_keep = Some(proxy_notify_fd);
-                        }
-                        Err(e) => {
-                            let detail =
-                                format!("nono: seccomp proxy filter not available: {}\n", e);
-                            let msg = detail.as_bytes();
-                            unsafe {
-                                libc::write(
-                                    libc::STDERR_FILENO,
-                                    msg.as_ptr().cast::<libc::c_void>(),
-                                    msg.len(),
-                                );
-                                libc::_exit(126);
-                            }
-                        }
-                    }
-                } else if install_network_notify {
-                    let msg =
-                        b"nono: seccomp network notify required but supervisor socket is unavailable\n";
-                    unsafe {
-                        libc::write(
-                            libc::STDERR_FILENO,
-                            msg.as_ptr().cast::<libc::c_void>(),
-                            msg.len(),
-                        );
-                        libc::_exit(126);
-                    }
-                }
-                if let Some(ref pnf) = proxy_notify_fd_keep {
-                    child_keep_fds.push(pnf.as_raw_fd());
-                }
-
+                // Network notification sessions take the allocation-free
+                // CLONE_FILES path and never enter this legacy fork child.
                 if !config.seccomp_policy.child_requires_dumpable() {
                     use nix::sys::prctl;
 
@@ -1430,8 +1370,9 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
             // notify fd from the child. If the child cannot provide it, this is
             // a sandbox initialisation failure rather than a degraded mode.
             #[cfg(target_os = "linux")]
-            let seccomp_notify_fd: Option<OwnedFd> = if config.seccomp_policy.needs_openat_notify()
-            {
+            let seccomp_notify_fd: Option<OwnedFd> = if clone_bootstrap.is_some() {
+                None
+            } else if config.seccomp_policy.needs_openat_notify() {
                 if let Some(ref sup_sock) = supervisor_sock {
                     match sup_sock.recv_fd() {
                         Ok(fd) => {
@@ -1459,80 +1400,10 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
                 None
             };
 
-            // On Linux: if the parent determined seccomp proxy fallback is needed,
-            // receive the proxy notify fd number from the child and acquire the
-            // fd via pidfd_getfd. The child writes the raw fd number via write()
-            // rather than SCM_RIGHTS so the AF_UNIX BPF filter (installed after
-            // the write) cannot intercept it.
             #[cfg(target_os = "linux")]
-            let proxy_notify_fd: Option<OwnedFd> = if config.seccomp_policy.needs_network_notify() {
-                if let Some(ref sup_sock) = supervisor_sock {
-                    match sup_sock.recv_raw_fd_number() {
-                        Ok(child_fd_num) => {
-                            let result = acquire_fd_from_child(child, child_fd_num);
-                            // Always ack so the child's blocking read unblocks
-                            // and exec can proceed (O_CLOEXEC closes the fd at
-                            // exec, which is safe only after pidfd_getfd ran).
-                            // Loop on EINTR so a signal cannot silently drop
-                            // the ack and leave the child blocked forever.
-                            let ack = [1u8];
-                            loop {
-                                // SAFETY: sup_sock fd is valid; ack is a
-                                // valid 1-byte buffer.
-                                let n = unsafe {
-                                    libc::write(
-                                        sup_sock.as_raw_fd(),
-                                        ack.as_ptr().cast::<libc::c_void>(),
-                                        1,
-                                    )
-                                };
-                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
-                                    continue;
-                                }
-                                break;
-                            }
-                            match result {
-                                Ok(fd) => {
-                                    debug!(
-                                        "Acquired proxy seccomp notify fd from child via pidfd_getfd"
-                                    );
-                                    Some(fd)
-                                }
-                                Err(e) => {
-                                    let _ = signal::kill(child, Signal::SIGKILL);
-                                    let _ = waitpid(child, None);
-                                    // Unwrap to avoid doubling the "Sandbox
-                                    // initialization failed: " prefix.
-                                    let detail = match e {
-                                        NonoError::SandboxInit(msg) => msg,
-                                        other => other.to_string(),
-                                    };
-                                    return Err(NonoError::SandboxInit(format!(
-                                        "failed to acquire required network seccomp notify fd from child: {detail}"
-                                    )));
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            let _ = signal::kill(child, Signal::SIGKILL);
-                            let _ = waitpid(child, None);
-                            return Err(NonoError::SandboxInit(format!(
-                                "Failed to receive required network seccomp notify fd number from child: {}",
-                                e
-                            )));
-                        }
-                    }
-                } else {
-                    let _ = signal::kill(child, Signal::SIGKILL);
-                    let _ = waitpid(child, None);
-                    return Err(NonoError::SandboxInit(
-                        "Network seccomp notify is required but no supervisor socket was created"
-                            .to_string(),
-                    ));
-                }
-            } else {
-                None
-            };
+            let proxy_notify_fd: Option<OwnedFd> = clone_bootstrap
+                .as_mut()
+                .and_then(|bootstrap| bootstrap.network.take());
 
             // Set up signal forwarding.
             setup_signal_forwarding(child, pty_proxy.as_ref().map(|p| p.poll_fds().0));
@@ -3116,11 +2987,17 @@ fn run_supervisor_loop(
                 if let Some(proxy_notify_idx) = proxy_notify_idx
                     && pfds[proxy_notify_idx].revents & libc::POLLIN != 0
                     && let Some(pfd) = proxy_notify_raw_fd
-                    && let Err(e) = supervisor_linux::handle_network_notification(
+                    && let Err(e) = supervisor_linux::handle_combined_notification(
                         pfd,
+                        child,
                         config,
-                        &mut rate_limiter,
-                        &mut denials.fs,
+                        initial_caps,
+                        supervisor_linux::SeccompNotificationState {
+                            rate_limiter: &mut rate_limiter,
+                            denials: &mut denials.fs,
+                            trust_interceptor: trust_interceptor.as_mut(),
+                            pty: pty.as_deref_mut(),
+                        },
                         &mut ipc_denials,
                     )
                 {
@@ -3882,49 +3759,6 @@ fn validate_url(url: &str, config: &SupervisorConfig<'_>) -> std::result::Result
 }
 
 /// Clear `FD_CLOEXEC` on a file descriptor so it survives `execve()`.
-/// Acquire a copy of file descriptor `child_fd` from process `child` using
-/// `pidfd_open` + `pidfd_getfd` (Linux 5.6+).
-///
-/// Used to receive the proxy seccomp notify fd: the child writes the fd
-/// number via `write()` (not `SCM_RIGHTS`, which would be intercepted by the
-/// AF_UNIX BPF filter), and the parent calls this to pull the fd across the
-/// process boundary without any filter involvement.
-#[cfg(target_os = "linux")]
-fn acquire_fd_from_child(
-    child: nix::unistd::Pid,
-    child_fd: std::os::unix::io::RawFd,
-) -> Result<std::os::fd::OwnedFd> {
-    use std::os::fd::FromRawFd as _;
-    let pidfd_raw =
-        unsafe { libc::syscall(libc::SYS_pidfd_open, child.as_raw() as libc::pid_t, 0_u32) };
-    if pidfd_raw < 0 {
-        return Err(NonoError::SandboxInit(format!(
-            "pidfd_open failed for child {}: {}",
-            child.as_raw(),
-            std::io::Error::last_os_error()
-        )));
-    }
-    // SAFETY: pidfd_open returned a fresh owned fd.
-    let pidfd = unsafe { std::os::fd::OwnedFd::from_raw_fd(pidfd_raw as i32) };
-    let new_fd_raw =
-        unsafe { libc::syscall(libc::SYS_pidfd_getfd, pidfd.as_raw_fd(), child_fd, 0_u32) };
-    if new_fd_raw < 0 {
-        let err = std::io::Error::last_os_error();
-        let hint = if err.raw_os_error() == Some(libc::EPERM) {
-            " (this commonly happens inside a container: pidfd_getfd requires \
-             CAP_SYS_PTRACE, which container runtimes drop by default -- retry with \
-             `docker run --cap-add=SYS_PTRACE ...` or the equivalent for your runtime)"
-        } else {
-            ""
-        };
-        return Err(NonoError::SandboxInit(format!(
-            "pidfd_getfd failed for child fd {child_fd}: {err}{hint}"
-        )));
-    }
-    // SAFETY: pidfd_getfd returned a fresh owned fd duplicated from the child.
-    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(new_fd_raw as i32) })
-}
-
 fn clear_close_on_exec(fd: i32) -> Result<()> {
     // SAFETY: `fcntl` is called with a valid fd owned by this process.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };

--- a/crates/nono-cli/src/exec_strategy/clone_files.rs
+++ b/crates/nono-cli/src/exec_strategy/clone_files.rs
@@ -1,0 +1,993 @@
+//! Linux listener bootstrap. The trusted child shares only the fd table, then
+//! detaches before setup/exec. No Rust allocation or locks are used in the child.
+//!
+//! Adapted from Luke Hinds / nolabs-ai's nono-py PR #113, specifically
+//! src/sandboxed_exec.rs at 5ac03f96ed6b15c24e7833b4fb12eea08698903c:
+//! https://github.com/nolabs-ai/nono-py/pull/113
+//! The parent-created ruleset, combined notifications, non-reaping liveness
+//! checks, and CLI integration are new. Library policy decisions remain in the
+//! CLI; library preparation only applies the capabilities supplied here.
+
+use super::ExecConfig;
+use crate::profile::LinuxSandboxPolicy;
+use nix::libc;
+use nono::sandbox::{self, PreparedLandlockSandbox, PreparedSeccompNotifyFilter};
+use nono::{CapabilitySet, DetectedAbi, NonoError, Result};
+use std::collections::BTreeSet;
+use std::ffi::CStr;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::net::UnixStream;
+use std::sync::{Mutex, MutexGuard};
+
+const READY: u8 = 0xc1;
+const DETACHED: u8 = 0xd1;
+const ACK: u8 = 0xa1;
+const BOOTSTRAP_SECONDS: i64 = 15;
+
+// All supervised notification sessions hold this lock until their listener
+// owners have been dropped. Thus no listener can appear/disappear in this fd
+// table during another shared bootstrap's discovery of an unreported listener.
+// Ordinary proxy-thread fd churn does not acquire this lock and is supported.
+static LISTENER_OWNERSHIP: Mutex<()> = Mutex::new(());
+
+pub(super) fn lock_listener_ownership() -> Result<MutexGuard<'static, ()>> {
+    LISTENER_OWNERSHIP
+        .lock()
+        .map_err(|_| failure("listener ownership lock poisoned"))
+}
+
+pub(super) struct Bootstrap {
+    pub child: nix::unistd::Pid,
+    pub network: Option<OwnedFd>,
+}
+
+pub(super) struct Command<'a> {
+    pub program: &'a CStr,
+    pub argv: &'a [*const libc::c_char],
+    pub envp: &'a [*const libc::c_char],
+    pub cwd: &'a CStr,
+    pub supervisor_fd: Option<RawFd>,
+    pub pty_slave: Option<RawFd>,
+    pub resource_procs: Option<RawFd>,
+    #[cfg(test)]
+    pub fault: Fault,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum Fault {
+    #[default]
+    None,
+    LateFd,
+    PendingSignal,
+    BeforeListener,
+    AfterFilesystem,
+    AfterListener,
+    BeforeDetach,
+    AfterDetach,
+    InvalidReport,
+    FailedAck,
+    BadAck,
+    AfterAck,
+    Fragmented,
+}
+
+fn failure(detail: &str) -> NonoError {
+    NonoError::SandboxInit(format!("CLONE_FILES bootstrap: {detail}"))
+}
+
+fn prepare(
+    caps: &CapabilitySet,
+    abi: &DetectedAbi,
+    policy: LinuxSandboxPolicy,
+) -> Result<PreparedLandlockSandbox> {
+    match policy {
+        LinuxSandboxPolicy::Auto => {
+            sandbox::prepare_seccomp_with_abi(caps, abi, nono::SeccompOpts::network_baseline())
+        }
+        LinuxSandboxPolicy::External => {
+            sandbox::prepare_seccomp_with_abi(caps, abi, nono::SeccompOpts::external_tcp())
+        }
+        LinuxSandboxPolicy::Landlock => sandbox::prepare_landlock_with_abi(caps, abi),
+    }
+}
+
+fn above_stdio(fd: OwnedFd) -> Result<OwnedFd> {
+    if fd.as_raw_fd() >= 3 {
+        return Ok(fd);
+    }
+    // SAFETY: fd is owned, and F_DUPFD_CLOEXEC returns a fresh descriptor.
+    let duplicate = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+    if duplicate < 0 {
+        return Err(failure("cannot move bootstrap endpoint above stdio"));
+    }
+    // SAFETY: duplicate was checked and is uniquely owned.
+    Ok(unsafe { OwnedFd::from_raw_fd(duplicate) })
+}
+
+pub(super) fn promote_supervisor_socket(
+    socket: nono::SupervisorSocket,
+) -> Result<nono::SupervisorSocket> {
+    if socket.as_raw_fd() >= 3 {
+        return Ok(socket);
+    }
+    // SAFETY: retain the original owner until a fresh duplicate is acquired.
+    let fd = unsafe { libc::fcntl(socket.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+    if fd < 0 {
+        return Err(failure("cannot move supervisor socket above stdio"));
+    }
+    // SAFETY: checked fresh descriptor, now owned by the new socket wrapper.
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    Ok(nono::SupervisorSocket::from_stream(UnixStream::from(fd)))
+}
+
+// Occupy otherwise closed stdio slots so NEW_LISTENER cannot return an fd
+// later confused with stdio. O_PATH keeps reads/writes failing as for closed
+// stdio. These owned placeholders are never installed over an occupied slot.
+fn reserve_stdio() -> Result<Vec<OwnedFd>> {
+    let mut reserved = Vec::new();
+    loop {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_PATH | libc::O_CLOEXEC)
+            .open("/dev/null")
+            .map_err(NonoError::Io)?;
+        if file.as_raw_fd() >= 3 {
+            break;
+        }
+        reserved.push(file.into());
+    }
+    Ok(reserved)
+}
+
+/// The caller holds LISTENER_OWNERSHIP through destruction of returned listeners.
+pub(super) fn spawn(
+    config: &ExecConfig<'_>,
+    command: Command<'_>,
+    caps: &CapabilitySet,
+    abi: DetectedAbi,
+) -> Result<Bootstrap> {
+    if sandbox::is_wsl2() {
+        return Err(failure("required notification filters unavailable on WSL2"));
+    }
+    let baseline = prepare(caps, &abi, config.sandbox_policy)?;
+    let network = if config.seccomp_policy.proxy_fallback {
+        let has_bind = matches!(caps.network_mode(), nono::NetworkMode::ProxyOnly { bind_ports, .. } if !bind_ports.is_empty());
+        sandbox::prepare_seccomp_proxy_filter(has_bind)
+    } else {
+        sandbox::prepare_seccomp_af_unix_filter()
+    };
+    let network = if config.seccomp_policy.needs_openat_notify() {
+        network.with_openat_notifications()
+    } else {
+        network
+    };
+    let gate = config
+        .tool_sandbox_runtime
+        .map(|runtime| runtime.prepare_outer_exec_gate())
+        .transpose()?
+        .map(above_stdio)
+        .transpose()?;
+    let (parent, child) =
+        UnixStream::pair().map_err(|_| failure("cannot create bootstrap socketpair"))?;
+    let parent = above_stdio(parent.into())?;
+    let child = above_stdio(child.into())?;
+    let closed_stdio = reserve_stdio()?;
+    let snapshot = listeners()?;
+    let mut signals = Signals::block()?;
+    // SAFETY: getpid takes no pointers and cannot fail.
+    let parent_pid = unsafe { libc::getpid() };
+    // SAFETY: only the fd table is shared. VM, TLS, signal handlers and FS
+    // context are copied. The child never returns into allocating Rust code.
+    let pid = unsafe {
+        libc::syscall(
+            libc::SYS_clone,
+            libc::CLONE_FILES | libc::SIGCHLD,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    if pid == 0 {
+        arm_allocator_guard();
+        child_exec(
+            &command,
+            &baseline,
+            &network,
+            gate.as_ref().map(AsRawFd::as_raw_fd),
+            child.as_raw_fd(),
+            parent.as_raw_fd(),
+            parent_pid,
+            &signals,
+            &closed_stdio,
+        );
+    }
+    if pid < 0 {
+        return Err(failure("clone failed"));
+    }
+    let pid = pid as libc::pid_t;
+
+    // Everything with a descriptor the child will use stays alive until the
+    // handshake returns DETACHED or cleanup has killed AND reaped the child.
+    let mut ruleset = None;
+    let mut cleanup_dir = None;
+    #[cfg(test)]
+    let mut late_fd = None;
+    let handshake = (|| -> Result<RawFd> {
+        // Harden before releasing the child, and before any untrusted code can
+        // exec. The child independently enables inspection for notifications.
+        // SAFETY: prctl changes only the parent's dumpability.
+        if unsafe { libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 0, 0, 0, 0) } < 0 {
+            return Err(failure("cannot harden parent"));
+        }
+        signals.restore()?;
+        let mut ready = [0_u8];
+        if !transfer(parent.as_raw_fd(), &mut ready, false, Some(pid)) || ready[0] != READY {
+            return Err(failure("child failed before preparation"));
+        }
+        #[cfg(test)]
+        if command.fault == Fault::LateFd {
+            // SAFETY: owned endpoint duplicated after the original fd snapshot.
+            let fd = unsafe { libc::fcntl(parent.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 512) };
+            if fd < 0 {
+                return Err(failure("test cannot allocate late high fd"));
+            }
+            // SAFETY: checked fresh owned descriptor, retained through detach.
+            late_fd = Some(unsafe { OwnedFd::from_raw_fd(fd) });
+        }
+        let mut child_caps = caps.clone();
+        child_caps.remap_procfs_self_references(pid as u32, None);
+        child_caps.widen_procfs_self_to_proc();
+        let prepared = prepare(&child_caps, &abi, config.sandbox_policy)?;
+        ruleset = Some(above_stdio(prepared.create_ruleset()?)?);
+        let Some(ref ruleset) = ruleset else {
+            return Err(failure("missing ruleset"));
+        };
+        cleanup_dir = Some(above_stdio(
+            std::fs::File::open(format!("/proc/{pid}/fd"))
+                .map_err(|_| failure("cannot open child descriptor directory"))?
+                .into(),
+        )?);
+        let Some(ref cleanup_dir) = cleanup_dir else {
+            return Err(failure("missing descriptor directory"));
+        };
+        let mut bytes = [0_u8; 8];
+        bytes[..4].copy_from_slice(&ruleset.as_raw_fd().to_ne_bytes());
+        bytes[4..].copy_from_slice(&cleanup_dir.as_raw_fd().to_ne_bytes());
+        if !transfer(parent.as_raw_fd(), &mut bytes, true, Some(pid)) {
+            return Err(failure("cannot send prepared ruleset"));
+        }
+        let mut report = [0_u8; 5];
+        if !transfer(parent.as_raw_fd(), &mut report, false, Some(pid)) {
+            return Err(failure("child died or timed out before DETACHED"));
+        }
+        if report[4] != DETACHED {
+            return Err(failure("invalid detachment confirmation"));
+        }
+        let network_fd = i32::from_ne_bytes([report[0], report[1], report[2], report[3]]);
+        validate_listener(network_fd, &snapshot)?;
+        let expected: BTreeSet<_> = [network_fd].into_iter().collect();
+        let actual: BTreeSet<_> = listeners()?.difference(&snapshot).copied().collect();
+        if actual != expected {
+            return Err(failure("listener ownership mismatch"));
+        }
+        // Use send(MSG_NOSIGNAL) only in the parent; the child's filter traps it.
+        #[cfg(test)]
+        if command.fault == Fault::FailedAck {
+            // SAFETY: fault injection affects only this owned endpoint.
+            unsafe {
+                libc::shutdown(parent.as_raw_fd(), libc::SHUT_WR);
+            }
+        }
+        let ack = ACK;
+        #[cfg(test)]
+        let ack = if command.fault == Fault::BadAck {
+            0
+        } else {
+            ack
+        };
+        if !transfer(parent.as_raw_fd(), &mut [ack], true, Some(pid)) {
+            return Err(failure("acknowledgment failed"));
+        }
+        Ok(network_fd)
+    })();
+    let network_fd = match handshake {
+        Ok(fds) => fds,
+        Err(error) => {
+            kill_and_reap(pid);
+            cleanup_listeners(&snapshot);
+            return Err(error);
+        }
+    };
+    // SAFETY: DETACHED was received, identity/ownership checked, and this is
+    // the only parent owner. The child closes its private copies before exec.
+    let network = Some(unsafe { OwnedFd::from_raw_fd(network_fd) });
+    Ok(Bootstrap {
+        child: nix::unistd::Pid::from_raw(pid),
+        network,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn child_exec(
+    command: &Command<'_>,
+    baseline: &PreparedLandlockSandbox,
+    network: &PreparedSeccompNotifyFilter,
+    gate: Option<RawFd>,
+    socket: RawFd,
+    parent_socket: RawFd,
+    parent_pid: libc::pid_t,
+    signals: &Signals,
+    closed_stdio: &[OwnedFd],
+) -> ! {
+    // SAFETY: raw scalar syscalls, no libc process/thread coordination.
+    if unsafe {
+        libc::syscall(
+            libc::SYS_prctl,
+            libc::PR_SET_PDEATHSIG,
+            libc::SIGKILL,
+            0,
+            0,
+            0,
+        )
+    } < 0
+        || unsafe { libc::syscall(libc::SYS_getppid) } != parent_pid as libc::c_long
+    {
+        die(126);
+    }
+    // SAFETY: runtime mediation reads this child's memory through procfs. This
+    // is set explicitly rather than depending on the parent's inherited value.
+    if unsafe { libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 1, 0, 0, 0) } < 0 {
+        die(126);
+    }
+    if !transfer(socket, &mut [READY], true, None) {
+        die(126);
+    }
+    #[cfg(test)]
+    if command.fault == Fault::PendingSignal {
+        // SAFETY: queue a signal to ourselves while all catchable signals are blocked.
+        unsafe {
+            libc::syscall(
+                libc::SYS_kill,
+                libc::syscall(libc::SYS_getpid),
+                libc::SIGUSR1,
+            );
+        }
+    }
+    let mut bytes = [0_u8; 8];
+    if !transfer(socket, &mut bytes, false, None) {
+        die(126);
+    }
+    let ruleset = i32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let cleanup_dir = i32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    if ruleset < 3 || cleanup_dir < 3 || ruleset == cleanup_dir {
+        die(126);
+    }
+    #[cfg(test)]
+    if command.fault == Fault::BeforeListener {
+        die(126);
+    }
+    let network_fd = match network.install_raw() {
+        Ok(fd) => fd,
+        Err(_) => die(126),
+    };
+    #[cfg(test)]
+    if matches!(
+        command.fault,
+        Fault::AfterFilesystem | Fault::AfterListener | Fault::BeforeDetach
+    ) {
+        die(126);
+    }
+    // Empty close_range unshares without closing anything. On older kernels,
+    // unshare(CLONE_FILES) has the same table-isolation property.
+    // SAFETY: scalar syscall arguments; no fd cleanup before success.
+    let detached = unsafe { libc::syscall(libc::SYS_close_range, u32::MAX, u32::MAX, 2_u32) };
+    if detached < 0 {
+        // SAFETY: shares no memory or FS state; only detaches the fd table.
+        if unsafe { libc::syscall(libc::SYS_unshare, libc::CLONE_FILES) } < 0 {
+            die(126);
+        }
+    }
+    #[cfg(test)]
+    if command.fault == Fault::AfterDetach {
+        die(126);
+    }
+    let mut report = [0_u8; 5];
+    report[..4].copy_from_slice(&network_fd.to_ne_bytes());
+    report[4] = DETACHED;
+    #[cfg(test)]
+    if command.fault == Fault::InvalidReport {
+        report[..4].copy_from_slice(&command.supervisor_fd.unwrap_or(1).to_ne_bytes());
+    }
+    #[cfg(test)]
+    let sent = if command.fault == Fault::Fragmented {
+        report
+            .iter_mut()
+            .all(|byte| transfer(socket, std::slice::from_mut(byte), true, None))
+    } else {
+        transfer(socket, &mut report, true, None)
+    };
+    #[cfg(not(test))]
+    let sent = transfer(socket, &mut report, true, None);
+    if !sent {
+        die(126);
+    }
+    let mut ack = [0_u8];
+    if !transfer(socket, &mut ack, false, None) || ack[0] != ACK {
+        die(126);
+    }
+    #[cfg(test)]
+    if command.fault == Fault::AfterAck {
+        die(126);
+    }
+    // SAFETY: confirmed private table, owned bootstrap endpoints.
+    unsafe {
+        libc::syscall(libc::SYS_close, socket);
+        libc::syscall(libc::SYS_close, parent_socket);
+    }
+    for fd in closed_stdio {
+        // SAFETY: these are owned placeholders in the now-private table.
+        unsafe {
+            libc::syscall(libc::SYS_close, fd.as_raw_fd());
+        }
+    }
+    if let Some(fd) = command.resource_procs
+        && !attach_resource_cgroup(fd)
+    {
+        die(126);
+    }
+    if let Some(fd) = command.pty_slave
+        && !setup_pty(fd)
+    {
+        die(126);
+    }
+    if gate.is_some() {
+        // SAFETY: cwd is a prebuilt NUL-terminated string, live through exec.
+        if unsafe { libc::syscall(libc::SYS_chdir, command.cwd.as_ptr()) } < 0 {
+            die(126);
+        }
+    }
+    // SAFETY: only scalar arguments and checked shared ruleset/gate fds. These
+    // kernel objects were fully populated in the parent before its release.
+    unsafe {
+        if libc::syscall(libc::SYS_prctl, libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
+            die(126);
+        }
+        if let Some(fd) = gate
+            && libc::syscall(libc::SYS_landlock_restrict_self, fd, 0_u32) < 0
+        {
+            die(126);
+        }
+        if libc::syscall(libc::SYS_landlock_restrict_self, ruleset, 0_u32) < 0 {
+            die(126);
+        }
+    }
+    if baseline.apply_static_network_raw().is_err() {
+        die(126);
+    }
+    if gate.is_none() {
+        // SAFETY: cwd remains live. Matches the existing post-sandbox chdir.
+        if unsafe { libc::syscall(libc::SYS_chdir, command.cwd.as_ptr()) } < 0 {
+            die(126);
+        }
+    }
+    if !scrub_fds(cleanup_dir, command.supervisor_fd) {
+        die(126);
+    }
+    if let Some(fd) = command.supervisor_fd {
+        // SAFETY: the sole intentionally inherited non-stdio descriptor.
+        if unsafe { libc::syscall(libc::SYS_fcntl, fd, libc::F_SETFD, 0) } < 0 {
+            die(126);
+        }
+    }
+    if !signals.restore_child() {
+        die(126);
+    }
+    // SAFETY: all strings/pointer arrays were prepared in the parent and have
+    // remained live in the child's private VM. No Rust unwinding on failure.
+    unsafe {
+        libc::syscall(
+            libc::SYS_execve,
+            command.program.as_ptr(),
+            command.argv.as_ptr(),
+            command.envp.as_ptr(),
+        );
+    }
+    die(127)
+}
+
+fn attach_resource_cgroup(fd: RawFd) -> bool {
+    // SAFETY: getpid is a scalar raw syscall.
+    let pid = unsafe { libc::syscall(libc::SYS_getpid) } as libc::pid_t;
+    let mut storage = itoa::Buffer::new();
+    let bytes = storage.format(pid).as_bytes();
+    loop {
+        // SAFETY: stack buffer and the caller's inherited cgroup.procs fd.
+        let written = unsafe { libc::syscall(libc::SYS_write, fd, bytes.as_ptr(), bytes.len()) };
+        if written < 0 && errno() == libc::EINTR {
+            continue;
+        }
+        return written == bytes.len() as libc::c_long;
+    }
+}
+
+fn setup_pty(slave: RawFd) -> bool {
+    // SAFETY: called only with a private table and valid inherited PTY slave.
+    unsafe {
+        if libc::syscall(libc::SYS_setsid) < 0
+            || libc::syscall(libc::SYS_ioctl, slave, libc::TIOCSCTTY, 0) < 0
+        {
+            return false;
+        }
+        for target in 0..=2 {
+            if slave == target {
+                if libc::syscall(libc::SYS_fcntl, slave, libc::F_SETFD, 0) < 0 {
+                    return false;
+                }
+            } else if libc::syscall(libc::SYS_dup3, slave, target, 0) < 0 {
+                return false;
+            }
+        }
+        if slave > 2 && libc::syscall(libc::SYS_close, slave) < 0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Enumerate the child's live table, not the parent's startup snapshot. The
+/// directory was opened by the parent using /proc/CHILD/fd before openat was
+/// trapped. It continues to refer to the child after the table detaches.
+fn scrub_fds(directory: RawFd, keep: Option<RawFd>) -> bool {
+    let mut buffer = [0_u8; 4096];
+    loop {
+        // SAFETY: initialized stack buffer, private descriptor table. Linux's
+        // proc fd directory position is the fd number, so closing earlier
+        // entries does not skip or renumber later entries.
+        let count = unsafe {
+            libc::syscall(
+                libc::SYS_getdents64,
+                directory,
+                buffer.as_mut_ptr(),
+                buffer.len(),
+            )
+        };
+        if count < 0 {
+            if errno() == libc::EINTR {
+                continue;
+            }
+            return false;
+        }
+        if count == 0 {
+            break;
+        }
+        let count = count as usize;
+        if count > buffer.len() {
+            return false;
+        }
+        let mut offset = 0_usize;
+        while offset < count {
+            // linux_dirent64: ino(8), offset(8), reclen(2), type(1), name.
+            if count - offset < 20 {
+                return false;
+            }
+            let length = u16::from_ne_bytes([buffer[offset + 16], buffer[offset + 17]]) as usize;
+            if length < 20 || length > count - offset {
+                return false;
+            }
+            let name = &buffer[offset + 19..offset + length];
+            let mut number = Some(0_i32);
+            let mut terminated = false;
+            for byte in name {
+                if *byte == 0 {
+                    terminated = true;
+                    break;
+                }
+                if !byte.is_ascii_digit() {
+                    number = None;
+                }
+                number = number
+                    .and_then(|n| n.checked_mul(10))
+                    .and_then(|n| n.checked_add(i32::from(*byte) - i32::from(b'0')));
+            }
+            if !terminated {
+                return false;
+            }
+            if let Some(fd) = number
+                && fd >= 3
+                && fd != directory
+                && Some(fd) != keep
+            {
+                // SAFETY: this entry belongs to our private table, and no
+                // thread or signal handler can create/reuse slots here.
+                let closed = unsafe { libc::syscall(libc::SYS_close, fd) };
+                if closed < 0 && errno() != libc::EINTR {
+                    return false;
+                }
+            }
+            offset += length;
+        }
+    }
+    // SAFETY: directory is no longer needed, and is not an inherited endpoint.
+    unsafe { libc::syscall(libc::SYS_close, directory) >= 0 }
+}
+
+fn listener_target(target: &std::path::Path) -> bool {
+    target == std::path::Path::new("anon_inode:seccomp notify")
+        || target == std::path::Path::new("anon_inode:[seccomp notify]")
+}
+
+fn listeners() -> Result<BTreeSet<RawFd>> {
+    let mut result = BTreeSet::new();
+    for entry in std::fs::read_dir("/proc/self/fd")
+        .map_err(|_| failure("cannot enumerate listener owners"))?
+    {
+        let entry = entry.map_err(|_| failure("cannot enumerate descriptor"))?;
+        let Ok(fd) = entry.file_name().to_string_lossy().parse::<RawFd>() else {
+            continue;
+        };
+        match std::fs::read_link(entry.path()) {
+            Ok(target) if listener_target(&target) => {
+                result.insert(fd);
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // ordinary fd churn
+            Err(_) => return Err(failure("cannot inspect descriptor identity")),
+        }
+    }
+    Ok(result)
+}
+
+fn validate_listener(fd: RawFd, snapshot: &BTreeSet<RawFd>) -> Result<()> {
+    if fd < 3 || snapshot.contains(&fd) {
+        return Err(failure("invalid or pre-existing listener slot"));
+    }
+    let target = std::fs::read_link(format!("/proc/self/fd/{fd}"))
+        .map_err(|_| failure("listener disappeared"))?;
+    // SAFETY: F_GETFD does not mutate the descriptor table.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if !listener_target(&target) || flags < 0 || flags & libc::FD_CLOEXEC == 0 {
+        return Err(failure(
+            "reported descriptor is not a close-on-exec listener",
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_listeners(snapshot: &BTreeSet<RawFd>) {
+    let current = match listeners() {
+        Ok(current) => current,
+        // Cannot prove which descriptors were created. The only fail-closed
+        // cleanup is to terminate this CLI process and release its entire table.
+        Err(_) => std::process::exit(126),
+    };
+    for fd in current.difference(snapshot) {
+        // SAFETY: child reaped; session ownership lock excludes other listener
+        // creators/destructors. Never close an unvalidated reported raw number.
+        unsafe {
+            libc::close(*fd);
+        }
+    }
+}
+
+fn kill_and_reap(pid: libc::pid_t) {
+    // SAFETY: bootstrap probes use WNOWAIT, so this PID has not been reaped
+    // and cannot be reused. It is our direct, trusted child.
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+    loop {
+        // SAFETY: waits for that exact child, without a status buffer.
+        let result = unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+        if result == pid || (result < 0 && errno() == libc::ECHILD) {
+            return;
+        }
+        if result < 0 && errno() != libc::EINTR {
+            std::process::exit(126);
+        }
+    }
+}
+
+fn errno() -> i32 {
+    // SAFETY: inherited TLS is private; errno access does not allocate or lock.
+    unsafe { *libc::__errno_location() }
+}
+
+fn monotonic_seconds() -> Option<i64> {
+    let mut time = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: valid stack buffer, raw syscall avoids vDSO/libc initialization.
+    if unsafe { libc::syscall(libc::SYS_clock_gettime, libc::CLOCK_MONOTONIC, &mut time) } < 0 {
+        None
+    } else {
+        Some(time.tv_sec)
+    }
+}
+
+/// Raw, bounded exact I/O. In the parent, additionally detect child death
+/// without reaping it; socket EOF cannot be relied on in the shared table.
+fn transfer(fd: RawFd, bytes: &mut [u8], write: bool, child: Option<libc::pid_t>) -> bool {
+    let Some(start) = monotonic_seconds() else {
+        return false;
+    };
+    let deadline = start.saturating_add(BOOTSTRAP_SECONDS);
+    let mut offset = 0;
+    while offset < bytes.len() {
+        if monotonic_seconds().is_none_or(|now| now >= deadline) {
+            return false;
+        }
+        if let Some(pid) = child {
+            // SAFETY: zeroed siginfo is valid storage for waitid; WNOWAIT
+            // preserves our ability to signal and reap this exact child.
+            let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+            let rc = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    pid as libc::id_t,
+                    &mut info,
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            if rc < 0 {
+                if errno() == libc::EINTR {
+                    continue;
+                }
+                return false;
+            }
+            // SAFETY: waitid initializes the child identity member.
+            if unsafe { info.si_pid() } == pid {
+                return false;
+            }
+        }
+        let mut poll = libc::pollfd {
+            fd,
+            events: if write { libc::POLLOUT } else { libc::POLLIN },
+            revents: 0,
+        };
+        // SAFETY: one initialized pollfd; bounded wait keeps liveness checked.
+        let timeout = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 20_000_000,
+        };
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_ppoll,
+                &mut poll,
+                1_usize,
+                &timeout,
+                std::ptr::null::<u64>(),
+                8_usize,
+            )
+        };
+        if rc < 0 {
+            if errno() == libc::EINTR {
+                continue;
+            }
+            return false;
+        }
+        if rc == 0 {
+            continue;
+        }
+        if poll.revents & poll.events == 0 {
+            return false;
+        }
+        // SAFETY: offset is bounded by bytes.len(); transfer length cannot
+        // exceed the remaining initialized buffer. Parent send avoids SIGPIPE.
+        let rc = unsafe {
+            if write && child.is_some() {
+                libc::send(
+                    fd,
+                    bytes[offset..].as_ptr().cast(),
+                    bytes.len() - offset,
+                    libc::MSG_NOSIGNAL,
+                )
+            } else if write {
+                libc::syscall(
+                    libc::SYS_write,
+                    fd,
+                    bytes[offset..].as_ptr(),
+                    bytes.len() - offset,
+                ) as isize
+            } else {
+                libc::syscall(
+                    libc::SYS_read,
+                    fd,
+                    bytes[offset..].as_mut_ptr(),
+                    bytes.len() - offset,
+                ) as isize
+            }
+        };
+        if rc < 0 && (errno() == libc::EINTR || errno() == libc::EAGAIN) {
+            continue;
+        }
+        if rc <= 0 {
+            return false;
+        }
+        offset += rc as usize;
+    }
+    true
+}
+
+struct Signals {
+    old: u64,
+    ignored: [bool; 65],
+    restored: bool,
+}
+impl Signals {
+    fn block() -> Result<Self> {
+        let mut result = Self {
+            old: 0,
+            ignored: [false; 65],
+            restored: false,
+        };
+        let all = u64::MAX;
+        // SAFETY: the Linux kernel signal mask is 64 bits (unlike libc's padded
+        // sigset_t). Block runtime-private signals too in the raw clone child.
+        if unsafe {
+            libc::syscall(
+                libc::SYS_rt_sigprocmask,
+                libc::SIG_SETMASK,
+                &all,
+                &mut result.old,
+                8_usize,
+            )
+        } < 0
+        {
+            result.restored = true;
+            return Err(failure("cannot block bootstrap signals"));
+        }
+        for signal in 1..=64 {
+            if signal == libc::SIGKILL || signal == libc::SIGSTOP {
+                continue;
+            }
+            let mut action = [0_usize; 4];
+            // SAFETY: oversized kernel sigaction buffer on supported Linux
+            // architectures; handler is its first word. No libc reserved-signal
+            // filtering, so runtime-private handlers are captured too.
+            if unsafe {
+                libc::syscall(
+                    libc::SYS_rt_sigaction,
+                    signal,
+                    std::ptr::null::<usize>(),
+                    action.as_mut_ptr(),
+                    8_usize,
+                )
+            } < 0
+            {
+                return Err(failure("cannot capture signal disposition"));
+            }
+            result.ignored[signal as usize] = action[0] == libc::SIG_IGN;
+        }
+        Ok(result)
+    }
+    fn restore(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+        // SAFETY: old was initialized by rt_sigprocmask for this thread.
+        if unsafe {
+            libc::syscall(
+                libc::SYS_rt_sigprocmask,
+                libc::SIG_SETMASK,
+                &self.old,
+                std::ptr::null_mut::<u64>(),
+                8_usize,
+            )
+        } < 0
+        {
+            return Err(failure("cannot restore parent signal mask"));
+        }
+        self.restored = true;
+        Ok(())
+    }
+    fn restore_child(&self) -> bool {
+        for signal in 1..=64 {
+            if signal == libc::SIGKILL || signal == libc::SIGSTOP {
+                continue;
+            }
+            // For a default/ignored action flags, restorer and mask are all
+            // zero, independent of architecture-specific sigaction layout.
+            let action = [
+                if self.ignored[signal as usize] {
+                    libc::SIG_IGN
+                } else {
+                    libc::SIG_DFL
+                },
+                0,
+                0,
+                0,
+            ];
+            // SAFETY: fixed kernel action, no user handler can run before exec.
+            if unsafe {
+                libc::syscall(
+                    libc::SYS_rt_sigaction,
+                    signal,
+                    action.as_ptr(),
+                    std::ptr::null_mut::<usize>(),
+                    8_usize,
+                )
+            } < 0
+            {
+                return false;
+            }
+        }
+        // SAFETY: restore only after replacing inherited runtime handlers.
+        unsafe {
+            libc::syscall(
+                libc::SYS_rt_sigprocmask,
+                libc::SIG_SETMASK,
+                &self.old,
+                std::ptr::null_mut::<u64>(),
+                8_usize,
+            ) >= 0
+        }
+    }
+}
+impl Drop for Signals {
+    fn drop(&mut self) {
+        if self.restore().is_err() {
+            std::process::exit(126);
+        }
+    }
+}
+
+fn die(status: i32) -> ! {
+    // SAFETY: no destructors, allocation, locks, or potentially blocking error
+    // writes. exit_group terminates the copied process, never the parent.
+    unsafe {
+        libc::syscall(libc::SYS_exit_group, status);
+        libc::_exit(status);
+    }
+}
+
+#[cfg(debug_assertions)]
+mod allocation_guard {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    pub(super) static ARMED: AtomicBool = AtomicBool::new(false);
+    struct Guarded;
+    #[global_allocator]
+    static ALLOCATOR: Guarded = Guarded;
+    fn check() {
+        if ARMED.load(Ordering::Relaxed) {
+            super::die(125);
+        }
+    }
+    // SAFETY: delegates the GlobalAlloc contract to System, unless the private
+    // raw-clone child flag forbids all allocator activity, including deallocation.
+    unsafe impl GlobalAlloc for Guarded {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            check();
+            // SAFETY: forwarded unchanged from GlobalAlloc's caller.
+            unsafe { System.alloc(layout) }
+        }
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            check();
+            // SAFETY: forwarded unchanged from GlobalAlloc's caller.
+            unsafe { System.alloc_zeroed(layout) }
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            check();
+            // SAFETY: forwarded unchanged from GlobalAlloc's caller.
+            unsafe {
+                System.dealloc(ptr, layout);
+            }
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+            check();
+            // SAFETY: forwarded unchanged from GlobalAlloc's caller.
+            unsafe { System.realloc(ptr, layout, size) }
+        }
+    }
+}
+fn arm_allocator_guard() {
+    #[cfg(debug_assertions)]
+    allocation_guard::ARMED.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/nono-cli/src/exec_strategy/clone_files/tests.rs
+++ b/crates/nono-cli/src/exec_strategy/clone_files/tests.rs
@@ -1,0 +1,1051 @@
+use super::*;
+use crate::exec_strategy::{SeccompPolicy, SupervisorConfig, ThreadingContext, supervisor_linux};
+use nono::{AccessMode, FsCapability};
+use std::ffi::CString;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn isolated(name: &str, test: impl FnOnce() -> Result<()>) -> Result<()> {
+    if std::env::var("NONO_CLONE_TEST").ok().as_deref() == Some(name) {
+        return test();
+    }
+    let executable = std::env::current_exe().map_err(NonoError::Io)?;
+    let mut process = std::process::Command::new(executable);
+    if name == "tool_gate_with_combined_notifications" {
+        process.env("PATH", "");
+    }
+    if name.starts_with("live_") {
+        process.arg("--ignored");
+    }
+    let mut child = process
+        .args([
+            "--exact",
+            &format!("exec_strategy::clone_files::tests::{name}"),
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("NONO_CLONE_TEST", name)
+        .spawn()
+        .map_err(NonoError::Io)?;
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Some(status) = child.try_wait().map_err(NonoError::Io)? {
+            assert!(status.success(), "isolated {name}: {status}");
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            child.kill().map_err(NonoError::Io)?;
+            child.wait().map_err(NonoError::Io)?;
+            return Err(failure("isolated test exceeded timeout"));
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn config(caps: &CapabilitySet, filesystem: bool, proxy: bool) -> ExecConfig<'_> {
+    ExecConfig {
+        command: &[],
+        resolved_program: Path::new("/usr/bin/python3"),
+        caps,
+        env_vars: vec![],
+        cap_file: Path::new("/unused"),
+        current_dir: Path::new("/"),
+        child_pwd: None,
+        host_pwd: None,
+        no_diagnostics: true,
+        diagnostics_json: false,
+        proxy_diagnostics: None,
+        diagnostic_verbosity: 0,
+        threading: ThreadingContext::Strict,
+        protected_paths: &[],
+        profile_save_base: None,
+        ignored_denial_paths: &[],
+        suppressed_system_service_operations: &[],
+        startup_timeout: None,
+        seccomp_policy: SeccompPolicy {
+            capability_elevation: filesystem,
+            proxy_fallback: proxy,
+            af_unix_mediation: true,
+            proc_comm_notify: filesystem,
+        },
+        sandbox_policy: LinuxSandboxPolicy::Auto,
+        allowed_env_vars: None,
+        denied_env_vars: None,
+        case_insensitive_env_vars: false,
+        set_vars: vec![],
+        tool_sandbox_runtime: None,
+    }
+}
+
+fn capabilities(port: u16, bind: u16) -> Result<CapabilitySet> {
+    let mut caps = CapabilitySet::new().proxy_only_with_bind(port, vec![bind]);
+    for directory in ["/usr", "/lib", "/lib64", "/etc", "/proc/self/fd"] {
+        if Path::new(directory).exists() {
+            caps.add_fs(FsCapability::new_dir(directory, AccessMode::Read)?);
+        }
+    }
+    caps.add_fs(FsCapability::new_file(
+        "/proc/self/status",
+        AccessMode::Read,
+    )?);
+    caps.add_fs(FsCapability::new_file("/dev/null", AccessMode::ReadWrite)?);
+    caps.deduplicate();
+    Ok(caps)
+}
+
+struct Deny;
+impl nono::ApprovalBackend for Deny {
+    fn request_approval(
+        &self,
+        _: &nono::supervisor::ApprovalRequest,
+    ) -> Result<nono::supervisor::ApprovalDecision> {
+        Ok(nono::supervisor::ApprovalDecision::Denied {
+            reason: "test".into(),
+        })
+    }
+    fn backend_name(&self) -> &str {
+        "test-deny"
+    }
+}
+
+fn supervise(
+    bootstrap: &Bootstrap,
+    caps: &CapabilitySet,
+    policy: SeccompPolicy,
+    port: u16,
+    bind: u16,
+) -> Result<i32> {
+    let scrub = nono::ScrubPolicy::secure_default();
+    let config = SupervisorConfig {
+        protected_roots: &[],
+        approval_backend: &Deny,
+        session_id: "clone-test",
+        attach_initial_client: false,
+        detach_sequence: None,
+        caps,
+        open_url_origins: &[],
+        open_url_allow_localhost: false,
+        audit_recorder: None,
+        network_audit_events: None,
+        redaction_policy: &scrub,
+        allow_launch_services_active: false,
+        seccomp_policy: policy,
+        proxy_port: port,
+        proxy_bind_ports: vec![bind],
+        proxy_bind_port_ranges: vec![],
+        unix_socket_allowlist: caps.unix_socket_capabilities(),
+        tool_sandbox_runtime: None,
+    };
+    let mut child_caps = caps.clone();
+    child_caps.remap_procfs_self_references(bootstrap.child.as_raw() as u32, None);
+    child_caps.widen_procfs_self_to_proc();
+    let initial: Vec<_> = child_caps
+        .fs_capabilities()
+        .iter()
+        .map(|cap| supervisor_linux::InitialCapability {
+            path: cap.resolved.clone(),
+            access: cap.access,
+            is_file: cap.is_file,
+        })
+        .collect();
+    let mut limiter = supervisor_linux::RateLimiter::new(10000, 10000);
+    let mut denials = vec![];
+    let mut ipc_denials = vec![];
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let mut status = 0;
+        // SAFETY: direct test child, status points to valid storage.
+        let waited = unsafe { libc::waitpid(bootstrap.child.as_raw(), &mut status, libc::WNOHANG) };
+        if waited == bootstrap.child.as_raw() {
+            return Ok(if libc::WIFEXITED(status) {
+                libc::WEXITSTATUS(status)
+            } else {
+                128 + libc::WTERMSIG(status)
+            });
+        }
+        if Instant::now() >= deadline {
+            kill_and_reap(bootstrap.child.as_raw());
+            return Err(failure("test supervisor timed out"));
+        }
+        let mut polls = [libc::pollfd {
+            fd: bootstrap.network.as_ref().map_or(-1, AsRawFd::as_raw_fd),
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+        // SAFETY: initialized poll array; no borrowed buffer outlives this call.
+        if unsafe { libc::poll(polls.as_mut_ptr(), polls.len() as libc::nfds_t, 20) } < 0 {
+            continue;
+        }
+        if polls[0].revents & libc::POLLIN != 0 {
+            supervisor_linux::handle_combined_notification(
+                polls[0].fd,
+                bootstrap.child,
+                &config,
+                &initial,
+                supervisor_linux::SeccompNotificationState {
+                    rate_limiter: &mut limiter,
+                    denials: &mut denials,
+                    trust_interceptor: None,
+                    pty: None,
+                },
+                &mut ipc_denials,
+            )?;
+        }
+    }
+}
+
+fn run(
+    config: &ExecConfig<'_>,
+    script: &str,
+    abi: landlock::ABI,
+    fault: Fault,
+    supervisor_fd: Option<RawFd>,
+    pty: Option<RawFd>,
+    resource: Option<RawFd>,
+) -> Result<Bootstrap> {
+    let program = CString::new("/usr/bin/python3").map_err(|_| failure("program CString"))?;
+    let arg = CString::new("-c").map_err(|_| failure("argument CString"))?;
+    let script = CString::new(script).map_err(|_| failure("script CString"))?;
+    let argv = [
+        program.as_ptr(),
+        arg.as_ptr(),
+        script.as_ptr(),
+        std::ptr::null(),
+    ];
+    let environment = c"PYTHONDONTWRITEBYTECODE=1";
+    let envp = [environment.as_ptr(), std::ptr::null()];
+    spawn(
+        config,
+        Command {
+            program: &program,
+            argv: &argv,
+            envp: &envp,
+            cwd: c"/",
+            supervisor_fd,
+            pty_slave: pty,
+            resource_procs: resource,
+            fault,
+        },
+        config.caps,
+        DetectedAbi::new(abi),
+    )
+}
+
+fn fd_count() -> Result<usize> {
+    Ok(std::fs::read_dir("/proc/self/fd")
+        .map_err(NonoError::Io)?
+        .count())
+}
+
+#[test]
+fn proxy_and_combined_notifications() -> Result<()> {
+    isolated("proxy_and_combined_notifications", || {
+        let _lock = lock_listener_ownership()?;
+        let status = std::fs::read_to_string("/proc/self/status").map_err(NonoError::Io)?;
+        let effective = status
+            .lines()
+            .find_map(|line| line.strip_prefix("CapEff:\t"))
+            .ok_or_else(|| failure("missing CapEff"))?;
+        let effective =
+            u64::from_str_radix(effective, 16).map_err(|_| failure("invalid CapEff"))?;
+        assert_eq!(
+            effective & (1 << 19),
+            0,
+            "test must run without CAP_SYS_PTRACE"
+        );
+        let proxy = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let direct = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let spare = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let port = proxy.local_addr().map_err(NonoError::Io)?.port();
+        let denied_port = direct.local_addr().map_err(NonoError::Io)?.port();
+        let bind = spare.local_addr().map_err(NonoError::Io)?.port();
+        drop(spare);
+        let dir = tempfile::tempdir().map_err(NonoError::Io)?;
+        let unix_path = dir.path().join("allowed.sock");
+        let denied_unix_path = dir.path().join("denied.sock");
+        let _unix = std::os::unix::net::UnixListener::bind(&unix_path).map_err(NonoError::Io)?;
+        let _denied_unix =
+            std::os::unix::net::UnixListener::bind(&denied_unix_path).map_err(NonoError::Io)?;
+        let secret = dir.path().join("secret");
+        std::fs::write(&secret, "must stay inaccessible").map_err(NonoError::Io)?;
+        let mut caps = capabilities(port, bind)?;
+        caps.add_unix_socket(nono::UnixSocketCapability::new_file(
+            &unix_path,
+            nono::UnixSocketMode::Connect,
+        )?);
+        let before = fd_count()?;
+        for (abi, filesystem) in [
+            (landlock::ABI::V3, false),
+            (landlock::ABI::V3, true),
+            (landlock::ABI::V4, false),
+            (landlock::ABI::V4, true),
+        ] {
+            let config = config(&caps, filesystem, abi == landlock::ABI::V3);
+            let script = format!(
+                r#"
+import errno, os, socket
+leaks = []
+for fd in range(3, 2048):
+    try: os.fstat(fd)
+    except OSError: continue
+    leaks.append(fd)
+assert not leaks, leaks
+socket.create_connection(('127.0.0.1', {port}), timeout=2).close()
+try: socket.create_connection(('127.0.0.1', {denied_port}), timeout=2)
+except PermissionError: pass
+else: raise AssertionError('direct TCP escaped')
+s = socket.socket(); s.bind(('127.0.0.1', {bind})); s.close()
+try: socket.socket().bind(('127.0.0.1', 0))
+except PermissionError: pass
+else: raise AssertionError('ungranted bind escaped')
+s = socket.socket(socket.AF_UNIX); s.connect({unix_path:?}); s.close()
+try: socket.socket(socket.AF_UNIX).connect({denied_unix_path:?})
+except PermissionError: pass
+else: raise AssertionError('ungranted AF_UNIX escaped')
+try: open({secret:?})
+except PermissionError: pass
+else: raise AssertionError('filesystem escaped')
+assert 'Pid:\t' + str(os.getpid()) + '\n' in open('/proc/self/status').read()
+try: open('/proc/{parent}/status')
+except PermissionError: pass
+else: raise AssertionError('parent procfs accidentally granted')
+"#,
+                unix_path = unix_path.to_string_lossy(),
+                denied_unix_path = denied_unix_path.to_string_lossy(),
+                secret = secret.to_string_lossy(),
+                parent = std::process::id()
+            );
+            let bootstrap = run(&config, &script, abi, Fault::Fragmented, None, None, None)?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, port, bind)?,
+                0,
+                "{abi:?}, filesystem={filesystem}"
+            );
+            drop(bootstrap);
+            assert_eq!(
+                fd_count()?,
+                before,
+                "fd leak after {abi:?}, filesystem={filesystem}"
+            );
+        }
+        Ok(())
+    })
+}
+
+#[test]
+fn failure_cleanup() -> Result<()> {
+    isolated("failure_cleanup", || {
+        let _lock = lock_listener_ownership()?;
+        let caps = capabilities(34567, 34568)?;
+        let config = config(&caps, true, true);
+        let sentinel = std::fs::File::open("/dev/null").map_err(NonoError::Io)?;
+        let existing = preexisting_listener()?;
+        let before = fd_count()?;
+        for fault in [
+            Fault::BeforeListener,
+            Fault::AfterFilesystem,
+            Fault::AfterListener,
+            Fault::BeforeDetach,
+            Fault::AfterDetach,
+            Fault::InvalidReport,
+            Fault::FailedAck,
+        ] {
+            assert!(
+                run(
+                    &config,
+                    "raise AssertionError('must not exec')",
+                    landlock::ABI::V3,
+                    fault,
+                    Some(sentinel.as_raw_fd()),
+                    None,
+                    None
+                )
+                .is_err()
+            );
+            assert_eq!(fd_count()?, before);
+            assert!(
+                !sentinel
+                    .metadata()
+                    .map_err(NonoError::Io)?
+                    .file_type()
+                    .is_file()
+            );
+        }
+        assert!(
+            run(
+                &config,
+                "raise AssertionError('must not exec')",
+                landlock::ABI::V3,
+                Fault::InvalidReport,
+                Some(existing.as_raw_fd()),
+                None,
+                None
+            )
+            .is_err()
+        );
+        assert_eq!(fd_count()?, before);
+        assert!(listener_target(
+            &std::fs::read_link(format!("/proc/self/fd/{}", existing.as_raw_fd()))
+                .map_err(NonoError::Io)?
+        ));
+        let argv = [
+            c"/nonexistent-nono-clone-command".as_ptr(),
+            std::ptr::null(),
+        ];
+        let envp = [std::ptr::null()];
+        let bootstrap = spawn(
+            &config,
+            Command {
+                program: c"/nonexistent-nono-clone-command",
+                argv: &argv,
+                envp: &envp,
+                cwd: c"/",
+                supervisor_fd: None,
+                pty_slave: None,
+                resource_procs: None,
+                fault: Fault::None,
+            },
+            &caps,
+            DetectedAbi::new(landlock::ABI::V3),
+        )?;
+        assert_eq!(
+            supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+            127
+        );
+        drop(bootstrap);
+        assert_eq!(fd_count()?, before);
+        for fault in [Fault::BadAck, Fault::AfterAck] {
+            let bootstrap = run(
+                &config,
+                "raise AssertionError('must not exec')",
+                landlock::ABI::V3,
+                fault,
+                None,
+                None,
+                None,
+            )?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+                126
+            );
+            drop(bootstrap);
+            assert_eq!(fd_count()?, before);
+        }
+        Ok(())
+    })
+}
+
+#[test]
+fn fd_churn_signals_and_late_descriptors() -> Result<()> {
+    isolated("fd_churn_signals_and_late_descriptors", || {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        static SIGNALS: AtomicUsize = AtomicUsize::new(0);
+        extern "C" fn handler(_: i32) {
+            SIGNALS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: actions are initialized before installation; the handler
+        // only performs an atomic operation, and is restored on every exit.
+        let mut previous: libc::sigaction = unsafe { std::mem::zeroed() };
+        let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+        action.sa_sigaction = handler as *const () as usize;
+        // SAFETY: both signal action pointers are valid.
+        assert_eq!(
+            unsafe { libc::sigaction(libc::SIGUSR1, &action, &mut previous) },
+            0
+        );
+        struct Restore(libc::sigaction);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                // SAFETY: restore the action saved by sigaction.
+                unsafe {
+                    libc::sigaction(libc::SIGUSR1, &self.0, std::ptr::null_mut());
+                }
+            }
+        }
+        let _restore = Restore(previous);
+        let _lock = lock_listener_ownership()?;
+        let caps = capabilities(34567, 34568)?;
+        let config = config(&caps, false, true);
+        let before = fd_count()?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let parent = std::process::id() as libc::pid_t;
+        let worker = std::thread::spawn(move || -> Result<()> {
+            while !worker_stop.load(Ordering::Relaxed) {
+                let file = std::fs::File::open("/dev/null").map_err(NonoError::Io)?;
+                // SAFETY: allocate and close only a descriptor owned by this
+                // worker. This deliberately races the shared-table bootstrap.
+                let high = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 768) };
+                if high < 0 {
+                    return Err(failure("fd churn could not allocate high descriptor"));
+                }
+                // SAFETY: checked, freshly allocated descriptor and our own PID.
+                unsafe {
+                    libc::close(high);
+                    libc::kill(parent, libc::SIGUSR1);
+                }
+                std::thread::sleep(Duration::from_micros(100));
+            }
+            Ok(())
+        });
+        let exercise = (|| -> Result<()> {
+            for _ in 0..24 {
+                let bootstrap = run(
+                    &config,
+                    r#"
+import os
+for name in os.listdir('/proc/self/fd'):
+    try: target = os.readlink('/proc/self/fd/' + name)
+    except FileNotFoundError: continue
+    assert int(name) <= 2, (name, target)
+"#,
+                    landlock::ABI::V3,
+                    Fault::LateFd,
+                    None,
+                    None,
+                    None,
+                )?;
+                assert_eq!(
+                    supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+                    0
+                );
+            }
+            let bootstrap = run(
+                &config,
+                "raise AssertionError('pending SIGUSR1 must terminate before exec')",
+                landlock::ABI::V3,
+                Fault::PendingSignal,
+                None,
+                None,
+                None,
+            )?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+                128 + libc::SIGUSR1
+            );
+            Ok(())
+        })();
+        stop.store(true, Ordering::Relaxed);
+        worker
+            .join()
+            .map_err(|_| failure("fd churn thread panicked"))??;
+        exercise?;
+        assert!(SIGNALS.load(Ordering::Relaxed) > 0);
+        assert_eq!(fd_count()?, before);
+        Ok(())
+    })
+}
+
+#[test]
+fn pty_cgroup_write_and_supervisor_inheritance() -> Result<()> {
+    isolated("pty_cgroup_write_and_supervisor_inheritance", || {
+        use std::io::{Read, Seek};
+        let _lock = lock_listener_ownership()?;
+        let caps = capabilities(34567, 34568)?;
+        let config = config(&caps, true, true);
+        let pty = crate::pty_proxy::open_pty()?;
+        let (supervisor, _peer) = UnixStream::pair().map_err(NonoError::Io)?;
+        let mut procs = tempfile::tempfile().map_err(NonoError::Io)?;
+        let script = format!(
+            r#"
+import os
+assert all(os.isatty(fd) for fd in (0, 1, 2))
+assert os.getsid(0) == os.getpid()
+assert os.get_inheritable({fd})
+live = []
+for number in range(3, 2048):
+    try: os.fstat(number)
+    except OSError: continue
+    live.append(number)
+assert live == [{fd}], live
+"#,
+            fd = supervisor.as_raw_fd()
+        );
+        let bootstrap = run(
+            &config,
+            &script,
+            landlock::ABI::V3,
+            Fault::None,
+            Some(supervisor.as_raw_fd()),
+            Some(pty.slave.as_raw_fd()),
+            Some(procs.as_raw_fd()),
+        )?;
+        let code = supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?;
+        if code != 0 {
+            let mut output = [0_u8; 8192];
+            // SAFETY: owned PTY master and initialized output buffer.
+            let read = unsafe {
+                libc::fcntl(pty.master.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+                libc::read(
+                    pty.master.as_raw_fd(),
+                    output.as_mut_ptr().cast(),
+                    output.len(),
+                )
+            };
+            if read > 0 {
+                eprintln!(
+                    "PTY child output: {}",
+                    String::from_utf8_lossy(&output[..read as usize])
+                );
+            }
+        }
+        assert_eq!(code, 0);
+        procs.rewind().map_err(NonoError::Io)?;
+        let mut written = String::new();
+        procs.read_to_string(&mut written).map_err(NonoError::Io)?;
+        assert_eq!(written, bootstrap.child.as_raw().to_string());
+        // This verifies the exact cgroup.procs write path; a real delegated
+        // cgroup is covered separately by resource_cgroup's live kernel tests.
+        let bootstrap = run(
+            &config,
+            "raise AssertionError('invalid cgroup fd must prevent exec')",
+            landlock::ABI::V3,
+            Fault::None,
+            None,
+            None,
+            Some(-1),
+        )?;
+        assert_eq!(
+            supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+            126
+        );
+        Ok(())
+    })
+}
+
+fn deny_syscalls(syscalls: &[libc::c_long]) -> Result<()> {
+    let mut filter = vec![libc::sock_filter {
+        code: 0x20,
+        jt: 0,
+        jf: 0,
+        k: 0,
+    }];
+    for syscall in syscalls {
+        filter.push(libc::sock_filter {
+            code: 0x15,
+            jt: 0,
+            jf: 1,
+            k: *syscall as u32,
+        });
+        filter.push(libc::sock_filter {
+            code: 0x06,
+            jt: 0,
+            jf: 0,
+            k: 0x00050000 | libc::EPERM as u32,
+        });
+    }
+    filter.push(libc::sock_filter {
+        code: 0x06,
+        jt: 0,
+        jf: 0,
+        k: 0x7fff0000,
+    });
+    let program = libc::sock_fprog {
+        len: filter.len() as u16,
+        filter: filter.as_mut_ptr(),
+    };
+    // SAFETY: test-only restrictive filter; array and header live through the
+    // syscall. Installed only inside the isolated test subprocess.
+    unsafe {
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0
+            || libc::syscall(libc::SYS_seccomp, 1, 0, &program) < 0
+        {
+            return Err(failure("cannot install regression syscall denial filter"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn kernel_detachment_failure_is_closed() -> Result<()> {
+    isolated("kernel_detachment_failure_is_closed", || {
+        let _lock = lock_listener_ownership()?;
+        deny_syscalls(&[libc::SYS_close_range, libc::SYS_unshare])?;
+        let caps = capabilities(34567, 34568)?;
+        let config = config(&caps, true, true);
+        let before = fd_count()?;
+        for _ in 0..8 {
+            assert!(
+                run(
+                    &config,
+                    "raise AssertionError('must not exec')",
+                    landlock::ABI::V3,
+                    Fault::None,
+                    None,
+                    None,
+                    None
+                )
+                .is_err()
+            );
+            assert_eq!(fd_count()?, before);
+        }
+        Ok(())
+    })
+}
+
+#[test]
+fn closed_stdio_and_unshare_fallback() -> Result<()> {
+    isolated("closed_stdio_and_unshare_fallback", || {
+        // Exercise the older-kernel detachment path and prove there is no
+        // dependency on either pidfd syscall even when explicitly denied.
+        deny_syscalls(&[
+            libc::SYS_close_range,
+            libc::SYS_pidfd_open,
+            libc::SYS_pidfd_getfd,
+        ])?;
+        let _lock = lock_listener_ownership()?;
+        let caps = capabilities(34567, 34568)?;
+        let config = config(&caps, false, true);
+        let mut saved = Vec::new();
+        for fd in 0..=2 {
+            // SAFETY: save each original stdio slot before closing it.
+            let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
+            if duplicate < 0 {
+                return Err(failure("cannot save test stdio"));
+            }
+            // SAFETY: checked, fresh owned duplicate.
+            saved.push(unsafe { OwnedFd::from_raw_fd(duplicate) });
+        }
+        struct Restore(Vec<OwnedFd>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                for (fd, saved) in self.0.iter().enumerate() {
+                    // SAFETY: restore only the stdio slots this test closed.
+                    unsafe {
+                        libc::dup2(saved.as_raw_fd(), fd as i32);
+                    }
+                }
+            }
+        }
+        let restore = Restore(saved);
+        for fd in 0..=2 {
+            // SAFETY: saved copies above remain alive until restoration.
+            unsafe {
+                libc::close(fd);
+            }
+        }
+        let (left, right) = nono::SupervisorSocket::pair()?;
+        let left = promote_supervisor_socket(left)?;
+        let right = promote_supervisor_socket(right)?;
+        assert!(left.as_raw_fd() >= 3 && right.as_raw_fd() >= 3);
+        drop(left);
+        drop(right);
+        let outcome = (|| -> Result<i32> {
+            let bootstrap = run(
+                &config,
+                r#"
+import os
+for fd in range(0, 2048):
+    try: os.fstat(fd)
+    except OSError: continue
+    raise AssertionError(('unexpected inherited fd', fd))
+"#,
+                landlock::ABI::V3,
+                Fault::None,
+                None,
+                None,
+                None,
+            )?;
+            for fd in 0..=2 {
+                // SAFETY: query only; parent placeholders must have been released.
+                assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+            }
+            supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)
+        })();
+        drop(restore);
+        assert_eq!(outcome?, 0);
+        Ok(())
+    })
+}
+
+#[test]
+fn full_cli_supervisor_combined_path() -> Result<()> {
+    isolated("full_cli_supervisor_combined_path", || {
+        deny_syscalls(&[libc::SYS_pidfd_getfd])?;
+        let proxy = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let direct = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let port = proxy.local_addr().map_err(NonoError::Io)?.port();
+        let denied = direct.local_addr().map_err(NonoError::Io)?.port();
+        let caps = capabilities(port, 34568)?;
+        let mut config = config(&caps, true, true);
+        let script = format!(
+            "import socket\nsocket.create_connection(('127.0.0.1',{port})).close()\ntry: socket.create_connection(('127.0.0.1',{denied}))\nexcept PermissionError: pass\nelse: raise AssertionError('direct TCP escaped')\n"
+        );
+        let argv = vec![
+            std::ffi::OsString::from("/usr/bin/python3"),
+            "-c".into(),
+            script.into(),
+        ];
+        config.command = &argv;
+        // The Rust test runner itself has a worker thread; the CLI's normal
+        // known-thread budget already covers this context.
+        config.threading = ThreadingContext::CryptoExpected;
+        let scrub = nono::ScrubPolicy::secure_default();
+        let supervisor = SupervisorConfig {
+            protected_roots: &[],
+            approval_backend: &Deny,
+            session_id: "clone-test",
+            attach_initial_client: false,
+            detach_sequence: None,
+            caps: &caps,
+            open_url_origins: &[],
+            open_url_allow_localhost: false,
+            audit_recorder: None,
+            network_audit_events: None,
+            redaction_policy: &scrub,
+            allow_launch_services_active: false,
+            seccomp_policy: config.seccomp_policy,
+            proxy_port: port,
+            proxy_bind_ports: vec![34568],
+            proxy_bind_port_ranges: vec![],
+            unix_socket_allowlist: &[],
+            tool_sandbox_runtime: None,
+        };
+        let before = fd_count()?;
+        let code = crate::exec_strategy::execute_supervised(
+            &config,
+            Some(&supervisor),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None::<fn(i32) -> bool>,
+        )?;
+        assert_eq!(code, 0);
+        assert_eq!(fd_count()?, before);
+        Ok(())
+    })
+}
+
+#[test]
+fn tool_gate_with_combined_notifications() -> Result<()> {
+    isolated("tool_gate_with_combined_notifications", || {
+        let _lock = lock_listener_ownership()?;
+        let proxy = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let port = proxy.local_addr().map_err(NonoError::Io)?.port();
+        let mut caps = capabilities(port, 34568)?;
+        let directory = tempfile::tempdir().map_err(NonoError::Io)?;
+        std::os::unix::fs::symlink("/usr/bin/python3", directory.path().join("python3"))
+            .map_err(NonoError::Io)?;
+        std::os::unix::fs::symlink("/usr/bin/true", directory.path().join("true"))
+            .map_err(NonoError::Io)?;
+        let mut policy = crate::command_policy::CommandPoliciesConfig {
+            executable_dirs: vec![directory.path().to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+        policy.commands.insert(
+            "true".into(),
+            crate::command_policy::CommandPolicyConfig {
+                executable: Some("/usr/bin/true".into()),
+                ..Default::default()
+            },
+        );
+        let credentials = std::collections::BTreeMap::new();
+        let runtime = crate::tool_sandbox::PreparedToolSandboxRuntime::prepare(
+            crate::tool_sandbox::ToolSandboxPrepare {
+                config: &policy,
+                resolved_command_binaries: None,
+                audit_context: crate::tool_sandbox::ToolSandboxAuditContext::new(
+                    None,
+                    nono::ScrubPolicy::secure_default(),
+                ),
+                allowed_commands: &[],
+                blocked_commands: &[],
+                outer_caps: &caps,
+                deny_paths: &[],
+                policy_root: directory.path(),
+                proxy_credential_env_vars: &credentials,
+                proxy_trust_bundle_paths: &[],
+                shared_broker: None,
+            },
+        )?;
+        let outcome = (|| -> Result<()> {
+            runtime.grant_outer_caps(&mut caps)?;
+            let mut config = config(&caps, true, true);
+            config.tool_sandbox_runtime = Some(&runtime);
+            let script = format!(
+                "import os, socket\ntry: os.execv('/usr/bin/true', ['true'])\nexcept PermissionError: pass\nelse: raise AssertionError('tool execution gate escaped')\nsocket.create_connection(('127.0.0.1',{port})).close()\n"
+            );
+            let bootstrap = run(
+                &config,
+                &script,
+                landlock::ABI::V3,
+                Fault::None,
+                None,
+                None,
+                None,
+            )?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, port, 34568)?,
+                0
+            );
+            // A gate created while stdin is closed must not occupy a stdio
+            // slot that later setup could replace or accidentally inherit.
+            // SAFETY: save only our original stdin, then restore it below.
+            let saved = unsafe { libc::fcntl(0, libc::F_DUPFD_CLOEXEC, 3) };
+            if saved < 0 {
+                return Err(failure("cannot save stdin for gate test"));
+            }
+            // SAFETY: checked fresh owned duplicate.
+            let saved = unsafe { OwnedFd::from_raw_fd(saved) };
+            // SAFETY: original stdin has been saved.
+            unsafe {
+                libc::close(0);
+            }
+            let closed = run(
+                &config,
+                &script,
+                landlock::ABI::V3,
+                Fault::None,
+                None,
+                None,
+                None,
+            );
+            // SAFETY: restore the exact slot saved above even if launch failed.
+            let restored = unsafe { libc::dup2(saved.as_raw_fd(), 0) };
+            assert_eq!(restored, 0);
+            let bootstrap = closed?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, port, 34568)?,
+                0
+            );
+            Ok(())
+        })();
+        runtime.cleanup_runtime_dir();
+        outcome
+    })
+}
+
+// Produce an unrelated listener in the parent table without installing its
+// filter in the parent. The temporary trusted raw child exits immediately.
+fn preexisting_listener() -> Result<OwnedFd> {
+    let snapshot = listeners()?;
+    let filter = sandbox::prepare_seccomp_proxy_filter(false);
+    let mut signals = Signals::block()?;
+    // SAFETY: only the fd table is shared, and the child calls raw APIs then exits.
+    let pid = unsafe {
+        libc::syscall(
+            libc::SYS_clone,
+            libc::CLONE_FILES | libc::SIGCHLD,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    if pid == 0 {
+        arm_allocator_guard();
+        if filter.install_raw().is_err() {
+            die(126);
+        }
+        die(0);
+    }
+    if pid < 0 {
+        return Err(failure("cannot create pre-existing test listener"));
+    }
+    signals.restore()?;
+    loop {
+        let mut status = 0;
+        // SAFETY: wait for our exact direct child, retaining the shared table.
+        let waited = unsafe { libc::waitpid(pid as i32, &mut status, 0) };
+        if waited < 0 && errno() == libc::EINTR {
+            continue;
+        }
+        assert_eq!(waited, pid as i32);
+        assert!(libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0);
+        break;
+    }
+    let current = listeners()?;
+    let created: Vec<_> = current.difference(&snapshot).copied().collect();
+    assert_eq!(created.len(), 1);
+    // SAFETY: child reaped, exclusive parent table ownership and validated listener.
+    Ok(unsafe { OwnedFd::from_raw_fd(created[0]) })
+}
+
+#[test]
+fn explicit_network_backends_with_af_unix() -> Result<()> {
+    isolated("explicit_network_backends_with_af_unix", || {
+        let _lock = lock_listener_ownership()?;
+        let tcp = std::net::TcpListener::bind("127.0.0.1:0").map_err(NonoError::Io)?;
+        let port = tcp.local_addr().map_err(NonoError::Io)?.port();
+        let directory = tempfile::tempdir().map_err(NonoError::Io)?;
+        let socket_path = directory.path().join("denied.sock");
+        let _unix = std::os::unix::net::UnixListener::bind(&socket_path).map_err(NonoError::Io)?;
+        let caps = capabilities(port, 34568)?.set_network_mode(nono::NetworkMode::AllowAll);
+        for policy in [LinuxSandboxPolicy::External, LinuxSandboxPolicy::Landlock] {
+            let mut config = config(&caps, true, false);
+            config.sandbox_policy = policy;
+            let script = format!(
+                "import socket\nsocket.create_connection(('127.0.0.1',{port})).close()\nsocket.socket(socket.AF_INET, socket.SOCK_DGRAM).close()\ntry: socket.socket(socket.AF_UNIX).connect({path:?})\nexcept PermissionError: pass\nelse: raise AssertionError('ungranted Unix socket escaped')\n",
+                path = socket_path.to_string_lossy()
+            );
+            let bootstrap = run(
+                &config,
+                &script,
+                landlock::ABI::V3,
+                Fault::None,
+                None,
+                None,
+                None,
+            )?;
+            assert_eq!(
+                supervise(&bootstrap, &caps, config.seccomp_policy, port, 34568)?,
+                0
+            );
+        }
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires live cgroup v2 memory delegation; run with --ignored"]
+fn live_cgroup_with_combined_notifications() -> Result<()> {
+    isolated("live_cgroup_with_combined_notifications", || {
+        let _lock = lock_listener_ownership()?;
+        let leaf = crate::resource_cgroup::CgroupLeaf::create(&nono::ResourceLimits {
+            memory_bytes: Some(64 * 1024 * 1024),
+            max_processes: None,
+        })?;
+        let procs = std::fs::read_link(format!("/proc/self/fd/{}", leaf.procs_raw_fd()))
+            .map_err(NonoError::Io)?;
+        let path = procs
+            .parent()
+            .ok_or_else(|| failure("missing cgroup directory"))?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| failure("missing cgroup name"))?
+            .to_string_lossy();
+        let mut caps = capabilities(34567, 34568)?;
+        caps.add_fs(FsCapability::new_file(
+            "/proc/self/cgroup",
+            AccessMode::Read,
+        )?);
+        let config = config(&caps, true, true);
+        let script = format!("assert '/{name}' in open('/proc/self/cgroup').read()\n");
+        let bootstrap = run(
+            &config,
+            &script,
+            landlock::ABI::V3,
+            Fault::None,
+            None,
+            None,
+            Some(leaf.procs_raw_fd()),
+        )?;
+        assert_eq!(
+            supervise(&bootstrap, &caps, config.seccomp_policy, 34567, 34568)?,
+            0
+        );
+        assert!(
+            std::fs::read_to_string(&procs)
+                .map_err(NonoError::Io)?
+                .trim()
+                .is_empty()
+        );
+        drop(bootstrap);
+        drop(leaf);
+        assert!(!path.exists());
+        Ok(())
+    })
+}

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -188,10 +188,22 @@ pub(super) fn handle_seccomp_notification(
     initial_caps: &[InitialCapability],
     state: SeccompNotificationState<'_>,
 ) -> Result<()> {
+    let notif = nono::sandbox::recv_notif(notify_fd)?;
+    handle_received_filesystem_notification(notify_fd, child, config, initial_caps, state, notif)
+}
+
+fn handle_received_filesystem_notification(
+    notify_fd: std::os::fd::RawFd,
+    child: Pid,
+    config: &SupervisorConfig<'_>,
+    initial_caps: &[InitialCapability],
+    state: SeccompNotificationState<'_>,
+    notif: nono::sandbox::SeccompNotif,
+) -> Result<()> {
     use nono::sandbox::{
         SYS_OPENAT, SYS_OPENAT2, classify_access_from_flags, continue_notif, deny_notif, inject_fd,
-        notif_id_valid, read_notif_path, read_open_how, recv_notif, resolve_notif_path,
-        respond_notif_errno, validate_openat2_size,
+        notif_id_valid, read_notif_path, read_open_how, resolve_notif_path, respond_notif_errno,
+        validate_openat2_size,
     };
     let SeccompNotificationState {
         rate_limiter,
@@ -201,7 +213,6 @@ pub(super) fn handle_seccomp_notification(
     } = state;
 
     // 1. Receive the notification
-    let notif = recv_notif(notify_fd)?;
 
     // 2. Read the path from the child's memory (args[1] = pathname for openat/openat2)
     //    Then resolve dirfd-relative paths using /proc/PID/fd/DIRFD or /proc/PID/cwd.
@@ -726,7 +737,7 @@ pub(super) fn decide_network_notification(
         }
     }
 
-    if config.seccomp_policy.af_unix_mediation {
+    if config.seccomp_policy.af_unix_mediation && !config.seccomp_policy.proxy_fallback {
         debug!(
             "AF_UNIX-only seccomp mediation: allowing non-AF_UNIX syscall family={} nr={}",
             sockaddr.family, syscall
@@ -936,6 +947,42 @@ fn canonicalize_unix_socket_bind_path(
 /// `SECCOMP_USER_NOTIF_FLAG_CONTINUE`, which preserves platform compatibility
 /// but carries the documented userspace-pointer TOCTOU limitation described
 /// by `read_notif_sockaddr`.
+pub(super) fn handle_combined_notification(
+    notify_fd: std::os::fd::RawFd,
+    child: Pid,
+    config: &SupervisorConfig<'_>,
+    initial_caps: &[InitialCapability],
+    state: SeccompNotificationState<'_>,
+    ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
+) -> Result<()> {
+    let notif = nono::sandbox::recv_notif(notify_fd)?;
+    if matches!(
+        notif.data.nr,
+        nono::sandbox::SYS_OPENAT | nono::sandbox::SYS_OPENAT2
+    ) {
+        if !config.seccomp_policy.needs_openat_notify() {
+            return nono::sandbox::deny_notif(notify_fd, notif.id);
+        }
+        handle_received_filesystem_notification(
+            notify_fd,
+            child,
+            config,
+            initial_caps,
+            state,
+            notif,
+        )
+    } else {
+        handle_received_network_notification(
+            notify_fd,
+            config,
+            state.rate_limiter,
+            state.denials,
+            ipc_denials,
+            notif,
+        )
+    }
+}
+
 pub(super) fn handle_network_notification(
     notify_fd: std::os::fd::RawFd,
     config: &SupervisorConfig<'_>,
@@ -943,13 +990,30 @@ pub(super) fn handle_network_notification(
     denials: &mut Vec<DenialRecord>,
     ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
 ) -> nono::error::Result<()> {
+    let notif = nono::sandbox::recv_notif(notify_fd)?;
+    handle_received_network_notification(
+        notify_fd,
+        config,
+        rate_limiter,
+        denials,
+        ipc_denials,
+        notif,
+    )
+}
+
+fn handle_received_network_notification(
+    notify_fd: std::os::fd::RawFd,
+    config: &SupervisorConfig<'_>,
+    rate_limiter: &mut RateLimiter,
+    denials: &mut Vec<DenialRecord>,
+    ipc_denials: &mut Vec<nono::diagnostic::IpcDenialRecord>,
+    notif: nono::sandbox::SeccompNotif,
+) -> nono::error::Result<()> {
     use nono::sandbox::{
         SYS_BIND, SYS_CONNECT, SYS_SENDMMSG, SYS_SENDMSG, SYS_SENDTO, continue_notif, deny_notif,
-        notif_id_valid, read_mmsghdr_dests, read_msghdr_dest, read_notif_sockaddr, recv_notif,
+        notif_id_valid, read_mmsghdr_dests, read_msghdr_dest, read_notif_sockaddr,
         respond_notif_errno,
     };
-
-    let notif = recv_notif(notify_fd)?;
 
     // Read sockaddr from child's memory. The location depends on the syscall:
     //   connect(fd, sockaddr*, addrlen):   args[1] = sockaddr*, args[2] = addrlen
@@ -1091,6 +1155,7 @@ pub(super) fn handle_network_notification(
     // rate-limiter token, which would otherwise starve legitimate network
     // traffic once the burst is exhausted.
     if config.seccomp_policy.af_unix_mediation
+        && !config.seccomp_policy.proxy_fallback
         && sockaddrs.iter().all(|s| s.family != libc::AF_UNIX as u16)
     {
         if let Err(e) = continue_notif(notify_fd, notif.id) {

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -488,6 +488,17 @@ impl PreparedToolSandboxRuntime {
         Ok(())
     }
 
+    pub(crate) fn prepare_outer_exec_gate(&self) -> Result<OwnedFd> {
+        let ruleset = prepare_outer_exec_gate(
+            &self.inner.allowed_outer_exec_files,
+            &self.inner.plan.outer_exec_writable_dirs,
+            self.inner.landlock_abi,
+        )?;
+        Option::<OwnedFd>::from(ruleset).ok_or_else(|| {
+            NonoError::SandboxInit("tool-sandbox execution gate was not created".to_string())
+        })
+    }
+
     pub(crate) fn apply_outer_exec_gate(&self) -> Result<()> {
         apply_outer_exec_gate(
             &self.inner.allowed_outer_exec_files,
@@ -3111,6 +3122,17 @@ fn apply_outer_exec_gate(
     writable_dirs: &[PathBuf],
     abi: nono::DetectedAbi,
 ) -> Result<()> {
+    let status = prepare_outer_exec_gate(paths, writable_dirs, abi)?
+        .restrict_self()
+        .map_err(|err| NonoError::SandboxInit(format!("tool-sandbox restrict_self: {err}")))?;
+    ensure_outer_exec_gate_fully_enforced(status.ruleset)
+}
+
+fn prepare_outer_exec_gate(
+    paths: &[PathBuf],
+    writable_dirs: &[PathBuf],
+    abi: nono::DetectedAbi,
+) -> Result<landlock::RulesetCreated> {
     if !abi.has_execute() {
         return Err(NonoError::SandboxInit(format!(
             "tool-sandbox outer exec gate requires Landlock ABI V3+; detected {}",
@@ -3190,12 +3212,7 @@ fn apply_outer_exec_gate(
             })?;
     }
 
-    let status = ruleset.restrict_self().map_err(|err| {
-        NonoError::SandboxInit(format!(
-            "tool-sandbox outer exec gate restrict_self failed: {err}"
-        ))
-    })?;
-    ensure_outer_exec_gate_fully_enforced(status.ruleset)
+    Ok(ruleset)
 }
 
 fn ensure_outer_exec_gate_fully_enforced(status: landlock::RulesetStatus) -> Result<()> {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -119,7 +119,8 @@ enum StaticNetworkFilter {
 }
 
 /// A Landlock ruleset whose allocation and path opening happened in the
-/// parent, before a raw-cloned child exists.
+/// parent. A synchronized child can use the resulting kernel ruleset without
+/// accessing the parent's allocation-dependent state.
 ///
 /// `apply_raw()` creates the ruleset, adds the already-opened path/port rules,
 /// and restricts the calling task using raw syscalls only.  It neither
@@ -139,9 +140,26 @@ impl PreparedLandlockSandbox {
         &self.fallback
     }
 
-    /// Apply this prepared policy without heap allocation or libc coordination
-    /// wrappers.  This is intended for the child side of raw `clone(2)`.
-    pub fn apply_raw(&self) -> std::result::Result<(), RawSandboxError> {
+    /// Create the kernel ruleset without restricting the calling process.
+    ///
+    /// This lets a supervisor prepare rules for a known child PID and share the
+    /// resulting descriptor during a synchronized `CLONE_FILES` bootstrap.
+    /// The caller must still set no_new_privs, restrict the child with this
+    /// ruleset, and install the matching static network filter.
+    #[must_use = "the prepared ruleset must be applied to the child"]
+    pub fn create_ruleset(&self) -> Result<OwnedFd> {
+        let fd = self.create_ruleset_raw().map_err(|error| {
+            NonoError::SandboxInit(format!(
+                "prepared Landlock ruleset {:?}: {}",
+                error.stage(),
+                std::io::Error::from_raw_os_error(error.errno())
+            ))
+        })?;
+        // SAFETY: create_ruleset_raw returned a fresh, uniquely owned fd.
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+
+    fn create_ruleset_raw(&self) -> std::result::Result<RawFd, RawSandboxError> {
         // SAFETY: all pointers below refer to fixed-size stack values or data
         // owned by `self`, which remains live for the duration of each syscall.
         unsafe {
@@ -202,6 +220,25 @@ impl PreparedLandlockSandbox {
                 }
             }
 
+            Ok(ruleset_fd)
+        }
+    }
+
+    /// Install only the prepared static network filter, without allocation.
+    ///
+    /// This does not enforce filesystem or Landlock port rules. Callers using
+    /// `create_ruleset` must separately restrict the child with that ruleset.
+    #[must_use = "a failed filter installation must prevent exec"]
+    pub fn apply_static_network_raw(&self) -> std::result::Result<(), RawSandboxError> {
+        install_static_network_filter_raw(self.static_network_filter)
+    }
+
+    /// Apply this prepared policy without heap allocation or libc coordination
+    /// wrappers. This is intended for the child side of raw `clone(2)`.
+    pub fn apply_raw(&self) -> std::result::Result<(), RawSandboxError> {
+        let ruleset_fd = self.create_ruleset_raw()?;
+        // SAFETY: ruleset_fd is newly owned and all syscall arguments are scalar.
+        unsafe {
             if libc::syscall(libc::SYS_prctl, libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
                 let errno = raw_errno();
                 libc::syscall(libc::SYS_close, ruleset_fd);
@@ -789,6 +826,15 @@ pub fn apply_landlock(caps: &CapabilitySet) -> Result<()> {
 /// Same contract as `apply_landlock` but avoids re-probing the kernel ABI.
 pub fn apply_landlock_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<()> {
     apply_with_abi_inner(caps, abi, TcpNetworkEnforcement::LandlockOnly).map(|_| ())
+}
+
+/// Prepare Landlock-only enforcement without installing a seccomp fallback.
+#[must_use = "preparation failure must prevent sandbox launch"]
+pub fn prepare_landlock_with_abi(
+    caps: &CapabilitySet,
+    abi: &DetectedAbi,
+) -> Result<PreparedLandlockSandbox> {
+    prepare_with_abi_inner(caps, abi, TcpNetworkEnforcement::LandlockOnly)
 }
 
 /// Apply Landlock filesystem/process sandboxing and use seccomp for TCP
@@ -3385,6 +3431,45 @@ pub struct PreparedSeccompNotifyFilter {
 }
 
 impl PreparedSeccompNotifyFilter {
+    /// Add filesystem notifications to this network notification program.
+    ///
+    /// Linux permits only one NEW_LISTENER filter per thread. A combined
+    /// supervisor must dispatch this listener by syscall number. The original
+    /// network program and its relative jumps are retained unchanged.
+    #[must_use]
+    pub fn with_openat_notifications(self) -> Self {
+        let mut filter = vec![
+            SockFilterInsn {
+                code: BPF_LD | BPF_W | BPF_ABS,
+                jt: 0,
+                jf: 0,
+                k: SECCOMP_DATA_NR_OFFSET,
+            },
+            SockFilterInsn {
+                code: BPF_JMP | BPF_JEQ | BPF_K,
+                jt: 1,
+                jf: 0,
+                k: SYS_OPENAT as u32,
+            },
+            SockFilterInsn {
+                code: BPF_JMP | BPF_JEQ | BPF_K,
+                jt: 0,
+                jf: 1,
+                k: SYS_OPENAT2 as u32,
+            },
+            SockFilterInsn {
+                code: BPF_RET | BPF_K,
+                jt: 0,
+                jf: 0,
+                k: SECCOMP_RET_USER_NOTIF,
+            },
+        ];
+        filter.extend_from_slice(self.filter.as_slice());
+        Self {
+            filter: prepend_seccomp_arch_guard_vec(filter, SECCOMP_RET_ERRNO | libc::EPERM as u32),
+        }
+    }
+
     /// Install the prepared filter and return the listener as a borrowed raw
     /// slot.  The caller must establish private fd-table ownership before
     /// constructing `OwnedFd` or running Rust destructors for this slot.
@@ -5199,6 +5284,56 @@ mod tests {
         assert_eq!(proxy.filter.len(), 37);
         let unix = prepare_seccomp_af_unix_filter();
         assert_eq!(unix.filter.len(), 14);
+    }
+
+    #[test]
+    fn combined_notifications_preserve_network_filter_decisions() {
+        for original in [
+            prepare_seccomp_proxy_filter(false),
+            prepare_seccomp_proxy_filter(true),
+            prepare_seccomp_af_unix_filter(),
+        ] {
+            let network = original.filter.as_slice().to_vec();
+            let combined = original.with_openat_notifications();
+            for syscall in [SYS_OPENAT, SYS_OPENAT2] {
+                assert_eq!(
+                    evaluate_static_bpf(combined.filter.as_slice(), syscall, [0; 6]),
+                    SECCOMP_RET_USER_NOTIF
+                );
+            }
+            for syscall in [
+                SYS_SOCKET,
+                SYS_SOCKETPAIR,
+                SYS_CONNECT,
+                SYS_BIND,
+                SYS_SENDTO,
+                SYS_SENDMSG,
+                SYS_SENDMMSG,
+                libc::SYS_read as i32,
+                libc::SYS_write as i32,
+                libc::SYS_execve as i32,
+                SYS_IO_URING_SETUP,
+            ] {
+                for family in [libc::AF_UNIX, libc::AF_INET, libc::AF_INET6] {
+                    for kind in [libc::SOCK_STREAM, libc::SOCK_DGRAM, libc::SOCK_RAW] {
+                        let args = [family as u64, kind as u64, 0, 0, 0, 0];
+                        assert_eq!(
+                            evaluate_static_bpf(combined.filter.as_slice(), syscall, args),
+                            evaluate_static_bpf(&network, syscall, args)
+                        );
+                    }
+                }
+            }
+            assert_eq!(
+                evaluate_static_bpf_with_arch(
+                    combined.filter.as_slice(),
+                    NATIVE_AUDIT_ARCH ^ 1,
+                    SYS_OPENAT as u32,
+                    [0; 6]
+                ),
+                SECCOMP_RET_ERRNO | libc::EPERM as u32
+            );
+        }
     }
 
     #[test]

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -36,10 +36,11 @@ pub use linux::{
     SYS_SENDTO, SeccompData, SeccompNetFallback, SeccompNotif, SeccompOpts, SockaddrInfo,
     UnixSocketKind, classify_access_from_flags, classify_af_unix, continue_notif, deny_notif,
     inject_fd, install_seccomp_af_unix_filter, install_seccomp_notify,
-    install_seccomp_proxy_filter, notif_id_valid, prepare_seccomp_af_unix_filter,
-    prepare_seccomp_proxy_filter, prepare_seccomp_with_abi, probe_seccomp_block_network_support,
-    read_mmsghdr_dests, read_msghdr_dest, read_notif_path, read_notif_sockaddr, read_open_how,
-    recv_notif, resolve_notif_path, respond_notif_errno, validate_openat2_size,
+    install_seccomp_proxy_filter, notif_id_valid, prepare_landlock_with_abi,
+    prepare_seccomp_af_unix_filter, prepare_seccomp_proxy_filter, prepare_seccomp_with_abi,
+    probe_seccomp_block_network_support, read_mmsghdr_dests, read_msghdr_dest, read_notif_path,
+    read_notif_sockaddr, read_open_how, recv_notif, resolve_notif_path, respond_notif_errno,
+    validate_openat2_size,
 };
 
 /// Information about sandbox support on this platform

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -412,19 +412,20 @@ This reports the detected kernel version, Landlock ABI, WSL2 detection status, a
 
 ## Running Inside Docker/Podman
 
-### `pidfd_getfd failed ... Operation not permitted`
+### Proxy notification bootstrap failures
 
-**Symptom:** `Sandbox initialization failed: Failed to acquire required network seccomp notify fd from child: pidfd_getfd failed for child fd N: Operation not permitted (os error 1)` when using `--allow-domain` (or any other capability that falls back to the seccomp proxy) inside a container.
+On Linux kernels without Landlock V4 networking, the CLI transfers the proxy
+notification listener through a short `CLONE_FILES` bootstrap. This handoff
+does not use `pidfd_getfd` or require `CAP_SYS_PTRACE`. An error mentioning
+`pidfd_getfd failed` comes from the older handoff; update nono to use the new one.
 
-**Cause:** The proxy fallback hands the network-notify file descriptor across the fork boundary with `pidfd_getfd(2)`, which requires `CAP_SYS_PTRACE`. Docker (and most container runtimes) drop that capability by default, so the call returns `EPERM`.
-
-**Solution:** Add the capability back when starting the container:
-
-```bash
-docker run --cap-add=SYS_PTRACE ...
-```
-
-or the equivalent in your Compose file / Kubernetes `securityContext.capabilities.add: ["SYS_PTRACE"]`. This doesn't weaken the container boundary in a way relevant to nono's threat model -- it only lets nono's own parent process duplicate a file descriptor from its own sandboxed child.
+A `CLONE_FILES bootstrap` error means startup failed before the listener handoff
+completed. Check that the container's syscall policy permits seccomp user
+notifications, `clone` with `CLONE_FILES`, and descriptor-table detachment through
+either `close_range` with `CLOSE_RANGE_UNSHARE` or `unshare(CLONE_FILES)`. The
+supervisor also needs access to the child's procfs entries for notification
+mediation. If these requirements cannot be met, nono aborts startup instead of
+running the command without its restrictions.
 
 ## Getting Help
 


### PR DESCRIPTION
Refactors network-notification sandbox setup on Linux to use a dedicated, allocation-free `CLONE_FILES` bootstrap instead of pulling file descriptors via `pidfd_getfd`.

- Implement `clone_files` bootstrap logic to handle notification listener setup and detachment
- Support combined seccomp user-notification filters for openat/network mediation
- Replace `pidfd_getfd` descriptor handoff to remove the `CAP_SYS_PTRACE` requirement in containers
- Update CLI usage docs for container execution and error troubleshooting
## Checklist

- [ ] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked
