### PR TITLE
fix(cli): ignore unhandled keys in the denied-path review selector

### DIFF
--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1087,13 +1087,76 @@ pub(crate) fn configure_prompt_termios(termios: &mut nix::sys::termios::Termios)
 
 // ─── Raw terminal mode for interactive selector ───────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Key {
     Up,
     Down,
     Space,
     Enter,
     CtrlC,
+    CtrlD,
+    Esc,
     Char(char),
+    /// An input sequence the selector does not act on (left/right arrows,
+    /// Home/End, function keys, Alt-modified keys, mouse reports).
+    Unknown,
+}
+
+fn decode_plain_byte(byte: u8) -> Key {
+    match byte {
+        b' ' => Key::Space,
+        b'\r' | b'\n' => Key::Enter,
+        0x03 => Key::CtrlC,
+        0x04 => Key::CtrlD,
+        c => Key::Char(c as char),
+    }
+}
+
+/// Decode an escape sequence after its leading `ESC` byte.
+///
+/// `reader` must be in a short-timeout mode, where a zero-byte read means
+/// nothing more arrived; that is what distinguishes a bare Esc keypress from
+/// the start of a sequence.
+fn decode_escape_sequence<R: std::io::Read>(reader: &mut R) -> Key {
+    let Some(second) = read_one(reader) else {
+        // Nothing followed: a bare Esc.
+        return Key::Esc;
+    };
+
+    match second {
+        // CSI and SS3 introducers.
+        b'[' | b'O' => match read_csi_final_byte(reader) {
+            Some(b'A') => Key::Up,
+            Some(b'B') => Key::Down,
+            _ => Key::Unknown,
+        },
+        // `ESC <char>` is Alt+<char>.
+        _ => Key::Unknown,
+    }
+}
+
+/// Consume a CSI/SS3 body and return its final byte, skipping parameter and
+/// intermediate bytes so sequences like `ESC [ 1 ; 5 C` are swallowed whole
+/// rather than leaving a tail to be misread as further keypresses.
+fn read_csi_final_byte<R: std::io::Read>(reader: &mut R) -> Option<u8> {
+    // Bounded so a malformed sequence cannot spin forever.
+    const MAX_SEQUENCE_BYTES: usize = 32;
+    for _ in 0..MAX_SEQUENCE_BYTES {
+        let byte = read_one(reader)?;
+        if (0x40..=0x7e).contains(&byte) {
+            return Some(byte);
+        }
+    }
+    None
+}
+
+/// Read one byte, treating a timeout, EOF, or error as "no byte".
+fn read_one<R: std::io::Read>(reader: &mut R) -> Option<u8> {
+    let mut buf = [0u8; 1];
+    match reader.read(&mut buf) {
+        Ok(1) => Some(buf[0]),
+        _ => None,
+    }
 }
 
 struct RawTtyGuard {
@@ -1119,38 +1182,15 @@ impl RawTtyGuard {
         self.tty
             .read_exact(&mut buf)
             .map_err(|e| NonoError::LearnError(format!("tty read: {e}")))?;
-        match buf[0] {
-            0x1b => {
-                // Switch to short-timeout non-blocking to detect escape sequences
-                self.set_vmin_vtime(0, 1)?;
-                let key = self.try_read_escape_sequence();
-                let _ = self.set_vmin_vtime(1, 0);
-                key
-            }
-            b' ' => Ok(Key::Space),
-            b'\r' | b'\n' => Ok(Key::Enter),
-            0x03 => Ok(Key::CtrlC),
-            c => Ok(Key::Char(c as char)),
+        if buf[0] != 0x1b {
+            return Ok(decode_plain_byte(buf[0]));
         }
-    }
-
-    fn try_read_escape_sequence(&mut self) -> Result<Key> {
-        use std::io::Read;
-        let mut buf = [0u8; 1];
-        if self.tty.read(&mut buf).unwrap_or(0) == 0 {
-            return Ok(Key::Char('\x1b'));
-        }
-        if buf[0] != b'[' {
-            return Ok(Key::Char('\x1b'));
-        }
-        if self.tty.read(&mut buf).unwrap_or(0) == 0 {
-            return Ok(Key::Char('\x1b'));
-        }
-        Ok(match buf[0] {
-            b'A' => Key::Up,
-            b'B' => Key::Down,
-            _ => Key::Char('\x1b'),
-        })
+        // Short-timeout non-blocking, so a bare Esc is distinguishable from
+        // the start of an escape sequence.
+        self.set_vmin_vtime(0, 1)?;
+        let key = decode_escape_sequence(&mut self.tty);
+        let _ = self.set_vmin_vtime(1, 0);
+        Ok(key)
     }
 
     fn set_vmin_vtime(&self, vmin: u8, vtime: u8) -> Result<()> {
@@ -1381,6 +1421,7 @@ fn interactive_denial_selector(patch: &profile::Profile) -> Result<Option<Vec<De
     let mut cursor: usize = 0;
     let mut line_count: usize = 0;
     let mut first_render = true;
+    let mut cancelled = false;
 
     loop {
         render_denial_selector(&mut raw.tty, &items, cursor, &mut line_count, first_render)?;
@@ -1436,21 +1477,44 @@ fn interactive_denial_selector(patch: &profile::Profile) -> Result<Option<Vec<De
                 }
             }
             Key::Enter => break,
-            Key::CtrlC | Key::Char('\x1b') => {
+            Key::CtrlC | Key::CtrlD | Key::Esc => {
                 for item in &mut items {
                     match item {
                         DenialItem::Fs { action, .. } => *action = ItemAction::Skip,
                         DenialItem::Url { action, .. } => *action = UrlItemAction::Skip,
                     }
                 }
+                cancelled = true;
                 break;
             }
-            Key::Char(_) => {}
+            // Ignored, so a stray keypress cannot discard the review.
+            Key::Char(_) | Key::Unknown => {}
         }
     }
 
     erase_selector(&mut raw.tty, line_count)?;
+    if cancelled {
+        print_selector_cancelled_hint(&mut raw.tty);
+    }
     Ok(Some(items))
+}
+
+/// Report that nothing was saved and how to bring the review back. Written to
+/// the selector's tty, so the hint survives stdout or stderr redirection.
+fn print_selector_cancelled_hint(tty: &mut std::fs::File) {
+    let t = theme::current();
+    let _ = writeln!(
+        tty,
+        "\r{} {}",
+        theme::fg(" [nono]", t.brand).bold(),
+        "Review cancelled - no profile changes were saved.".dimmed()
+    );
+    let _ = writeln!(
+        tty,
+        "\r        {}",
+        "Re-run the same command to review the denied paths again.".dimmed()
+    );
+    let _ = tty.flush();
 }
 
 // ─── Build patch from per-item decisions ──────────────────────────────────
@@ -2948,5 +3012,90 @@ mod tests {
         let urls = base.open_urls.expect("open_urls preserved");
         assert_eq!(urls.allow_origins, vec!["https://keep.example.com"]);
         assert!(urls.allow_localhost);
+    }
+
+    // ─── Interactive selector key decoding ────────────────────────────────
+
+    /// Decode a byte sequence the way `read_key` does. An exhausted buffer
+    /// stands in for the tty's VTIME timeout.
+    fn decode(bytes: &[u8]) -> Key {
+        let (first, rest) = bytes.split_first().expect("non-empty input");
+        if *first == 0x1b {
+            decode_escape_sequence(&mut std::io::Cursor::new(rest))
+        } else {
+            decode_plain_byte(*first)
+        }
+    }
+
+    #[test]
+    fn bare_esc_decodes_as_cancel() {
+        assert_eq!(decode(b"\x1b"), Key::Esc);
+    }
+
+    #[test]
+    fn up_and_down_arrows_still_decode() {
+        assert_eq!(decode(b"\x1b[A"), Key::Up);
+        assert_eq!(decode(b"\x1b[B"), Key::Down);
+        // SS3 form emitted by some terminals in application cursor mode.
+        assert_eq!(decode(b"\x1bOA"), Key::Up);
+        assert_eq!(decode(b"\x1bOB"), Key::Down);
+    }
+
+    #[test]
+    fn unhandled_escape_sequences_are_not_cancel() {
+        // Issue #1845: right arrow used to decode as Esc and close the menu.
+        for seq in [
+            &b"\x1b[C"[..],    // right arrow
+            &b"\x1b[D"[..],    // left arrow
+            &b"\x1b[H"[..],    // home
+            &b"\x1b[F"[..],    // end
+            &b"\x1b[5~"[..],   // page up
+            &b"\x1b[6~"[..],   // page down
+            &b"\x1b[1;5C"[..], // ctrl+right
+            &b"\x1b[200~"[..], // bracketed paste start
+            &b"\x1bOP"[..],    // F1 (SS3)
+            &b"\x1bx"[..],     // alt+x
+        ] {
+            assert_eq!(
+                decode(seq),
+                Key::Unknown,
+                "sequence {seq:?} must be ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_byte_sequence_is_consumed_whole() {
+        // Ctrl+Right then Enter: only the Enter may be left to read.
+        let mut input = std::io::Cursor::new(&b"[1;5C\r"[..]);
+        assert_eq!(decode_escape_sequence(&mut input), Key::Unknown);
+
+        let mut remaining = Vec::new();
+        std::io::Read::read_to_end(&mut input, &mut remaining).expect("read remainder");
+        assert_eq!(remaining, b"\r");
+    }
+
+    #[test]
+    fn malformed_escape_sequence_terminates() {
+        // No final byte ever arrives; the scan must stop.
+        let mut input = std::io::Cursor::new(vec![b';'; 4096]);
+        assert_eq!(
+            decode_escape_sequence_with_introducer(&mut input),
+            Key::Unknown
+        );
+    }
+
+    fn decode_escape_sequence_with_introducer<R: std::io::Read>(reader: &mut R) -> Key {
+        decode_escape_sequence(&mut std::io::Read::chain(&b"["[..], reader))
+    }
+
+    #[test]
+    fn control_keys_decode_as_cancel_or_confirm() {
+        assert_eq!(decode(b"\x03"), Key::CtrlC);
+        assert_eq!(decode(b"\x04"), Key::CtrlD);
+        assert_eq!(decode(b"\r"), Key::Enter);
+        assert_eq!(decode(b"\n"), Key::Enter);
+        assert_eq!(decode(b" "), Key::Space);
+        assert_eq!(decode(b"a"), Key::Char('a'));
     }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1845

## Summary

The denied-path review selector's escape-sequence reader collapsed every unrecognized sequence into `Key::Char('\x1b')`, which the event loop matched in the same arm as Ctrl+C and treated as cancel. It also read at most 3 bytes, so longer sequences like `ESC [ 1 ; 5 C` left trailing bytes to be misread as further keypresses.

Split `Key::Esc` (a real Esc: nothing followed within the VTIME window) from `Key::Unknown` (consumed but unhandled), added `Key::CtrlD`, and changed the decoder to handle both CSI (`ESC [`) and SS3 (`ESC O`) introducers, consuming through the final byte (`0x40..=0x7e`) with a 32-byte bound. Only Esc, Ctrl+C, and Ctrl+D now cancel; everything else is ignored. 

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

Reproduced against the pre-fix binary by running `nono run --profile default -- cat ~/.zshrc` under a PTY and injecting one keypress: `x` redrew the menu, `ESC [ C` erased it. Re-ran the same harness after the fix. `ESC [ C`, `[ D`, `[ 5~` and `[ 1;5C` all redraw and the menu stays; bare Esc, Ctrl+C and Ctrl+D cancel and print the hint; Ctrl+Right followed by `d` then Enter ignores the noise, applies deny-all, and confirms. Added 6 unit tests over the extracted decoder covering those sequences, both arrow-key encodings, whole-sequence consumption, and the malformed-input bound.

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [x] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
