### PR TITLE
fix(cli): keep legacy ~/.claude.json in sync with CLAUDE_CONFIG_DIR redirects

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -128,6 +128,85 @@ fn env_non_empty(key: &str) -> bool {
     std::env::var_os(key).is_some_and(|value| !value.is_empty())
 }
 
+// One-time migration onto canonical ~/.claude/.claude.json (what Claude Code
+// actually reads/writes once CLAUDE_CONFIG_DIR is set). No-op forever after
+// canonical exists. Priority, first match wins:
+//   1. canonical exists -> already migrated, do nothing.
+//   2. ~/.claude/claude.json (no dot, pre-#1820 nono) -> move in.
+//   3. ~/.claude.json (legacy) -> move in.
+// The moved-from side becomes a symlink to canonical, so bare `claude`
+// outside nono still resolves to the same file. Only ever done to legacy,
+// never to canonical: rename() replaces a symlink instead of writing
+// through it, and canonical is what nono's atomic writes target.
+//
+// lstat throughout: any unexpected symlink is left untouched, not followed
+// (this runs pre-sandbox, with write access to all these paths already).
+#[cfg(unix)]
+fn migrate_claude_json(legacy: &Path, canonical: &Path, claude_dir: &Path) {
+    fn is_regular_file(path: &Path) -> bool {
+        std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_file())
+    }
+
+    // rename() relocates a symlink rather than following it, so a race that
+    // swaps src for a symlink between our check and this call would leave
+    // canonical as that symlink. Verify and undo rather than trust it.
+    fn rename_verified(src: &Path, canonical: &Path) -> bool {
+        if let Err(error) = std::fs::rename(src, canonical) {
+            warn!("Failed to migrate {}: {error}", src.display());
+            return false;
+        }
+        if is_regular_file(canonical) {
+            return true;
+        }
+        warn!(
+            "{} was not a regular file immediately after migration (possible race); removing it",
+            canonical.display()
+        );
+        let _ = std::fs::remove_file(canonical);
+        false
+    }
+
+    fn relink_legacy(legacy: &Path, canonical: &Path) {
+        match std::fs::symlink_metadata(legacy) {
+            Err(_) => {}
+            Ok(meta) if meta.file_type().is_symlink() => {
+                if let Err(error) = std::fs::remove_file(legacy) {
+                    warn!(
+                        "Failed to remove old symlink at {}: {error}",
+                        legacy.display()
+                    );
+                    return;
+                }
+            }
+            Ok(_) => return, // unexpected non-symlink left behind; don't touch it
+        }
+        if let Err(error) = std::os::unix::fs::symlink(canonical, legacy) {
+            warn!(
+                "Failed to symlink {} -> {}: {error}",
+                legacy.display(),
+                canonical.display()
+            );
+        }
+    }
+
+    if std::fs::symlink_metadata(canonical).is_ok() {
+        return; // canonical exists (or is something we won't touch) - it wins
+    }
+
+    let old_style = claude_dir.join("claude.json");
+    if is_regular_file(&old_style) {
+        if rename_verified(&old_style, canonical) {
+            relink_legacy(legacy, canonical);
+        }
+        return;
+    }
+
+    if is_regular_file(legacy) && rename_verified(legacy, canonical) {
+        relink_legacy(legacy, canonical);
+    }
+    // Neither existed: nothing to migrate, Claude Code creates canonical fresh.
+}
+
 #[cfg(target_os = "macos")]
 fn claude_config_dir() -> std::result::Result<(PathBuf, bool), String> {
     if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
@@ -1568,6 +1647,21 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         if let Err(error) = std::fs::create_dir_all(&claude_dir) {
             warn!("Failed to create ~/.claude: {error}");
         } else if std::env::var_os("CLAUDE_CONFIG_DIR").is_none() {
+            // Reuse claude_global_config_path for the oauth-suffix filename.
+            #[cfg(target_os = "macos")]
+            let (legacy_json, redirected_json) = {
+                let legacy = claude_global_config_path(home_path, false)
+                    .unwrap_or_else(|_| home_path.join(".claude.json"));
+                let redirected = claude_global_config_path(&claude_dir, true)
+                    .unwrap_or_else(|_| claude_dir.join(".claude.json"));
+                (legacy, redirected)
+            };
+            #[cfg(not(target_os = "macos"))]
+            let (legacy_json, redirected_json) = (
+                home_path.join(".claude.json"),
+                claude_dir.join(".claude.json"),
+            );
+            migrate_claude_json(&legacy_json, &redirected_json, &claude_dir);
             profile_set_vars.get_or_insert_with(Vec::new).push((
                 "CLAUDE_CONFIG_DIR".to_string(),
                 claude_dir.to_string_lossy().into_owned(),
@@ -1833,6 +1927,112 @@ mod tests {
     #[cfg(target_os = "macos")]
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_noop_when_canonical_already_exists() {
+        let dir = tempdir().expect("tempdir");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = dir.path().join("claude").join("canonical.json");
+        std::fs::create_dir_all(canonical.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&canonical, "canonical").expect("write canonical");
+        std::fs::write(&legacy, "legacy").expect("write legacy");
+
+        migrate_claude_json(&legacy, &canonical, dir.path());
+
+        assert_eq!(
+            std::fs::read_to_string(&canonical).expect("read canonical"),
+            "canonical"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&legacy).expect("read legacy"),
+            "legacy"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_prefers_old_style_no_dot_file() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = claude_dir.join("canonical.json");
+        let old_style = claude_dir.join("claude.json");
+        std::fs::write(&old_style, "old style").expect("write old style");
+        std::os::unix::fs::symlink(&old_style, &legacy).expect("symlink legacy to old style");
+
+        migrate_claude_json(&legacy, &canonical, &claude_dir);
+
+        assert_eq!(
+            std::fs::read_to_string(&canonical).expect("read canonical"),
+            "old style"
+        );
+        assert!(!old_style.exists(), "old-style file should have moved");
+        assert_eq!(
+            std::fs::read_link(&legacy).expect("legacy should be a symlink"),
+            canonical
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_moves_plain_legacy_file_and_symlinks_it() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = claude_dir.join("canonical.json");
+        std::fs::write(&legacy, "legacy content").expect("write legacy");
+
+        migrate_claude_json(&legacy, &canonical, &claude_dir);
+
+        assert_eq!(
+            std::fs::read_to_string(&canonical).expect("read canonical"),
+            "legacy content"
+        );
+        assert_eq!(
+            std::fs::read_link(&legacy).expect("legacy should be a symlink"),
+            canonical
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_noop_when_nothing_exists() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = claude_dir.join("canonical.json");
+
+        migrate_claude_json(&legacy, &canonical, &claude_dir);
+
+        assert!(!canonical.exists());
+        assert!(!legacy.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_refuses_to_follow_a_symlinked_legacy() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let secret = dir.path().join("secret");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = claude_dir.join("canonical.json");
+        std::fs::write(&secret, "host secret").expect("write secret");
+        std::os::unix::fs::symlink(&secret, &legacy).expect("symlink legacy to secret");
+
+        migrate_claude_json(&legacy, &canonical, &claude_dir);
+
+        // Not migrated: an untrusted symlink target must never be moved or read.
+        assert!(!canonical.exists());
+        assert_eq!(
+            std::fs::read_to_string(&secret).expect("read secret"),
+            "host secret"
+        );
+    }
 
     /// `check_writable_path_dirs` reads real PATH, so these mutate it under
     /// the shared env lock rather than mocking — mirrors the pattern used

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -167,6 +167,26 @@ fn migrate_claude_json(legacy: &Path, canonical: &Path, claude_dir: &Path) {
     }
 
     fn relink_legacy(legacy: &Path, canonical: &Path) {
+        // Keep the compatibility link portable when HOME is mounted at a
+        // different path (for example, inside a container). The migration
+        // only links a legacy file to its sibling Claude directory, so this
+        // relationship must be provable before replacing an existing link.
+        let Some(legacy_parent) = legacy.parent() else {
+            warn!(
+                "Cannot create Claude compatibility symlink: {} has no parent",
+                legacy.display()
+            );
+            return;
+        };
+        let Ok(relative_target) = canonical.strip_prefix(legacy_parent) else {
+            warn!(
+                "Cannot create Claude compatibility symlink: {} is not beneath {}",
+                canonical.display(),
+                legacy_parent.display()
+            );
+            return;
+        };
+
         match std::fs::symlink_metadata(legacy) {
             Err(_) => {}
             Ok(meta) if meta.file_type().is_symlink() => {
@@ -180,7 +200,7 @@ fn migrate_claude_json(legacy: &Path, canonical: &Path, claude_dir: &Path) {
             }
             Ok(_) => return, // unexpected non-symlink left behind; don't touch it
         }
-        if let Err(error) = std::os::unix::fs::symlink(canonical, legacy) {
+        if let Err(error) = std::os::unix::fs::symlink(relative_target, legacy) {
             warn!(
                 "Failed to symlink {} -> {}: {error}",
                 legacy.display(),
@@ -1960,7 +1980,8 @@ mod tests {
         let canonical = claude_dir.join("canonical.json");
         let old_style = claude_dir.join("claude.json");
         std::fs::write(&old_style, "old style").expect("write old style");
-        std::os::unix::fs::symlink(&old_style, &legacy).expect("symlink legacy to old style");
+        std::os::unix::fs::symlink(".claude/claude.json", &legacy)
+            .expect("symlink legacy to old style");
 
         migrate_claude_json(&legacy, &canonical, &claude_dir);
 
@@ -1971,7 +1992,37 @@ mod tests {
         assert!(!old_style.exists(), "old-style file should have moved");
         assert_eq!(
             std::fs::read_link(&legacy).expect("legacy should be a symlink"),
-            canonical
+            Path::new("claude/canonical.json")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migrate_claude_json_preserves_existing_076_canonical_config() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let legacy = dir.path().join("legacy.json");
+        let canonical = claude_dir.join("canonical.json");
+        let old_style = claude_dir.join("claude.json");
+        std::fs::write(&canonical, "created by 0.76").expect("write canonical");
+        std::fs::write(&old_style, "pre-0.76 config").expect("write old style");
+        std::os::unix::fs::symlink(".claude/claude.json", &legacy)
+            .expect("symlink legacy to old style");
+
+        migrate_claude_json(&legacy, &canonical, &claude_dir);
+
+        assert_eq!(
+            std::fs::read_to_string(&canonical).expect("read canonical"),
+            "created by 0.76"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&old_style).expect("read old style"),
+            "pre-0.76 config"
+        );
+        assert_eq!(
+            std::fs::read_link(&legacy).expect("read legacy symlink"),
+            Path::new(".claude/claude.json")
         );
     }
 
@@ -1993,7 +2044,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_link(&legacy).expect("legacy should be a symlink"),
-            canonical
+            Path::new("claude/canonical.json")
         );
     }
 

--- a/docs/cli/clients/claude.mdx
+++ b/docs/cli/clients/claude.mdx
@@ -129,6 +129,18 @@ Do not set `CLAUDE_CONFIG_DIR` to its default value (`~/.claude`) explicitly —
 For the default `~/.claude` config directory, no extra flags or directories are needed — the profile already grants access to both `~/.claude` and `~/.claude.lock`.
 </Note>
 
+### Config file migration
+
+When using the default config directory, `nono` sets `CLAUDE_CONFIG_DIR=~/.claude` so Claude Code's config (and the temp files it writes during atomic saves) land inside a directory `nono` already grants read+write, rather than as loose dotfiles in `~/` — closer to the XDG convention of keeping an app's state in its own directory instead of scattering it across `$HOME`. It also sidesteps a real sandboxing constraint: Landlock/Seatbelt can't scope a grant to the dynamically-named temp files Claude Code would otherwise write directly in `~/`.
+
+Claude Code then reads and writes `~/.claude/.claude.json`, not the historical `~/.claude.json`. The first time `nono` runs with an existing legacy config, it moves it into place automatically:
+
+- If `~/.claude/.claude.json` already exists, nothing changes.
+- Otherwise, an old-style `~/.claude/claude.json` (no dot, from `nono` versions predating this redirect) is moved in.
+- Otherwise, `~/.claude.json` is moved in.
+
+Whichever legacy file was moved is replaced with a symlink to the new location, so bare `claude` (run outside `nono`) keeps working against the same config. This migration only happens once — once `~/.claude/.claude.json` exists, it's left alone.
+
 ## Security Tips
 
 ### Use Secrets Management


### PR DESCRIPTION



## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1834 

@lfrancke Hi! Apologies for the oversight, I have included the reasoning behind this change below which I hope makes sense. If possible, feel free to test this PR and see if it solves the issue via a migration on nono invocation.

We had some odd hacky stuff beforehand to make claude work alongside the security modules we use, which could cause drift between files. This overall is a cleaner fix to that and less prone to failures. Thanks

## Summary

nono redirects Claude Code config into $CLAUDE_CONFIG_DIR (~/.claude) because Landlock/Seatbelt cannot scope a grant to the dynamically named temp files Claude Code writes during its atomic config saves. Granting access to ~/.claude.json* directly would mean widening the sandbox to arbitrary paths in the home directory, which is a much larger attack surface than a single directory nono already owns. The redirect avoids that tradeoff entirely, at the cost of Claude Code now reading and writing ~/.claude/.claude.json instead of the historical ~/.claude.json path.

That redirect broke existing users silently: anyone who authenticated before nono started setting CLAUDE_CONFIG_DIR looked logged out (and lost every MCP servers OAuth token, since those live in the same config blob) because Claude Code found no file at the new path.

Sync the two paths on every invocation instead, copying whichever side has the newer mtime over the other before launching. This keeps legacy ~/.claude.json converged for anyone still running bare claude outside of nono, without ever granting broader filesystem access.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
