### PR TITLE
feat(cli): backend-signed approval webhooks with submit-and-poll

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1731,7 +1731,12 @@
         },
         "url": {
           "type": "string",
-          "description": "Webhook URL for webhook approval backends."
+          "description": "Webhook URL for webhook approval backends. Optional when auth is platform: nono then derives <platform_url>/api/v1/approvals from its enrollment."
+        },
+        "auth": {
+          "type": "string",
+          "enum": ["platform"],
+          "description": "Webhook authentication. platform signs every request with this client's platform enrollment key (nono-request-v1), requires an https or loopback URL, and switches to submit-and-poll against the platform approval ledger."
         },
         "timeout_secs": {
           "type": "integer",

--- a/crates/nono-cli/src/approval_runtime.rs
+++ b/crates/nono-cli/src/approval_runtime.rs
@@ -303,8 +303,9 @@ impl WebhookApproval {
             })
     }
 
-    /// Legacy contract: one blocking POST, the response is the decision. This
-    /// is what the console ingest and the in-cell approval shim speak.
+    /// Unsigned contract: one blocking POST, the response body is the
+    /// decision. Any approval endpoint that does not verify enrolled
+    /// identities speaks this (`docs/protocols/approval-webhook-v1.md`).
     fn request_unsigned(&self, body: &[u8], started: Instant) -> Result<ApprovalDecision> {
         let mut response = self
             .http
@@ -331,11 +332,11 @@ impl WebhookApproval {
         self.parse_response(&response_body)
     }
 
-    /// Platform contract: submit, then poll `GET <url>/{request_id}` with
-    /// signed requests until a final state or this backend's timeout. Each
-    /// hop is given only the remaining budget, both as the server hold hint
-    /// and as its own HTTP timeout. The transport is injected so the state
-    /// machine is testable without HTTP.
+    /// Signed contract (`docs/protocols/approval-webhook-v1.md`): submit, then
+    /// poll `GET <url>/{request_id}` with signed requests until a final state
+    /// or this backend's timeout. Each hop is given only the remaining budget,
+    /// both as the server hold hint and as its own HTTP timeout. The transport
+    /// is injected so the state machine is testable without HTTP.
     fn drive_platform_approval(
         &self,
         request_id: &str,
@@ -987,5 +988,125 @@ mod tests {
         uuid::Uuid::parse_str(&value("X-Nono-Request-Id")).unwrap();
         value("X-Nono-Timestamp").parse::<u128>().unwrap();
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[derive(Deserialize)]
+    struct StatusFixture {
+        name: String,
+        http_status: u16,
+        body: serde_json::Value,
+        expected: String,
+    }
+
+    #[derive(Deserialize)]
+    struct LegacyFixture {
+        name: String,
+        body: serde_json::Value,
+        expected: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ApprovalStatusFixtures {
+        signed: Vec<StatusFixture>,
+        unsigned: Vec<LegacyFixture>,
+    }
+
+    fn decision_name(decision: &ApprovalDecision) -> &'static str {
+        match decision {
+            ApprovalDecision::Granted => "granted",
+            ApprovalDecision::Denied { .. } => "denied",
+            ApprovalDecision::Timeout => "timeout",
+        }
+    }
+
+    /// The documented response shapes (`docs/protocols/approval-webhook-v1.md`)
+    /// map to the decisions the protocol promises.
+    #[test]
+    fn approval_status_fixtures_match_protocol_document() {
+        let fixtures: ApprovalStatusFixtures = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/approval-status-v1.json"
+        ))
+        .expect("valid approval status fixture");
+        let backend = test_webhook(Duration::from_secs(30));
+
+        for fixture in &fixtures.signed {
+            let body = fixture.body.to_string();
+            let mut polls = 0;
+            let decision = backend
+                .drive_platform_approval("req-fixture", b"{}", Instant::now(), |_, _| {
+                    polls += 1;
+                    if polls == 1 {
+                        Ok(reply(fixture.http_status, &body))
+                    } else {
+                        // A pending fixture is followed by a grant so the loop ends.
+                        Ok(reply(200, r#"{"state":"granted","decision":"granted"}"#))
+                    }
+                })
+                .expect(&fixture.name);
+            if fixture.expected == "pending" {
+                assert_eq!(polls, 2, "{}: pending must be polled again", fixture.name);
+                assert!(decision.is_granted(), "{}", fixture.name);
+            } else {
+                assert_eq!(polls, 1, "{}: final states end the exchange", fixture.name);
+                assert_eq!(
+                    decision_name(&decision),
+                    fixture.expected,
+                    "{}",
+                    fixture.name
+                );
+            }
+        }
+
+        for fixture in &fixtures.unsigned {
+            let decision = backend
+                .parse_response(&fixture.body.to_string())
+                .expect(&fixture.name);
+            assert_eq!(
+                decision_name(&decision),
+                fixture.expected,
+                "{}",
+                fixture.name
+            );
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct CanonicalFixture {
+        method: String,
+        path: String,
+        subject_id: String,
+        timestamp_ms: String,
+        request_id: String,
+        body_digest: String,
+        canonical: String,
+    }
+
+    /// The poll is a bodiless GET: its content digest is the SHA-256 of zero
+    /// bytes, and the canonical string follows `nono-request-v1` unchanged.
+    #[test]
+    fn approval_poll_canonical_request_matches_fixture() {
+        let fixture: CanonicalFixture = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/approval-poll-request-v1.json"
+        ))
+        .expect("valid poll fixture");
+        assert_eq!(
+            crate::platform_client::canonical_request_v1(
+                &fixture.method,
+                &fixture.path,
+                &fixture.subject_id,
+                &fixture.timestamp_ms,
+                &fixture.request_id,
+                &fixture.body_digest,
+            ),
+            fixture.canonical
+        );
+        let empty_digest = format!(
+            "sha256:{}",
+            sha2::Sha256::digest(b"")
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        );
+        assert_eq!(fixture.body_digest, empty_digest);
     }
 }

--- a/crates/nono-cli/src/approval_runtime.rs
+++ b/crates/nono-cli/src/approval_runtime.rs
@@ -191,6 +191,24 @@ struct HttpReply {
     body: String,
 }
 
+/// HTTP agent for approval webhooks. Redirects are disabled: a decision must
+/// come from the configured URL itself, otherwise a redirect (including HTTPS
+/// to HTTP) could carry the signed `X-Nono-*` headers to another host and let
+/// that host answer `granted`. A 3xx therefore surfaces as a non-2xx status
+/// and is treated as a denial.
+fn build_agent(timeout: Duration) -> ureq::Agent {
+    let tls_config = ureq::tls::TlsConfig::builder()
+        .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+        .build();
+    ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .max_redirects(0)
+        .max_redirects_will_error(false)
+        .tls_config(tls_config)
+        .build()
+        .new_agent()
+}
+
 impl WebhookApproval {
     fn new(name: &str, config: &ApprovalBackendConfig) -> Result<Self> {
         let platform = match config.auth {
@@ -220,14 +238,7 @@ impl WebhookApproval {
             )));
         }
         let timeout = Duration::from_secs(config.timeout_secs.unwrap_or(60));
-        let tls_config = ureq::tls::TlsConfig::builder()
-            .root_certs(ureq::tls::RootCerts::PlatformVerifier)
-            .build();
-        let http = ureq::Agent::config_builder()
-            .timeout_global(Some(timeout))
-            .tls_config(tls_config)
-            .build()
-            .new_agent();
+        let http = build_agent(timeout);
         Ok(Self {
             name: name.to_string(),
             url,
@@ -321,8 +332,10 @@ impl WebhookApproval {
     }
 
     /// Platform contract: submit, then poll `GET <url>/{request_id}` with
-    /// signed requests until a final state or this backend's timeout. The
-    /// transport is injected so the state machine is testable without HTTP.
+    /// signed requests until a final state or this backend's timeout. Each
+    /// hop is given only the remaining budget, both as the server hold hint
+    /// and as its own HTTP timeout. The transport is injected so the state
+    /// machine is testable without HTTP.
     fn drive_platform_approval(
         &self,
         request_id: &str,
@@ -342,6 +355,12 @@ impl WebhookApproval {
                 PlatformStep::Submit(body)
             };
             let reply = send(step, remaining)?;
+            // The deadline is checked again after the round trip: a decision
+            // that arrives once this backend's timeout has elapsed is never
+            // applied, however long the individual request took.
+            if started.elapsed() >= self.timeout {
+                return Ok(ApprovalDecision::Timeout);
+            }
             if !(200..300).contains(&reply.status) {
                 return Ok(self.http_status_denial(reply.status, started));
             }
@@ -436,6 +455,9 @@ impl WebhookApproval {
             }
         };
         let headers = Self::platform_headers(state, method, url.path(), body, remaining)?;
+        // Bound this hop by what is left of the backend timeout, not the whole
+        // configured timeout, so a late poll cannot outlive the deadline.
+        let hop_timeout = remaining.max(Duration::from_secs(1));
         let user_agent = format!("nono-cli/{}", env!("CARGO_PKG_VERSION"));
         let failed = |e: ureq::Error| {
             NonoError::SandboxInit(format!("approval webhook '{}' failed: {e}", self.name))
@@ -446,6 +468,7 @@ impl WebhookApproval {
                 .post(url.as_str())
                 .config()
                 .http_status_as_error(false)
+                .timeout_global(Some(hop_timeout))
                 .build()
                 .header("Content-Type", "application/json")
                 .header("User-Agent", &user_agent);
@@ -459,6 +482,7 @@ impl WebhookApproval {
                 .get(url.as_str())
                 .config()
                 .http_status_as_error(false)
+                .timeout_global(Some(hop_timeout))
                 .build()
                 .header("User-Agent", &user_agent);
             for (name, value) in &headers {
@@ -812,6 +836,35 @@ mod tests {
         assert!(
             polls >= 2,
             "expected several polls before giving up, saw {polls}"
+        );
+    }
+
+    #[test]
+    fn platform_poll_loop_rejects_a_grant_that_arrives_after_the_deadline() {
+        let backend = test_webhook(Duration::from_millis(40));
+        let decision = backend
+            .drive_platform_approval("req-late", b"{}", Instant::now(), |_, remaining| {
+                // The hop is handed only the remaining budget...
+                assert!(remaining <= Duration::from_millis(40));
+                // ...but simulate a server that answers after the deadline.
+                std::thread::sleep(Duration::from_millis(60));
+                Ok(reply(200, r#"{"state":"granted","decision":"granted"}"#))
+            })
+            .unwrap();
+        assert!(
+            matches!(decision, ApprovalDecision::Timeout),
+            "a late grant must not be applied"
+        );
+    }
+
+    #[test]
+    fn approval_webhook_agent_never_follows_redirects() {
+        let agent = build_agent(Duration::from_secs(5));
+        assert_eq!(agent.config().max_redirects(), 0);
+        assert!(!agent.config().max_redirects_will_error());
+        assert_eq!(
+            agent.config().timeouts().global,
+            Some(Duration::from_secs(5))
         );
     }
 

--- a/crates/nono-cli/src/approval_runtime.rs
+++ b/crates/nono-cli/src/approval_runtime.rs
@@ -6,7 +6,7 @@ use nono::{ApprovalBackend, ApprovalDecision, ApprovalRequest, NonoError, Result
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const WEBHOOK_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
 
@@ -138,11 +138,25 @@ impl ApprovalBackend for NamedTerminalApproval {
     }
 }
 
+/// Path of the platform's enrolled approval ingest, relative to the enrolled
+/// platform URL. The poll route is `<this>/{request_id}`.
+const PLATFORM_APPROVALS_PATH: &str = "/api/v1/approvals";
+/// Pause between polls when the server answers `pending` immediately instead
+/// of holding the request open.
+const PLATFORM_POLL_BACKOFF: Duration = Duration::from_millis(250);
+/// Header carrying the client's remaining patience so the server-side hold and
+/// deadline match this backend's `timeout_secs`.
+const HEADER_TIMEOUT_SECS: &str = "X-Nono-Timeout-Secs";
+
 struct WebhookApproval {
     name: String,
     url: String,
     timeout: Duration,
     http: ureq::Agent,
+    /// Present when `auth: "platform"`: sign each request with the enrolled
+    /// key and follow the platform's submit-and-poll contract.
+    platform: Option<crate::platform_client::PlatformState>,
+    poll_backoff: Duration,
 }
 
 #[derive(Serialize)]
@@ -158,11 +172,53 @@ struct WebhookDecisionResponse {
     reason: Option<String>,
 }
 
+/// Platform submit/poll response (`platform-protocol::approvals::ApprovalStatus`).
+#[derive(Deserialize)]
+struct PlatformApprovalStatus {
+    state: String,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// One hop of the platform exchange.
+enum PlatformStep<'a> {
+    Submit(&'a [u8]),
+    Poll { request_id: &'a str },
+}
+
+struct HttpReply {
+    status: u16,
+    body: String,
+}
+
 impl WebhookApproval {
     fn new(name: &str, config: &ApprovalBackendConfig) -> Result<Self> {
-        let url = config.url.clone().ok_or_else(|| {
-            NonoError::ConfigParse(format!("approval backend '{name}' webhook missing url"))
-        })?;
+        let platform = match config.auth {
+            Some(crate::command_policy::ApprovalBackendAuth::Platform) => Some(
+                crate::platform_client::load_state()?.ok_or_else(|| {
+                    NonoError::ConfigParse(format!(
+                        "approval backend '{name}' uses auth platform but this client is not enrolled; run `nono platform enroll` first"
+                    ))
+                })?,
+            ),
+            None => None,
+        };
+        let url = match (&config.url, &platform) {
+            (Some(url), _) => url.clone(),
+            (None, Some(state)) => {
+                crate::platform_client::endpoint_url(&state.platform_url, PLATFORM_APPROVALS_PATH)?
+            }
+            (None, None) => {
+                return Err(NonoError::ConfigParse(format!(
+                    "approval backend '{name}' webhook missing url"
+                )));
+            }
+        };
+        if platform.is_some() && !crate::command_policy::is_platform_grade_url(&url) {
+            return Err(NonoError::ConfigParse(format!(
+                "approval backend '{name}' with auth platform must use an https URL (plain http is allowed only for loopback)"
+            )));
+        }
         let timeout = Duration::from_secs(config.timeout_secs.unwrap_or(60));
         let tls_config = ureq::tls::TlsConfig::builder()
             .root_certs(ureq::tls::RootCerts::PlatformVerifier)
@@ -177,6 +233,8 @@ impl WebhookApproval {
             url,
             timeout,
             http,
+            platform,
+            poll_backoff: PLATFORM_POLL_BACKOFF,
         })
     }
 
@@ -209,6 +267,209 @@ impl WebhookApproval {
             ))),
         }
     }
+
+    fn http_status_denial(&self, status: u16, started: Instant) -> ApprovalDecision {
+        ApprovalDecision::Denied {
+            reason: format!(
+                "approval webhook '{}' returned HTTP {status} after {}s",
+                self.name,
+                started.elapsed().as_secs()
+            ),
+        }
+    }
+
+    fn read_body(&self, response: &mut ureq::http::Response<ureq::Body>) -> Result<String> {
+        response
+            .body_mut()
+            .with_config()
+            .limit(WEBHOOK_RESPONSE_LIMIT_BYTES)
+            .read_to_string()
+            .map_err(|e| {
+                NonoError::SandboxInit(format!(
+                    "failed to read approval webhook '{}' response: {e}",
+                    self.name
+                ))
+            })
+    }
+
+    /// Legacy contract: one blocking POST, the response is the decision. This
+    /// is what the console ingest and the in-cell approval shim speak.
+    fn request_unsigned(&self, body: &[u8], started: Instant) -> Result<ApprovalDecision> {
+        let mut response = self
+            .http
+            .post(&self.url)
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header("Content-Type", "application/json")
+            .header(
+                "User-Agent",
+                &format!("nono-cli/{}", env!("CARGO_PKG_VERSION")),
+            )
+            .header(HEADER_TIMEOUT_SECS, &self.timeout.as_secs().to_string())
+            .send(body)
+            .map_err(|e| {
+                NonoError::SandboxInit(format!("approval webhook '{}' failed: {e}", self.name))
+            })?;
+
+        let status = response.status().as_u16();
+        let response_body = self.read_body(&mut response)?;
+        if !(200..300).contains(&status) {
+            return Ok(self.http_status_denial(status, started));
+        }
+        self.parse_response(&response_body)
+    }
+
+    /// Platform contract: submit, then poll `GET <url>/{request_id}` with
+    /// signed requests until a final state or this backend's timeout. The
+    /// transport is injected so the state machine is testable without HTTP.
+    fn drive_platform_approval(
+        &self,
+        request_id: &str,
+        body: &[u8],
+        started: Instant,
+        mut send: impl FnMut(PlatformStep<'_>, Duration) -> Result<HttpReply>,
+    ) -> Result<ApprovalDecision> {
+        let mut submitted = false;
+        loop {
+            let remaining = self.timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return Ok(ApprovalDecision::Timeout);
+            }
+            let step = if submitted {
+                PlatformStep::Poll { request_id }
+            } else {
+                PlatformStep::Submit(body)
+            };
+            let reply = send(step, remaining)?;
+            if !(200..300).contains(&reply.status) {
+                return Ok(self.http_status_denial(reply.status, started));
+            }
+            let status: PlatformApprovalStatus =
+                serde_json::from_str(&reply.body).map_err(|e| {
+                    NonoError::SandboxInit(format!(
+                        "approval webhook '{}' returned invalid JSON: {e}",
+                        self.name
+                    ))
+                })?;
+            match status.state.as_str() {
+                "pending" => {
+                    submitted = true;
+                    if !self.poll_backoff.is_zero() {
+                        std::thread::sleep(self.poll_backoff.min(remaining));
+                    }
+                }
+                "granted" => return Ok(ApprovalDecision::Granted),
+                "denied" => {
+                    return Ok(ApprovalDecision::Denied {
+                        reason: status.reason.unwrap_or_else(|| {
+                            format!("approval webhook '{}' denied request", self.name)
+                        }),
+                    });
+                }
+                "timeout" => return Ok(ApprovalDecision::Timeout),
+                other => {
+                    return Err(NonoError::SandboxInit(format!(
+                        "approval webhook '{}' returned unknown state '{other}'",
+                        self.name
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Stamp the six `nono-request-v1` headers plus the timeout hint for one
+    /// platform request. `path` is the URL path as the server will see it.
+    fn platform_headers(
+        state: &crate::platform_client::PlatformState,
+        method: &str,
+        path: &str,
+        body: &[u8],
+        remaining: Duration,
+    ) -> Result<Vec<(&'static str, String)>> {
+        let signed = crate::platform_client::sign_request_v1(
+            state,
+            method,
+            path,
+            uuid::Uuid::now_v7(),
+            body,
+        )?;
+        Ok(vec![
+            (
+                "X-Nono-Protocol-Version",
+                crate::platform_client::REQUEST_PROTOCOL_V1.to_string(),
+            ),
+            ("X-Nono-Subject-Id", state.subject_id.clone()),
+            ("X-Nono-Timestamp", signed.timestamp),
+            ("X-Nono-Request-Id", signed.request_id),
+            ("X-Nono-Content-SHA256", signed.body_digest),
+            ("X-Nono-Signature", signed.signature),
+            (HEADER_TIMEOUT_SECS, remaining.as_secs().max(1).to_string()),
+        ])
+    }
+
+    fn send_platform(
+        &self,
+        state: &crate::platform_client::PlatformState,
+        step: PlatformStep<'_>,
+        remaining: Duration,
+    ) -> Result<HttpReply> {
+        let mut url = url::Url::parse(&self.url).map_err(|e| {
+            NonoError::ConfigParse(format!(
+                "approval backend '{}' has an invalid url: {e}",
+                self.name
+            ))
+        })?;
+        let (method, body) = match step {
+            PlatformStep::Submit(body) => ("POST", body),
+            PlatformStep::Poll { request_id } => {
+                url.path_segments_mut()
+                    .map_err(|_| {
+                        NonoError::ConfigParse(format!(
+                            "approval backend '{}' url cannot take a path",
+                            self.name
+                        ))
+                    })?
+                    .pop_if_empty()
+                    .push(request_id);
+                ("GET", &[][..])
+            }
+        };
+        let headers = Self::platform_headers(state, method, url.path(), body, remaining)?;
+        let user_agent = format!("nono-cli/{}", env!("CARGO_PKG_VERSION"));
+        let failed = |e: ureq::Error| {
+            NonoError::SandboxInit(format!("approval webhook '{}' failed: {e}", self.name))
+        };
+        let mut response = if method == "POST" {
+            let mut request = self
+                .http
+                .post(url.as_str())
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .header("Content-Type", "application/json")
+                .header("User-Agent", &user_agent);
+            for (name, value) in &headers {
+                request = request.header(*name, value);
+            }
+            request.send(body).map_err(failed)?
+        } else {
+            let mut request = self
+                .http
+                .get(url.as_str())
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .header("User-Agent", &user_agent);
+            for (name, value) in &headers {
+                request = request.header(*name, value);
+            }
+            request.call().map_err(failed)?
+        };
+        let status = response.status().as_u16();
+        let body = self.read_body(&mut response)?;
+        Ok(HttpReply { status, body })
+    }
 }
 
 impl ApprovalBackend for WebhookApproval {
@@ -223,46 +484,16 @@ impl ApprovalBackend for WebhookApproval {
                 self.name
             ))
         })?;
-
-        let mut response = self
-            .http
-            .post(&self.url)
-            .config()
-            .http_status_as_error(false)
-            .build()
-            .header("Content-Type", "application/json")
-            .header(
-                "User-Agent",
-                &format!("nono-cli/{}", env!("CARGO_PKG_VERSION")),
-            )
-            .send(body)
-            .map_err(|e| {
-                NonoError::SandboxInit(format!("approval webhook '{}' failed: {e}", self.name))
-            })?;
-
-        let status = response.status().as_u16();
-        let response_body = response
-            .body_mut()
-            .with_config()
-            .limit(WEBHOOK_RESPONSE_LIMIT_BYTES)
-            .read_to_string()
-            .map_err(|e| {
-                NonoError::SandboxInit(format!(
-                    "failed to read approval webhook '{}' response: {e}",
-                    self.name
-                ))
-            })?;
-
-        if !(200..300).contains(&status) {
-            return Ok(ApprovalDecision::Denied {
-                reason: format!(
-                    "approval webhook '{}' returned HTTP {} after {:?}",
-                    self.name, status, self.timeout
-                ),
-            });
+        let started = Instant::now();
+        match &self.platform {
+            None => self.request_unsigned(&body, started),
+            Some(state) => self.drive_platform_approval(
+                request.request_id(),
+                &body,
+                started,
+                |step, remaining| self.send_platform(state, step, remaining),
+            ),
         }
-
-        self.parse_response(&response_body)
     }
 
     fn backend_name(&self) -> &str {
@@ -343,6 +574,7 @@ impl ChainApproval {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use sha2::Digest as _;
 
     struct StaticBackend {
         name: &'static str,
@@ -428,6 +660,7 @@ mod tests {
                 timeout_secs: Some(5),
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 
@@ -451,6 +684,7 @@ mod tests {
                 timeout_secs: None,
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 
@@ -485,6 +719,7 @@ mod tests {
                 timeout_secs: None,
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 
@@ -496,12 +731,7 @@ mod tests {
 
     #[test]
     fn webhook_response_parser_accepts_simple_decision_shape() {
-        let backend = WebhookApproval {
-            name: "security-review".to_string(),
-            url: "https://approval.example".to_string(),
-            timeout: Duration::from_secs(1),
-            http: ureq::Agent::new_with_defaults(),
-        };
+        let backend = test_webhook(Duration::from_secs(1));
 
         assert!(
             backend
@@ -515,5 +745,194 @@ mod tests {
                 .unwrap()
                 .is_denied()
         );
+    }
+
+    fn test_webhook(timeout: Duration) -> WebhookApproval {
+        WebhookApproval {
+            name: "security-review".to_string(),
+            url: "https://approval.example/api/v1/approvals".to_string(),
+            timeout,
+            http: ureq::Agent::new_with_defaults(),
+            platform: None,
+            poll_backoff: Duration::ZERO,
+        }
+    }
+
+    fn reply(status: u16, body: &str) -> HttpReply {
+        HttpReply {
+            status,
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn platform_poll_loop_submits_then_polls_until_granted() {
+        let backend = test_webhook(Duration::from_secs(30));
+        let mut steps = Vec::new();
+        let decision = backend
+            .drive_platform_approval("req-1", b"{}", Instant::now(), |step, remaining| {
+                assert!(remaining <= Duration::from_secs(30));
+                match step {
+                    PlatformStep::Submit(body) => {
+                        assert_eq!(body, b"{}");
+                        steps.push("submit");
+                        Ok(reply(202, r#"{"request_id":"req-1","state":"pending"}"#))
+                    }
+                    PlatformStep::Poll { request_id } => {
+                        assert_eq!(request_id, "req-1");
+                        steps.push("poll");
+                        if steps.len() < 3 {
+                            Ok(reply(202, r#"{"request_id":"req-1","state":"pending"}"#))
+                        } else {
+                            Ok(reply(
+                                200,
+                                r#"{"request_id":"req-1","state":"granted","decision":"granted"}"#,
+                            ))
+                        }
+                    }
+                }
+            })
+            .unwrap();
+        assert!(decision.is_granted());
+        assert_eq!(steps, vec!["submit", "poll", "poll"]);
+    }
+
+    #[test]
+    fn platform_poll_loop_gives_up_at_the_configured_timeout() {
+        let backend = test_webhook(Duration::from_millis(40));
+        let mut polls = 0;
+        let decision = backend
+            .drive_platform_approval("req-2", b"{}", Instant::now(), |_step, _remaining| {
+                polls += 1;
+                std::thread::sleep(Duration::from_millis(10));
+                Ok(reply(202, r#"{"state":"pending"}"#))
+            })
+            .unwrap();
+        assert!(matches!(decision, ApprovalDecision::Timeout));
+        assert!(
+            polls >= 2,
+            "expected several polls before giving up, saw {polls}"
+        );
+    }
+
+    #[test]
+    fn platform_poll_loop_reports_immediate_deny_and_server_timeout() {
+        let backend = test_webhook(Duration::from_secs(5));
+        let denied = backend
+            .drive_platform_approval("req-3", b"{}", Instant::now(), |step, _| {
+                assert!(matches!(step, PlatformStep::Submit(_)));
+                Ok(reply(
+                    200,
+                    r#"{"state":"denied","decision":"denied","reason":"not today"}"#,
+                ))
+            })
+            .unwrap();
+        match denied {
+            ApprovalDecision::Denied { reason } => assert_eq!(reason, "not today"),
+            other => panic!("expected denial, got {other:?}"),
+        }
+
+        let timed_out = backend
+            .drive_platform_approval("req-4", b"{}", Instant::now(), |_, _| {
+                Ok(reply(200, r#"{"state":"timeout","decision":"timeout"}"#))
+            })
+            .unwrap();
+        assert!(matches!(timed_out, ApprovalDecision::Timeout));
+    }
+
+    #[test]
+    fn platform_poll_loop_reports_elapsed_time_on_http_errors() {
+        let backend = test_webhook(Duration::from_secs(5));
+        let decision = backend
+            .drive_platform_approval("req-5", b"{}", Instant::now(), |_, _| {
+                Ok(reply(404, r#"{"error":"not_found"}"#))
+            })
+            .unwrap();
+        match decision {
+            ApprovalDecision::Denied { reason } => {
+                assert!(reason.contains("HTTP 404"), "{reason}");
+                assert!(reason.contains("after 0s"), "{reason}");
+            }
+            other => panic!("expected denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn platform_headers_stamp_the_signed_request_contract() {
+        use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+        use base64::Engine as _;
+
+        let dir =
+            std::env::temp_dir().join(format!("nono-approval-headers-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_path = dir.join("key");
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(
+            &ECDSA_P256_SHA256_FIXED_SIGNING,
+            &aws_lc_rs::rand::SystemRandom::new(),
+        )
+        .unwrap();
+        std::fs::write(
+            &key_path,
+            base64::engine::general_purpose::STANDARD.encode(pkcs8.as_ref()),
+        )
+        .unwrap();
+        let state = crate::platform_client::PlatformState {
+            protocol_version: "1".to_string(),
+            platform_url: "https://platform.example.com".to_string(),
+            tenant_id: "019f0000-0000-7000-8000-000000000001".to_string(),
+            subject_id: "019f0000-0000-7000-8000-000000000002".to_string(),
+            subject_kind: "workload".to_string(),
+            management_mode: "audit_only".to_string(),
+            key_algorithm: "ecdsa_p256_sha256_fixed".to_string(),
+            key_ref: format!("file://{}", key_path.display()),
+            enrolled_at: "2026-09-01T00:00:00Z".to_string(),
+        };
+
+        let headers = WebhookApproval::platform_headers(
+            &state,
+            "POST",
+            "/api/v1/approvals",
+            b"{\"request\":{}}",
+            Duration::from_secs(90),
+        )
+        .unwrap();
+        let names: Vec<&str> = headers.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "X-Nono-Protocol-Version",
+                "X-Nono-Subject-Id",
+                "X-Nono-Timestamp",
+                "X-Nono-Request-Id",
+                "X-Nono-Content-SHA256",
+                "X-Nono-Signature",
+                "X-Nono-Timeout-Secs",
+            ]
+        );
+        let value = |name: &str| {
+            headers
+                .iter()
+                .find(|(n, _)| *n == name)
+                .map(|(_, v)| v.clone())
+                .unwrap()
+        };
+        assert_eq!(value("X-Nono-Protocol-Version"), "1");
+        assert_eq!(value("X-Nono-Subject-Id"), state.subject_id);
+        assert_eq!(value("X-Nono-Timeout-Secs"), "90");
+        assert!(value("X-Nono-Signature").starts_with("p256-sha256="));
+        // Body digest is the platform's `sha256:<hex>` shape over the exact bytes.
+        assert_eq!(
+            value("X-Nono-Content-SHA256"),
+            format!(
+                "sha256:{}",
+                sha2::Sha256::digest(b"{\"request\":{}}")
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>()
+            )
+        );
+        uuid::Uuid::parse_str(&value("X-Nono-Request-Id")).unwrap();
+        value("X-Nono-Timestamp").parse::<u128>().unwrap();
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -366,12 +366,24 @@ pub struct ApprovalBackendConfig {
     pub backend_type: ApprovalBackendType,
     #[serde(default)]
     pub url: Option<String>,
+    /// How a webhook backend authenticates to its endpoint. `platform` signs
+    /// every request with this client's platform enrollment key
+    /// (`nono-request-v1`), lets `url` default to the enrolled platform's
+    /// approval route, and switches to submit-and-poll.
+    #[serde(default)]
+    pub auth: Option<ApprovalBackendAuth>,
     #[serde(default)]
     pub timeout_secs: Option<u64>,
     #[serde(default)]
     pub mode: Option<ApprovalChainMode>,
     #[serde(default)]
     pub backends: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalBackendAuth {
+    Platform,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2161,12 +2173,28 @@ fn validate_approval_backend(
                     format!("approval backend '{name}' type terminal cannot define url, mode, or backends"),
                 );
             }
+            if backend.auth.is_some() {
+                report.error(
+                    "invalid_approval_backend",
+                    format!("approval backend '{name}' type terminal cannot define auth"),
+                );
+            }
         }
         ApprovalBackendType::Webhook => {
-            if backend.url.as_deref().unwrap_or_default().is_empty() {
+            let platform_auth = backend.auth == Some(ApprovalBackendAuth::Platform);
+            let url = backend.url.as_deref().unwrap_or_default();
+            if url.is_empty() && !platform_auth {
                 report.error(
                     "invalid_approval_backend",
                     format!("approval backend '{name}' type webhook must define url"),
+                );
+            }
+            if platform_auth && !url.is_empty() && !is_platform_grade_url(url) {
+                report.error(
+                    "invalid_approval_backend",
+                    format!(
+                        "approval backend '{name}' with auth platform must use an https URL (plain http is allowed only for loopback)"
+                    ),
                 );
             }
             if backend.mode.is_some() || !backend.backends.is_empty() {
@@ -2195,6 +2223,12 @@ fn validate_approval_backend(
                 report.error(
                     "invalid_approval_backend",
                     format!("approval backend '{name}' type chain cannot define url"),
+                );
+            }
+            if backend.auth.is_some() {
+                report.error(
+                    "invalid_approval_backend",
+                    format!("approval backend '{name}' type chain cannot define auth"),
                 );
             }
             for child_backend in &backend.backends {
@@ -2467,6 +2501,19 @@ fn validate_endpoint_policy(
                 report.error("invalid_endpoint_policy", format!("{label} contains NUL"));
             }
         }
+    }
+}
+
+/// Signed platform requests carry an enrolled identity; they never travel over
+/// plain HTTP except to a loopback development platform.
+pub(crate) fn is_platform_grade_url(value: &str) -> bool {
+    match url::Url::parse(value) {
+        Ok(url) => {
+            url.scheme() == "https"
+                || (url.scheme() == "http"
+                    && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1")))
+        }
+        Err(_) => false,
     }
 }
 
@@ -5936,7 +5983,115 @@ mod tests {
             timeout_secs: None,
             mode: None,
             backends: Vec::new(),
+            auth: None,
         }
+    }
+
+    #[test]
+    fn security_approval_backends_platform_auth_matrix() {
+        // Platform-signed webhook may omit url: it is derived from enrollment.
+        let mut backends = BTreeMap::new();
+        backends.insert(
+            "platform".to_string(),
+            ApprovalBackendConfig {
+                auth: Some(ApprovalBackendAuth::Platform),
+                timeout_secs: Some(120),
+                ..security_backend(ApprovalBackendType::Webhook)
+            },
+        );
+        assert!(validate_security_approval_backends(&backends, None).is_ok());
+
+        // An explicit https URL is fine; loopback http is fine.
+        for url in [
+            "https://platform.example.com/api/v1/approvals",
+            "http://127.0.0.1:8090/api/v1/approvals",
+        ] {
+            let mut backends = BTreeMap::new();
+            backends.insert(
+                "platform".to_string(),
+                ApprovalBackendConfig {
+                    auth: Some(ApprovalBackendAuth::Platform),
+                    url: Some(url.to_string()),
+                    ..security_backend(ApprovalBackendType::Webhook)
+                },
+            );
+            assert!(
+                validate_security_approval_backends(&backends, None).is_ok(),
+                "{url}"
+            );
+        }
+
+        // Plain http to a remote host would leak the signed request in clear.
+        let mut backends = BTreeMap::new();
+        backends.insert(
+            "platform".to_string(),
+            ApprovalBackendConfig {
+                auth: Some(ApprovalBackendAuth::Platform),
+                url: Some("http://platform.example.com/api/v1/approvals".to_string()),
+                ..security_backend(ApprovalBackendType::Webhook)
+            },
+        );
+        let err = validate_security_approval_backends(&backends, None)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(err.contains("https"), "{err}");
+
+        // auth is a webhook concept only.
+        for backend_type in [ApprovalBackendType::Terminal, ApprovalBackendType::Chain] {
+            let mut backends = BTreeMap::new();
+            backends.insert(
+                "gate".to_string(),
+                ApprovalBackendConfig {
+                    auth: Some(ApprovalBackendAuth::Platform),
+                    mode: (backend_type == ApprovalBackendType::Chain)
+                        .then_some(ApprovalChainMode::All),
+                    backends: if backend_type == ApprovalBackendType::Chain {
+                        vec!["other".to_string()]
+                    } else {
+                        Vec::new()
+                    },
+                    ..security_backend(backend_type)
+                },
+            );
+            backends.insert(
+                "other".to_string(),
+                security_backend(ApprovalBackendType::Terminal),
+            );
+            let err = validate_security_approval_backends(&backends, None)
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_default();
+            assert!(
+                err.contains("cannot define auth"),
+                "{backend_type:?}: {err}"
+            );
+        }
+
+        // A plain webhook still needs its url.
+        let mut backends = BTreeMap::new();
+        backends.insert(
+            "hook".to_string(),
+            security_backend(ApprovalBackendType::Webhook),
+        );
+        let err = validate_security_approval_backends(&backends, None)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(err.contains("must define url"), "{err}");
+    }
+
+    #[test]
+    fn approval_backend_auth_parses_from_profile_json() {
+        let parsed: ApprovalBackendConfig =
+            serde_json::from_str(r#"{"type":"webhook","auth":"platform","timeout_secs":90}"#)
+                .expect("platform auth webhook parses");
+        assert_eq!(parsed.auth, Some(ApprovalBackendAuth::Platform));
+        assert!(parsed.url.is_none());
+        assert!(
+            serde_json::from_str::<ApprovalBackendConfig>(r#"{"type":"webhook","auth":"basic"}"#)
+                .is_err()
+        );
     }
 
     #[test]
@@ -6020,6 +6175,7 @@ mod tests {
             ApprovalBackendConfig {
                 mode: Some(ApprovalChainMode::All),
                 backends: vec!["loop".to_string()],
+                auth: None,
                 ..security_backend(ApprovalBackendType::Chain)
             },
         );
@@ -6044,6 +6200,7 @@ mod tests {
                 timeout_secs: Some(0),
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 

--- a/crates/nono-cli/src/platform_client.rs
+++ b/crates/nono-cli/src/platform_client.rs
@@ -426,7 +426,7 @@ fn validate_wire_identifier(name: &str, value: &str) -> Result<()> {
     }
 }
 
-fn validate_platform_url(value: &str) -> Result<String> {
+pub(crate) fn validate_platform_url(value: &str) -> Result<String> {
     let mut url = url::Url::parse(value)
         .map_err(|error| NonoError::ConfigParse(format!("invalid platform URL: {error}")))?;
     let loopback_http =

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -7179,6 +7179,7 @@ mod tests {
                 timeout_secs: None,
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
         base.security.approval_defaults = Some(ApprovalDefaultsConfig {
@@ -7195,6 +7196,7 @@ mod tests {
                 timeout_secs: Some(30),
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -4052,6 +4052,7 @@ mod tests {
                 timeout_secs: Some(10),
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
         policies.credentials.insert(

--- a/crates/nono-cli/src/tool-sandbox/policy.rs
+++ b/crates/nono-cli/src/tool-sandbox/policy.rs
@@ -1307,6 +1307,7 @@ mod intercept_tests {
                 timeout_secs: Some(30),
                 mode: None,
                 backends: Vec::new(),
+                auth: None,
             },
         );
 

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -592,7 +592,7 @@ fn test_schema_command_policies_match_tool_sandbox_guide_shape() {
     assert_schema_properties(
         &schema,
         "ApprovalBackendConfig",
-        &["backends", "mode", "timeout_secs", "type", "url"],
+        &["auth", "backends", "mode", "timeout_secs", "type", "url"],
     );
     assert_schema_properties(
         &schema,

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -56,6 +56,14 @@ The top-level `command_policies` object accepts these fields:
 | `approval_defaults` | object | Default approval backend and timeout. |
 | `entrypoint` | command name | Legacy session hint. Prefer `commands.<name>.sandbox` or `commands.<name>.from.session`. |
 
+Each entry under `approval_backends` is one of:
+
+| `type` | Fields | Use |
+|---|---|---|
+| `terminal` | `timeout_secs` | Prompt the operator in the terminal. |
+| `webhook` | `url`, `auth`, `timeout_secs` | Ask an HTTP endpoint. Omit `auth` for a plain endpoint that answers the `POST` with the decision. Set `auth: "platform"` to sign every request with this client's enrollment key and follow the submit-and-poll exchange; `url` may then be omitted and defaults to the enrolled platform's approval route. Both variants are specified in `docs/protocols/approval-webhook-v1.md`. |
+| `chain` | `mode` (`all` or `any`), `backends` | Combine other backends. |
+
 Each entry under `commands` uses the command name as the key:
 
 | Field | Value | Use |

--- a/docs/protocols/approval-webhook-v1.md
+++ b/docs/protocols/approval-webhook-v1.md
@@ -1,0 +1,191 @@
+# Approval webhook protocol v1
+
+This document specifies the open contract between `nono` and an HTTP approval
+endpoint. When a policy decision is `approve`, `nono` pauses the sandboxed
+action, asks the endpoint, and applies exactly one of three outcomes: granted,
+denied, or timed out. Timeouts and every error are treated as denial.
+
+There are two variants of the contract:
+
+- **Unsigned.** One blocking `POST`; the response body is the decision. Any
+  HTTP service can implement it. Configure with `type: "webhook"` and a `url`.
+- **Signed.** For a client enrolled with a control plane (see
+  [Audit delivery protocol v1](audit-delivery-v1.md) for enrollment). Requests
+  are authenticated with the enrolled key, the tenant is derived server-side,
+  and the exchange is submit-then-poll so the server may hold requests durably
+  across replicas. Configure with `type: "webhook"` and `auth: "platform"`.
+
+## Configuration
+
+```json
+{
+  "command_policies": {
+    "approval_backends": {
+      "review": { "type": "webhook", "url": "https://approvals.example.com/hook", "timeout_secs": 60 },
+      "platform": { "type": "webhook", "auth": "platform", "timeout_secs": 120 }
+    },
+    "approval_defaults": { "backend": "platform" }
+  }
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `url` | Endpoint to call. Required for unsigned backends. With `auth: "platform"` it defaults to `<enrolled platform URL>/api/v1/approvals`, and if given must be `https://`, or `http://` to a loopback host. |
+| `auth` | Omit for unsigned. `"platform"` selects the signed variant and fails closed if the client is not enrolled. |
+| `timeout_secs` | Total time this backend waits for a decision (default 60). It is also sent to the server as the hold hint. |
+
+## Request
+
+Both variants `POST` the same JSON body:
+
+```json
+{
+  "backend": "<backend name from the profile>",
+  "request": { "capability_type": "endpoint", "request_id": "...", "session_id": "...", "...": "..." }
+}
+```
+
+`request` is the `ApprovalRequest`, internally tagged by `capability_type`.
+`request_id` is unique per request and is the identity the server keys on;
+`session_id` identifies the sandboxed session. The variants are:
+
+| `capability_type` | Fields |
+| --- | --- |
+| `capability` | `path`, `access` (`Read`, `Write`, `ReadWrite`) |
+| `network` | `host`, `port`, `protocol`, `resolved_ips` |
+| `endpoint` | `route_id`, `upstream`, `method`, `path`, `rule_label` |
+| `command` | `command`, `args`, `caller`, `intercept_rule` |
+
+Every variant also carries `request_id`, `session_id`, `reason` (nullable), and
+`child_pid`.
+
+Headers on every request, in both variants:
+
+```text
+Content-Type: application/json
+User-Agent: nono-cli/<version>
+X-Nono-Timeout-Secs: <seconds>
+```
+
+`X-Nono-Timeout-Secs` is the client's remaining patience. On the first request
+it equals `timeout_secs`; on each signed poll it is what is left. A server
+should hold a request open for no longer than this value minus a small margin,
+so it answers before the client gives up.
+
+The client never follows redirects. A `3xx` response is a denial.
+
+## Unsigned variant
+
+The endpoint answers the `POST` with `2xx` and a JSON body:
+
+```json
+{ "decision": "granted" }
+{ "decision": "denied", "reason": "why" }
+{ "decision": "timeout" }
+```
+
+Accepted spellings for `decision` are `grant`, `granted`, `approve`,
+`approved`, `allow`, `allowed`; `deny`, `denied`, `reject`, `rejected`,
+`block`, `blocked`; and `timeout`, `timed_out`. Any other value is an error and
+therefore a denial. A non-`2xx` status is a denial whose reason names the
+status and the elapsed time. The connection stays open until the endpoint
+answers or `timeout_secs` elapses.
+
+## Signed variant
+
+### Authentication
+
+Each request carries the `nono-request-v1` headers defined in
+[Audit delivery protocol v1](audit-delivery-v1.md):
+
+```text
+X-Nono-Protocol-Version: 1
+X-Nono-Subject-Id: <enrolled subject>
+X-Nono-Timestamp: <Unix milliseconds>
+X-Nono-Request-Id: <UUID, fresh per HTTP request>
+X-Nono-Content-SHA256: sha256:<lowercase hex digest of the exact body bytes>
+X-Nono-Signature: p256-sha256=<base64url fixed-width ECDSA signature>
+```
+
+The signed string is unchanged from the audit protocol:
+
+```text
+nono-request-v1
+<METHOD>
+<path as the server sees it>
+<subject_id>
+<timestamp_ms>
+<request_id>
+<body_digest>
+```
+
+The poll is a bodiless `GET`, so its digest is the SHA-256 of zero bytes,
+`sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+`tests/fixtures/approval-poll-request-v1.json` is a worked example.
+
+`X-Nono-Request-Id` is a transport nonce and is distinct from the approval's
+`request_id` in the body. The server must consume each transport nonce once
+and reject reuse; it must accept a repeated body `request_id` from the same
+subject as an idempotent retry of the same approval.
+
+### Submit
+
+```http
+POST /api/v1/approvals
+```
+
+The server verifies the signature, derives the tenant from the enrolled
+subject, records the request, and holds the connection for up to
+`min(X-Nono-Timeout-Secs - margin, its own cap)` waiting for a decision. It
+answers:
+
+- `200` with a final status when a decision exists, including an immediate
+  decision from a standing grant;
+- `202` with `state: "pending"` when the hold expires without a decision.
+
+### Poll
+
+```http
+GET /api/v1/approvals/{request_id}
+```
+
+Same authentication and hold semantics. Only the subject that submitted the
+request may poll it; the server answers `404` for any other subject or an
+unknown id. The client repeats the poll until a final state or its own
+deadline. The client bounds each HTTP request by its remaining budget and
+re-checks the deadline after every response, so a decision that arrives after
+`timeout_secs` is never applied.
+
+### Status body
+
+```json
+{ "request_id": "<body request_id>", "state": "pending" }
+{ "request_id": "<body request_id>", "state": "granted", "decision": "granted" }
+{ "request_id": "<body request_id>", "state": "denied", "decision": "denied", "reason": "why" }
+{ "request_id": "<body request_id>", "state": "timeout", "decision": "timeout", "reason": "..." }
+```
+
+`state` is one of `pending`, `granted`, `denied`, `timeout`. `decision`
+repeats the final `state` so the body also satisfies the unsigned parser.
+`tests/fixtures/approval-status-v1.json` lists the accepted shapes and the
+decision each produces.
+
+### Server requirements
+
+- Reject unsupported protocol versions, timestamps outside a short skew
+  window, modified bodies, unknown or revoked subjects, and reused transport
+  nonces with `401`.
+- Derive the tenant from the verified subject. Never trust tenant or subject
+  identifiers from the body.
+- Accept only subjects enrolled as workloads. A device enrollment identifies a
+  person's machine, not a policy-enforcing run.
+- Make the request durable before answering, and resolve it with exactly one
+  decision. A request past the client's deadline must become `timeout` and
+  refuse a later decision.
+- Fail secure: when in doubt, answer `denied` or let the client time out.
+
+A server may additionally remember a "for this session" grant keyed on the
+verified subject, the body `session_id`, and the exact capability, and answer a
+matching repeat with `granted` without a human. Such a grant must never widen
+to a different method, path, host, or command.

--- a/tests/fixtures/approval-poll-request-v1.json
+++ b/tests/fixtures/approval-poll-request-v1.json
@@ -1,0 +1,9 @@
+{
+  "method": "GET",
+  "path": "/api/v1/approvals/proxy-endpoint-approval-example-api-1789198307331603818",
+  "subject_id": "019f0000-0000-7000-8000-000000000002",
+  "timestamp_ms": "1789198310000",
+  "request_id": "0197d04c-c000-7000-8000-000000000002",
+  "body_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "canonical": "nono-request-v1\nGET\n/api/v1/approvals/proxy-endpoint-approval-example-api-1789198307331603818\n019f0000-0000-7000-8000-000000000002\n1789198310000\n0197d04c-c000-7000-8000-000000000002\nsha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}

--- a/tests/fixtures/approval-status-v1.json
+++ b/tests/fixtures/approval-status-v1.json
@@ -1,0 +1,61 @@
+{
+  "$comment": "Response shapes from docs/protocols/approval-webhook-v1.md and the decision each must produce.",
+  "signed": [
+    {
+      "name": "submit accepted, still pending after the server hold",
+      "http_status": 202,
+      "body": { "request_id": "req-1", "state": "pending" },
+      "expected": "pending"
+    },
+    {
+      "name": "granted by a reviewer",
+      "http_status": 200,
+      "body": { "request_id": "req-1", "state": "granted", "decision": "granted" },
+      "expected": "granted"
+    },
+    {
+      "name": "granted by a live session grant on submit",
+      "http_status": 200,
+      "body": { "request_id": "req-1", "state": "granted", "decision": "granted" },
+      "expected": "granted"
+    },
+    {
+      "name": "denied with a reason",
+      "http_status": 200,
+      "body": { "request_id": "req-1", "state": "denied", "decision": "denied", "reason": "not today" },
+      "expected": "denied"
+    },
+    {
+      "name": "timed out on the server before a decision",
+      "http_status": 200,
+      "body": { "request_id": "req-1", "state": "timeout", "decision": "timeout", "reason": "no decision before the client deadline" },
+      "expected": "timeout"
+    },
+    {
+      "name": "rejected signature",
+      "http_status": 401,
+      "body": { "error": "Unauthorized", "message": "unauthorized" },
+      "expected": "denied"
+    },
+    {
+      "name": "unknown or foreign request id on poll",
+      "http_status": 404,
+      "body": { "error": "Not Found", "message": "not found" },
+      "expected": "denied"
+    },
+    {
+      "name": "redirect is never followed",
+      "http_status": 302,
+      "body": {},
+      "expected": "denied"
+    }
+  ],
+  "unsigned": [
+    { "name": "simple grant", "body": { "decision": "granted" }, "expected": "granted" },
+    { "name": "grant synonym", "body": { "decision": "allow" }, "expected": "granted" },
+    { "name": "deny with reason", "body": { "decision": "denied", "reason": "policy" }, "expected": "denied" },
+    { "name": "deny synonym", "body": { "decision": "reject" }, "expected": "denied" },
+    { "name": "timeout", "body": { "decision": "timeout" }, "expected": "timeout" },
+    { "name": "signed status shape also parses unsigned", "body": { "request_id": "req-1", "state": "granted", "decision": "granted" }, "expected": "granted" }
+  ]
+}


### PR DESCRIPTION
- Sign every approval request with the enrollment key (`nono-request-v1`),
  stamping the six `X-Nono-*` headers a backend verifies.
- Derive `<backend_url>/api/v1/approvals` from enrollment state when `url`
  is omitted; require https or loopback http for signed requests.
- Follow the platform contract: submit, then poll
  `GET /api/v1/approvals/{request_id}` until a decision or `timeout_secs`.
- Send `X-Nono-Timeout-Secs` on every webhook request (signed or not) so
  the backend hold for the client's actual patience.
- Report elapsed time, not the configured timeout, in HTTP error denials.
- Reject `auth` on terminal and chain backends; keep the legacy single
  blocking POST for unsigned webhooks unchanged.

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked
