### PR TITLE
test(cli): pin HOME in the shell block-net conflict test

### DIFF
--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -420,12 +420,55 @@ mod tests {
     use nono::{CapabilitySet, ResourceLimits};
     use std::path::PathBuf;
 
+    /// Pins `HOME` and the XDG dirs to a fixed test root, mirroring
+    /// `launch_runtime::tests::run_launch_plan_rejects_block_net_with_upstream_proxy`,
+    /// which covers the same flag conflict for `nono run`.
+    ///
+    /// Two reasons, both load-bearing. Taking `ENV_LOCK` keeps a
+    /// concurrent test's temporary `HOME` from being observed here:
+    /// `validate_proxy_conflicts` needs a `&PreparedSandbox`, so the
+    /// sandbox — and its `HOME`-derived state root — is built before the
+    /// conflict check runs, and a foreign `HOME` makes construction fail
+    /// first with an unrelated error. And rooting under `target/` rather
+    /// than a temp dir keeps the state root out of `/private/var`, which
+    /// `system_read_macos` grants and the overlap check then refuses.
     #[test]
     fn shell_dry_run_rejects_block_net_with_upstream_proxy() {
+        let _env_lock = crate::test_env::ENV_LOCK.lock().expect("env lock");
+        let test_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("test-env")
+            .join(format!(
+                "shell-dry-run-block-net-upstream-proxy-{}",
+                std::process::id()
+            ));
+        let home = test_root.join("home");
+        let state = test_root.join("state");
+        let config = test_root.join("config");
+        let workdir = test_root.join("workdir");
+        std::fs::create_dir_all(&home).expect("create test home");
+        std::fs::create_dir_all(&state).expect("create test state");
+        std::fs::create_dir_all(&config).expect("create test config");
+        std::fs::create_dir_all(&workdir).expect("create test workdir");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", home.to_str().expect("home path is utf-8")),
+            (
+                "XDG_STATE_HOME",
+                state.to_str().expect("state path is utf-8"),
+            ),
+            (
+                "XDG_CONFIG_HOME",
+                config.to_str().expect("config path is utf-8"),
+            ),
+        ]);
+
         let args = ShellArgs {
             sandbox: SandboxArgs {
                 dry_run: true,
                 allow_cwd: true,
+                workdir: Some(workdir),
                 block_net: true,
                 external_proxy: Some("squid.corp:3128".to_string()),
                 ..SandboxArgs::default()


### PR DESCRIPTION
## Linked Issue

Closes #1881

## Summary

`command_runtime::tests::shell_dry_run_rejects_block_net_with_upstream_proxy` fails in the full parallel suite and passes in isolation, with an error that never mentions the flags it is testing:

```
Sandbox initialization failed: Refusing to grant '/private/var'
(source: group:system_read_macos) because it overlaps protected nono state root
'/private/var/folders/…/T/.tmp0bBnO7/.local/state/nono'
```

The test never touches `HOME` itself. But `validate_proxy_conflicts` takes a `&PreparedSandbox` (`sandbox_prepare.rs:896`), so the sandbox — and its `HOME`-derived state root — must be built before the flag-conflict check can run. When a concurrent test has `HOME` pointed at a `TempDir`, sandbox construction fails first with an unrelated error and the assertion on the message fails. `.tmp0bBnO7` in that output is another test's temp dir.

`launch_runtime::tests::run_launch_plan_rejects_block_net_with_upstream_proxy` covers the same `--block-net` + `--upstream-proxy` conflict for `nono run` and already handles this correctly. This PR adopts that pattern rather than inventing a new one: take `ENV_LOCK`, pin `HOME`, `XDG_STATE_HOME` and `XDG_CONFIG_HOME` to a fixed root under `target/test-env/<name>-<pid>`, and pass an explicit `workdir`.

Both halves of the sibling's pattern are load-bearing, which is why the comment in the diff spells them out:

- **Taking `ENV_LOCK`** is what stops a concurrent test's temporary `HOME` being observed.
- **Rooting under `target/` rather than a temp dir** keeps the state root out of `/private/var`, which `system_read_macos` grants and the overlap check then refuses. A `TempDir`-based fix would have taken the lock and still failed on macOS.

Test-only change; no production code is touched.

### On the wider issue

The report frames this as the reader-side half of #567: `ENV_LOCK` serializes tests that *write* environment variables but not those that read them indirectly, so other latent instances may exist. I proposed two larger fixes there and then argued myself out of both — see https://github.com/nolabs-ai/nono/issues/1881#issuecomment-5647531628. Converting `ENV_LOCK` from `Mutex` to `RwLock` would touch ~200 call sites across 40 files unrelated to this bug and would still require each reader to opt in, buying reader-reader parallelism nothing currently needs. If you would rather have that refactor, I am happy to do it as a separate PR; this one fixes the failure with the pattern the codebase already uses.

## Agent Disclosure

This PR was generated by an AI agent (Claude).

Found while running `make ci` for an unrelated change (#1880 / #1883). I confirmed it was pre-existing by stashing that work and reproducing the failure on a clean `c11a976`, then filed it separately so the other PR could state plainly why the suite was red.

Files and sections consulted: `crates/nono-cli/src/command_runtime.rs`, `launch_runtime.rs` (the sibling test, lines 723-770), `sandbox_prepare.rs` (`validate_proxy_conflicts`), `test_env.rs` (`ENV_LOCK`, `EnvVarGuard`), plus `AGENTS.md`, `CONTRIBUTING.md`, `neps/README.md`, and issue #567 for the history.

No NEP: a test-only fix, well inside the "bug fix" exemption in `neps/README.md`.

## Test Plan

```bash
make fmt-check   # clean
make clippy      # clean (-D warnings -D clippy::unwrap_used)
make test-lib    # all green
make test-doc    # all green
```

The failure was scheduling-dependent, so a single green run proves little. On macOS 26.6.2 (arm64), full CLI suite, four consecutive runs each way:

| | Result |
|---|---|
| Before (clean `c11a976`) | **4 of 4 FAILED** — 2085 passed, 1 failed |
| After | **4 of 4 ok** — 2086 passed, 0 failed |

Also verified the test still passes in isolation and under `--test-threads=1`, so the fix did not simply move the dependency somewhere else.

I have not reproduced the failure on Linux. It may be macOS-specific: the overlap that triggers it is between `system_read_macos`'s `/private/var` grant and a `TempDir` under `TMPDIR`, and on Linux both the group and the temp root differ. CI on this PR will exercise both.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests — the change *is* a test; it follows the env save/restore rule in AGENTS.md via `EnvVarGuard` plus `ENV_LOCK`
- [x] Public-facing changes are paired with documentation updates — none; test-only
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked — **not applicable**, test-only bug fix

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy — I am not an OpenClaw or Pi Coding agent, and this is not part of a contributor-presence campaign
- [x] An issue already exists (#1881)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion, and posted a follow-up when I revised it to the smaller fix
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code — the test setup is adapted from `launch_runtime::tests::run_launch_plan_rejects_block_net_with_upstream_proxy` in this repository, which is named in both the commit message and an in-code comment
- [x] I did not use forbidden patterns such as unwrap/expect — `.expect()` in test code only, matching the sibling test and the surrounding module
- [x] I used NonoError where required — not applicable; no error paths added
- [x] I validated and canonicalized all relevant paths — not applicable; no path validation logic added. The test's own paths are constructed from `CARGO_MANIFEST_DIR`
- [x] This PR matches the approved or disclosed issue scope, as revised in the linked comment
