### PR TITLE
feat(wiring): add pack-declared variables for agent config dirs

### DIFF
--- a/crates/nono-cli/src/package.rs
+++ b/crates/nono-cli/src/package.rs
@@ -60,6 +60,24 @@ pub struct PackageManifest {
     /// agent-specific install steps).
     #[serde(default)]
     pub wiring: Vec<WiringDirective>,
+    /// Pack-declared variables usable in `wiring` destinations, on top
+    /// of the built-in set. Lets a pack say "wherever this agent keeps
+    /// its config" without the CLI having to know which agent that is
+    /// — the pack names the environment variable, the CLI resolves and
+    /// validates it. Empty for packs whose destinations are fixed.
+    #[serde(default)]
+    pub wiring_vars: BTreeMap<String, WiringVar>,
+}
+
+/// A pack-declared wiring variable: an environment variable to consult,
+/// plus the value to use when it is unset or rejected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WiringVar {
+    /// Environment variable read at install time.
+    pub env: String,
+    /// Fallback when `env` is unset, empty, or fails validation.
+    /// Expanded against the built-in variable table only.
+    pub default: String,
 }
 
 impl PackageManifest {

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -829,11 +829,16 @@ fn install_package(
     let wiring_record = if manifest.wiring.is_empty() {
         Vec::new()
     } else {
-        let ctx = crate::wiring::WiringContext {
+        // Resolve the pack's declared variables before any directive
+        // runs, so an unusable one fails the install up front rather
+        // than part-way through writing files.
+        let mut ctx = crate::wiring::WiringContext {
             pack_dir: final_root.clone(),
             namespace: package_ref.namespace.clone(),
             pack_name: package_ref.name.clone(),
+            vars: BTreeMap::new(),
         };
+        ctx.vars = crate::wiring::resolve_vars(&manifest.wiring_vars, &ctx)?;
         let report = crate::wiring::execute(&manifest.wiring, &ctx, pack_owned_files)?;
         for conflict in &report.conflicts {
             eprintln!("  warning: {conflict}");

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -16,11 +16,16 @@
 //!   - Variables expanded at execution time: `$PACK_DIR`, `$NS`
 //!     (pack namespace), `$PLUGIN` (pack name, the second segment
 //!     of `<ns>/<pack>`), `$HOME`, `$XDG_CONFIG_HOME`, `$NONO_CONFIG`,
-//!     `$NONO_PACKAGES`. No shell evaluation, no user-controlled inputs
-//!     flow in.
+//!     `$NONO_PACKAGES`, `$NOW`. No shell evaluation.
+//!   - A pack may declare additional variables in `wiring_vars`, each
+//!     backed by an environment variable. That is the one path by which
+//!     user-controlled input reaches a destination path; it is resolved
+//!     and validated exactly once per install by `resolve_vars`, which
+//!     rejects anything not an absolute, traversal-free path.
 //!   - Idempotent: re-running a directive with the same inputs is a
 //!     no-op and reports `wiring_changed = false`.
 
+use crate::package::WiringVar;
 use chrono::Utc;
 use nono::{NonoError, Result};
 use serde::{Deserialize, Serialize};
@@ -297,6 +302,9 @@ pub struct WiringContext {
     pub namespace: String,
     /// Pack name (the `<pack>` in `<ns>/<pack>`).
     pub pack_name: String,
+    /// Pack-declared variables, already resolved by `resolve_vars`.
+    /// Empty for packs that only use the built-in set.
+    pub vars: BTreeMap<String, String>,
 }
 
 /// Outcome of executing a directive list.
@@ -683,29 +691,104 @@ fn expand_vars(template: &str, ctx: &WiringContext) -> Result<String> {
     let nono_config_str = nono_config.to_string_lossy().into_owned();
     let nono_packages_str = nono_packages.to_string_lossy().into_owned();
 
+    let builtin = |name: &str| -> Option<String> {
+        match name {
+            "PACK_DIR" => Some(pack_dir.clone()),
+            "NS" => Some(ctx.namespace.clone()),
+            "PLUGIN" => Some(ctx.pack_name.clone()),
+            "HOME" => Some(home_str.clone()),
+            "XDG_CONFIG_HOME" => Some(xdg_str.clone()),
+            "NONO_CONFIG" => Some(nono_config_str.clone()),
+            "NONO_PACKAGES" => Some(nono_packages_str.clone()),
+            // Install-time UTC timestamp (RFC3339, milliseconds).
+            "NOW" => Some(Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()),
+            _ => None,
+        }
+    };
+
     // Uppercase-only start: leaves `$` regex anchors and jq `$var` untouched.
     crate::policy::substitute_vars(
         template,
         |nc| nc.is_ascii_uppercase() || nc == '_',
         |name| -> Result<Option<String>> {
-            match name {
-                "PACK_DIR" => Ok(Some(pack_dir.clone())),
-                "NS" => Ok(Some(ctx.namespace.clone())),
-                "PLUGIN" => Ok(Some(ctx.pack_name.clone())),
-                "HOME" => Ok(Some(home_str.clone())),
-                "XDG_CONFIG_HOME" => Ok(Some(xdg_str.clone())),
-                "NONO_CONFIG" => Ok(Some(nono_config_str.clone())),
-                "NONO_PACKAGES" => Ok(Some(nono_packages_str.clone())),
-                // Install-time UTC timestamp (RFC3339, milliseconds).
-                "NOW" => Ok(Some(
-                    Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string(),
-                )),
-                other => Err(NonoError::PackageInstall(format!(
-                    "wiring template references unknown variable '${other}' in '{template}'"
-                ))),
+            if let Some(value) = builtin(name) {
+                return Ok(Some(value));
             }
+            if let Some(value) = ctx.vars.get(name) {
+                return Ok(Some(value.clone()));
+            }
+            Err(NonoError::PackageInstall(format!(
+                "wiring template references unknown variable '${name}' in '{template}'"
+            )))
         },
     )
+}
+
+/// Resolve a pack's declared `wiring_vars` once, before any directive
+/// runs.
+///
+/// Resolving up front rather than per-occurrence matters for more than
+/// speed: `expand_vars` is called per field per directive, so a lazy
+/// resolve would re-read the environment — and re-report any problem —
+/// once for every mention of the variable, and two directives could in
+/// principle disagree if the environment changed mid-install.
+///
+/// An environment value is the one user-controlled input that reaches a
+/// destination path, so it must be an absolute path with no `..`
+/// component. Anything else is a hard error: the variable exists to
+/// point the install somewhere specific, and quietly using the pack's
+/// default instead is how the bug this feature fixes behaved in the
+/// first place. An unset variable is the ordinary case and falls back to
+/// the declared default without comment.
+///
+/// Note what is deliberately *not* checked: containment under `$HOME`.
+/// Relocating an agent's config onto another volume, or behind a
+/// symlink, is a legitimate setup, and a containment rule would reject
+/// it while buying nothing — `expand_to_path` already accepts any
+/// absolute literal destination a pack cares to write, so the check
+/// would constrain honest users without constraining a hostile pack.
+pub fn resolve_vars(
+    declared: &BTreeMap<String, WiringVar>,
+    ctx: &WiringContext,
+) -> Result<BTreeMap<String, String>> {
+    let mut resolved = BTreeMap::new();
+    for (name, var) in declared {
+        resolved.insert(name.clone(), resolve_one_var(name, var, ctx)?);
+    }
+    Ok(resolved)
+}
+
+fn resolve_one_var(name: &str, var: &WiringVar, ctx: &WiringContext) -> Result<String> {
+    let Some(raw) = std::env::var_os(&var.env) else {
+        // Unset: the pack's default is the answer. Expanded against the
+        // built-in table only — `ctx.vars` is still empty at this point,
+        // so a default naming another pack variable fails as unknown
+        // rather than needing cycle detection.
+        return expand_vars(&var.default, ctx);
+    };
+
+    let rejected = |reason: &str| {
+        NonoError::PackageInstall(format!(
+            "${} is set but {reason}, so the wiring variable ${name} cannot be resolved.              Fix or unset ${}, then retry.",
+            var.env, var.env
+        ))
+    };
+
+    let value = raw.to_str().ok_or_else(|| rejected("not valid UTF-8"))?;
+    if value.is_empty() {
+        return Err(rejected("empty"));
+    }
+    let path = Path::new(value);
+    if !path.is_absolute() {
+        return Err(rejected(&format!("not an absolute path ('{value}')")));
+    }
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(rejected(&format!("contains '..' ('{value}')")));
+    }
+    Ok(value.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -1608,6 +1691,7 @@ mod tests {
             pack_dir,
             namespace: "nolabs-ai".to_string(),
             pack_name: "claude".to_string(),
+            vars: BTreeMap::new(),
         }
     }
 
@@ -1645,6 +1729,7 @@ mod tests {
             pack_dir,
             namespace: "ns".to_string(),
             pack_name: "name".to_string(),
+            vars: BTreeMap::new(),
         };
         let _g = match ENV_LOCK.lock() {
             Ok(g) => g,
@@ -1682,6 +1767,7 @@ mod tests {
             pack_dir: PathBuf::from("/p"),
             namespace: "nolabs-ai".to_string(),
             pack_name: "claude".to_string(),
+            vars: BTreeMap::new(),
         };
         let _env = EnvVarGuard::set_all(&[("HOME", home_str), ("XDG_CONFIG_HOME", config_str)]);
         let expected_config = format!("{config_str}/nono/profile-drafts");
@@ -1700,12 +1786,221 @@ mod tests {
         );
     }
 
+    /// A pack declaring one variable, shaped the way the claude pack
+    /// would declare where Claude Code keeps its config. Returns the
+    /// resolve result so rejection tests can assert on the error.
+    fn ctx_with_var(env: &str, default: &str) -> Result<WiringContext> {
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            "AGENT_CONFIG".to_string(),
+            WiringVar {
+                env: env.to_string(),
+                default: default.to_string(),
+            },
+        );
+        let mut ctx = WiringContext {
+            pack_dir: PathBuf::from("/p"),
+            namespace: "ns".to_string(),
+            pack_name: "name".to_string(),
+            vars: BTreeMap::new(),
+        };
+        ctx.vars = resolve_vars(&declared, &ctx)?;
+        Ok(ctx)
+    }
+
+    /// The whole point of the feature: a pack that points at an agent's
+    /// relocated config dir must wire into that dir, not the default.
+    #[test]
+    fn pack_var_prefers_env_value() {
+        with_fake_home(|home| {
+            let relocated = home.join("relocated-agent");
+            std::fs::create_dir_all(&relocated).expect("mkdir");
+            let _env = EnvVarGuard::set_all(&[(
+                "NONO_TEST_AGENT_CONFIG",
+                relocated.to_str().expect("utf8"),
+            )]);
+            let ctx = ctx_with_var("NONO_TEST_AGENT_CONFIG", "$HOME/.agent").expect("resolve");
+            assert_eq!(
+                expand_vars("$AGENT_CONFIG/plugins", &ctx).expect("expand"),
+                format!("{}/plugins", relocated.display())
+            );
+        });
+    }
+
+    /// Packs that declare a variable must keep working for the majority
+    /// who never set the environment variable at all.
+    #[test]
+    fn pack_var_falls_back_to_default_when_env_unset() {
+        with_fake_home(|home| {
+            let guard = EnvVarGuard::set_all(&[("NONO_TEST_AGENT_CONFIG_UNSET", "placeholder")]);
+            guard.remove("NONO_TEST_AGENT_CONFIG_UNSET");
+            let ctx =
+                ctx_with_var("NONO_TEST_AGENT_CONFIG_UNSET", "$HOME/.agent").expect("resolve");
+            assert_eq!(
+                expand_vars("$AGENT_CONFIG/plugins", &ctx).expect("expand"),
+                format!("{}/.agent/plugins", home.display())
+            );
+        });
+    }
+
+    /// A config dir relocated onto another volume by symlink is a normal
+    /// setup, and the earlier `$HOME`-containment rule got it exactly
+    /// backwards: it rejected the value, fell back to the default — the
+    /// same symlink — and wrote outside `$HOME` anyway, after warning
+    /// that it would not. Honor the value instead.
+    #[test]
+    fn pack_var_honors_symlinked_config_dir() {
+        with_fake_home(|home| {
+            let outside = TempDir::new().expect("outside tmpdir");
+            let link = home.join(".agent-link");
+            std::os::unix::fs::symlink(outside.path(), &link).expect("symlink");
+            let _env = EnvVarGuard::set_all(&[(
+                "NONO_TEST_AGENT_CONFIG_SYMLINK",
+                link.to_str().expect("utf8"),
+            )]);
+            let ctx =
+                ctx_with_var("NONO_TEST_AGENT_CONFIG_SYMLINK", "$HOME/.agent").expect("resolve");
+            assert_eq!(
+                expand_vars("$AGENT_CONFIG/x", &ctx).expect("expand"),
+                format!("{}/x", link.display())
+            );
+        });
+    }
+
+    /// The target directory usually does not exist yet on a first
+    /// install — resolution must not depend on it being there.
+    #[test]
+    fn pack_var_accepts_not_yet_existing_dir() {
+        with_fake_home(|home| {
+            let missing = home.join("not/created/yet");
+            let _env = EnvVarGuard::set_all(&[(
+                "NONO_TEST_AGENT_CONFIG_MISSING",
+                missing.to_str().expect("utf8"),
+            )]);
+            let ctx =
+                ctx_with_var("NONO_TEST_AGENT_CONFIG_MISSING", "$HOME/.agent").expect("resolve");
+            assert_eq!(
+                expand_vars("$AGENT_CONFIG/x", &ctx).expect("expand"),
+                format!("{}/x", missing.display())
+            );
+        });
+    }
+
+    /// Config outside `$HOME` is deliberately allowed: an external
+    /// volume is a legitimate place to keep it, and a containment rule
+    /// would not stop a hostile pack, which can already name any
+    /// absolute destination literally.
+    #[test]
+    fn pack_var_accepts_dir_outside_home() {
+        with_fake_home(|_home| {
+            let outside = TempDir::new().expect("outside tmpdir");
+            let _env = EnvVarGuard::set_all(&[(
+                "NONO_TEST_AGENT_CONFIG_OUTSIDE",
+                outside.path().to_str().expect("utf8"),
+            )]);
+            let ctx =
+                ctx_with_var("NONO_TEST_AGENT_CONFIG_OUTSIDE", "$HOME/.agent").expect("resolve");
+            assert_eq!(
+                expand_vars("$AGENT_CONFIG/x", &ctx).expect("expand"),
+                format!("{}/x", outside.path().display())
+            );
+        });
+    }
+
+    /// Set-but-unusable is a hard error, not a quiet fallback. Falling
+    /// back would reproduce the silent misplacement this feature exists
+    /// to fix: the user asked for a specific directory and nono would
+    /// use a different one while reporting success.
+    #[test]
+    fn pack_var_rejects_unusable_env_values() {
+        // reason fragment the error must mention, and the value producing it
+        let cases: [(&str, &str); 3] = [
+            ("not an absolute path", "relative/path"),
+            ("contains '..'", "/tmp/../escaped"),
+            ("empty", ""),
+        ];
+        for (expected, value) in cases {
+            with_fake_home(|_home| {
+                let _env = EnvVarGuard::set_all(&[("NONO_TEST_AGENT_CONFIG_BAD", value)]);
+                let err = ctx_with_var("NONO_TEST_AGENT_CONFIG_BAD", "$HOME/.agent")
+                    .expect_err("expected rejection");
+                let msg = err.to_string();
+                assert!(
+                    msg.contains(expected),
+                    "value {value:?}: expected error mentioning {expected:?}, got: {msg}"
+                );
+                assert!(
+                    msg.contains("NONO_TEST_AGENT_CONFIG_BAD"),
+                    "error should name the offending variable, got: {msg}"
+                );
+            });
+        }
+    }
+
+    /// Defaults resolve against built-ins only. Allowing them to name
+    /// other pack variables would need cycle detection for no gain.
+    #[test]
+    fn pack_var_default_cannot_reference_another_pack_var() {
+        with_fake_home(|_home| {
+            let mut declared = BTreeMap::new();
+            declared.insert(
+                "A".to_string(),
+                WiringVar {
+                    env: "NONO_TEST_AGENT_CONFIG_CHAIN_A".to_string(),
+                    default: "$B/x".to_string(),
+                },
+            );
+            declared.insert(
+                "B".to_string(),
+                WiringVar {
+                    env: "NONO_TEST_AGENT_CONFIG_CHAIN_B".to_string(),
+                    default: "$HOME/b".to_string(),
+                },
+            );
+            let ctx = WiringContext {
+                pack_dir: PathBuf::from("/p"),
+                namespace: "ns".to_string(),
+                pack_name: "name".to_string(),
+                vars: BTreeMap::new(),
+            };
+            assert!(resolve_vars(&declared, &ctx).is_err());
+        });
+    }
+
+    /// A pack cannot shadow a built-in: built-ins are consulted first.
+    #[test]
+    fn pack_var_cannot_shadow_builtin() {
+        with_fake_home(|home| {
+            let _env = EnvVarGuard::set_all(&[("NONO_TEST_AGENT_CONFIG_SHADOW", "/somewhere")]);
+            let mut declared = BTreeMap::new();
+            declared.insert(
+                "HOME".to_string(),
+                WiringVar {
+                    env: "NONO_TEST_AGENT_CONFIG_SHADOW".to_string(),
+                    default: "/other".to_string(),
+                },
+            );
+            let mut ctx = WiringContext {
+                pack_dir: PathBuf::from("/p"),
+                namespace: "ns".to_string(),
+                pack_name: "name".to_string(),
+                vars: BTreeMap::new(),
+            };
+            ctx.vars = resolve_vars(&declared, &ctx).expect("resolve");
+            assert_eq!(
+                expand_vars("$HOME/x", &ctx).expect("expand"),
+                format!("{}/x", home.display())
+            );
+        });
+    }
+
     #[test]
     fn expand_vars_rejects_unknown() {
         let ctx = WiringContext {
             pack_dir: PathBuf::from("/p"),
             namespace: "n".to_string(),
             pack_name: "p".to_string(),
+            vars: BTreeMap::new(),
         };
         assert!(expand_vars("$BOGUS/x", &ctx).is_err());
         // Bare `$` not followed by an uppercase identifier passes through.

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -691,6 +691,8 @@ fn expand_vars(template: &str, ctx: &WiringContext) -> Result<String> {
     let nono_config_str = nono_config.to_string_lossy().into_owned();
     let nono_packages_str = nono_packages.to_string_lossy().into_owned();
 
+    // Keep in step with BUILTIN_VAR_NAMES below; `validate_var_name`
+    // uses that list to reject a pack variable that would be shadowed.
     let builtin = |name: &str| -> Option<String> {
         match name {
             "PACK_DIR" => Some(pack_dir.clone()),
@@ -753,9 +755,73 @@ pub fn resolve_vars(
 ) -> Result<BTreeMap<String, String>> {
     let mut resolved = BTreeMap::new();
     for (name, var) in declared {
+        validate_var_name(name)?;
         resolved.insert(name.clone(), resolve_one_var(name, var, ctx)?);
     }
     Ok(resolved)
+}
+
+/// Names the built-in table supplies. A pack variable may not reuse one:
+/// built-ins are consulted first, so the declaration would be dead config.
+const BUILTIN_VAR_NAMES: &[&str] = &[
+    "PACK_DIR",
+    "NS",
+    "PLUGIN",
+    "HOME",
+    "XDG_CONFIG_HOME",
+    "NONO_CONFIG",
+    "NONO_PACKAGES",
+    "NOW",
+];
+
+/// Reject a declared name that could never be referenced, or one that a
+/// built-in would shadow. Both are silent dead config otherwise: an
+/// unmatched `$name` is left verbatim in the destination by
+/// `substitute_vars`, so the pack writes to a path with a literal `$` in
+/// it, and a shadowed name simply never takes effect.
+///
+/// The accepted shape mirrors what `policy::substitute_vars` will match —
+/// an uppercase letter or `_`, then letters, digits or `_`. Note the
+/// continuation deliberately allows lowercase, so `FOO_bar` is valid;
+/// requiring all-caps throughout would reject names that work.
+fn validate_var_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let shape_ok = matches!(chars.next(), Some(c) if c.is_ascii_uppercase() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if !shape_ok {
+        return Err(NonoError::PackageInstall(format!(
+            "wiring_vars key '{name}' can never be referenced: a name must start with \
+             an uppercase letter or '_', then contain only letters, digits or '_'"
+        )));
+    }
+    if BUILTIN_VAR_NAMES.contains(&name) {
+        return Err(NonoError::PackageInstall(format!(
+            "wiring_vars key '{name}' shadows a built-in variable, which is always \
+             consulted first — rename it"
+        )));
+    }
+    Ok(())
+}
+
+/// Why a resolved root cannot be used as a destination, or `None` if it
+/// can. A relative value is as bad as a traversing one: `expand_to_path`
+/// rejects `..` but not relative paths, so it would land wherever
+/// `nono pull` happened to be run from.
+fn root_rejection(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return Some("empty".to_string());
+    }
+    let path = Path::new(value);
+    if !path.is_absolute() {
+        return Some(format!("not an absolute path ('{value}')"));
+    }
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Some(format!("contains '..' ('{value}')"));
+    }
+    None
 }
 
 fn resolve_one_var(name: &str, var: &WiringVar, ctx: &WiringContext) -> Result<String> {
@@ -764,29 +830,31 @@ fn resolve_one_var(name: &str, var: &WiringVar, ctx: &WiringContext) -> Result<S
         // built-in table only — `ctx.vars` is still empty at this point,
         // so a default naming another pack variable fails as unknown
         // rather than needing cycle detection.
-        return expand_vars(&var.default, ctx);
+        //
+        // The default is pack-authored rather than user-supplied, but it
+        // gets the same check: a malformed one should fail the install
+        // loudly instead of writing to a relative path.
+        let value = expand_vars(&var.default, ctx)?;
+        if let Some(reason) = root_rejection(&value) {
+            return Err(NonoError::PackageInstall(format!(
+                "wiring_vars['{name}'].default is {reason}; a pack must declare an \
+                 absolute, traversal-free path"
+            )));
+        }
+        return Ok(value);
     };
 
     let rejected = |reason: &str| {
         NonoError::PackageInstall(format!(
-            "${} is set but {reason}, so the wiring variable ${name} cannot be resolved.              Fix or unset ${}, then retry.",
+            "${} is set but {reason}, so the wiring variable ${name} cannot be resolved. \
+             Fix or unset ${}, then retry.",
             var.env, var.env
         ))
     };
 
     let value = raw.to_str().ok_or_else(|| rejected("not valid UTF-8"))?;
-    if value.is_empty() {
-        return Err(rejected("empty"));
-    }
-    let path = Path::new(value);
-    if !path.is_absolute() {
-        return Err(rejected(&format!("not an absolute path ('{value}')")));
-    }
-    if path
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(rejected(&format!("contains '..' ('{value}')")));
+    if let Some(reason) = root_rejection(value) {
+        return Err(rejected(&reason));
     }
     Ok(value.to_string())
 }
@@ -1967,30 +2035,124 @@ mod tests {
         });
     }
 
-    /// A pack cannot shadow a built-in: built-ins are consulted first.
+    fn declared(name: &str, env: &str, default: &str) -> BTreeMap<String, WiringVar> {
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            name.to_string(),
+            WiringVar {
+                env: env.to_string(),
+                default: default.to_string(),
+            },
+        );
+        declared
+    }
+
+    fn bare_ctx() -> WiringContext {
+        WiringContext {
+            pack_dir: PathBuf::from("/p"),
+            namespace: "ns".to_string(),
+            pack_name: "name".to_string(),
+            vars: BTreeMap::new(),
+        }
+    }
+
+    /// Shadowing a built-in is dead config — built-ins are consulted
+    /// first — so say so at install time instead of ignoring it.
     #[test]
-    fn pack_var_cannot_shadow_builtin() {
+    fn pack_var_rejects_name_shadowing_builtin() {
+        with_fake_home(|_home| {
+            for name in BUILTIN_VAR_NAMES {
+                let err = resolve_vars(
+                    &declared(name, "NONO_TEST_AGENT_CONFIG_SHADOW", "/somewhere"),
+                    &bare_ctx(),
+                )
+                .expect_err("expected rejection");
+                assert!(
+                    err.to_string().contains("shadows a built-in"),
+                    "{name}: unexpected error: {err}"
+                );
+            }
+        });
+    }
+
+    /// A name the expander can never match would be left verbatim in the
+    /// destination, so the pack would write to a path containing a
+    /// literal `$`. Reject it rather than produce that.
+    #[test]
+    fn pack_var_rejects_unreferenceable_name() {
+        with_fake_home(|_home| {
+            for name in ["claude_config", "9LIVES", "", "HAS-DASH"] {
+                let err = resolve_vars(
+                    &declared(name, "NONO_TEST_AGENT_CONFIG_BADNAME", "/somewhere"),
+                    &bare_ctx(),
+                )
+                .expect_err("expected rejection");
+                assert!(
+                    err.to_string().contains("can never be referenced"),
+                    "{name:?}: unexpected error: {err}"
+                );
+            }
+        });
+    }
+
+    /// `substitute_vars` allows lowercase after the first character, so
+    /// validation must too — rejecting these would refuse names that work.
+    #[test]
+    fn pack_var_accepts_mixed_case_name() {
         with_fake_home(|home| {
-            let _env = EnvVarGuard::set_all(&[("NONO_TEST_AGENT_CONFIG_SHADOW", "/somewhere")]);
-            let mut declared = BTreeMap::new();
-            declared.insert(
-                "HOME".to_string(),
-                WiringVar {
-                    env: "NONO_TEST_AGENT_CONFIG_SHADOW".to_string(),
-                    default: "/other".to_string(),
-                },
-            );
-            let mut ctx = WiringContext {
-                pack_dir: PathBuf::from("/p"),
-                namespace: "ns".to_string(),
-                pack_name: "name".to_string(),
-                vars: BTreeMap::new(),
-            };
-            ctx.vars = resolve_vars(&declared, &ctx).expect("resolve");
+            let mut ctx = bare_ctx();
+            ctx.vars = resolve_vars(
+                &declared(
+                    "Agent_config2",
+                    "NONO_TEST_AGENT_CONFIG_MIXED",
+                    "$HOME/.agent",
+                ),
+                &ctx,
+            )
+            .expect("resolve");
             assert_eq!(
-                expand_vars("$HOME/x", &ctx).expect("expand"),
-                format!("{}/x", home.display())
+                expand_vars("$Agent_config2/x", &ctx).expect("expand"),
+                format!("{}/.agent/x", home.display())
             );
+        });
+    }
+
+    /// The default is pack-authored rather than user-supplied, but an
+    /// unusable one still has to fail: `expand_to_path` rejects `..` and
+    /// not relative paths, so a relative default would write wherever
+    /// `nono pull` was run from.
+    #[test]
+    fn pack_var_rejects_unusable_default() {
+        with_fake_home(|_home| {
+            for default in ["relative/dir", "", "/tmp/../escaped"] {
+                let err = resolve_vars(
+                    &declared("AGENT_CONFIG", "NONO_TEST_AGENT_CONFIG_UNSET_DEF", default),
+                    &bare_ctx(),
+                )
+                .expect_err("expected rejection");
+                assert!(
+                    err.to_string().contains(".default is"),
+                    "{default:?}: unexpected error: {err}"
+                );
+            }
+        });
+    }
+
+    /// Guards the hand-maintained BUILTIN_VAR_NAMES list against drifting
+    /// away from the table `expand_vars` actually consults.
+    #[test]
+    fn builtin_var_names_all_resolve() {
+        with_fake_home(|_home| {
+            let ctx = bare_ctx();
+            for name in BUILTIN_VAR_NAMES {
+                let expanded = expand_vars(&format!("${name}"), &ctx)
+                    .unwrap_or_else(|e| panic!("{name} should be a known built-in: {e}"));
+                assert_ne!(
+                    expanded,
+                    format!("${name}"),
+                    "{name} was left unexpanded, so it is not actually a built-in"
+                );
+            }
         });
     }
 

--- a/docs/cli/features/package-publishing.mdx
+++ b/docs/cli/features/package-publishing.mdx
@@ -145,6 +145,35 @@ Predicates support OS, Linux distro and distro-family, version comparisons, nega
 
 If a pack uses `when`, set `min_nono_version` to a CLI release that supports predicates. Older CLIs must refuse the pack rather than silently applying conditional entries unconditionally.
 
+### Agent Config Directories
+
+Wiring destinations expand a fixed set of variables: `$PACK_DIR`, `$NS`, `$PLUGIN`, `$HOME`, `$XDG_CONFIG_HOME`, `$NONO_CONFIG`, `$NONO_PACKAGES`, and `$NOW`. None of them says "wherever this agent keeps its config", which matters for agents that let users relocate it — Claude Code reads `CLAUDE_CONFIG_DIR`, Codex reads `CODEX_HOME`. A pack that hardcodes `$HOME/.claude` writes into a directory the agent never reads, and nothing reports an error.
+
+Declare the variable your pack needs in `wiring_vars` and the CLI resolves it at install time:
+
+```json
+{
+  "wiring_vars": {
+    "CLAUDE_CONFIG": { "env": "CLAUDE_CONFIG_DIR", "default": "$HOME/.claude" }
+  },
+  "wiring": [
+    {
+      "type": "write_file",
+      "source": "hooks/hooks.json",
+      "dest": "$CLAUDE_CONFIG/plugins/marketplaces/$NS/plugins/nono/hooks/hooks.json"
+    }
+  ]
+}
+```
+
+Each declared variable is resolved once, before any directive runs:
+
+- **Unset** — the pack's `default` is used. It expands against the built-in variables only, so a default cannot reference another `wiring_vars` entry.
+- **Set to an absolute path with no `..` component** — that value is used, including when it points outside `$HOME` or through a symlink. Keeping an agent's config on another volume is a supported setup.
+- **Set to anything else** — empty, relative, non-UTF-8, or containing `..` — the install fails with an error naming the variable. It does not fall back to the default: the user asked for a specific directory, and quietly using a different one is the failure mode this feature exists to remove.
+
+Set `min_nono_version` to a release that supports `wiring_vars`. Older CLIs ignore the block and then fail the install on the unknown `$CLAUDE_CONFIG` variable, rather than silently writing to the wrong place.
+
 ### Profiles That Replace a Former Preset
 
 If your pack ships a profile with an `install_as` name that used to be compiled into the CLI (e.g. `claude-code` was a preset until v0.43), you also need to register it in the migration table so users on older versions get a friendly auto-pull prompt instead of a "profile not found" error. See [PACK_PROVIDED_PROFILES](#registering-a-pack-provided-profile) below.

--- a/docs/cli/features/package-publishing.mdx
+++ b/docs/cli/features/package-publishing.mdx
@@ -172,6 +172,10 @@ Each declared variable is resolved once, before any directive runs:
 - **Set to an absolute path with no `..` component** — that value is used, including when it points outside `$HOME` or through a symlink. Keeping an agent's config on another volume is a supported setup.
 - **Set to anything else** — empty, relative, non-UTF-8, or containing `..` — the install fails with an error naming the variable. It does not fall back to the default: the user asked for a specific directory, and quietly using a different one is the failure mode this feature exists to remove.
 
+The `default` is held to the same bar as the environment value — it must expand to an absolute, `..`-free path — so a malformed pack fails the install instead of writing somewhere relative to wherever `nono pull` was run.
+
+Variable names must start with an uppercase letter or `_` and contain only letters, digits or `_`, and may not reuse a built-in name (`PACK_DIR`, `NS`, `PLUGIN`, `HOME`, `XDG_CONFIG_HOME`, `NONO_CONFIG`, `NONO_PACKAGES`, `NOW`). Both are rejected at install time rather than ignored: an unmatched name is left verbatim in the destination, and a shadowed one never takes effect, so either would fail silently.
+
 Set `min_nono_version` to a release that supports `wiring_vars`. Older CLIs ignore the block and then fail the install on the unknown `$CLAUDE_CONFIG` variable, rather than silently writing to the wrong place.
 
 ### Profiles That Replace a Former Preset


### PR DESCRIPTION
## Linked Issue

Closes #1880

## Summary

Wiring destinations expand against a fixed variable table in `expand_vars`, so a pack has no way to say "wherever this agent keeps its config". `nolabs-ai/claude` 0.1.4 consequently hardcodes `$HOME/.claude` in 11 of its 12 wiring destinations, and a user who has relocated Claude Code's config via `CLAUDE_CONFIG_DIR` gets the plugin half of the pack written into a directory Claude Code never reads — silently, with `nono pull` reporting success.

This adds an optional `wiring_vars` block to `package.json` so the **pack** names the environment variable and the CLI resolves it, keeping the module's "the CLI knows nothing about specific agents" rule (`wiring.rs:9`) intact:

```json
"wiring_vars": {
  "CLAUDE_CONFIG": { "env": "CLAUDE_CONFIG_DIR", "default": "$HOME/.claude" }
}
```

Three design points worth a reviewer's attention:

**Resolution happens once, up front.** `resolve_vars` runs in `package_cmd.rs` before any directive executes. `expand_vars` is called per field per directive, so resolving lazily would re-read the environment — and re-report any problem — once per mention, and two directives could disagree if the environment changed mid-install.

**A set-but-unusable value is a hard error, not a fallback.** Empty, relative, non-UTF-8, or containing `..` fails the install naming the offending variable. Falling back would reproduce the exact failure this change removes: the user names a directory, nono uses a different one, and reports success. Unset remains an ordinary fallback to the pack's default.

**Containment under `$HOME` is deliberately not required**, and this is the part I'd most like challenged. My original proposal in #1880 *did* require it; implementing it showed the rule gets its motivating case backwards. A user who relocates a config dir by symlinking it off `$HOME` and points `CLAUDE_CONFIG_DIR` at it gets: canonicalization resolves the symlink, containment fails, nono warns and falls back to the pack default — the same symlink — and the write lands outside `$HOME` anyway, after warning that it would not. I verified that with a scratch test before removing it. The rule also buys nothing against a hostile pack, since `expand_to_path` already accepts any absolute literal destination. Full reasoning and the repro are in https://github.com/nolabs-ai/nono/issues/1880#issuecomment-5647448473. If you'd rather keep containment — say, accepting a value whose canonical form matches that of the declared default — I'm happy to implement that instead.

`wiring_vars` is `#[serde(default)]` and `PackageManifest` does not use `deny_unknown_fields`, so existing packs are bit-identical in behavior, and an older CLI meeting a pack that uses this fails closed on the unknown `$CLAUDE_CONFIG` variable rather than writing to the wrong place — mitigated by `min_nono_version`, the same contract already used for `when` predicates.

This is the CLI mechanism only. Nothing changes for any user until a follow-up PR on `nolabs-ai/nono-packs` switches the claude pack's wiring to `$CLAUDE_CONFIG`.

## Agent Disclosure

This PR was generated by an AI agent (Claude), working from the disclosed approach in #1880.

Files and sections consulted: `crates/nono-cli/src/wiring.rs` (module rules at lines 9-20, `expand_vars`, `expand_to_path`), `package.rs` (`PackageManifest`), `package_cmd.rs` (wiring call site, `run_remove` reversal), `policy.rs` (`substitute_vars`), `crates/nono/src/path.rs` (`try_canonicalize`), `test_env.rs` (`ENV_LOCK`, `EnvVarGuard`), plus `AGENTS.md`, `CONTRIBUTING.md`, `neps/README.md`, and `.github/workflows/pr-lint.yml`.

Per `neps/README.md`, no NEP: this is a small feature addition, not a change to the profile format, CLI flags, library public API, policy resolution, or the library/CLI boundary. Say the word if you read it differently and I'll open one before this goes further.

The change was reviewed by two independent adversarial review passes before submission; findings on silent-failure behavior, warning duplication, and the containment flaw above were folded in. Two items were deliberately left out of scope and filed separately rather than bundled: #1882 (reporting the resolved wiring root in the pull summary) and #1881.

## Test Plan

```bash
make fmt-check   # clean
make clippy      # clean (-D warnings -D clippy::unwrap_used)
make test-lib    # all green
make test-doc    # all green
cargo test -p nono-cli --bin nono   # 2093 passed; 1 failed (see below)
```

Eight new unit tests in `wiring.rs`, each named for the intent it defends:

| Test | Pins |
|---|---|
| `pack_var_prefers_env_value` | the feature's whole purpose |
| `pack_var_falls_back_to_default_when_env_unset` | the majority who never set it |
| `pack_var_honors_symlinked_config_dir` | the case the `$HOME` rule got backwards |
| `pack_var_accepts_not_yet_existing_dir` | first install, destination absent |
| `pack_var_accepts_dir_outside_home` | documents the deliberate containment decision |
| `pack_var_rejects_unusable_env_values` | empty / relative / `..`, each asserting the reason **and** that the error names the variable |
| `pack_var_cannot_shadow_builtin` | built-ins win |
| `pack_var_default_cannot_reference_another_pack_var` | no cycle detection needed |

Tests use the existing `ENV_LOCK` + `EnvVarGuard` helpers with unique `NONO_TEST_*` variable names, per the parallel-test env rule in AGENTS.md.

**One pre-existing failure, not caused by this PR.** `command_runtime::tests::shell_dry_run_rejects_block_net_with_upstream_proxy` fails in the parallel suite and passes in isolation and under `--test-threads=1`. I confirmed it is pre-existing by stashing this branch's changes and reproducing it on a clean `c11a976`: 2085 passed / 1 failed, same test, same error. Filed as #1881 with analysis — it is the reader-side half of #567, where `ENV_LOCK` serializes tests that *write* env vars but not those that read them indirectly. Deliberately not fixed here, to keep this PR to one subject.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked — **not applicable**, see the NEP note under Agent Disclosure

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy — I am not an OpenClaw or Pi Coding agent, and this is not part of a contributor-presence campaign
- [x] An issue already exists (#1880)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion, and posted a follow-up when implementation caused me to revise it
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code — none was reused or adapted; all logic here is newly written
- [x] I did not use forbidden patterns such as unwrap/expect — none in non-test code; `.expect()` in tests only, matching existing convention in this module
- [x] I used NonoError where required — all failures are `NonoError::PackageInstall`, propagated with `?`. `validate`-style helpers return `Result<_, String>` only for warning text that is never propagated, matching existing precedent in `sandbox_prepare.rs` and `trust_cmd.rs`
- [x] I validated and canonicalized all relevant paths — **with one deliberate deviation you should read before ticking this off on my behalf:** paths are validated (absolute, no `..` component, checked via `Path::components` rather than string matching), but resolved values are **not** canonicalized. Canonicalization is what produced the symlink bug described in the Summary. The trade-off is discussed in #1880 and I will happily reverse it on request
- [x] This PR matches the approved or disclosed issue scope, as revised in the linked comment
