### PR TITLE
test(ci): report how a failed integration suite exited

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -260,6 +260,26 @@ done
 
 PASSED_SUITES=0
 FAILED_SUITES=0
+# Describe how a suite exited. Without this, an assertion failure (1), a
+# timeout (124) and a fatal signal (>128, which is how an OOM kill or a
+# stray process-group kill shows up) are indistinguishable in CI output —
+# the exit code is recorded per suite and then only ever tested against
+# zero. That ambiguity is why intermittent suite failures have been hard
+# to attribute after the fact.
+describe_exit() {
+    local code="$1"
+    if [[ "$code" -eq 124 ]]; then
+        echo "timed out after ${SUITE_TIMEOUT}s"
+    elif [[ "$code" -gt 128 && "$code" -lt 256 ]]; then
+        local signum=$((code - 128))
+        local signame
+        signame=$(kill -l "$signum" 2>/dev/null) || signame="unknown"
+        echo "killed by SIG${signame} (exit $code)"
+    else
+        echo "exit $code"
+    fi
+}
+
 FAILED_NAMES=""
 
 for i in "${!SUITE_NAMES[@]}"; do
@@ -281,9 +301,10 @@ for i in "${!SUITE_NAMES[@]}"; do
         echo -e "${GREEN}Suite PASSED${NC}: $name"
         PASSED_SUITES=$((PASSED_SUITES + 1))
     else
-        echo -e "${RED}Suite FAILED${NC}: $name"
+        how=$(describe_exit "$exit_code")
+        echo -e "${RED}Suite FAILED${NC}: $name ($how)"
         FAILED_SUITES=$((FAILED_SUITES + 1))
-        FAILED_NAMES="$FAILED_NAMES  - $name\n"
+        FAILED_NAMES="$FAILED_NAMES  - $name ($how)\n"
     fi
 done
 


### PR DESCRIPTION
## Linked Issue

Refs #1732

(Deliberately `Refs`, not `Closes` — this does not fix the flake. It makes the next occurrence attributable.)

## Summary

`scripts/run_all_tests.sh` records each suite's exit code (line 207/210) and then, at line 272, uses it only as zero/non-zero. The code itself is never printed. So these all render identically in CI:

| Exit | Means | Currently shown as |
|---|---|---|
| `1` | assertions failed | `Suite FAILED: <name>` |
| `124` | `timeout` fired | `Suite FAILED: <name>` |
| `137` | SIGKILL — an OOM kill, or a stray process-group kill | `Suite FAILED: <name>` |
| `143` | SIGTERM | `Suite FAILED: <name>` |

That ambiguity is why #1732 has been open since August with three candidate causes and no way to choose between them after the fact. Investigating a fresh occurrence, I could only rule out "timeout" by noticing the absence of a `SUITE TIMED OUT` marker string in the raw log — and only because the runner happens to append one. There is no equivalent tell for a signal.

This decodes the code in both the per-suite line and the failed-suites summary:

```
Suite FAILED: child tool boundaries (killed by SIGKILL (exit 137))
Suite FAILED: shell (exit 1)
Suite FAILED: env sanitization (timed out after 120s)
```

Diagnostic only. No test behaviour changes, no suite is run differently, and a passing run is byte-identical to before.

## Agent Disclosure

This PR was generated by an AI agent (Claude). Intent and the supporting analysis were posted to #1732 before opening it: https://github.com/nolabs-ai/nono/issues/1732#issuecomment-5647768964

That comment also records a negative result — the flake does not reproduce in a privileged Docker container across 8 full runs at `NONO_TEST_JOBS=16` — so the next person does not repeat the attempt.

No NEP: a diagnostic change to a test script, well inside the bug-fix exemption in `neps/README.md`.

## Test Plan

The decoder was checked against known values:

```
    0 -> exit 0
    1 -> exit 1
  124 -> timed out after 120s
  137 -> killed by SIGKILL (exit 137)
  143 -> killed by SIGTERM (exit 143)
  130 -> killed by SIGINT (exit 130)
```

`bash -n scripts/run_all_tests.sh` passes.

More usefully, it was exercised on real failures rather than synthetic ones. Running the full suite in a Linux container surfaced two genuine (container-fidelity) failures, and the new output classified both correctly:

```
Failed suites:
  - env sanitization (exit 1)
  - shell (exit 1)
```

On `main` those two lines are indistinguishable from a SIGKILL, which is exactly the distinction #1732 needs.

`kill -l "$signum"` is used for the signal name, with a fallback to `unknown` if it fails, so an out-of-range code cannot break the summary.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests — shell change to the test runner; decoder verified against known exit codes as above
- [x] Public-facing changes are paired with documentation updates — none; CI output only
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked — **not applicable**

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy — I am not an OpenClaw or Pi Coding agent, and this is not part of a contributor-presence campaign
- [x] An issue already exists (#1732)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion before opening this
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code — none reused; the decoder is newly written
- [x] I did not use forbidden patterns such as unwrap/expect — not applicable; shell
- [x] I used NonoError where required — not applicable; shell
- [x] I validated and canonicalized all relevant paths — not applicable; no paths handled
- [x] This PR matches the disclosed issue scope
