### PR TITLE
fix(ui): sanitize agent and registry strings before terminal display

### DIFF
--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -422,7 +422,11 @@ fn cmd_show(args: AuditShowArgs) -> Result<()> {
 
             for change in &changes {
                 let symbol = change_symbol(&change.change_type);
-                eprintln!("        {} {}", symbol, change.path.display());
+                eprintln!(
+                    "        {} {}",
+                    symbol,
+                    crate::terminal_approval::safe_path(&change.path)
+                );
             }
         }
     }

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -195,7 +195,9 @@ fn env_flag(key: &str) -> bool {
 }
 
 fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> Result<bool> {
-    let pack_ref = provider.pack_ref();
+    // Display only — the pull itself uses the unsanitized ref, which the
+    // registry client validates separately.
+    let pack_ref = sanitize_for_terminal(&provider.pack_ref());
     let mut err = io::stderr().lock();
     let _ = writeln!(err);
     let _ = writeln!(err, "  {}  Install {}?", "⊕".cyan(), pack_ref.bold(),);
@@ -264,7 +266,9 @@ enum SkipReason {
 }
 
 fn emit_skipped_hint(provider: &ProfileProvider, reason: SkipReason) {
-    let pack_ref = provider.pack_ref();
+    // Display only, and it is printed as a command for the user to copy —
+    // all the more reason it must not carry escapes.
+    let pack_ref = sanitize_for_terminal(&provider.pack_ref());
     let mut err = io::stderr().lock();
     let _ = writeln!(err);
     match reason {

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -17,6 +17,7 @@ use crate::cli::PullArgs;
 use crate::package::ProfileProvider;
 use crate::package_cmd;
 use crate::registry_client::{PullReason, RegistryClient, resolve_registry_url};
+use crate::terminal_approval::sanitize_for_terminal;
 use colored::Colorize;
 use nono::Result;
 use std::io::{self, IsTerminal, Write};
@@ -206,10 +207,16 @@ fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> Result<bool> 
     let _ = writeln!(err);
 
     let label_w = "Provenance".len();
+    // Registry-supplied, and rendered before anything is downloaded or
+    // signature-verified. This is a consent prompt, so injected escapes
+    // could redraw the very lines the user is being asked to approve.
     write_field(
         &mut err,
         "Publisher",
-        &format!("{} GitHub organisation", provider.namespace),
+        &format!(
+            "{} GitHub organisation",
+            sanitize_for_terminal(&provider.namespace)
+        ),
         label_w,
     );
     write_field(
@@ -219,7 +226,12 @@ fn confirm_pull(profile_name: &str, provider: &ProfileProvider) -> Result<bool> 
         label_w,
     );
     if let Some(summary) = provider.installs_summary.as_deref() {
-        write_field(&mut err, "Installs", summary, label_w);
+        write_field(
+            &mut err,
+            "Installs",
+            &sanitize_for_terminal(summary),
+            label_w,
+        );
     }
 
     let _ = writeln!(err);

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -186,9 +186,12 @@ fn group_by_project<'a>(
     groups
 }
 
-/// Replace the home directory prefix with ~ for display
+/// Replace the home directory prefix with ~ for display.
+///
+/// Display-only by contract, so the result is sanitized: callers render
+/// it to a terminal, and the path may be one a sandboxed agent named.
 fn shorten_home(path: &Path) -> String {
-    let s = path.display().to_string();
+    let s = crate::terminal_approval::safe_path(path).to_string();
     if let Some(home) = dirs::home_dir() {
         let home_str = home.display().to_string();
         if let Some(rest) = s.strip_prefix(&home_str) {
@@ -350,7 +353,7 @@ fn print_change_summary(changes: &[nono::undo::Change], object_store: &ObjectSto
             .path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| change.path.display().to_string());
+            .unwrap_or_else(|| crate::terminal_approval::safe_path(&change.path).to_string());
 
         let line_info = match change.change_type {
             ChangeType::Created => {
@@ -411,7 +414,7 @@ fn print_unified_diff(changes: &[nono::undo::Change], object_store: &ObjectStore
     use similar::{ChangeTag, TextDiff};
 
     for change in changes {
-        let path_str = change.path.display().to_string();
+        let path_str = crate::terminal_approval::safe_path(&change.path).to_string();
 
         let old_content = change
             .old_hash
@@ -469,7 +472,12 @@ fn print_side_by_side_diff(
     for change in changes {
         eprintln!(
             "{}",
-            format!("=== {} ===", change.path.display()).white().bold()
+            format!(
+                "=== {} ===",
+                crate::terminal_approval::safe_path(&change.path)
+            )
+            .white()
+            .bold()
         );
 
         let old_content = change
@@ -527,7 +535,10 @@ fn print_full_content(changes: &[nono::undo::Change], object_store: &ObjectStore
         eprintln!(
             "{} {} {}",
             symbol,
-            change.path.display().to_string().white().bold(),
+            crate::terminal_approval::safe_path(&change.path)
+                .to_string()
+                .white()
+                .bold(),
             format!("({})", change.change_type).truecolor(100, 100, 100)
         );
 
@@ -581,6 +592,9 @@ fn print_show_json(session: &SessionInfo) -> Result<()> {
             "file_count": manifest.files.len(),
             "merkle_root": manifest.merkle_root.to_string(),
             "changes": changes.iter().map(|c| serde_json::json!({
+                // Raw, deliberately: this is machine-readable output.
+                // `serde_json` escapes control characters, so there is no
+                // injection vector here — only a value consumers parse.
                 "path": c.path.display().to_string(),
                 "type": format!("{}", c.change_type),
                 "size_delta": c.size_delta,
@@ -1077,7 +1091,11 @@ fn change_symbol(ct: &nono::undo::ChangeType) -> colored::ColoredString {
 fn print_changes(changes: &[nono::undo::Change]) {
     for change in changes {
         let symbol = change_symbol(&change.change_type);
-        eprintln!("  {} {}", symbol, change.path.display());
+        eprintln!(
+            "  {} {}",
+            symbol,
+            crate::terminal_approval::safe_path(&change.path)
+        );
     }
 }
 

--- a/crates/nono-cli/src/rollback_ui.rs
+++ b/crates/nono-cli/src/rollback_ui.rs
@@ -101,7 +101,7 @@ fn print_change_details(changes: &[Change]) {
         eprintln!(
             "  {} {} ({}){}",
             symbol,
-            change.path.display(),
+            crate::terminal_approval::safe_path(&change.path),
             theme::fg(label, t.subtext),
             theme::fg(&size_info, t.overlay)
         );

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -136,6 +136,29 @@ fn is_affirmative_response(response: &str) -> bool {
 /// - DCS (ESC P), APC (ESC _), PM (ESC ^), SOS (ESC X): all consume through ST
 ///
 /// All control characters (0x00-0x1F, 0x7F) are replaced with space.
+/// A path on its way to a human, with escape sequences stripped on
+/// display.
+///
+/// Use this anywhere a path reaches a terminal, in place of
+/// `Path::display()`. Paths that a sandboxed agent chose are the case
+/// that matters: the agent is the untrusted party by definition here, it
+/// picks its own filenames, and nono prints them back to the user.
+///
+/// Do **not** use it for machine-readable output. `--json` consumers need
+/// the real value, and `serde_json` already escapes control characters,
+/// so there is no injection vector to close there — only data to corrupt.
+pub(crate) fn safe_path(path: &std::path::Path) -> impl std::fmt::Display + '_ {
+    struct SafePath<'a>(&'a std::path::Path);
+
+    impl std::fmt::Display for SafePath<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&sanitize_for_terminal(&self.0.display().to_string()))
+        }
+    }
+
+    SafePath(path)
+}
+
 pub(crate) fn sanitize_for_terminal(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
@@ -189,6 +212,42 @@ fn format_access_mode(access: &AccessMode) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    /// A sandboxed agent picks its own filenames, and nono prints them
+    /// back to the user's terminal when a session ends. Escapes must not
+    /// survive that trip.
+    #[test]
+    fn safe_path_strips_escapes_from_agent_chosen_names() {
+        let raw = std::path::PathBuf::from("/tmp/ev\u{1b}[2K\u{1b}[31mil.txt");
+        let shown = safe_path(&raw).to_string();
+        assert!(
+            !shown.contains("\u{1b}[2K"),
+            "erase-line survived: {shown:?}"
+        );
+        assert!(
+            !shown.contains("\u{1b}[31m"),
+            "color escape survived: {shown:?}"
+        );
+        assert!(shown.contains("evil.txt"), "visible text lost: {shown:?}");
+    }
+
+    /// Newlines are the other way to forge output — an extra line in a
+    /// change list or a consent prompt reads as nono's own. They are
+    /// folded to spaces, not passed through.
+    #[test]
+    fn safe_path_folds_newlines_rather_than_forging_lines() {
+        let raw = std::path::PathBuf::from("/tmp/a\nSuccessfully restored 0 files\nb.txt");
+        let shown = safe_path(&raw).to_string();
+        assert!(!shown.contains('\n'), "newline survived: {shown:?}");
+    }
+
+    /// An ordinary path must render unchanged — this sits on output the
+    /// user reads on every rollback.
+    #[test]
+    fn safe_path_leaves_ordinary_paths_alone() {
+        let raw = std::path::PathBuf::from("/home/u/project/src/main.rs");
+        assert_eq!(safe_path(&raw).to_string(), "/home/u/project/src/main.rs");
+    }
+
     use super::*;
     use nono::{AccessMode, ApprovalRequest};
 


### PR DESCRIPTION
## Linked Issue

Closes #1889

## Summary

Two display paths printed untrusted text straight to stderr. Both matter more than the one fixed in #1888, because of who controls the string and when it is shown.

**Rollback output prints paths the sandboxed agent chose.** `rollback_ui.rs:104` plus `rollback_commands.rs:353, 414, 472, 530, 1080` printed `change.path.display()` unsanitized; neither file called `sanitize_for_terminal` anywhere. The agent is the untrusted party by definition in this product, it picks its own filenames, and nono renders that list back to the user at session end — while they are deciding what to roll back. That is a channel from inside the sandbox to the user's terminal.

**`confirm_pull` prints registry metadata inside a consent prompt.** `provider.namespace` and `provider.installs_summary` came from `/api/v1/profiles/{name}/providers` and were rendered **before** anything was downloaded or Sigstore-verified. Injected escapes could erase the real publisher line and redraw a different one, collecting a "yes" for something other than what is displayed.

Both now go through `sanitize_for_terminal`.

### The open question from the issue, answered

I had flagged that the consent prompt might need a stricter bar than sanitizing — stripping to printable ASCII. Checking the implementation, that is unnecessary: after handling CSI/OSC/DCS/APC/PM/SOS, `sanitize_for_terminal` maps **any remaining control character to a space** (`terminal_approval.rs`), so newlines and carriage returns cannot forge extra lines that read as nono's own output. There is a test pinning that specifically.

What sanitizing does not address is *length* — a very long `installs_summary` can still push the prompt around. That is a layout concern rather than a spoofing one, and I have deliberately not bundled a cap into a security fix.

### Why an adapter rather than a call at each site

Paths go through a new `safe_path` display adapter in `terminal_approval.rs`. The call-site count is identical; what it buys is a name for the intent, and one obvious thing to reach for next time.

It also makes the **exception** explicit. `rollback_commands.rs:584` deliberately keeps the raw value, because that is `--json` output: `serde_json` already escapes control characters, so there is no injection vector there, only a value machine consumers parse. Sanitizing it would corrupt data. That line now carries a comment saying so, so a future audit does not "fix" it.

### Approaches considered and rejected

**Type-level enforcement** — making the raw value unprintable. `Change.path` is a `PathBuf` in the library (`crates/nono/src/undo/types.rs:161`) and is serialized in the JSON API. Encoding display policy in its type would push a CLI concern into the policy-free library, against the boundary rule in CLAUDE.md.

**A `disallowed_methods` entry for `Path::display`** — the repo already uses that mechanism for `env::set_var`. But `.display()` is used legitimately throughout for logs, errors and JSON, so the lint would be almost all false positives and would end up silenced rather than heeded.

So this is the mechanical fix plus a named abstraction, not a structural guarantee. Worth saying plainly rather than overselling.

## Agent Disclosure

This PR was generated by an AI agent (Claude). I filed #1889 after the automated reviewer raised these as findings "not tied to a changed line" on #1888, and I verified each against the source before filing rather than taking them as read. The design above was posted to the issue before this PR was opened: https://github.com/nolabs-ai/nono/issues/1889#issuecomment-5647843460

No NEP: a contained fix to output handling. It does not change the profile format, CLI flags, the library API, policy resolution, or the library/CLI boundary — indeed one of the rejected options was rejected precisely for crossing that boundary.

## Test Plan

```bash
make fmt-check   # clean
make clippy      # clean (-D warnings -D clippy::unwrap_used)
cargo test -p nono-cli --bin nono   # 2089 passed; 0 failed
```

Three new unit tests on the adapter, each named for the intent it defends:

| Test | Pins |
|---|---|
| `safe_path_strips_escapes_from_agent_chosen_names` | CSI sequences do not survive; visible filename text does |
| `safe_path_folds_newlines_rather_than_forging_lines` | a newline cannot inject a line that reads as nono's own output |
| `safe_path_leaves_ordinary_paths_alone` | ordinary paths render byte-identically — this sits on output read on every rollback |

All three were mutation-checked: removing `sanitize_for_terminal` from the adapter makes the two security tests fail and leaves the third passing, which is exactly the split you want — they fail for the right reason and the ordinary-path test is not just mirroring the implementation.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates — none; terminal output only, no user-facing behaviour change beyond escapes no longer rendering
- [ ] If this PR introduces a major feature, capability, or security-relevant change, a corresponding NEP has been opened or accepted and is linked — **not applicable**: security-relevant, but a contained fix rather than a change to the security model

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy — I am not an OpenClaw or Pi Coding agent, and this is not part of a contributor-presence campaign
- [x] An issue already exists (#1889)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion, including the two rejected alternatives, before opening this
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code — none reused; `sanitize_for_terminal` is an existing in-repo helper, used as intended
- [x] I did not use forbidden patterns such as unwrap/expect — none added; `.expect()` in tests only
- [x] I used NonoError where required — not applicable; no fallible paths added
- [x] I validated and canonicalized all relevant paths — not applicable; these are display-only conversions and deliberately do not alter path resolution. `safe_path` returns a `Display` adapter, so a sanitized string can never be mistaken for a usable path
- [x] This PR matches the approved or disclosed issue scope
