### PR TITLE
feat(pull): report where wiring wrote, not just where the pack was stored

### DIFF
--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -111,6 +111,7 @@ pub fn run_pull(args: PullArgs, reason: PullReason) -> Result<()> {
         &install_dir,
         install.installed_artifacts,
         install.copied_to_project,
+        &crate::wiring::written_roots(&install.wiring_record),
     );
 
     // Direct-pull path: if the user just installed the canonical claude

--- a/crates/nono-cli/src/pull_ui.rs
+++ b/crates/nono-cli/src/pull_ui.rs
@@ -131,6 +131,14 @@ pub fn render_summary(
 /// the rest of the summary.
 const MAX_SHOWN_ROOTS: usize = 3;
 
+/// Paths here come from the pack's own wiring directives, so they are
+/// pack-controlled text heading for a terminal. Strip escape sequences
+/// before display — a directory name carrying ANSI could otherwise
+/// rewrite the summary around it and misreport where the install wrote.
+fn display_root(root: &std::path::Path) -> String {
+    crate::terminal_approval::sanitize_for_terminal(&root.display().to_string())
+}
+
 fn render_wiring_roots(err: &mut impl Write, roots: &[std::path::PathBuf]) {
     let Some((first, rest)) = roots.split_first() else {
         return;
@@ -139,14 +147,10 @@ fn render_wiring_roots(err: &mut impl Write, roots: &[std::path::PathBuf]) {
         err,
         "     {label}    {body}",
         label = "Wired into".bold(),
-        body = first.display().to_string().dimmed(),
+        body = display_root(first).dimmed(),
     );
     for root in rest.iter().take(MAX_SHOWN_ROOTS - 1) {
-        let _ = writeln!(
-            err,
-            "                   {}",
-            root.display().to_string().dimmed()
-        );
+        let _ = writeln!(err, "                   {}", display_root(root).dimmed());
     }
     if let Some(hidden) = rest.len().checked_sub(MAX_SHOWN_ROOTS - 1)
         && hidden > 0
@@ -225,6 +229,24 @@ mod tests {
         }
         assert!(out.contains("+2 more"), "expected remainder of 2: {out}");
         assert!(!out.contains("/d"), "fourth root should be hidden: {out}");
+    }
+
+    /// Wiring paths are pack-controlled text on its way to a terminal.
+    /// An escape sequence in a directory name must not survive to the
+    /// screen, where it could rewrite the summary around it and
+    /// misreport where the install actually wrote.
+    #[test]
+    fn wiring_roots_strip_terminal_escapes() {
+        let out = rendered(&["/home/u/\u{1b}[2K\u{1b}[31mevil"]);
+        // Assert on the injected sequences rather than "no ESC at all":
+        // `.dimmed()` emits its own escapes whenever color is enabled,
+        // so a blanket check would pass or fail based on the terminal.
+        assert!(!out.contains("\u{1b}[2K"), "erase-line survived: {out:?}");
+        assert!(
+            !out.contains("\u{1b}[31m"),
+            "color escape survived: {out:?}"
+        );
+        assert!(out.contains("evil"), "path text should remain: {out:?}");
     }
 
     #[test]

--- a/crates/nono-cli/src/pull_ui.rs
+++ b/crates/nono-cli/src/pull_ui.rs
@@ -85,6 +85,7 @@ pub fn render_summary(
     install_dir: &std::path::Path,
     installed_artifacts: usize,
     copied_to_project: usize,
+    wiring_roots: &[std::path::PathBuf],
 ) {
     let mut err = io::stderr().lock();
     let _ = writeln!(err);
@@ -109,6 +110,12 @@ pub fn render_summary(
         format!("{installed_artifacts} artifact(s)").dimmed(),
     );
 
+    // Where the pack was stored is not where its agent files went.
+    // Report both: with `wiring_vars`, two installs of the same pack on
+    // one machine can write to different places, and a summary that only
+    // ever names the package store cannot tell them apart.
+    render_wiring_roots(&mut err, wiring_roots);
+
     if copied_to_project > 0 {
         let _ = writeln!(err);
         let _ = writeln!(
@@ -117,6 +124,39 @@ pub fn render_summary(
         );
     }
     let _ = writeln!(err);
+}
+
+/// At most `MAX_SHOWN` roots, then a count. A pack writing into many
+/// trees is unusual; truncating keeps one anomalous pack from burying
+/// the rest of the summary.
+const MAX_SHOWN_ROOTS: usize = 3;
+
+fn render_wiring_roots(err: &mut impl Write, roots: &[std::path::PathBuf]) {
+    let Some((first, rest)) = roots.split_first() else {
+        return;
+    };
+    let _ = writeln!(
+        err,
+        "     {label}    {body}",
+        label = "Wired into".bold(),
+        body = first.display().to_string().dimmed(),
+    );
+    for root in rest.iter().take(MAX_SHOWN_ROOTS - 1) {
+        let _ = writeln!(
+            err,
+            "                   {}",
+            root.display().to_string().dimmed()
+        );
+    }
+    if let Some(hidden) = rest.len().checked_sub(MAX_SHOWN_ROOTS - 1)
+        && hidden > 0
+    {
+        let _ = writeln!(
+            err,
+            "                   {}",
+            format!("+{hidden} more").dimmed()
+        );
+    }
 }
 
 /// "1.30 KB" / "412 B" / "2.10 MB" — three significant digits. Human
@@ -143,6 +183,49 @@ pub fn format_size(bytes: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rendered(roots: &[&str]) -> String {
+        let roots: Vec<std::path::PathBuf> = roots.iter().map(std::path::PathBuf::from).collect();
+        let mut buf: Vec<u8> = Vec::new();
+        render_wiring_roots(&mut buf, &roots);
+        String::from_utf8(buf).expect("utf8")
+    }
+
+    /// A pack with no wiring must not print an empty heading.
+    #[test]
+    fn wiring_roots_render_nothing_when_empty() {
+        assert_eq!(rendered(&[]), "");
+    }
+
+    /// The module's own rule: every line still parses with ANSI
+    /// stripped, so assert on content rather than styling.
+    #[test]
+    fn wiring_roots_render_each_root() {
+        let out = rendered(&["/home/u/.claude", "/home/u/.config/nono/profile-drafts"]);
+        assert!(out.contains("Wired into"), "missing label: {out}");
+        assert!(out.contains("/home/u/.claude"), "missing first root: {out}");
+        assert!(
+            out.contains("/home/u/.config/nono/profile-drafts"),
+            "missing second root: {out}"
+        );
+        assert!(
+            !out.contains("more"),
+            "should not truncate two roots: {out}"
+        );
+    }
+
+    /// Truncation must report an accurate remainder — an undercount
+    /// would hide a directory the pack wrote to, which is the very
+    /// thing this output exists to prevent.
+    #[test]
+    fn wiring_roots_truncate_with_accurate_count() {
+        let out = rendered(&["/a", "/b", "/c", "/d", "/e"]);
+        for shown in ["/a", "/b", "/c"] {
+            assert!(out.contains(shown), "expected {shown} shown: {out}");
+        }
+        assert!(out.contains("+2 more"), "expected remainder of 2: {out}");
+        assert!(!out.contains("/d"), "fourth root should be hidden: {out}");
+    }
 
     #[test]
     fn format_size_thresholds() {

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -248,6 +248,46 @@ pub enum WiringRecord {
     },
 }
 
+/// The directories a pack's wiring actually wrote into, as the smallest
+/// set that covers every touched path.
+///
+/// `nono pull` otherwise only reports where the pack was *stored*, which
+/// is not where its agent files went. Callers use this to say so.
+///
+/// Paths are reduced to their parent directories, then any directory
+/// already covered by a shallower one is dropped — so a pack that writes
+/// a dozen files spread through `~/.claude` reports `~/.claude` once,
+/// while a pack that also touches `~/.config/nono/profile-drafts` reports
+/// both. Sorting first is what makes the single pass correct: an ancestor
+/// always sorts before its descendants.
+#[must_use]
+pub fn written_roots(records: &[WiringRecord]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = records
+        .iter()
+        .filter_map(|r| {
+            let path = match r {
+                WiringRecord::Symlink { link } => link,
+                WiringRecord::WriteFile { dest, .. } => dest,
+                WiringRecord::JsonMerge { file, .. }
+                | WiringRecord::JsonArrayAppend { file, .. }
+                | WiringRecord::TomlBlock { file, .. }
+                | WiringRecord::YamlMerge { file, .. } => file,
+            };
+            Path::new(path).parent().map(Path::to_path_buf)
+        })
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for dir in dirs {
+        if !roots.iter().any(|kept| dir.starts_with(kept)) {
+            roots.push(dir);
+        }
+    }
+    roots
+}
+
 /// Per-leaf record for `JsonMerge`. `path` is the chain of object
 /// keys from the document root to the leaf (e.g.
 /// `["enabledPlugins", "nono@nolabs-ai"]`). `installed_value` is
@@ -1698,6 +1738,63 @@ mod tests {
             )),
             nono::try_canonicalize(Path::new(&expected_packages))
         );
+    }
+
+    fn wf(dest: &str) -> WiringRecord {
+        WiringRecord::WriteFile {
+            dest: dest.to_string(),
+            sha256: "x".to_string(),
+        }
+    }
+
+    /// The claude pack's real shape: a dozen files spread through one
+    /// tree plus a marker in another. The user wants to see the two
+    /// trees, not twelve directories.
+    #[test]
+    fn written_roots_collapses_nested_dirs_and_keeps_distinct_trees() {
+        let records = vec![
+            wf("/home/u/.claude/plugins/marketplaces/ns/plugins/nono/bin/hook.sh"),
+            wf("/home/u/.claude/plugins/marketplaces/ns/.claude-plugin/marketplace.json"),
+            wf("/home/u/.claude/settings.json"),
+            WiringRecord::Symlink {
+                link: "/home/u/.claude/plugins/cache/ns/nono/1.0.0".to_string(),
+            },
+            WiringRecord::JsonMerge {
+                file: "/home/u/.claude/plugins/known_marketplaces.json".to_string(),
+                leaves: Vec::new(),
+                created_parents: Vec::new(),
+            },
+            wf("/home/u/.config/nono/profile-drafts/.marker"),
+        ];
+        assert_eq!(
+            written_roots(&records),
+            vec![
+                PathBuf::from("/home/u/.claude"),
+                PathBuf::from("/home/u/.config/nono/profile-drafts"),
+            ]
+        );
+    }
+
+    /// Without a file directly in the shared parent there is nothing to
+    /// collapse to, so each distinct directory is reported rather than
+    /// inventing an ancestor the pack never wrote to.
+    #[test]
+    fn written_roots_keeps_siblings_when_no_shared_dir_was_written() {
+        let records = vec![wf("/home/u/.agent/a/one"), wf("/home/u/.agent/b/two")];
+        assert_eq!(
+            written_roots(&records),
+            vec![
+                PathBuf::from("/home/u/.agent/a"),
+                PathBuf::from("/home/u/.agent/b"),
+            ]
+        );
+    }
+
+    /// A pack that ships only a profile runs no directives, and must not
+    /// produce an empty "Wired into" heading.
+    #[test]
+    fn written_roots_is_empty_without_records() {
+        assert!(written_roots(&[]).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1882

## Summary

`nono pull`'s success summary reports where the pack was *stored* and stops there:

```
  ✓ nolabs-ai/claude 0.1.4

     Installed at  /Users/me/.config/nono/packages/nolabs-ai/claude
                   14 artifact(s)
```

That path is the package store. The files a user actually cares about — the agent plugin, its hooks, the marketplace entries — went somewhere else, and nothing says where. This adds one more field:

```
     Wired into    /Users/me/.claude
                   /Users/me/.config/nono/profile-drafts
```

Today wiring destinations are fixed per pack, so the omission is merely unhelpful. It stops being merely unhelpful with #1880 (PR #1883), which lets a pack resolve a destination root from the environment: two installs of the same pack on one machine can then write to different places and produce byte-identical summaries. The data already exists — `wiring_record` holds the resolved absolute paths for reversal — it just never reached the screen.

**`written_roots` is where the real behavior lives.** It reduces the records to the smallest set of directories covering every touched path: take each record's parent, sort, drop any directory already covered by a shallower one. Sorting first is what makes the single pass correct, since an ancestor always sorts before its descendants. For the claude pack that collapses twelve directories to two.

Common-prefix was the obvious alternative and is wrong: for that same pack it collapses to `$HOME`, which tells the user nothing. Where no shared directory was actually written to, siblings are listed rather than inventing an ancestor the pack never touched. Output is capped at three roots plus a `+N more` count.

### Decisions I made that the issue left open

The issue posed three questions for maintainers and I answered them to write the code. Each is cheap to reverse — full reasoning in https://github.com/nolabs-ai/nono/issues/1882#issuecomment-5647561061.

1. **Always, not only when non-default.** "Silence means default" is the assumption that produced #1880. It would also require the summary to reconstruct what "default" means, which with `wiring_vars` is a pack-level notion the UI has no business knowing.
2. **Roots, not prefixes** — as above.
3. **All `PullReason` paths.** `render_summary` already prints its whole block on every path, so one line does not change the character of the output, and `ProfileAuto` / `Migration` are where a user is least likely to know a pack was installed at all.

I also did not take the issue's `nono list --installed` alternative. That answers "where is it now", which is useful; it does not answer "did nono just honour my configuration", which is the question that follows an install.

### Relationship to #1883

Independent — this branches from `main`, touches different lines, and is useful on its own. It is *motivated* by #1883, so if `wiring_vars` is rejected this loses much of its point, though not all of it. Merge order does not matter. Happy to park this until #1880 is decided.

## Agent Disclosure

This PR was generated by an AI agent (Claude).

Note one deviation worth your attention: in #1882 I wrote "not proposing to implement this yet — it should be decided after #1880 settles." I have now implemented it anyway, at the repository owner's request, and disclosed the change of position in the issue before opening this. The three design answers above are mine, not a maintainer's, and should be read as proposals.

The underlying observation came from two independent adversarial reviews of #1883, which both landed on the same point: a feature whose purpose is "write where the user configured" should confirm where it wrote. I kept it out of that PR deliberately, since it changes output for every pack rather than only those using `wiring_vars`.

Files and sections consulted: `crates/nono-cli/src/pull_ui.rs` (`render_summary` and the module's output rules at lines 6-12), `wiring.rs` (`WiringRecord` variants), `package_cmd.rs` (`run_pull`), `registry_client.rs` (`PullReason`), plus `AGENTS.md`, `CONTRIBUTING.md`, and `neps/README.md`.

No NEP: additive output change, no effect on the profile format, CLI flags, library API, policy resolution, or the library/CLI boundary.

## Test Plan

```bash
make fmt-check   # clean
make clippy      # clean (-D warnings -D clippy::unwrap_used)
make test-lib    # all green
make test-doc    # all green
```

Six new unit tests, each named for the intent it defends:

| Test | Pins |
|---|---|
| `written_roots_collapses_nested_dirs_and_keeps_distinct_trees` | the claude pack's real shape — two trees, not twelve dirs |
| `written_roots_keeps_siblings_when_no_shared_dir_was_written` | no inventing an ancestor that was never written to |
| `written_roots_is_empty_without_records` | a profile-only pack prints no empty heading |
| `wiring_roots_render_nothing_when_empty` | same, at the render layer |
| `wiring_roots_render_each_root` | asserts on content, not styling, per the module's "color is decoration, not information" rule |
| `wiring_roots_truncate_with_accurate_count` | an undercount would hide a directory the pack wrote to — the exact failure this output exists to prevent |

**One pre-existing failure in the CLI suite**, unrelated to this change: `command_runtime::tests::shell_dry_run_rejects_block_net_with_upstream_proxy`, filed as #1881 and fixed by #1884. This branch is cut from `main` and so does not include that fix. With #1884 applied locally the suite is fully green.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates — this changes terminal output only; no doc page describes the pull summary's fields. Happy to add one if you would rather it were documented
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked — **not applicable**, additive output change

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy — I am not an OpenClaw or Pi Coding agent, and this is not part of a contributor-presence campaign
- [x] An issue already exists (#1882)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion, and posted the three design decisions there before opening this PR
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code — none was reused or adapted; all logic here is newly written
- [x] I did not use forbidden patterns such as unwrap/expect — none in non-test code; `.expect()` in tests only, matching the surrounding modules. Truncation arithmetic uses `checked_sub` per the arithmetic rule in AGENTS.md
- [x] I used NonoError where required — not applicable; no fallible paths added. Writes to stderr keep the module's existing `let _ = writeln!(...)` convention
- [x] I validated and canonicalized all relevant paths — not applicable; no path validation logic added. `written_roots` only reads paths already recorded in the lockfile and never touches the filesystem
- [x] This PR matches the disclosed issue scope, with the deviation noted under Agent Disclosure
