### PR TITLE
fix(proxy): make `*` stop at `/` in endpoint path patterns

### DIFF
--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -521,7 +521,10 @@ fn path_matches_endpoint_rules(
     }
     let normalized = normalize_path(path);
     rules.iter().any(|r| {
-        let Ok(glob) = globset::Glob::new(&r.path) else {
+        let Ok(glob) = globset::GlobBuilder::new(&r.path)
+            .literal_separator(true)
+            .build()
+        else {
             return false;
         };
         let matcher = glob.compile_matcher();
@@ -1423,6 +1426,19 @@ mod tests {
     #[test]
     fn test_path_matches_empty_rules_allows_all() {
         assert!(path_matches_endpoint_rules("/any/path", &[]));
+    }
+
+    // Regression test for https://github.com/nolabs-ai/nono/issues/1824:
+    // a single `*` segment must not cross `/` the way `**` does.
+    #[test]
+    fn test_path_matches_endpoint_rules_single_wildcard_rejects_multi_segment() {
+        let rules = vec![crate::sandbox_state::EndpointRuleState {
+            method: "*".to_string(),
+            path: "/repos/*".to_string(),
+        }];
+        assert!(path_matches_endpoint_rules("/repos/one", &rules));
+        assert!(!path_matches_endpoint_rules("/repos/one/two", &rules));
+        assert!(!path_matches_endpoint_rules("/repos/a/b/c/d", &rules));
     }
 
     // suggested_flag_parts: non-existent file directly under $HOME must not widen to ~/

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -3,7 +3,7 @@
 //! Defines the configuration for the proxy server, including allowed hosts,
 //! credential routes, and external proxy settings.
 
-use globset::Glob;
+use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -1183,7 +1183,9 @@ impl CompiledEndpointRules {
     pub fn compile(rules: &[EndpointRule]) -> Result<Self, String> {
         let mut compiled = Vec::with_capacity(rules.len());
         for rule in rules {
-            let glob = Glob::new(&rule.path)
+            let glob = GlobBuilder::new(&rule.path)
+                .literal_separator(true)
+                .build()
                 .map_err(|e| format!("invalid endpoint path pattern '{}': {}", rule.path, e))?;
             compiled.push(CompiledRule {
                 method: rule.method.clone(),
@@ -1325,7 +1327,9 @@ impl CompiledEndpointPolicy {
 fn compile_policy_rules(rules: &[EndpointPolicyRule]) -> Result<Vec<CompiledPolicyRule>, String> {
     let mut compiled = Vec::with_capacity(rules.len());
     for rule in rules {
-        let glob = Glob::new(&rule.path)
+        let glob = GlobBuilder::new(&rule.path)
+            .literal_separator(true)
+            .build()
             .map_err(|e| format!("invalid endpoint path pattern '{}': {}", rule.path, e))?;
         compiled.push(CompiledPolicyRule {
             method: rule.method.clone(),
@@ -1383,7 +1387,9 @@ fn endpoint_allowed(rules: &[EndpointRule], method: &str, path: &str) -> bool {
     let normalized = normalize_path(path);
     rules.iter().any(|r| {
         (r.method == "*" || r.method.eq_ignore_ascii_case(method))
-            && Glob::new(&r.path)
+            && GlobBuilder::new(&r.path)
+                .literal_separator(true)
+                .build()
                 .ok()
                 .map(|g| g.compile_matcher())
                 .is_some_and(|m| m.is_match(&normalized))
@@ -1789,6 +1795,37 @@ mod tests {
         assert!(!check(&rule, "GET", "/api/v4/projects/merge_requests"));
     }
 
+    // Regression test for https://github.com/nolabs-ai/nono/issues/1824:
+    // `*` must not cross a `/` segment boundary the way `**` does.
+    #[test]
+    fn test_endpoint_rule_single_wildcard_rejects_multi_segment() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/v4/projects/*/merge_requests".to_string(),
+        };
+        assert!(!check(
+            &rule,
+            "GET",
+            "/api/v4/projects/123/456/merge_requests"
+        ));
+
+        let one_star = EndpointRule {
+            method: "*".to_string(),
+            path: "/repos/*".to_string(),
+        };
+        assert!(check(&one_star, "GET", "/repos/one"));
+        assert!(!check(&one_star, "GET", "/repos/one/two"));
+        assert!(!check(&one_star, "GET", "/repos/a/b/c/d"));
+
+        let two_star = EndpointRule {
+            method: "*".to_string(),
+            path: "/repos/**".to_string(),
+        };
+        assert!(check(&two_star, "GET", "/repos/one"));
+        assert!(check(&two_star, "GET", "/repos/one/two"));
+        assert!(check(&two_star, "GET", "/repos/a/b/c/d"));
+    }
+
     #[test]
     fn test_endpoint_rule_double_wildcard() {
         let rule = EndpointRule {
@@ -1941,6 +1978,37 @@ mod tests {
                 reason: Some("blocked"),
                 ..
             }
+        ));
+    }
+
+    // Regression test for https://github.com/nolabs-ai/nono/issues/1824:
+    // policy-config paths (allow/deny/approve) must honor the same
+    // one-segment `*` semantics as legacy EndpointRule.
+    #[test]
+    fn test_compiled_endpoint_policy_single_wildcard_rejects_multi_segment() {
+        let policy = EndpointPolicyConfig {
+            allow: vec![EndpointPolicyRule {
+                method: "GET".to_string(),
+                path: "/repos/*".to_string(),
+                backend: None,
+                reason: None,
+                timeout_secs: None,
+            }],
+            ..EndpointPolicyConfig::default()
+        };
+        let compiled = CompiledEndpointPolicy::compile(Some(&policy), &[]).unwrap();
+
+        assert!(matches!(
+            compiled.evaluate("GET", "/repos/one"),
+            EndpointPolicyOutcome::Allow { .. }
+        ));
+        assert!(matches!(
+            compiled.evaluate("GET", "/repos/one/two"),
+            EndpointPolicyOutcome::Deny { .. }
+        ));
+        assert!(matches!(
+            compiled.evaluate("GET", "/repos/a/b/c/d"),
+            EndpointPolicyOutcome::Deny { .. }
         ));
     }
 

--- a/crates/nono-proxy/src/tls_intercept/h2_forward.rs
+++ b/crates/nono-proxy/src/tls_intercept/h2_forward.rs
@@ -2064,7 +2064,7 @@ mod tests {
                 env_var: None,
                 endpoint_rules: vec![EndpointRule {
                     method: "*".to_string(),
-                    path: "/v1/*".to_string(),
+                    path: "/v1/**".to_string(),
                 }],
                 tls_ca: None,
                 tls_client_cert: None,
@@ -2091,7 +2091,7 @@ mod tests {
                 env_var: None,
                 endpoint_rules: vec![EndpointRule {
                     method: "*".to_string(),
-                    path: "/v1/*".to_string(),
+                    path: "/v1/**".to_string(),
                 }],
                 tls_ca: None,
                 tls_client_cert: None,


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1824 

## Summary

<!-- Briefly describe what this PR does and why. -->

EndpointRule/EndpointPolicyRule path patterns were compiled with globset::Glob::new(), which defaults literal_separator to false, letting `*` cross `/` boundaries and behave like `**`; contradicting the documented one-segment contract in config.rs. A rule like `/repos/*` therefore also matched `/repos/a/b/c/d`, over-granting proxy access. Fixed by compiling with GlobBuilder::literal_separator(true) in both nono-proxy/src/config.rs and the duplicated matcher in nono-cli/src/query_ext.rs (used by `nono why`).

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

Added regression tests asserting `*` rejects multi-segment paths while `**` still matches any depth. Confirmed red→green by reverting just the fix and seeing the new tests fail, then restoring it. Rebuilt `nono` and reran the issue's repro script directly. `cargo clippy -D warnings -D clippy::unwrap_used` and `cargo fmt --check` clean.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [x] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
