### PR TITLE
fix(proxy): stop allow_domain endpoint routes shadowing oauth_capture credential routes

### DIFF
--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2596,7 +2596,7 @@ fn synthesize_credential_provider_proxy_config(
             consumers_by_provider
                 .entry(route.provider.clone())
                 .or_default()
-                .push(format!("proxy.{prefix}"));
+                .push(nono_proxy::oauth_capture::route_consumer(&prefix));
             if let Some(host_port) = origin_host_port(api_host)? {
                 push_unique(&mut proxy_config.allowed_hosts, host_port);
             }

--- a/crates/nono-proxy/src/oauth_capture/mod.rs
+++ b/crates/nono-proxy/src/oauth_capture/mod.rs
@@ -50,6 +50,16 @@ pub struct OAuthCaptureStore {
 const MAX_PERSISTED_PHANTOMS: usize = 4096;
 const PHANTOM_TTL_SECS: u64 = 90 * 24 * 60 * 60;
 
+#[must_use]
+pub fn route_consumer(prefix: &str) -> String {
+    format!("proxy.{prefix}")
+}
+
+#[must_use]
+pub fn route_prefix_for_consumer(consumer: &str) -> Option<&str> {
+    consumer.strip_prefix("proxy.")
+}
+
 impl OAuthCaptureStore {
     pub fn load(configs: &[OAuthCaptureConfig]) -> Result<Self> {
         Self::load_with_persistence(configs, None)

--- a/crates/nono-proxy/src/oauth_capture/mod.rs
+++ b/crates/nono-proxy/src/oauth_capture/mod.rs
@@ -52,12 +52,20 @@ const PHANTOM_TTL_SECS: u64 = 90 * 24 * 60 * 60;
 
 #[must_use]
 pub fn route_consumer(prefix: &str) -> String {
-    format!("proxy.{prefix}")
+    format!("proxy.{}", prefix.trim_matches('/'))
 }
 
 #[must_use]
 pub fn route_prefix_for_consumer(consumer: &str) -> Option<&str> {
     consumer.strip_prefix("proxy.")
+}
+
+#[must_use]
+fn normalise_admitted_consumer(consumer: &str) -> String {
+    match route_prefix_for_consumer(consumer) {
+        Some(prefix) => route_consumer(prefix),
+        None => consumer.to_string(),
+    }
 }
 
 impl OAuthCaptureStore {
@@ -76,7 +84,7 @@ impl OAuthCaptureStore {
             let mut admitted = config
                 .admitted_consumers
                 .iter()
-                .cloned()
+                .map(|consumer| normalise_admitted_consumer(consumer))
                 .collect::<HashSet<_>>();
             admitted.insert(provider_consumer(&config.provider));
             for endpoint in &config.token_endpoints {
@@ -852,5 +860,38 @@ mod tests {
         assert!(p_o.starts_with("oth_"));
         assert_eq!(r_a, "Bearer A");
         assert_eq!(r_o, "Bearer B");
+    }
+
+    #[test]
+    fn admitted_consumer_with_slashed_prefix_resolves_for_loaded_route_key() {
+        let store = OAuthCaptureStore::load(&[OAuthCaptureConfig {
+            provider: "codex".to_string(),
+            token_endpoints: vec![OAuthTokenEndpointConfig {
+                host: "https://auth.openai.com".to_string(),
+                path: "/oauth/token".to_string(),
+                response_fields: opaque_fields(["access_token"]),
+                request_body: OAuthTokenRequestBodyFormat::Auto,
+                request_nonce_fields: vec![],
+            }],
+            admitted_consumers: vec!["proxy./svc/".to_string()],
+        }])
+        .unwrap();
+        let endpoint = store.lookup("auth.openai.com:443", "/oauth/token").unwrap();
+        let rewritten = store
+            .rewrite_response_body(endpoint, br#"{"access_token":"real-access"}"#)
+            .unwrap();
+        let json: Value = serde_json::from_slice(&rewritten).unwrap();
+        let access = json["access_token"].as_str().unwrap();
+
+        assert_eq!(route_consumer("/svc/"), "proxy.svc");
+        assert_eq!(
+            std::str::from_utf8(
+                &store
+                    .resolve(access, &route_consumer("svc"))
+                    .expect("the loaded route key must resolve the phantom")
+            )
+            .unwrap(),
+            "real-access"
+        );
     }
 }

--- a/crates/nono-proxy/src/oauth_capture/mod.rs
+++ b/crates/nono-proxy/src/oauth_capture/mod.rs
@@ -669,6 +669,50 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    #[test]
+    fn persisted_admitted_consumers_are_normalised_on_reload() {
+        let dir = std::env::temp_dir().join(format!(
+            "nono-oauth-capture-normalise-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("providers.json");
+
+        let phantom = format!("nono_{}", "a".repeat(64));
+        let mut tokens = serde_json::Map::new();
+        tokens.insert(
+            phantom.clone(),
+            serde_json::json!({
+                "real": "real-access",
+                "admitted_consumers": ["proxy./svc/"],
+                "created_at_secs": now_secs(),
+            }),
+        );
+        fs::write(
+            &path,
+            serde_json::json!({ "version": 1, "tokens": Value::Object(tokens) }).to_string(),
+        )
+        .unwrap();
+
+        let store = store_with_persistence(path);
+        assert_eq!(
+            std::str::from_utf8(
+                &store
+                    .resolve(&phantom, &route_consumer("svc"))
+                    .expect("a persisted phantom must resolve under the normalised consumer")
+            )
+            .unwrap(),
+            "real-access"
+        );
+        assert!(
+            store.resolve(&phantom, "proxy.other").is_none(),
+            "normalisation must not widen the persisted consumer set"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     fn opaque_fields<const N: usize>(paths: [&str; N]) -> Vec<OAuthTokenResponseFieldConfig> {
         paths
             .into_iter()

--- a/crates/nono-proxy/src/oauth_capture/persist.rs
+++ b/crates/nono-proxy/src/oauth_capture/persist.rs
@@ -51,7 +51,11 @@ pub(super) fn load_persisted_tokens(path: &Path) -> Result<HashMap<String, Store
             phantom,
             StoredOAuthToken {
                 real: Zeroizing::new(token.real.into_bytes()),
-                admitted_consumers: token.admitted_consumers.into_iter().collect(),
+                admitted_consumers: token
+                    .admitted_consumers
+                    .iter()
+                    .map(|consumer| super::normalise_admitted_consumer(consumer))
+                    .collect(),
                 created_at_secs: token.created_at_secs,
             },
         );

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -433,13 +433,29 @@ impl RouteStore {
     #[must_use]
     pub fn lookup_by_upstream(&self, host_port: &str) -> Option<(&str, &LoadedRoute)> {
         let normalised = normalise_host_port(host_port);
-        self.routes.iter().find_map(|(prefix, route)| {
-            route
-                .upstream_host_port
-                .as_ref()
-                .filter(|hp| host_port_matches(hp, &normalised))
-                .map(|_| (prefix.as_str(), route))
-        })
+        self.routes
+            .iter()
+            .filter(|(_, route)| {
+                route
+                    .upstream_host_port
+                    .as_ref()
+                    .is_some_and(|hp| host_port_matches(hp, &normalised))
+            })
+            .min_by_key(|(prefix, _)| prefix.as_str())
+            .map(|(prefix, route)| (prefix.as_str(), route))
+    }
+
+    #[must_use]
+    pub fn lookup_credential_bearing_by_upstream(
+        &self,
+        host_port: &str,
+    ) -> Option<(&str, &LoadedRoute)> {
+        let candidates = self.lookup_all_by_upstream(host_port);
+        candidates
+            .iter()
+            .find(|(_, route)| route.carries_managed_credential)
+            .or_else(|| candidates.first())
+            .copied()
     }
 
     /// Return all routes whose upstream matches `host:port`, sorted by
@@ -2537,5 +2553,44 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             "the phantom cannot be swapped without L7 visibility"
         );
         assert!(store.has_intercept_route("api.anthropic.com:443"));
+    }
+
+    #[tokio::test]
+    async fn test_lookup_by_upstream_is_prefix_ordered() {
+        let ep_route = RouteConfig {
+            prefix: "_ep_api.example.com".to_string(),
+            upstream: "http://api.example.com:8080".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let redeem_route = RouteConfig {
+            prefix: "provider".to_string(),
+            upstream: "http://api.example.com:8080".to_string(),
+            redeem_phantoms: vec!["example".to_string()],
+            ..Default::default()
+        };
+
+        for _ in 0..64 {
+            let store = RouteStore::load(&[ep_route.clone(), redeem_route.clone()])
+                .await
+                .unwrap();
+            assert_eq!(
+                store
+                    .lookup_by_upstream("api.example.com:8080")
+                    .map(|(prefix, _)| prefix),
+                Some("_ep_api.example.com"),
+                "lookup must not depend on HashMap iteration order"
+            );
+            assert_eq!(
+                store
+                    .lookup_credential_bearing_by_upstream("api.example.com:8080")
+                    .map(|(prefix, _)| prefix),
+                Some("provider"),
+                "phantom redemption must name the credential-bearing route"
+            );
+        }
     }
 }

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -2485,6 +2485,46 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
     }
 
     #[tokio::test]
+    async fn test_matched_redeem_route_outranks_credential_catchall() {
+        let redeem_route = RouteConfig {
+            prefix: "redeemer".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            redeem_phantoms: vec!["example".to_string()],
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "POST".to_string(),
+                path: "/v1/messages".to_string(),
+            }],
+            ..Default::default()
+        };
+        let cred_catchall = RouteConfig {
+            prefix: "creds".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            credential_key: Some("env://TOK".to_string()),
+            credential_format: Some("Bearer {}".to_string()),
+            env_var: Some("TOK".to_string()),
+            ..Default::default()
+        };
+
+        let store = RouteStore::load(&[redeem_route, cred_catchall])
+            .await
+            .unwrap();
+        let candidates = store.lookup_all_by_upstream("api.example.com:443");
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            select(&candidates, "POST", "/v1/messages"),
+            Selection::Route("redeemer"),
+            "an endpoint-matched phantom redeemer wins over a credential catch-all, \
+             so the catch-all's managed credential is not injected for this request"
+        );
+        assert_eq!(
+            select(&candidates, "GET", "/v1/other"),
+            Selection::EndpointDenied,
+            "the redeemer's endpoint rules still gate the upstream: a credential \
+             catch-all must not widen them"
+        );
+    }
+
+    #[tokio::test]
     async fn test_two_provider_routes_one_api_host_is_not_ambiguous() {
         let provider_route = |prefix: &str| RouteConfig {
             prefix: prefix.to_string(),

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -78,6 +78,8 @@ pub struct LoadedRoute {
     /// authentication itself rather than accept agent-provided credentials.
     pub requires_managed_credential: bool,
 
+    pub carries_managed_credential: bool,
+
     /// Audit auth mechanism implied by the managed credential configuration.
     /// Kept even if credential material failed to load so fail-closed denial
     /// events can describe what auth shape the route expected.
@@ -114,6 +116,10 @@ impl std::fmt::Debug for LoadedRoute {
             .field(
                 "requires_managed_credential",
                 &self.requires_managed_credential,
+            )
+            .field(
+                "carries_managed_credential",
+                &self.carries_managed_credential,
             )
             .field("managed_auth_mechanism", &self.managed_auth_mechanism)
             .field("managed_injection_mode", &self.managed_injection_mode)
@@ -204,8 +210,16 @@ impl RouteStore {
     /// does a regex match, not a glob compile. Routes with a `tls_ca` field
     /// get a per-route TLS connector built from the custom CA certificate.
     pub async fn load(routes: &[RouteConfig]) -> Result<Self> {
+        Self::load_with_oauth_capture(routes, &[]).await
+    }
+
+    pub async fn load_with_oauth_capture(
+        routes: &[RouteConfig],
+        oauth_capture: &[crate::config::OAuthCaptureConfig],
+    ) -> Result<Self> {
         let mut loaded = HashMap::new();
 
+        let oauth_capture_routes = oauth_capture_route_prefixes(oauth_capture);
         let base_root_store = build_base_root_store();
 
         for route in routes {
@@ -328,8 +342,10 @@ impl RouteStore {
                 || route.oauth2.is_some()
                 || route.aws_auth.is_some()
                 || route.spiffe.is_some();
-            let requires_intercept = requires_managed_credential
+            let carries_managed_credential = requires_managed_credential
                 || !route.redeem_phantoms.is_empty()
+                || oauth_capture_routes.contains(normalized_prefix.as_str());
+            let requires_intercept = carries_managed_credential
                 || !endpoint_policy.allows_all_without_l7()
                 || !upgrade_rules.is_empty();
             let managed_auth_mechanism = auth_mechanism_for_route(route);
@@ -357,6 +373,7 @@ impl RouteStore {
                     tls_config_key,
                     requires_intercept,
                     requires_managed_credential,
+                    carries_managed_credential,
                     managed_auth_mechanism,
                     managed_injection_mode,
                     managed_auth,
@@ -495,6 +512,17 @@ impl RouteStore {
     }
 }
 
+fn oauth_capture_route_prefixes(
+    oauth_capture: &[crate::config::OAuthCaptureConfig],
+) -> std::collections::HashSet<String> {
+    oauth_capture
+        .iter()
+        .flat_map(|config| config.admitted_consumers.iter())
+        .filter_map(|consumer| crate::oauth_capture::route_prefix_for_consumer(consumer))
+        .map(|prefix| prefix.trim_matches('/').to_string())
+        .collect()
+}
+
 /// Whether any configured route targets a loopback upstream that must traverse
 /// the proxy (managed credentials, SPIFFE, or TLS-intercepted custom upstreams).
 #[must_use]
@@ -561,12 +589,13 @@ pub(crate) enum RouteSelection<'a> {
 ///
 /// The *credential layer* is `matched_cred` when any credential route matched,
 /// otherwise `catchall_cred` (so a credential catch-all is still in play when
-/// only credential-less `_ep_` routes matched). Two credential routes in the
-/// active layer are ambiguous (the proxy must not silently pick one). Otherwise
-/// selection prefers, in order:
-/// 1. the single credential route from the active layer — a credential catch-all
-///    thus wins over a credential-less `_ep_` match so the managed token is
-///    injected rather than silently dropped,
+/// only credential-less `_ep_` routes matched). Two routes in the active layer
+/// that require a proxy-owned credential are ambiguous (the proxy must not
+/// silently pick one). Otherwise selection prefers, in order:
+/// 1. a route from the active layer that requires a managed credential, else the
+///    first route in that layer — a credential catch-all thus wins over a
+///    credential-less `_ep_` match so the managed token is injected rather than
+///    silently dropped,
 /// 2. a matched credential-less route (bare endpoint authorization),
 /// 3. a credential-less catch-all (un-credentialed passthrough).
 #[cfg(test)]
@@ -584,17 +613,19 @@ pub(crate) fn select_route<'a>(
     let mut endpoint_authorized = false;
     for (prefix, route) in candidates {
         if route.endpoint_rules.is_empty() {
-            if route.requires_managed_credential {
+            if route.carries_managed_credential {
                 catchall_cred.push((prefix, route));
             } else {
                 catchall_passthrough.push((prefix, route));
             }
         } else if route.endpoint_rules.is_allowed(method, path) {
-            if route.requires_managed_credential {
+            if !route.requires_managed_credential {
+                endpoint_authorized = true;
+            }
+            if route.carries_managed_credential {
                 matched_cred.push((prefix, route));
             } else {
                 matched_passthrough.push((prefix, route));
-                endpoint_authorized = true;
             }
         } else if !route.requires_managed_credential {
             has_endpoint_only_route = true;
@@ -617,13 +648,19 @@ pub(crate) fn select_route<'a>(
     } else {
         &matched_cred
     };
-    if credential_layer.len() > 1 {
-        let names = credential_layer.iter().map(|(p, _)| *p).collect();
-        return RouteSelection::Ambiguous(names);
+    let contested: Vec<&str> = credential_layer
+        .iter()
+        .filter(|(_, route)| route.requires_managed_credential)
+        .map(|(prefix, _)| *prefix)
+        .collect();
+    if contested.len() > 1 {
+        return RouteSelection::Ambiguous(contested);
     }
 
     let selected = credential_layer
-        .first()
+        .iter()
+        .find(|(_, route)| route.requires_managed_credential)
+        .or_else(|| credential_layer.first())
         .copied()
         .or_else(|| matched_passthrough.first().copied())
         .or_else(|| catchall_passthrough.first().copied());
@@ -1333,6 +1370,7 @@ mod tests {
             tls_config_key: None,
             requires_intercept: false,
             requires_managed_credential: false,
+            carries_managed_credential: false,
             managed_auth_mechanism: None,
             managed_injection_mode: None,
             managed_auth: None,
@@ -1589,6 +1627,7 @@ mod tests {
             tls_config_key: None,
             requires_intercept: true,
             requires_managed_credential: true,
+            carries_managed_credential: true,
             managed_auth_mechanism: Some(NetworkAuditAuthMechanism::PhantomHeader),
             managed_injection_mode: Some(NetworkAuditInjectionMode::Header),
             managed_auth: None,
@@ -1612,6 +1651,7 @@ mod tests {
             tls_config_key: None,
             requires_intercept: true,
             requires_managed_credential: false,
+            carries_managed_credential: false,
             managed_auth_mechanism: None,
             managed_injection_mode: None,
             managed_auth: None,
@@ -1887,6 +1927,136 @@ mod tests {
         assert_eq!(
             select(&candidates, "GET", "/other/repo"),
             Selection::EndpointDenied
+        );
+    }
+
+    #[tokio::test]
+    async fn test_route_selection_oauth_capture_not_shadowed_by_endpoint_route() {
+        let ep_route = RouteConfig {
+            prefix: "_ep_*".to_string(),
+            upstream: "https://*".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let oauth_route = RouteConfig {
+            prefix: "anthropic_oauth".to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            endpoint_rules: vec![
+                crate::config::EndpointRule {
+                    method: "GET".to_string(),
+                    path: "/v1/mcp_servers".to_string(),
+                },
+                crate::config::EndpointRule {
+                    method: "POST".to_string(),
+                    path: "/v1/messages".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let capture = vec![crate::config::OAuthCaptureConfig {
+            provider: "claude_code".to_string(),
+            token_endpoints: vec![],
+            admitted_consumers: vec![crate::oauth_capture::route_consumer("anthropic_oauth")],
+        }];
+
+        let store = RouteStore::load_with_oauth_capture(&[ep_route, oauth_route], &capture)
+            .await
+            .unwrap();
+        let route = store.get("anthropic_oauth").unwrap();
+        assert!(
+            route.carries_managed_credential,
+            "an admitted oauth_capture consumer must be credential-bearing for selection"
+        );
+        assert!(
+            !route.requires_managed_credential,
+            "the credential arrives with the request, so the fail-closed \
+             availability gate must not claim the proxy owes one"
+        );
+
+        let candidates = store.lookup_all_by_upstream("api.anthropic.com:443");
+        assert_eq!(candidates.len(), 2);
+
+        assert_eq!(
+            select(&candidates, "GET", "/v1/mcp_servers"),
+            Selection::Route("anthropic_oauth"),
+            "oauth_capture route must not be shadowed by the _ep_ wildcard"
+        );
+        assert_eq!(
+            select(&candidates, "POST", "/v1/messages"),
+            Selection::Route("anthropic_oauth"),
+            "a credential route's own rules authorize the request"
+        );
+        assert_eq!(
+            select(&candidates, "DELETE", "/v1/messages"),
+            Selection::EndpointDenied
+        );
+    }
+
+    #[tokio::test]
+    async fn test_route_selection_redeem_phantoms_not_shadowed() {
+        let ep_route = RouteConfig {
+            prefix: "_ep_api.example.com".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let redeem_route = RouteConfig {
+            prefix: "example_redeem".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            redeem_phantoms: vec!["example".to_string()],
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/v1/**".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let store = RouteStore::load(&[ep_route, redeem_route]).await.unwrap();
+        let candidates = store.lookup_all_by_upstream("api.example.com:443");
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            select(&candidates, "GET", "/v1/thing"),
+            Selection::Route("example_redeem"),
+            "a phantom-redeeming route must not be shadowed by an _ep_ route"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oauth_capture_marking_requires_admitted_consumer() {
+        let oauth_route = RouteConfig {
+            prefix: "anthropic_oauth".to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            ..Default::default()
+        };
+        let store = RouteStore::load(std::slice::from_ref(&oauth_route))
+            .await
+            .unwrap();
+        assert!(
+            !store
+                .get("anthropic_oauth")
+                .unwrap()
+                .carries_managed_credential
+        );
+
+        let capture = vec![crate::config::OAuthCaptureConfig {
+            provider: "anthropic_oauth".to_string(),
+            token_endpoints: vec![],
+            admitted_consumers: vec!["oauth.anthropic_oauth".to_string()],
+        }];
+        let store = RouteStore::load_with_oauth_capture(&[oauth_route], &capture)
+            .await
+            .unwrap();
+        assert!(
+            !store
+                .get("anthropic_oauth")
+                .unwrap()
+                .carries_managed_credential
         );
     }
 
@@ -2229,5 +2399,143 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         .unwrap();
         let store = RouteStore::load(&[route]).await.unwrap();
         assert!(store.get("chat").unwrap().requires_intercept);
+    }
+
+    #[tokio::test]
+    async fn test_credential_route_cannot_lift_endpoint_only_gate() {
+        let ep_route = RouteConfig {
+            prefix: "_ep_*".to_string(),
+            upstream: "https://*".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let cred_route = RouteConfig {
+            prefix: "gh".to_string(),
+            upstream: "https://api.github.com".to_string(),
+            credential_key: Some("env://GH_TOKEN".to_string()),
+            credential_format: Some("Bearer {}".to_string()),
+            env_var: Some("GH_TOKEN".to_string()),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "POST".to_string(),
+                path: "/repos/**".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let store = RouteStore::load(&[ep_route, cred_route]).await.unwrap();
+        let candidates = store.lookup_all_by_upstream("api.github.com:443");
+        assert_eq!(candidates.len(), 2);
+
+        assert_eq!(
+            select(&candidates, "POST", "/repos/x"),
+            Selection::EndpointDenied,
+            "a read-only _ep_ wildcard must still deny POST when only a \
+             credential route authorizes it"
+        );
+        assert_eq!(
+            select(&candidates, "GET", "/repos/x"),
+            Selection::Route("_ep_*")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redeem_and_credential_catchall_is_not_ambiguous() {
+        let redeem_route = RouteConfig {
+            prefix: "redeemer".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            redeem_phantoms: vec!["example".to_string()],
+            ..Default::default()
+        };
+        let cred_route = RouteConfig {
+            prefix: "creds".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            credential_key: Some("env://TOK".to_string()),
+            credential_format: Some("Bearer {}".to_string()),
+            env_var: Some("TOK".to_string()),
+            ..Default::default()
+        };
+
+        let store = RouteStore::load(&[redeem_route, cred_route]).await.unwrap();
+        let candidates = store.lookup_all_by_upstream("api.example.com:443");
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            select(&candidates, "GET", "/v1/thing"),
+            Selection::Route("creds"),
+            "the route owning a proxy credential wins over a phantom redeemer"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_two_provider_routes_one_api_host_is_not_ambiguous() {
+        let provider_route = |prefix: &str| RouteConfig {
+            prefix: prefix.to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "*".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let capture = vec![crate::config::OAuthCaptureConfig {
+            provider: "claude_code".to_string(),
+            token_endpoints: vec![],
+            admitted_consumers: vec![
+                crate::oauth_capture::route_consumer("route_a"),
+                crate::oauth_capture::route_consumer("route_b"),
+            ],
+        }];
+
+        let store = RouteStore::load_with_oauth_capture(
+            &[provider_route("route_a"), provider_route("route_b")],
+            &capture,
+        )
+        .await
+        .unwrap();
+        let candidates = store.lookup_all_by_upstream("api.anthropic.com:443");
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            select(&candidates, "POST", "/v1/messages"),
+            Selection::Route("route_a"),
+            "two routes sharing one provider phantom must not 403 as ambiguous"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oauth_capture_consumer_route_requires_intercept() {
+        let oauth_route = RouteConfig {
+            prefix: "anthropic_oauth".to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            endpoint_policy: Some(crate::config::EndpointPolicyConfig {
+                default: crate::config::EndpointPolicyDefault {
+                    decision: crate::config::EndpointPolicyDecision::Allow,
+                    backend: None,
+                    timeout_secs: None,
+                },
+                deny: vec![],
+                approve: vec![],
+                allow: vec![],
+            }),
+            ..Default::default()
+        };
+        let capture = vec![crate::config::OAuthCaptureConfig {
+            provider: "claude_code".to_string(),
+            token_endpoints: vec![],
+            admitted_consumers: vec![crate::oauth_capture::route_consumer("anthropic_oauth")],
+        }];
+
+        let store = RouteStore::load_with_oauth_capture(&[oauth_route], &capture)
+            .await
+            .unwrap();
+        let route = store.get("anthropic_oauth").unwrap();
+        assert!(route.carries_managed_credential);
+        assert!(!route.requires_managed_credential);
+        assert!(
+            route.requires_intercept,
+            "the phantom cannot be swapped without L7 visibility"
+        );
+        assert!(store.has_intercept_route("api.anthropic.com:443"));
     }
 }

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -1055,7 +1055,7 @@ pub async fn start_with_nonce_resolver(
     let route_store = if config.routes.is_empty() {
         RouteStore::empty()
     } else {
-        RouteStore::load(&config.routes).await?
+        RouteStore::load_with_oauth_capture(&config.routes, &config.oauth_capture).await?
     };
     let route_hosts = route_store.route_upstream_hosts();
     validate_no_proxy_route_conflicts(&config.no_proxy, &route_hosts)?;

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -2096,7 +2096,7 @@ async fn handle_forward_http(
     let host_port = crate::route::format_host_port(&host, port);
     let matched_route = state
         .route_store
-        .lookup_by_upstream(&host_port)
+        .lookup_credential_bearing_by_upstream(&host_port)
         .map(|(prefix, _)| prefix.to_string());
     let redeemable = matched_route.as_ref().and_then(|prefix| {
         Some((
@@ -2112,7 +2112,7 @@ async fn handle_forward_http(
                  redeeming phantom headers before forwarding",
                     host_port, prefix
                 );
-                let consumer = format!("proxy.{prefix}");
+                let consumer = crate::oauth_capture::route_consumer(prefix);
                 strip_and_redeem_proxy_headers(header_bytes, &consumer, redeem_phantoms, resolver)
             }
             _ => (strip_proxy_headers(header_bytes), false),

--- a/crates/nono-proxy/src/tls_intercept/h2_forward.rs
+++ b/crates/nono-proxy/src/tls_intercept/h2_forward.rs
@@ -375,7 +375,7 @@ async fn handle_h2_stream(
     // values, mirroring the HTTP/1.1 path. Without this, an h2/gRPC request that
     // carries a broker nonce in a header would forward the raw nonce upstream
     // instead of the resolved credential.
-    let nonce_consumer = service.map(|s| format!("proxy.{s}"));
+    let nonce_consumer = service.map(crate::oauth_capture::route_consumer);
     let redeem_phantoms: &[String] = route.map_or(&[], |r| r.redeem_phantoms.as_slice());
     let mut upstream_headers = HeaderMap::new();
     for (name, value) in request.headers() {

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -3755,6 +3755,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn select_intercept_route_matched_redeemer_outranks_credential_catchall() {
+        fn req<'a>(method: &'a str, path: &'a str) -> InterceptRouteRequest<'a> {
+            InterceptRouteRequest {
+                method,
+                path,
+                websocket_path: None,
+            }
+        }
+
+        let redeem_route = crate::config::RouteConfig {
+            prefix: "redeemer".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            redeem_phantoms: vec!["example".to_string()],
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "POST".to_string(),
+                path: "/v1/messages".to_string(),
+            }],
+            ..Default::default()
+        };
+        let cred_catchall = crate::config::RouteConfig {
+            prefix: "creds".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            credential_key: Some("env://TOK".to_string()),
+            credential_format: Some("Bearer {}".to_string()),
+            env_var: Some("TOK".to_string()),
+            ..Default::default()
+        };
+        let store = RouteStore::load(&[redeem_route, cred_catchall])
+            .await
+            .unwrap();
+
+        match select_intercept_route(
+            &store,
+            "api.example.com",
+            443,
+            req("POST", "/v1/messages"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Selected(Some(selected)) => assert_eq!(
+                selected.id, "redeemer",
+                "an endpoint-matched phantom redeemer wins over a credential catch-all"
+            ),
+            RouteSelection::Selected(None) => {
+                panic!("expected the redeemer route, got passthrough")
+            }
+            RouteSelection::Rejected(status) => {
+                panic!("expected the redeemer route, got a {status} rejection")
+            }
+        }
+
+        match select_intercept_route(
+            &store,
+            "api.example.com",
+            443,
+            req("GET", "/v1/other"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Rejected(status) => assert_eq!(
+                status, 403,
+                "the redeemer's endpoint rules still gate the upstream: a credential \
+                 catch-all must not widen them"
+            ),
+            RouteSelection::Selected(Some(selected)) => {
+                panic!("expected a hard deny, got route '{}'", selected.id)
+            }
+            RouteSelection::Selected(None) => panic!("expected a hard deny, got passthrough"),
+        }
+    }
+
+    #[tokio::test]
     async fn select_intercept_route_credential_route_cannot_lift_endpoint_only_gate() {
         fn req<'a>(method: &'a str, path: &'a str) -> InterceptRouteRequest<'a> {
             InterceptRouteRequest {

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1268,7 +1268,7 @@ where
         request.push_str(&format!("Authorization: Bearer {}\r\n", token.as_str()));
     }
     let injected_header_names = reverse::injected_credential_header_names(cred);
-    let nonce_consumer = service.map(|s| format!("proxy.{s}"));
+    let nonce_consumer = service.map(crate::oauth_capture::route_consumer);
     let redeem_phantoms: &[String] = route.map_or(&[], |r| r.redeem_phantoms.as_slice());
     for (name, value) in &filtered_headers {
         if injected_header_names
@@ -2169,7 +2169,7 @@ fn build_websocket_upstream_request(
     if let Some(cred) = cred {
         reverse::inject_credential_for_mode(cred, &mut request);
     }
-    let nonce_consumer = service.map(|name| format!("proxy.{name}"));
+    let nonce_consumer = service.map(crate::oauth_capture::route_consumer);
     for field in filtered_headers {
         // Ask the resolver, not a bare `nono_` scan: a templated phantom carries
         // no marker and would otherwise be forwarded upstream unrewritten.

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -428,7 +428,7 @@ pub(crate) async fn select_intercept_route<'a>(
             continue;
         }
         if route.endpoint_policy.allows_all_without_l7() {
-            if route.requires_managed_credential {
+            if route.carries_managed_credential {
                 catchall_cred.push((prefix, route));
             } else {
                 catchall_passthrough.push((prefix, route));
@@ -456,11 +456,13 @@ pub(crate) async fn select_intercept_route<'a>(
                     &rule_label,
                     None,
                 );
-                if route.requires_managed_credential {
+                if !route.requires_managed_credential {
+                    endpoint_authorized = true;
+                }
+                if route.carries_managed_credential {
                     matched_cred.push((prefix, route));
                 } else {
                     matched_passthrough.push((prefix, route));
-                    endpoint_authorized = true;
                 }
             }
             EndpointPolicyOutcome::Approve {
@@ -584,11 +586,13 @@ pub(crate) async fn select_intercept_route<'a>(
                             &rule_label,
                             None,
                         );
-                        if route.requires_managed_credential {
+                        if !route.requires_managed_credential {
+                            endpoint_authorized = true;
+                        }
+                        if route.carries_managed_credential {
                             matched_cred.push((prefix, route));
                         } else {
                             matched_passthrough.push((prefix, route));
-                            endpoint_authorized = true;
                         }
                     }
                     Ok(Ok(Ok(nono::supervisor::ApprovalDecision::Denied { reason }))) => {
@@ -774,15 +778,19 @@ pub(crate) async fn select_intercept_route<'a>(
     } else {
         &matched_cred
     };
-    if credential_layer.len() > 1 {
-        let names: Vec<&str> = credential_layer.iter().map(|(p, _)| *p).collect();
+    let contested: Vec<&str> = credential_layer
+        .iter()
+        .filter(|(_, route)| route.requires_managed_credential)
+        .map(|(prefix, _)| *prefix)
+        .collect();
+    if contested.len() > 1 {
         let reason = format!(
             "ambiguous route: {} {} matched {} credential routes: {:?}. \
              Narrow endpoint rules so each request matches exactly one route.",
             method,
             path,
-            names.len(),
-            names
+            contested.len(),
+            contested
         );
         warn!("tls_intercept: {}", reason);
         audit::log_denied(
@@ -800,7 +808,9 @@ pub(crate) async fn select_intercept_route<'a>(
     }
 
     let selected = credential_layer
-        .first()
+        .iter()
+        .find(|(_, route)| route.requires_managed_credential)
+        .or_else(|| credential_layer.first())
         .copied()
         .or_else(|| matched_passthrough.first().copied())
         .or_else(|| catchall_passthrough.first().copied());
@@ -2586,6 +2596,115 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn select_intercept_route_oauth_capture_not_shadowed_by_endpoint_route() {
+        fn req<'a>(method: &'a str, path: &'a str) -> InterceptRouteRequest<'a> {
+            InterceptRouteRequest {
+                method,
+                path,
+                websocket_path: None,
+            }
+        }
+
+        let ep_route = crate::config::RouteConfig {
+            prefix: "_ep_*".to_string(),
+            upstream: "https://*".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let oauth_route = crate::config::RouteConfig {
+            prefix: "anthropic_oauth".to_string(),
+            upstream: "https://api.anthropic.com".to_string(),
+            endpoint_policy: Some(crate::config::EndpointPolicyConfig {
+                default: crate::config::EndpointPolicyDefault::default(),
+                deny: vec![],
+                approve: vec![],
+                allow: vec![
+                    crate::config::EndpointPolicyRule {
+                        method: "GET".to_string(),
+                        path: "/v1/mcp_servers".to_string(),
+                        backend: None,
+                        reason: None,
+                        timeout_secs: None,
+                    },
+                    crate::config::EndpointPolicyRule {
+                        method: "POST".to_string(),
+                        path: "/v1/messages".to_string(),
+                        backend: None,
+                        reason: None,
+                        timeout_secs: None,
+                    },
+                ],
+            }),
+            ..Default::default()
+        };
+        let capture = vec![crate::config::OAuthCaptureConfig {
+            provider: "claude_code".to_string(),
+            token_endpoints: vec![],
+            admitted_consumers: vec![crate::oauth_capture::route_consumer("anthropic_oauth")],
+        }];
+        let store = RouteStore::load_with_oauth_capture(&[ep_route, oauth_route], &capture)
+            .await
+            .unwrap();
+
+        match select_intercept_route(
+            &store,
+            "api.anthropic.com",
+            443,
+            req("GET", "/v1/mcp_servers?limit=1000"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Selected(Some(selected)) => assert_eq!(
+                selected.id, "anthropic_oauth",
+                "_ep_* must not shadow the oauth_capture route"
+            ),
+            RouteSelection::Selected(None) => panic!("must not forward without the credential"),
+            RouteSelection::Rejected(status) => panic!("unexpected rejection with status {status}"),
+        }
+
+        match select_intercept_route(
+            &store,
+            "api.anthropic.com",
+            443,
+            req("POST", "/v1/messages"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Selected(Some(selected)) => {
+                assert_eq!(selected.id, "anthropic_oauth")
+            }
+            RouteSelection::Selected(None) => panic!("must not forward without the credential"),
+            RouteSelection::Rejected(status) => {
+                panic!("POST /v1/messages must stay allowed, got status {status}")
+            }
+        }
+
+        match select_intercept_route(
+            &store,
+            "api.anthropic.com",
+            443,
+            req("DELETE", "/v1/messages"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Rejected(status) => assert_eq!(status, 403),
+            RouteSelection::Selected(Some(selected)) => {
+                panic!("unauthorized method selected route '{}'", selected.id)
+            }
+            RouteSelection::Selected(None) => panic!("unauthorized method must not pass through"),
+        }
+    }
+
     /// Two managed-credential routes sharing one upstream with disjoint
     /// `endpoint_rules` must each authorize their own path and inject their own
     /// credential; a path covered by neither is an un-credentialed passthrough.
@@ -3633,5 +3752,60 @@ mod tests {
         .unwrap();
 
         assert!(tunnel_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn select_intercept_route_credential_route_cannot_lift_endpoint_only_gate() {
+        fn req<'a>(method: &'a str, path: &'a str) -> InterceptRouteRequest<'a> {
+            InterceptRouteRequest {
+                method,
+                path,
+                websocket_path: None,
+            }
+        }
+
+        let ep_route = crate::config::RouteConfig {
+            prefix: "_ep_*".to_string(),
+            upstream: "https://*".to_string(),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "GET".to_string(),
+                path: "/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let cred_route = crate::config::RouteConfig {
+            prefix: "gh".to_string(),
+            upstream: "https://api.github.com".to_string(),
+            credential_key: Some("env://GH_TOKEN".to_string()),
+            credential_format: Some("Bearer {}".to_string()),
+            env_var: Some("GH_TOKEN".to_string()),
+            endpoint_rules: vec![crate::config::EndpointRule {
+                method: "POST".to_string(),
+                path: "/repos/**".to_string(),
+            }],
+            ..Default::default()
+        };
+        let store = RouteStore::load(&[ep_route, cred_route]).await.unwrap();
+
+        match select_intercept_route(
+            &store,
+            "api.github.com",
+            443,
+            req("POST", "/repos/x"),
+            None,
+            None,
+        )
+        .await
+        {
+            RouteSelection::Rejected(status) => assert_eq!(
+                status, 403,
+                "a read-only _ep_ wildcard must still deny POST"
+            ),
+            RouteSelection::Selected(Some(selected)) => panic!(
+                "credential route '{}' must not widen the _ep_ allow-list",
+                selected.id
+            ),
+            RouteSelection::Selected(None) => panic!("expected a hard deny, got passthrough"),
+        }
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1831

## Summary

`synthesize_credential_provider_proxy_config` emits `oauth_capture` provider routes with `credential_key`, `oauth2`, `aws_auth` and `spiffe` all `None`, so `RouteStore::load` classified them as passthrough. Selection then took the first candidate by prefix sort order and `_` sorts before lowercase, so `_ep_*` beat `anthropic_oauth`: the phantom token was forwarded verbatim and the upstream answered 401.

Add `LoadedRoute::carries_managed_credential` — true when the proxy supplies the credential, when the route redeems a caller-presented phantom, or when the route is an admitted consumer of an `oauth_capture` provider — and key selection priority and interception on it. It stays distinct from `requires_managed_credential`, which still gates the fail-closed availability check and the ambiguity 403: a route that only carries what the caller presented has no proxy-owned token to choose between, and failing it closed would 503 every request.

Two smaller fixes on the same path:

- Route consumers are derived through one `route_consumer` helper that normalises the prefix. A prefix with a leading or trailing slash produced `proxy./svc/` in `admitted_consumers` against `proxy.svc` on egress, so `resolve` returned `None` and the phantom went upstream unresolved. Persisted phantoms are normalised on reload too, so a store file written before this change converges instead of 401ing until the token endpoint is hit again.
- `handle_forward_http` selects the credential-bearing route rather than an arbitrary `HashMap` hit, so the absolute-form path names the route that actually carries the credential. Ordering `lookup_by_upstream` by prefix also settles the audit `route_id` at the CONNECT dispatch site, which had the same arbitrary pick.

## Agent Disclosure

This PR was prepared by an AI agent (Claude Code) on behalf of @terotuomala.

Consulted:
- `AGENTS.md` / `CLAUDE.md` — coding standards, security considerations, coding agent contribution policy
- `.github/pull_request_template.md`, and #1704 / #1837 for PR structure
- Issue #1831, including its reproduction and log excerpts
- `crates/nono-proxy/src/route.rs`, `crates/nono-proxy/src/server.rs`, `crates/nono-proxy/src/tls_intercept/{handle.rs,h2_forward.rs}`, `crates/nono-proxy/src/oauth_capture/{mod.rs,persist.rs}`, `crates/nono-cli/src/proxy_runtime.rs`

Compliance: no reused or adapted third-party code; no `unwrap`/`expect` outside tests (`make clippy` runs with `-D clippy::unwrap_used`); no new error surface or path handling; all commits carry a DCO sign-off.

## Test Plan

- `make ci` — build, clippy, fmt and workspace tests pass locally. The `cargo audit` step does not run on this machine (cargo-audit not installed); CI covers it.
- `cargo test -p nono-proxy --lib` — 581 passed, 0 failed.
- New unit tests, on both the `select_route` decision and the `select_intercept_route` shipping path:
  - an `oauth_capture` consumer route is not shadowed by an `_ep_` route, and requires interception under a `default: allow` endpoint policy
  - two provider routes on one api host are not ambiguous
  - an endpoint-matched phantom redeemer outranks a credential catch-all, and the redeemer's own endpoint rules still gate the upstream
  - a persisted phantom resolves under the normalised consumer after reload, without widening the persisted consumer set
- Not run locally: the end-to-end profile reproduction from the issue.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates (N/A — bug fix, no user-facing surface change)
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no reused or adapted code)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required (N/A — `nono-proxy` uses `ProxyError`; no new error surface)
- [x] I validated and canonicalized all relevant paths (N/A — no new path handling)
- [x] This PR matches the disclosed issue scope
