### PR TITLE
fix(cli): guard denied-path selector against type-ahead

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -77,6 +77,7 @@ mod startup_runtime;
 mod state_paths;
 mod supervised_runtime;
 mod terminal_approval;
+mod terminal_prompt;
 mod theme;
 mod timeouts;
 #[path = "tool-sandbox/mod.rs"]

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -19,7 +19,7 @@ use crate::package_cmd;
 use crate::registry_client::{PullReason, RegistryClient, resolve_registry_url};
 use colored::Colorize;
 use nono::Result;
-use std::io::{self, BufRead, IsTerminal, Write};
+use std::io::{self, IsTerminal, Write};
 
 const ENV_AUTO_MIGRATE: &str = "NONO_AUTO_MIGRATE";
 const ENV_NO_MIGRATE: &str = "NONO_NO_MIGRATE";
@@ -139,13 +139,14 @@ pub fn check_and_run(profile_name: &str) -> Result<MigrationOutcome> {
     };
 
     let auto = env_flag(ENV_AUTO_MIGRATE);
-    let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+    let interactive =
+        io::stderr().is_terminal() && crate::terminal_prompt::consent_prompt_available();
 
     if !auto && !interactive {
         emit_skipped_hint(&chosen, SkipReason::NonInteractive);
         return Ok(MigrationOutcome::Skipped);
     }
-    if !auto && !confirm_pull(profile_name, &chosen) {
+    if !auto && !confirm_pull(profile_name, &chosen)? {
         emit_skipped_hint(&chosen, SkipReason::Declined);
         return Ok(MigrationOutcome::Skipped);
     }
@@ -192,7 +193,7 @@ fn env_flag(key: &str) -> bool {
     )
 }
 
-fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> bool {
+fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> Result<bool> {
     let pack_ref = provider.pack_ref();
     let mut err = io::stderr().lock();
     let _ = writeln!(err);
@@ -234,16 +235,14 @@ fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> bool {
     );
 
     let _ = writeln!(err);
-    let _ = write!(err, "  Continue? [Y/n] ");
-    let _ = err.flush();
     drop(err);
 
-    let mut line = String::new();
-    if io::stdin().lock().read_line(&mut line).is_err() {
-        return false;
-    }
-    let answer = line.trim().to_ascii_lowercase();
-    answer.is_empty() || answer == "y" || answer == "yes"
+    let line = crate::terminal_prompt::read_consent_line("  Continue? [y/N] ")?;
+    Ok(is_affirmative_response(&line))
+}
+
+fn is_affirmative_response(response: &str) -> bool {
+    matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 #[derive(Clone, Copy)]
@@ -359,5 +358,14 @@ mod tests {
         };
         let _env = EnvVarGuard::set_all(&[("NONO_TEST_FLAG_VALUE", "0")]);
         assert!(!env_flag("NONO_TEST_FLAG_VALUE"));
+    }
+
+    #[test]
+    fn migration_confirmation_requires_explicit_yes() {
+        assert!(is_affirmative_response("y"));
+        assert!(is_affirmative_response(" YES \n"));
+        assert!(!is_affirmative_response(""));
+        assert!(!is_affirmative_response("n"));
+        assert!(!is_affirmative_response("anything else"));
     }
 }

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -9,6 +9,7 @@ use nono::{AccessMode, CapabilitySet, NonoError, Result, UrlDenialReason, UrlDen
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 #[derive(Clone, Copy)]
 pub(crate) enum SaveAction {
@@ -133,6 +134,7 @@ enum DenialItem {
 }
 
 const DENIAL_SELECTOR_MAX_VISIBLE_ITEMS: usize = 15;
+const DENIAL_SELECTOR_INPUT_DELAY: Duration = Duration::from_secs(1);
 
 fn denial_selector_visible_range(
     item_count: usize,
@@ -1193,6 +1195,14 @@ impl RawTtyGuard {
         Ok(key)
     }
 
+    /// Wait for the selector's input guard, then discard any type-ahead that
+    /// arrived before the operator had time to read the prompt.
+    fn arm_input_after(&self, delay: Duration) -> Result<()> {
+        std::thread::sleep(delay);
+        nix::sys::termios::tcflush(&self.tty, nix::sys::termios::FlushArg::TCIFLUSH)
+            .map_err(|e| NonoError::LearnError(format!("tcflush: {e}")))
+    }
+
     fn set_vmin_vtime(&self, vmin: u8, vtime: u8) -> Result<()> {
         use nix::sys::termios::SpecialCharacterIndices;
         let mut t = nix::sys::termios::tcgetattr(&self.tty)
@@ -1234,6 +1244,7 @@ fn render_denial_selector(
     cursor: usize,
     line_count: &mut usize,
     first_render: bool,
+    input_armed: bool,
 ) -> Result<()> {
     if !first_render && *line_count > 0 {
         write!(tty, "\x1b[{}A", line_count)
@@ -1273,11 +1284,18 @@ fn render_denial_selector(
             theme::fg(" [nono] Review denied paths", t.brand).bold()
         );
     }
-    tty_ln!(
-        "  {}",
-        "↑/↓ move  ·  Space cycle  ·  a grant-all  ·  d deny-all  ·  Enter confirm  ·  Esc cancel"
-            .dimmed()
-    );
+    if input_armed {
+        tty_ln!(
+            "  {}",
+            "↑/↓ move  ·  Space cycle  ·  a grant-all  ·  d deny-all  ·  Enter confirm  ·  Esc cancel"
+                .dimmed()
+        );
+    } else {
+        tty_ln!(
+            "  {}",
+            "Input enables in 1 second · early keys ignored".dimmed()
+        );
+    }
     tty_ln!("");
 
     for (offset, item) in items[start..end].iter().enumerate() {
@@ -1420,12 +1438,13 @@ fn interactive_denial_selector(patch: &profile::Profile) -> Result<Option<Vec<De
 
     let mut cursor: usize = 0;
     let mut line_count: usize = 0;
-    let mut first_render = true;
     let mut cancelled = false;
 
+    render_denial_selector(&mut raw.tty, &items, cursor, &mut line_count, true, false)?;
+    raw.arm_input_after(DENIAL_SELECTOR_INPUT_DELAY)?;
+
     loop {
-        render_denial_selector(&mut raw.tty, &items, cursor, &mut line_count, first_render)?;
-        first_render = false;
+        render_denial_selector(&mut raw.tty, &items, cursor, &mut line_count, false, true)?;
 
         match raw.read_key()? {
             Key::Up => {
@@ -3097,5 +3116,29 @@ mod tests {
         assert_eq!(decode(b"\n"), Key::Enter);
         assert_eq!(decode(b" "), Key::Space);
         assert_eq!(decode(b"a"), Key::Char('a'));
+    }
+
+    #[test]
+    fn input_guard_discards_queued_keys_before_arming() {
+        use nix::pty::{OpenptyResult, openpty};
+
+        let OpenptyResult { master, slave } = openpty(None, None).expect("openpty");
+        let saved = nix::sys::termios::tcgetattr(&slave).expect("tcgetattr");
+        let mut raw_termios = saved.clone();
+        configure_raw_termios(&mut raw_termios);
+        nix::sys::termios::tcsetattr(&slave, nix::sys::termios::SetArg::TCSANOW, &raw_termios)
+            .expect("tcsetattr");
+
+        nix::unistd::write(&master, b"\r").expect("queue early Enter");
+        let mut guard = RawTtyGuard {
+            tty: std::fs::File::from(slave),
+            saved,
+        };
+        guard
+            .arm_input_after(Duration::ZERO)
+            .expect("arm selector input");
+
+        nix::unistd::write(&master, b"d").expect("write key after arming");
+        assert_eq!(guard.read_key().expect("read key"), Key::Char('d'));
     }
 }

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -4,8 +4,8 @@
 //! additional filesystem access. This is the default approval backend
 //! for `nono run`.
 
-use nono::{AccessMode, ApprovalBackend, ApprovalDecision, ApprovalRequest, NonoError, Result};
-use std::io::{BufRead, IsTerminal, Write};
+use nono::{AccessMode, ApprovalBackend, ApprovalDecision, ApprovalRequest, Result};
+use std::io::IsTerminal;
 
 /// Interactive terminal approval backend.
 ///
@@ -105,21 +105,9 @@ impl ApprovalBackend for TerminalApproval {
             }
         }
         eprintln!("[nono]");
-        eprint!("[nono] Grant access? [y/N] ");
-        let _ = std::io::stderr().flush();
+        let input = crate::terminal_prompt::read_consent_line("[nono] Grant access? [y/N] ")?;
 
-        // Read from /dev/tty, not stdin (which belongs to the sandboxed child)
-        let tty = std::fs::File::open("/dev/tty").map_err(|e| {
-            NonoError::SandboxInit(format!("Failed to open /dev/tty for approval prompt: {e}"))
-        })?;
-        let mut reader = std::io::BufReader::new(tty);
-        let mut input = String::new();
-        reader.read_line(&mut input).map_err(|e| {
-            NonoError::SandboxInit(format!("Failed to read approval response: {e}"))
-        })?;
-
-        let input = input.trim().to_lowercase();
-        if input == "y" || input == "yes" {
+        if is_affirmative_response(&input) {
             eprintln!("[nono] Access granted.");
             Ok(ApprovalDecision::Granted)
         } else {
@@ -133,6 +121,10 @@ impl ApprovalBackend for TerminalApproval {
     fn backend_name(&self) -> &str {
         "terminal"
     }
+}
+
+fn is_affirmative_response(response: &str) -> bool {
+    matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 /// Strip control characters and ANSI escape sequences from untrusted input
@@ -259,6 +251,15 @@ mod tests {
     fn test_terminal_approval_backend_name() {
         let backend = TerminalApproval;
         assert_eq!(backend.backend_name(), "terminal");
+    }
+
+    #[test]
+    fn terminal_approval_requires_explicit_yes() {
+        assert!(is_affirmative_response("y"));
+        assert!(is_affirmative_response(" YES \n"));
+        assert!(!is_affirmative_response(""));
+        assert!(!is_affirmative_response("n"));
+        assert!(!is_affirmative_response("anything else"));
     }
 
     // ── non-TTY auto-deny (all three variants) ────────────────────────────────

--- a/crates/nono-cli/src/terminal_prompt.rs
+++ b/crates/nono-cli/src/terminal_prompt.rs
@@ -1,0 +1,133 @@
+//! Guarded terminal input for security-sensitive line prompts.
+
+use nono::{NonoError, Result};
+use std::io::{BufRead, IsTerminal, Write};
+use std::time::Duration;
+
+const CONSENT_INPUT_DELAY: Duration = Duration::from_secs(1);
+
+/// Return whether a controlling terminal is available for a consent prompt.
+pub(crate) fn consent_prompt_available() -> bool {
+    open_tty().is_ok_and(|tty| tty.is_terminal())
+}
+
+/// Read a line from the controlling terminal after discarding type-ahead.
+pub(crate) fn read_consent_line(prompt: &str) -> Result<String> {
+    read_consent_line_from(open_tty()?, prompt, CONSENT_INPUT_DELAY)
+}
+
+fn open_tty() -> Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .map_err(NonoError::Io)
+}
+
+fn read_consent_line_from(mut tty: std::fs::File, prompt: &str, delay: Duration) -> Result<String> {
+    let saved = nix::sys::termios::tcgetattr(&tty).map_err(termios_error)?;
+    let restore_tty = tty.try_clone().map_err(NonoError::Io)?;
+    let _guard = TermiosRestoreGuard {
+        tty: restore_tty,
+        saved: saved.clone(),
+    };
+
+    let mut prompt_termios = saved;
+    configure_line_input(&mut prompt_termios);
+    nix::sys::termios::tcsetattr(&tty, nix::sys::termios::SetArg::TCSANOW, &prompt_termios)
+        .map_err(termios_error)?;
+
+    write!(tty, "Input enables in 1 second · early keys ignored").map_err(NonoError::Io)?;
+    tty.flush().map_err(NonoError::Io)?;
+    std::thread::sleep(delay);
+
+    nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH)
+        .map_err(termios_error)?;
+    write!(tty, "\r\x1b[2K{prompt}").map_err(NonoError::Io)?;
+    tty.flush().map_err(NonoError::Io)?;
+
+    let mut input = String::new();
+    std::io::BufReader::new(tty)
+        .read_line(&mut input)
+        .map_err(NonoError::Io)?;
+    Ok(input)
+}
+
+fn termios_error(error: nix::errno::Errno) -> NonoError {
+    NonoError::Io(std::io::Error::from_raw_os_error(error as i32))
+}
+
+fn configure_line_input(termios: &mut nix::sys::termios::Termios) {
+    use nix::sys::termios::{
+        ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
+    };
+
+    termios.input_flags.remove(
+        InputFlags::IGNBRK
+            | InputFlags::BRKINT
+            | InputFlags::PARMRK
+            | InputFlags::ISTRIP
+            | InputFlags::INLCR
+            | InputFlags::IGNCR,
+    );
+    termios
+        .input_flags
+        .insert(InputFlags::ICRNL | InputFlags::IXON);
+    termios.output_flags.insert(OutputFlags::OPOST);
+    termios.local_flags.insert(
+        LocalFlags::ECHO
+            | LocalFlags::ECHONL
+            | LocalFlags::ICANON
+            | LocalFlags::ISIG
+            | LocalFlags::IEXTEN,
+    );
+    termios
+        .control_flags
+        .remove(ControlFlags::CSIZE | ControlFlags::PARENB);
+    termios.control_flags.insert(ControlFlags::CS8);
+    termios.control_chars[SpecialCharacterIndices::VMIN as usize] = 1;
+    termios.control_chars[SpecialCharacterIndices::VTIME as usize] = 0;
+}
+
+struct TermiosRestoreGuard {
+    tty: std::fs::File,
+    saved: nix::sys::termios::Termios,
+}
+
+impl Drop for TermiosRestoreGuard {
+    fn drop(&mut self) {
+        let _ = nix::sys::termios::tcsetattr(
+            &self.tty,
+            nix::sys::termios::SetArg::TCSANOW,
+            &self.saved,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::pty::{OpenptyResult, openpty};
+
+    #[test]
+    fn consent_reader_discards_early_input_and_accepts_fresh_response() {
+        let OpenptyResult { master, slave } = openpty(None, None).expect("openpty");
+        nix::unistd::write(&master, b"y\n").expect("queue early approval");
+
+        let writer_master = nix::unistd::dup(&master).expect("duplicate pty master");
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            nix::unistd::write(writer_master, b"n\n").expect("write fresh response");
+        });
+
+        let response = read_consent_line_from(
+            std::fs::File::from(slave),
+            "Continue? [y/N] ",
+            Duration::ZERO,
+        )
+        .expect("read guarded response");
+        writer.join().expect("join response writer");
+
+        assert_eq!(response.trim(), "n");
+    }
+}

--- a/docs/cli/clients/claude.mdx
+++ b/docs/cli/clients/claude.mdx
@@ -352,10 +352,13 @@ The first time you run `nono run --profile nolabs-ai/claude -- claude`, nono pro
      Provenance   Sigstore cryptographic supply chain (verified on pull)
      Installs     sandbox profile + Claude Code plugin
 
-  Continue? [Y/n]
+  Continue? [y/N]
 ```
 
-Press `Y` (or just Enter). nono pulls the pack, verifies its Sigstore provenance, and prints a summary that ties the release artifacts back to the source repository.
+After the one-second input guard enables the prompt, press `Y`. Pressing Enter
+uses the safe default and skips installation. nono pulls the pack, verifies its
+Sigstore provenance, and prints a summary that ties the release artifacts back
+to the source repository.
 
 ### What "Pull" Actually Does
 

--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -59,10 +59,14 @@ The first time you run `nono run --profile nolabs-ai/codex -- codex`, nono promp
      Provenance   Sigstore cryptographic supply chain (verified on pull)
      Installs     sandbox profile + Codex hooks + diagnostic skill
 
-  Continue? [Y/n]
+  Continue? [y/N]
 ```
 
-Press `Y`. nono pulls the pack, verifies its Sigstore provenance, and writes Codex's plugin wiring directly to the files Codex actually reads (verified against `openai/codex` source — not the `~/.agents/plugins/marketplace.json` that some external docs hint at).
+After the one-second input guard enables the prompt, press `Y`. Pressing Enter
+uses the safe default and skips installation. nono pulls the pack, verifies its
+Sigstore provenance, and writes Codex's plugin wiring directly to the files
+Codex actually reads (verified against `openai/codex` source — not the
+`~/.agents/plugins/marketplace.json` that some external docs hint at).
 
 ### What the pull writes
 

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -457,7 +457,10 @@ explicit so it is not mistaken for allowing the denied path.
 
 The post-run save prompt offers the same behavior interactively: choose
 `suppress` to save all listed denied-path suggestions here instead of adding
-them as `read`, `read_file`, `allow`, or `allow_file` grants.
+them as `read`, `read_file`, `allow`, or `allow_file` grants. The interactive
+selector ignores input for its first second and discards queued keypresses
+before enabling its controls, preventing input intended for the command that
+just exited from immediately confirming the default grants.
 
 ### Suppressing Expected macOS System-Service Diagnostics
 

--- a/docs/cli/features/supervisor.mdx
+++ b/docs/cli/features/supervisor.mdx
@@ -112,6 +112,9 @@ The default backend reads approval from `/dev/tty` directly (since stdin belongs
         Allow? [y/N]
 ```
 
+The prompt ignores and discards terminal input during a one-second arming
+window before accepting a response. An empty response defaults to denial.
+
 ### Webhook / Policy Approval (planned)
 
 Future backends will support:


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1854
Closes #1864 

## Summary

<!-- Briefly describe what this PR does and why. -->
The denied-path review selector accepted input immediately after appearing. Buffered or accidental keypresses intended for the command that had just exited could therefore reach the selector, and a stray Enter could confirm its default grants before the operator had time to review them.

  Render the selector in a visibly unarmed state for one second, then flush queued terminal input before enabling the normal
  controls. If the input flush fails, the selector returns an error instead of continuing with potentially stale input.

  The existing choices and key bindings are unchanged once input is armed. The profile authoring documentation now describes the input guard.
<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

Added a PTY-backed regression test that queues Enter before input is armed, applies the input guard, then sends `d`
  afterward. The test verifies that the early Enter is discarded and only the post-arming key is returned.

  Ran:

  - `cargo test -p nono-cli profile_save_runtime::tests::`
  - `make build`
  - `make test`
  - `make ci`

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
